### PR TITLE
fix(docker): fix docker-compose.yml rename + frontend Alpine font fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,10 @@
-version: '3.9'
-
-# ── Nexus — Full stack ────────────────────────────────────────────────────────
+# ── Nodyx — Full stack ────────────────────────────────────────────────────────
 #
 # Usage:
-#   1. cp .env.example .env                     ← set DB_PASSWORD
-#   2. cp nexus-core/.env.example nexus-core/.env    ← configure your community
-#   3. cp nexus-frontend/.env.example nexus-frontend/.env
-#   4. docker-compose up -d
+#   1. cp .env.example .env                          ← set DB_PASSWORD
+#   2. cp nodyx-core/.env.example nodyx-core/.env    ← configure your community
+#   3. cp nodyx-frontend/.env.example nodyx-frontend/.env
+#   4. docker compose up -d
 #
 # Reverse proxy (nginx / Caddy) must forward:
 #   /api/  and /uploads/ and /socket.io/  →  http://localhost:3000
@@ -21,13 +19,13 @@ services:
     image: postgres:16-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_DB:       nexus
-      POSTGRES_USER:     nexus_user
+      POSTGRES_DB:       nodyx
+      POSTGRES_USER:     nodyx_user
       POSTGRES_PASSWORD: ${DB_PASSWORD:?Set DB_PASSWORD in your .env file}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test:     ["CMD-SHELL", "pg_isready -U nexus_user -d nexus"]
+      test:     ["CMD-SHELL", "pg_isready -U nodyx_user -d nodyx"]
       interval: 5s
       timeout:  5s
       retries:  10
@@ -39,35 +37,35 @@ services:
     volumes:
       - redis_data:/data
 
-  # ── Nexus API (Fastify + TypeScript) ─────────────────────────────────────────
+  # ── Nodyx API (Fastify + TypeScript) ─────────────────────────────────────────
   api:
-    build: ./nexus-core
+    build: ./nodyx-core
     restart: unless-stopped
-    env_file: ./nexus-core/.env
+    env_file: ./nodyx-core/.env
     environment:
-      # These override values in nexus-core/.env to use Docker service names
+      # These override values in nodyx-core/.env to use Docker service names
       DB_HOST:     postgres
       DB_PORT:     "5432"
-      DB_NAME:     nexus
-      DB_USER:     nexus_user
+      DB_NAME:     nodyx
+      DB_USER:     nodyx_user
       DB_PASSWORD: ${DB_PASSWORD:?Set DB_PASSWORD in your .env file}
       REDIS_HOST:  redis
       REDIS_PORT:  "6379"
     ports:
       - "3000:3000"
     volumes:
-      - ./nexus-core/uploads:/app/uploads
+      - ./nodyx-core/uploads:/app/uploads
     depends_on:
       postgres:
         condition: service_healthy
       redis:
         condition: service_started
 
-  # ── Nexus Frontend (SvelteKit) ────────────────────────────────────────────────
+  # ── Nodyx Frontend (SvelteKit) ────────────────────────────────────────────────
   frontend:
-    build: ./nexus-frontend
+    build: ./nodyx-frontend
     restart: unless-stopped
-    env_file: ./nexus-frontend/.env
+    env_file: ./nodyx-frontend/.env
     ports:
       - "3001:3001"
     depends_on:

--- a/nodyx-frontend/Dockerfile
+++ b/nodyx-frontend/Dockerfile
@@ -1,6 +1,10 @@
 # ── Build stage ──────────────────────────────────────────────────────────────
 FROM node:22-alpine AS builder
 
+RUN apk add --no-cache ttf-dejavu && \
+    mkdir -p /usr/share/fonts/truetype && \
+    ln -s /usr/share/fonts/dejavu /usr/share/fonts/truetype/dejavu
+
 WORKDIR /app
 
 COPY package*.json ./
@@ -11,6 +15,10 @@ RUN npm run build
 
 # ── Production stage ─────────────────────────────────────────────────────────
 FROM node:22-alpine AS runner
+
+RUN apk add --no-cache ttf-dejavu && \
+    mkdir -p /usr/share/fonts/truetype && \
+    ln -s /usr/share/fonts/dejavu /usr/share/fonts/truetype/dejavu
 
 WORKDIR /app
 


### PR DESCRIPTION
Two small Docker fixes found while setting up a local instance.

## Fix 1 — docker-compose.yml outdated references

The compose file still referenced `nexus-core` and `nexus-frontend` 
(old project name) instead of `nodyx-core` and `nodyx-frontend`, 
causing `docker compose up` to fail immediately with build errors.
Also fixes the PostgreSQL DB/user names and removes the obsolete 
`version` attribute.

## Fix 2 — Frontend Alpine image missing DejaVu fonts

`satori` (used for OG image generation) looks for DejaVu fonts at 
`/usr/share/fonts/truetype/dejavu/` (Debian path). Alpine installs 
them at `/usr/share/fonts/dejavu/` — without a symlink the frontend 
build fails with `ENOENT: no such file or directory`.

Fix: install `ttf-dejavu` and symlink the directory in both build 
and runner stages.

## Tested

- ✅ `docker compose up -d` completes successfully
- ✅ All 4 services start cleanly (postgres, redis, api, frontend)
- ✅ 80 migrations applied on first run
- ✅ Frontend accessible and functional