### PR TITLE
feat: add Ctrl/Cmd + D to duplicate selected canvas elements with offset positioning

### DIFF
--- a/nodyx-frontend/src/lib/components/NodyxCanvas.svelte
+++ b/nodyx-frontend/src/lib/components/NodyxCanvas.svelte
@@ -1726,13 +1726,36 @@
 	// ── Keyboard ──────────────────────────────────────────────────────────────
 
 	function onKeydown(e: KeyboardEvent) {
-		// Ne pas interférer quand l'utilisateur tape dans un input/textarea/chat
+		
 		const tag = (e.target as HTMLElement)?.tagName
 		if (tag === 'INPUT' || tag === 'TEXTAREA' || (e.target as HTMLElement)?.isContentEditable) return
 
 		if (e.code === 'Space' && !overlayEdit) { spaceDown = true; e.preventDefault() }
 		if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey)  { e.preventDefault(); undo() }
 		if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.shiftKey && e.key === 'z'))) { e.preventDefault(); redo() }
+		if ((e.ctrlKey || e.metaKey) && e.key === 'd' && selectedIds.size > 0) {
+			e.preventDefault()
+			const ts = Date.now()
+			const newIds = new Set<string>()
+			for (const id of selectedIds) {
+				const el = cs.elements.get(id)
+				if (el && !el.deleted && !el.locked) {
+					const clone = {
+						...el,
+						id: crypto.randomUUID(),
+						ts,
+						x: (el.x ?? 0) + 20,
+						y: (el.y ?? 0) + 20,
+					}
+					pushUndo({ id: clone.id, before: null, after: clone })
+					cs.apply(clone)
+					socket?.emit('canvas:op', { boardId, op: clone })
+					newIds.add(clone.id)
+				}
+			}
+			selectedIds = newIds
+			render()
+		}
 		if ((e.key === 'g' || e.key === 'G') && !overlayEdit) { showGrid = !showGrid; render() }
 		if (!e.ctrlKey && !e.metaKey && !overlayEdit && !frameNameOverlay) {
 			const k = e.key.toLowerCase()


### PR DESCRIPTION
## 🚀 Overview
This PR introduces a quick duplication feature for selected canvas elements using Ctrl/Cmd + D, improving productivity and editing speed within the canvas editor.

## ✨ Feature Added
- Added keyboard shortcut support: Ctrl + D (Windows/Linux) / Cmd + D (Mac)
- Duplicates all selected canvas elements instantly
- Applies +20px X and Y offset to avoid overlap
- Generates new unique IDs using crypto.randomUUID()
- Updates timestamps using Date.now()
- Emits duplicated elements via socket for real-time sync
- Integrates with undo/redo system
- Automatically selects new cloned elements and deselects originals

## ⚙️ Behavior
When user presses:
- Ctrl/Cmd + D → selected elements are cloned and placed slightly offset on canvas

## 🔁 State Handling
- Clones are added using existing `cs.apply()` pipeline
- Each clone is pushed to undo stack
- Socket emits individual element updates for collaboration sync
- Selection state is updated to focus on newly created elements

## 🧪 Testing Performed
- Verified duplication for single selection
- Verified duplication for multiple selected elements
- Confirmed socket sync works in collaborative mode
- Checked undo/redo correctness
- Ensured no overlap with existing Delete / keyboard shortcuts

## 📌 Notes
- Works consistently across Mac and Windows systems
- Maintains existing canvas architecture and patterns (mirrors element creation flow in pointer handlers)