### PR TITLE
docs(es): complete Spanish documentation translation

### DIFF
--- a/docs/es/CONTRIBUTING.md
+++ b/docs/es/CONTRIBUTING.md
@@ -1,0 +1,204 @@
+# Contribuir a Nodyx
+### Bienvenido a la comunidad Nodyx
+
+---
+
+> "Nodyx pertenece a su comunidad. No a sus creadores."
+> Si estás leyendo este archivo, eres potencialmente un constructor de la internet libre.
+> Bienvenido.
+
+---
+
+## Antes de empezar
+
+Lee estos archivos en este orden:
+1. `ARCHITECTURE.md` — Cómo está construido Nodyx
+2. `MANIFESTO.md` — El alma del proyecto
+3. `ROADMAP.md` — Hacia dónde vamos
+
+Si no estás de acuerdo con el Manifiesto, puede que Nodyx no sea el proyecto adecuado para ti.
+No pasa nada.
+
+---
+
+## Dónde contribuir
+
+### Puedes contribuir libremente en
+```
+nodyx-plugins/    — Crear plugins
+nodyx-themes/     — Crear temas visuales
+nodyx-docs/       — Mejorar la documentación
+i18n/             — Traducir a tu idioma
+community/        — Contenido de la comunidad
+```
+
+### No puedes modificar sin validación
+```
+nodyx-core/src/           — Código principal del servidor
+nodyx-core/ARCHITECTURE.md
+nodyx-core/NODYX_CONTEXT.md
+docs/en/MANIFESTO.md
+```
+
+Si crees que algo en el núcleo debería cambiar, abre un Issue y explica por qué. El debate está abierto. La modificación unilateral, no.
+
+---
+
+## Crear un plugin
+
+### Estructura mínima
+```
+nodyx-plugins/mi-plugin/
+├── plugin.json     — Manifiesto obligatorio
+├── index.ts        — Punto de entrada
+├── README.md       — Documentación
+└── LICENSE         — Licencia (MIT recomendada)
+```
+
+### plugin.json mínimo
+```json
+{
+  "name": "mi-plugin",
+  "version": "1.0.0",
+  "description": "Qué hace mi plugin",
+  "author": "Tu nombre o usuario",
+  "license": "MIT",
+  "nodyxVersion": ">=1.0.0"
+}
+```
+
+### Reglas de los plugins
+1. Un plugin nunca modifica las tablas del núcleo (usuarios, comunidades, categorías, hilos, publicaciones)
+2. Un plugin puede añadir sus propias tablas con el prefijo `plugin_{nombre}_`
+3. Un plugin solo usa los hooks documentados en ARCHITECTURE.md
+4. Un plugin no puede deshabilitar otro plugin
+5. Un plugin debe funcionar aunque sus dependencias opcionales no estén presentes
+
+---
+
+## Contribuir al código del núcleo
+
+### Proceso
+1. Haz un fork del repositorio
+2. Crea una rama: `feat/mi-funcionalidad` o `fix/mi-corrección`
+3. Código en TypeScript, comentarios en inglés
+4. Los tests son obligatorios para cualquier nueva ruta de API
+5. Abre un Pull Request con una descripción clara
+
+### Formato de los commits (obligatorio)
+
+Sigue [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add voice channel mute shortcut
+fix: correct JWT expiry check
+docs: update installation guide
+refactor: extract voice signaling to separate module
+test: add auth middleware unit tests
+chore: update dependencies
+```
+
+Todos los mensajes de commit y comentarios de código deben estar en **inglés**.
+
+### Lo que no vamos a fusionar
+- Código sin tests
+- Código que rompe los tests existentes
+- Código con dependencias propietarias
+- Código con puertas traseras (obvio)
+- Código que centraliza datos de los usuarios
+- Código que contradice ARCHITECTURE.md sin debate previo
+
+---
+
+## Traducir Nodyx
+
+Traducir es la contribución más accesible. No se necesita saber programar.
+
+### Cómo hacerlo
+1. Ve a `docs/`
+2. Copia la carpeta `en/` y renómbrala con el código de tu idioma (`de/`, `es/`, `ja/`, etc.)
+3. Traduce los archivos
+4. Abre un Pull Request
+
+### Archivos a traducir
+```
+MANIFESTO.md    — El texto fundacional
+THANKS.md       — Agradecimientos
+README.md       — Descripción general del proyecto
+CONTRIBUTING.md — Esta guía
+ARCHITECTURE.md — Referencia técnica
+ROADMAP.md      — Hoja de ruta del desarrollo
+```
+
+### Reglas de traducción
+- Traduce el significado, no palabra por palabra
+- Mantén el tono original (directo, humano, sin corporativismo)
+- Si un concepto no tiene equivalente en tu idioma, conserva el término en inglés
+- Los nombres propios (Nodyx, NodyxPoints, Guard Protocol, etc.) nunca se traducen
+
+---
+
+## Reportar un bug
+
+Abre un Issue con:
+- La versión de Nodyx
+- El sistema operativo del servidor
+- Los pasos para reproducirlo
+- Lo que viste frente a lo que esperabas
+- Los logs si están disponibles
+
+---
+
+## Proponer una funcionalidad
+
+Abre un Issue con la etiqueta `[FEATURE]` y explica:
+- Qué problema resuelve
+- Para quién (qué tipo de usuario)
+- Cómo te imaginas que funcionaría
+- ¿Debería estar en el núcleo o en un plugin?
+
+La regla: si puede ser un plugin, debe ser un plugin.
+
+---
+
+## Código de conducta
+
+### Estamos aquí para
+- Construir algo bueno
+- Aprender juntos
+- Respetar el trabajo de los demás
+- Criticar ideas, no personas
+
+### No estamos aquí para
+- Imponer nuestras opiniones técnicas
+- Menospreciar las contribuciones de otros
+- Promocionar herramientas o servicios propietarios
+- Saltarnos las reglas del núcleo
+
+---
+
+## Preguntas
+
+- GitHub Issues para bugs y funcionalidades
+- GitHub Discussions para preguntas generales
+- El propio foro de Nodyx para todo lo demás
+
+---
+
+## Gracias
+
+Cada contribución, por pequeña que sea, forma parte de algo más grande.
+Corregir una errata en la documentación. Una traducción. Un plugin. Un bug reportado.
+
+Todo cuenta. Todo queda registrado en la historia del proyecto.
+
+```
+git log --oneline
+```
+
+Tu nombre estará ahí.
+
+---
+
+*"La red es la gente."*
+*AGPL-3.0 — El código pertenece a su comunidad.*

--- a/docs/es/DOMAIN.md
+++ b/docs/es/DOMAIN.md
@@ -1,0 +1,207 @@
+# 🌐 Nodyx — Guía completa de dominios
+
+> Esta guía responde a la pregunta que todo el mundo hace al instalar Nodyx:
+> **"¿Necesito un dominio? ¿Cuál? ¿Por qué no me funciona mi No-IP?"**
+
+---
+
+## Tabla de contenidos
+
+- [Los 3 tipos de "dominio"](#-los-3-tipos-de-dominio)
+- [Tabla de compatibilidad](#-tabla-de-compatibilidad)
+- [Árbol de decisión](#-árbol-de-decisión--qué-script-debo-usar)
+- [Por qué No-IP y DuckDNS no funcionan con CF Tunnel](#-por-qué-no-ip-duckdns-etc-no-funcionan-con-cloudflare-tunnel)
+- [Dónde comprar un dominio barato](#-dónde-comprar-un-dominio-barato)
+- [Configuración DNS](#-configuración-dns)
+
+---
+
+## 🧩 Los 3 tipos de "dominio"
+
+Detrás de la palabra "dominio" se esconden tres realidades muy distintas, y confundirlas es la causa de la mayoría de los problemas.
+
+### Tipo 1 — Dominio real (TLD)
+
+> `micomunidad.com`, `clubdetejer.net`, `asociacion.org`
+
+**Compras** este dominio a un registrador (Namecheap, OVH, Porkbun…). Es tuyo. Puedes cambiar sus **servidores DNS** libremente — es decir, controlas quién gestiona su DNS.
+
+- ✅ Compatible con `install.sh`
+- ✅ Compatible con `install_tunnel.sh` (Cloudflare Tunnel)
+- ✅ Compatible con nodyx.org
+- ✅ Estable, profesional, portable
+- 💰 ~$1/año (`.xyz`, `.site`) a ~$15/año (`.com`, `.org`)
+
+---
+
+### Tipo 2 — Subdominio DNS dinámico gratuito (DDNS)
+
+> `miserv.ddns.net` (No-IP), `micomunidad.duckdns.org` (DuckDNS), `miweb.mooo.com` (Afraid.org)
+
+Obtienes un **subdominio** de un dominio que pertenece a No-IP, DuckDNS, etc. **No** eres propietario del dominio raíz (`ddns.net`, `duckdns.org`). Estos servicios están diseñados para apuntar un nombre de host a una IP que cambia frecuentemente (IP dinámica residencial).
+
+- ✅ Compatible con `install.sh` *(solo con configuración manual de Caddy — no automatizado)*
+- ❌ **Incompatible con `install_tunnel.sh`** — [ver por qué más abajo](#-por-qué-no-ip-duckdns-etc-no-funcionan-con-cloudflare-tunnel)
+- ⚠️ Inestable si tu IP cambia (residencial sin IP estática)
+- 🆓 Gratuito
+
+---
+
+### Tipo 3 — Subdominio proporcionado por Nodyx
+
+> `mi-comunidad.nodyx.org` (a través del directorio Nodyx)
+> `46-225-20-193.sslip.io` (a través de la IP pública del servidor)
+
+> 💡 **¿Qué es sslip.io?** Un servicio DNS público que convierte IPs en dominios automáticamente: `46-225-20-193.sslip.io` resuelve a `46.225.20.193` sin ninguna cuenta ni configuración. Si tu IP pública es `46.225.20.193`, ese es tu dominio gratuito instantáneo.
+
+Estos subdominios los proporciona **automáticamente** `install.sh`. Sin configuración necesaria.
+
+- ✅ Compatible con `install.sh` (puertos 80/443 abiertos)
+- ❌ **Incompatible con `install_tunnel.sh`** — `nodyx.org` es nuestra zona DNS, no la tuya
+- ✅ Certificado HTTPS automático a través de Let's Encrypt (Caddy)
+- 🆓 100% gratuito, sin configuración
+
+---
+
+## 📊 Tabla de compatibilidad
+
+| Solución | `install.sh` | `install_tunnel.sh` | HTTPS automático | Estable en producción |
+|---|:---:|:---:|:---:|:---:|
+| **Dominio real de pago** (~$1/año) | ✅ | ✅ | ✅ | ✅ |
+| **nodyx.org** (proporcionado por Nodyx) | ✅ | ❌ | ✅ | ✅ |
+| **sslip.io** (automático desde la IP) | ✅ | ❌ | ✅ | ✅ (IP estática) |
+| **No-IP / DuckDNS / Afraid** | ⚠️ manual | ❌ | ⚠️ manual | ⚠️ IP dinámica |
+| **Freenom (.tk, .ml, .ga…)** | ❌ servicio cerrado | ❌ | ❌ | ❌ |
+| **CF Quick Tunnel** (`trycloudflare.com`) | — | ⚠️ solo para pruebas | ✅ | ❌ URL cambia |
+
+> **Leyenda:**
+> ✅ Compatible y automatizado
+> ⚠️ Posible pero con limitaciones o configuración manual
+> ❌ Incompatible o no recomendado
+
+---
+
+## 🗺️ Árbol de decisión — ¿Qué script debo usar?
+
+```
+Quiero instalar Nodyx en mi servidor
+│
+├── ¿Puedo abrir los puertos 80 y 443 en mi router?
+│   │
+│   ├── SÍ → bash install.sh
+│   │          │
+│   │          ├── Tengo un dominio → introdúcelo durante la instalación
+│   │          └── Sin dominio → sslip.io + nodyx.org gratuito
+│   │                         → totalmente automático ✅
+│   │
+│   └── NO → bash install_tunnel.sh
+│              │
+│              ├── Tengo un dominio real gestionado por Cloudflare
+│              │   → introdúcelo durante la instalación ✅
+│              │
+│              ├── Tengo un subdominio de No-IP / DuckDNS
+│              │   → ❌ incompatible (no soy propietario del dominio raíz)
+│              │   → Solución: compra un dominio real (~$1/año)
+│              │
+│              └── Sin dominio
+│                  → Opción 1: compra un dominio (~$1/año) + CF Tunnel
+│                  → Opción 2: abre los puertos 80/443 + install.sh
+```
+
+---
+
+## ❓ Por qué No-IP, DuckDNS, etc. no funcionan con Cloudflare Tunnel
+
+Es la pregunta más frecuente. La explicación es técnica pero fácil de entender.
+
+### Cómo funciona Cloudflare Tunnel con el DNS
+
+Cuando ejecutas `cloudflared tunnel route dns mi-tunel micomunidad.com`, el comando:
+
+1. Se conecta a tu cuenta de Cloudflare
+2. Accede a la **zona DNS** de `micomunidad.com` *(que gestionas en CF)*
+3. Crea automáticamente un registro **CNAME**:
+   ```
+   micomunidad.com  →  CNAME  →  abc123.cfargotunnel.com
+   ```
+4. Los visitantes que van a `micomunidad.com` llegan a Cloudflare, que los redirige a través de tu túnel
+
+### Por qué un subdominio DDNS lo bloquea todo
+
+Imagina que tienes `micomunidad.duckdns.org`.
+
+- La zona DNS de `duckdns.org` pertenece a **DuckDNS**, no a ti
+- Tu cuenta de Cloudflare **no tiene acceso** a esa zona
+- `cloudflared tunnel route dns` fallará con un error como:
+  ```
+  Error: failed to add route: code: 1003, reason: You do not own this domain
+  ```
+
+Es así de simple: **debes ser propietario del dominio raíz** para que Cloudflare pueda escribir registros DNS en él.
+
+### El mismo problema con nodyx.org
+
+`nodyx.org` es nuestro dominio. Su DNS lo gestiona nuestra instancia de Cloudflare, no la tuya. Aunque intentaras añadir una ruta de túnel, Cloudflare te diría que no eres su propietario.
+
+### Por qué sslip.io tampoco funciona con CF Tunnel
+
+`sslip.io` funciona mediante un mecanismo DNS especial: `46-225-20-193.sslip.io` resuelve automáticamente a `46.225.20.193`. Es un dominio público gestionado por sus creadores — tú no eres su propietario. El mismo razonamiento.
+
+### La única solución real
+
+Para `install_tunnel.sh`, necesitas un **dominio real que hayas comprado** y cuyos servidores DNS hayas transferido a Cloudflare. Es el requisito innegociable.
+
+La buena noticia: los dominios se han vuelto muy asequibles.
+
+---
+
+## 💰 Dónde comprar un dominio barato
+
+| Registrador | Extensiones | Precio orientativo | Ventaja |
+|---|---|---|---|
+| [Porkbun](https://porkbun.com) | `.xyz`, `.site`, `.app`, `.net`… | **~$0,95/año** (primer año) | El más barato, interfaz limpia |
+| [Namecheap](https://namecheap.com) | `.com`, `.net`, `.org`… | ~$2–$10/año | Promociones frecuentes, privacidad WHOIS gratuita |
+| [Cloudflare Registrar](https://cloudflare.com/products/registrar/) | `.com`, `.net`, `.org`… | A precio de coste (~$8/año) | Sin margen, DNS de CF nativo |
+| [OVH](https://ovh.com) | `.com`, `.net`, `.eu`… | ~$7–$12/año | Proveedor europeo, soporte en español |
+| [Gandi](https://gandi.net) | `.com`, `.org`, `.net`… | ~$15/año | Ético, centrado en la privacidad |
+
+> 💡 **Truco:** Si vas a comprar un dominio para CF Tunnel, cómpralo directamente en **Cloudflare Registrar** — te saltarás el paso de "cambiar los servidores DNS" ya que se gestiona de forma nativa.
+
+### Las extensiones más baratas para empezar
+
+- `.xyz` → a menudo **< $1/año** el primer año
+- `.site` → a menudo **< $1/año** el primer año
+- `.app` → ~$1/año, ventaja añadida: Google exige HTTPS de forma nativa
+- `.com` → ~$8–10/año, la extensión más reconocida
+
+---
+
+## 🛠️ Configuración DNS
+
+### Con `install.sh` — Registro A clásico
+
+Una vez que tienes un dominio, añade estos registros en el panel DNS de tu registrador:
+
+```
+Tipo   Nombre   Valor          TTL
+A      @        IP_SERVIDOR    300
+A      www      IP_SERVIDOR    300
+```
+
+Sustituye `IP_SERVIDOR` por la IP pública de tu servidor (que aparece al inicio de `install.sh`).
+
+> ⚠️ Si tu dominio está proxificado por Cloudflare (nube naranja), el puerto TURN 3478 no será accesible por nombre de dominio. `install.sh` usa la IP directa para la URL TURN — esto es intencionado y correcto.
+
+### Con `install_tunnel.sh` — CNAME automático
+
+**No hay que configurar nada manualmente.** El script crea el CNAME automáticamente mediante `cloudflared tunnel route dns`. Lo único que debes hacer es añadir tu dominio a Cloudflare con sus servidores DNS (Paso 1 de la guía de CF Tunnel).
+
+---
+
+## 📎 Enlaces útiles
+
+- [Guía de instalación completa](INSTALL.md)
+- [Sección Cloudflare Tunnel en INSTALL.md](INSTALL.md#-alojar-en-casa-sin-abrir-puertos)
+- [Cloudflare Registrar](https://cloudflare.com/products/registrar/)
+- [Porkbun — dominios asequibles](https://porkbun.com)
+- [¿Qué es sslip.io?](https://sslip.io)

--- a/docs/es/EMAIL.md
+++ b/docs/es/EMAIL.md
@@ -1,0 +1,143 @@
+# 📧 Nodyx — Configurar el correo electrónico
+
+> **Resumen rápido:** Nodyx funciona perfectamente sin correo configurado. Pero si un miembro olvida su contraseña, tendrás que enviarle manualmente el enlace de restablecimiento. Configurar el correo lo hace automáticamente.
+
+---
+
+## ¿Para qué sirve?
+
+Nodyx envía correos en dos situaciones:
+
+- **Contraseña olvidada** — un miembro hace clic en "Olvidé mi contraseña" y recibe un enlace seguro por correo
+- **Correo de bienvenida** *(opcional)* — un mensaje de bienvenida al registrarse
+
+Eso es todo. Nodyx no envía boletines, spam ni notificaciones por correo.
+
+---
+
+## ¿Es obligatorio?
+
+**No.** Sin correo configurado:
+
+- Nodyx funciona con normalidad
+- Los restablecimientos de contraseña no se envían automáticamente
+- Como administrador, puedes generar un enlace de restablecimiento desde el panel de administración → Miembros → "Restablecer contraseña"
+
+---
+
+## Cómo configurarlo
+
+Necesitas tres datos de tu proveedor de correo:
+
+- **Dirección del servidor SMTP** (ej. `smtp.brevo.com`)
+- **Tu usuario** (normalmente tu dirección de correo)
+- **Tu contraseña SMTP** (atención: puede no ser tu contraseña habitual — algunos servicios generan una contraseña específica para aplicaciones)
+
+Abre el archivo `.env` en la carpeta `nodyx-core` y añade estas líneas:
+
+```bash
+SMTP_HOST=smtp.brevo.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=tu@correo.com
+SMTP_PASS=tu_contraseña_smtp
+SMTP_FROM=noreply@midominio.com   # opcional — usa SMTP_USER si no se define
+```
+
+Luego reinicia Nodyx:
+
+```bash
+pm2 restart nodyx-core
+```
+
+---
+
+## ¿Qué proveedor elegir?
+
+No necesitas un servidor de correo dedicado. Una cuenta con un proveedor de correo transaccional es suficiente — la mayoría tienen un plan gratuito más que suficiente para una comunidad pequeña.
+
+### Brevo *(recomendado — gratuito, empresa francesa)*
+
+**¿Por qué Brevo?**
+Empresa francesa, conforme con el RGPD, 300 correos/día gratis. Más que suficiente para una comunidad de unos cientos de miembros.
+
+1. Crea una cuenta en [brevo.com](https://www.brevo.com)
+2. Ve a **Configuración → SMTP & API → SMTP**
+3. Haz clic en **"Generar una nueva contraseña SMTP"**
+4. Copia los datos en tu `.env`:
+
+```bash
+SMTP_HOST=smtp-relay.brevo.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=tu@correo.com
+SMTP_PASS=la_contraseña_generada
+```
+
+---
+
+### Mailjet *(gratuito, empresa francesa)*
+
+1. Crea una cuenta en [mailjet.com](https://www.mailjet.com)
+2. Ve a **Configuración de cuenta → Configuración SMTP**
+3. Copia la clave API y la clave secreta
+
+```bash
+SMTP_HOST=in-v3.mailjet.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=tu_clave_api
+SMTP_PASS=tu_clave_secreta
+```
+
+---
+
+### OVH *(si ya tienes alojamiento en OVH)*
+
+Si tienes un plan de correo de OVH (`noreply@midominio.com`), usa sus credenciales directamente:
+
+```bash
+SMTP_HOST=ssl0.ovh.net
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=noreply@midominio.com
+SMTP_PASS=tu_contraseña_ovh
+```
+
+---
+
+### Infomaniak *(suizo, ético — ~€1/mes)*
+
+Si quieres una dirección con tu propio dominio alojada en Suiza:
+
+1. Contrata una dirección de correo en [infomaniak.com](https://www.infomaniak.com)
+2. Usa la configuración SMTP de tu área de cliente
+
+```bash
+SMTP_HOST=mail.infomaniak.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=noreply@midominio.com
+SMTP_PASS=tu_contraseña
+```
+
+---
+
+## Probar la configuración
+
+Desde el panel de administración de Nodyx → **Ajustes** → **Correo electrónico**, puedes enviar un correo de prueba para verificar que todo funciona.
+
+Si el correo no llega:
+
+1. Comprueba las credenciales en `.env`
+2. Comprueba que el puerto 587 no esté bloqueado por tu servidor (poco frecuente, pero posible)
+3. Algunos proveedores requieren que verifiques tu dominio de envío — consulta su documentación
+
+---
+
+## Lo que Nodyx nunca hará con tus correos
+
+- Nodyx nunca envía correos de marketing
+- Nodyx nunca comparte direcciones de correo con terceros
+- Nodyx no usa servicios de envío de correo de terceros en su código (solo SMTP estándar)
+- Las direcciones de correo de tus miembros solo pasan por **tu** servidor SMTP

--- a/docs/es/INSTALL.md
+++ b/docs/es/INSTALL.md
@@ -1,0 +1,970 @@
+# 🚀 Nodyx — Guía de instalación completa
+
+> **TL;DR:** Clona el repositorio en un servidor Linux, ejecuta `bash install.sh` y responde a unas pocas preguntas. Listo. ☕
+>
+> **Novedad — Nodyx Relay:** ¿Sin dominio y sin puertos abiertos? ¿Raspberry Pi, PC viejo, router doméstico?
+> **Elige la opción `[2] Nodyx Relay`** durante la instalación → tu instancia estará disponible desde la dirección `mi-comunidad.nodyx.org` sin ninguna configuración.
+> [→ Guía completa de Nodyx Relay](RELAY.md)
+
+---
+
+## Tabla de contenidos
+
+- [Antes de empezar](#-antes-de-empezar)
+- [¿Dónde alojar?](#-dónde-alojar)
+- [¿Necesito un dominio?](#-necesito-un-dominio) — [Guía completa de dominios →](DOMAIN.md)
+- [¿Qué puertos abrir?](#-qué-puertos-abrir)
+- [Instalación — La forma fácil](#-instalación--la-forma-fácil-recomendada)
+- [Usuarios de Windows — Guía WSL](#-usuarios-de-windows--guía-wsl)
+- [Servidor en casa / Detrás de NAT](#-servidor-en-casa--detrás-de-nat)
+- [Alojar SIN abrir puertos (Nodyx Relay, Cloudflare Tunnel, Tailscale)](#-alojar-en-casa-sin-abrir-puertos)
+- [Detrás de una VPN o WireGuard](#-detrás-de-una-vpn-o-wireguard)
+- [Errores comunes y soluciones](#-errores-comunes-y-soluciones)
+- [Tras la instalación](#-tras-la-instalación)
+- [Trucos y consejos](#-trucos-y-consejos)
+- [Configurar el correo →](EMAIL.md)
+
+---
+
+## 📋 Antes de empezar
+
+### Requisitos mínimos de hardware
+
+| Componente | Mínimo | Recomendado |
+|---|---|---|
+| CPU | 1 vCPU / 1 núcleo | 2 vCPU o más |
+| RAM | 1 GB | 2 GB o más |
+| Disco | 10 GB SSD | 20 GB SSD |
+| Ancho de banda | 10 Mbps | 100 Mbps |
+| SO | Ubuntu 22.04 | Ubuntu 24.04 LTS |
+
+> 💡 **Ejemplo real:** Una comunidad de 50 usuarios activos funciona sin problemas en un VPS de €4/mes (Hetzner CX22, 2 vCPU / 4 GB RAM). Las salas de voz son P2P — no consumen ancho de banda del servidor.
+
+### Límites de memoria PM2 — Ajustados automáticamente por el instalador
+
+El instalador detecta la RAM total disponible y configura PM2 en consecuencia. No hace falta ningún ajuste manual.
+
+| RAM total | Límite nodyx-core | Límite nodyx-frontend | Swap automático | Heap Node (build) |
+|---|---|---|---|---|
+| < 1,5 GB (RPi 1 GB) | 256 MB | 192 MB | Se crean 2 GB | 512 MB |
+| 1,5 – 3 GB (RPi 4 / VPS pequeño) | 384 MB | 256 MB | 1 GB si hace falta | 1024 MB |
+| ≥ 3 GB (VPS estándar) | 512 MB | 512 MB | 1 GB si hace falta | 1024 MB |
+
+> **Nota para Raspberry Pi:** Usa un **SO de 64 bits** (Raspberry Pi OS 64-bit o Ubuntu 24.04 ARM64). El modo 32 bits no está soportado. En una Pi de 1 GB, la compilación de SvelteKit puede tardar unos 8 minutos — es normal.
+
+### Sistemas operativos compatibles
+
+| SO | Soporte | Notas |
+|---|---|---|
+| Ubuntu 24.04 LTS | ✅ Recomendado | El más probado |
+| Ubuntu 22.04 LTS | ✅ Compatible | Funciona perfectamente |
+| Debian 12 (Bookworm) | ✅ Compatible | Totalmente compatible |
+| Debian 11 (Bullseye) | ✅ Compatible | Compatible |
+| Windows (WSL2) | ✅ Compatible | [Ver sección WSL](#-usuarios-de-windows--guía-wsl) |
+| macOS | ⚠️ Solo manual | install.sh es solo para Linux |
+| CentOS / RHEL / Fedora | ❌ No soportado | Usa Docker en su lugar |
+| Raspberry Pi OS | ✅ Compatible | Usa la versión de 64 bits |
+
+### Solo un requisito previo — Git
+
+El instalador necesita `git` para clonar el repositorio de Nodyx. La mayoría de imágenes de VPS no lo incluyen por defecto. Instálalo primero:
+
+```bash
+# Ubuntu / Debian
+sudo apt-get update && sudo apt-get install -y git
+
+# Eso es todo. El instalador se encarga del resto.
+```
+
+---
+
+### Qué instala `install.sh` automáticamente
+
+No necesitas instalar nada más manualmente. El script se encarga de:
+
+- **Node.js 20 LTS** — Entorno de ejecución JavaScript
+- **PostgreSQL 16** — Base de datos principal
+- **Redis 7** — Caché y sesiones en tiempo real
+- **Coturn** — Relay TURN/STUN para salas de voz (NAT traversal con WebRTC)
+- **Caddy** — Proxy inverso + HTTPS automático (Let's Encrypt)
+- **PM2** — Gestor de procesos (reinicio automático, arranque al inicio)
+
+---
+
+## 🖥️ ¿Dónde alojar?
+
+### Opción 1 — VPS (Recomendado para empezar)
+
+Un VPS (Servidor Privado Virtual) es una máquina Linux remota que alquilas por meses. Siempre está encendida, tiene una IP fija y puedes conectarte a ella por SSH desde cualquier sitio.
+
+**Proveedores recomendados:**
+
+| Proveedor | Plan de entrada | Precio mensual | Notas |
+|---|---|---|---|
+| [Hetzner Cloud](https://hetzner.com/cloud) | CX22 (2 vCPU, 4 GB) | ~€3,5 | Mejor relación calidad-precio en Europa |
+| [DigitalOcean](https://digitalocean.com) | Basic (1 vCPU, 1 GB) | $6 | Panel amigable para principiantes |
+| [Vultr](https://vultr.com) | Cloud Compute 1 vCPU | $6 | Buena cobertura global |
+| [OVH](https://ovh.com) | VPS Starter | ~€3 | Proveedor europeo |
+
+> 💡 **Consejo:** Elige siempre un VPS ubicado cerca de tus usuarios (Europa → Fráncfort o París, Norteamérica → Nueva York o Dallas).
+
+**Cómo crear un VPS (ejemplo con Hetzner):**
+1. Crea una cuenta en hetzner.com
+2. Ve a **Cloud → Projects → New Project**
+3. Haz clic en **Add Server**
+4. Elige: Ubicación (ej. Núremberg), Imagen = **Ubuntu 24.04**, Tipo = **CX22**
+5. Añade tu clave SSH pública (recomendado) o establece una contraseña de root
+6. Haz clic en **Create & Buy**
+7. La IP de tu servidor aparece en el panel en unos 30 segundos
+
+**Conectarte a tu VPS:**
+```bash
+ssh root@IP_DE_TU_VPS
+```
+
+---
+
+### Opción 2 — Servidor en casa
+
+Un PC antiguo, un portátil viejo o una Raspberry Pi enchufados en casa. Funciona muy bien, pero requiere:
+- Una IP estática **o** un servicio DDNS (ver [sección Servidor en casa](#-servidor-en-casa--detrás-de-nat))
+- Redireccionamiento de puertos en tu router
+- Que tu máquina esté encendida las 24 horas
+
+> ⚠️ **Aviso:** Muchos ISP bloquean los puertos entrantes 80/443. Compruébalo con tu ISP antes de invertir tiempo. Algunos ISP (especialmente de fibra) pueden darte una IP fija por un pequeño coste adicional.
+
+---
+
+### Opción 3 — Windows con WSL (Pruebas / Desarrollo)
+
+Puedes ejecutar Nodyx en Windows 10/11 usando WSL2 (Subsistema de Windows para Linux). Es ideal para pruebas o desarrollo, pero no es la mejor opción para un servidor en producción 24/7.
+
+→ [Ver la guía detallada de WSL más abajo](#-usuarios-de-windows--guía-wsl)
+
+---
+
+## 🌐 ¿Necesito un dominio?
+
+**Respuesta corta: ¡No!** Para un VPS con `install.sh`, el instalador crea automáticamente un dominio gratuito `46-225-20-193.sslip.io` más unos alias fáciles de recordar `mi-comunidad.nodyx.org`. HTTPS funciona sin comprar nada.
+
+**Para `install_tunnel.sh` (Cloudflare Tunnel)**, sí es necesario un dominio propio — los subdominios gratuitos como No-IP o DuckDNS no son compatibles.
+
+> 📖 **[→ Guía completa de dominios: tipos, compatibilidad, árbol de decisión, dónde comprar](DOMAIN.md)**
+>
+> Explica por qué No-IP/DuckDNS no son compatibles con Cloudflare Tunnel, y una tabla comparativa completa de todas las opciones.
+
+**Resumen rápido:**
+
+| Situación | Solución |
+|---|---|
+| VPS, puertos 80/443 abiertos, sin dominio | `install.sh` → sslip.io + nodyx.org gratuito |
+| VPS, puertos 80/443 abiertos, dominio propio | `install.sh` → introduce tu dominio |
+| Servidor en casa, sin puertos abiertos, dominio CF | `install_tunnel.sh` |
+| Servidor en casa, sin puertos abiertos, No-IP/DuckDNS | ❌ no compatible — [ver DOMAIN.md](DOMAIN.md) |
+| Servidor en casa, sin puertos abiertos, sin dominio | Compra un dominio ~$1/año — [ver DOMAIN.md](DOMAIN.md) |
+
+> 💡 **Truco para Cloudflare:** Si usas Cloudflare como proveedor DNS, activa la nube naranja (proxy) para HTTP/HTTPS — protección DDoS gratuita. **Desactiva el proxy (nube gris) para cualquier subdominio TURN** — las salas de voz no funcionarán a través del proxy de Cloudflare.
+
+---
+
+## 🔌 ¿Qué puertos abrir?
+
+El script `install.sh` configura el firewall (UFW) automáticamente. Esto es lo que abre:
+
+| Puerto | Protocolo | Servicio | ¿Obligatorio? |
+|---|---|---|---|
+| 22 | TCP | SSH | ✅ Sí (para gestionar tu servidor) |
+| 80 | TCP | HTTP | ✅ Sí (verificación Let's Encrypt) |
+| 443 | TCP | HTTPS | ✅ Sí (tu sitio web) |
+| 3478 | TCP + UDP | TURN/STUN (relay de voz) | ✅ Sí (salas de voz) |
+| 5349 | TCP + UDP | TURN/STUN sobre TLS | ⚠️ Opcional |
+| 49152–65535 | UDP | Relay de medios WebRTC | ✅ Sí (salas de voz) |
+
+> ❓ **¿Qué es un relay TURN?** Cuando dos usuarios quieren hablar en una sala de voz, necesitan una conexión directa (P2P). Si uno de ellos está detrás de un NAT (como una conexión 4G o una red corporativa), la conexión no puede establecerse directamente. El relay TURN actúa como intermediario — la voz pasa por tu servidor en lugar de hacerlo de forma directa. Solo se usa como alternativa cuando el P2P falla.
+
+---
+
+## 🚀 Instalación — La forma fácil (Recomendada)
+
+### Paso 1 — Clona el repositorio
+
+En tu servidor Linux (vía SSH):
+
+```bash
+git clone https://github.com/Pokled/Nodyx.git /opt/nodyx-install
+cd /opt/nodyx-install
+```
+
+O descarga solo el script de instalación:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Pokled/Nodyx/main/install.sh -o install.sh
+```
+
+### Paso 2 — Ejecuta el instalador
+
+```bash
+sudo bash install.sh
+```
+
+> 🔐 El script debe ejecutarse como root (o con sudo). Instala paquetes del sistema, configura el firewall y establece los servicios.
+
+### Paso 3 — Responde a las preguntas
+
+El instalador te preguntará:
+
+```
+? Nombre de la comunidad (ej. Linux Francia): Mi comunidad
+? Identificador único de la URL [mi-comunidad]:
+? Idioma principal (fr/en/de/es/it/pt) [en]:
+
+  Dominio de la instancia
+  ┌─ Si tienes un dominio (ej. midominio.com), introdúcelo abajo.
+  └─ Si no, pulsa Enter → se usará automáticamente el dominio gratuito 46-225-20-193.sslip.io
+
+? Dominio (pulsa Enter para usar un dominio gratuito): midominio.com   ← o Enter para sslip.io
+
+? Nombre de usuario del administrador: alice
+? Correo del administrador: alice@ejemplo.com
+? Contraseña del administrador: ••••••••
+```
+
+> 💡 **¿Sin dominio?** Pulsa Enter — tu instancia estará accesible en `46-225-20-193.sslip.io` con HTTPS automático. Puedes cambiar a tu propio dominio más adelante.
+
+Eso es todo. El script se encarga del resto automáticamente (≈ 3–10 minutos según la velocidad de tu servidor).
+
+### Paso 4 — Espera y disfruta ☕
+
+El instalador te mostrará un resumen al final:
+
+```
+╔══════════════════════════════════════════════════╗
+║       ✔  ¡Nodyx instalado correctamente!         ║
+╚══════════════════════════════════════════════════╝
+
+  Instancia : https://midominio.com
+  Admin     : alice / alice@ejemplo.com
+  Voz       : Relay TURN en 46.225.20.193:3478
+
+  Credenciales guardadas en: /root/nodyx-credentials.txt
+```
+
+> 💡 **El DNS tarda en propagarse por la red.** Tras apuntar tu dominio a la IP de tu servidor, puede tardar hasta 24–48 horas en propagarse por todo el mundo (en la práctica suele ser 5–30 minutos). Caddy obtendrá tu certificado SSL automáticamente en cuanto el DNS resuelva.
+
+---
+
+## 🪟 Usuarios de Windows — Guía WSL
+
+WSL (Subsistema de Windows para Linux) te permite ejecutar Ubuntu directamente dentro de Windows. El `install.sh` de Nodyx funciona perfectamente dentro de WSL2.
+
+### Paso 1 — Activa WSL2
+
+Abre **PowerShell como Administrador** y ejecuta:
+
+```powershell
+wsl --install
+```
+
+Esto instala WSL2 y Ubuntu automáticamente. **Reinicia el PC** cuando se te indique.
+
+> 💡 Si WSL ya está instalado, actualízalo: `wsl --update`
+
+### Paso 2 — Abre Ubuntu
+
+Tras reiniciar, busca **"Ubuntu"** en el menú Inicio y ábrelo. La primera vez te pedirá que crees un nombre de usuario y contraseña para Linux.
+
+### Paso 3 — Actualiza Ubuntu
+
+```bash
+sudo apt update && sudo apt upgrade -y
+```
+
+### Paso 4 — Instala Git (si hace falta)
+
+```bash
+sudo apt install -y git
+```
+
+### Paso 5 — Clona Nodyx
+
+```bash
+git clone https://github.com/Pokled/Nodyx.git
+cd Nodyx
+```
+
+### Paso 6 — Ejecuta el instalador
+
+```bash
+sudo bash install.sh
+```
+
+> ⚠️ **Limitación de WSL:** Los servicios iniciados dentro de WSL no se reinician automáticamente con Windows. Para un servidor 24/7, usa un VPS o servidor Linux real. WSL es ideal para pruebas y desarrollo.
+
+> 💡 **Acceder desde tu navegador Windows:** Una vez terminada la instalación, abre el navegador y ve a `http://localhost` — Nodyx estará ahí.
+
+### Consejos específicos para WSL
+
+- **Acceso a archivos:** Tus archivos de Windows están en `/mnt/c/Users/TuNombre/` dentro de WSL
+- **Atajo para la terminal WSL:** En cualquier carpeta de Windows, escribe `wsl` en la barra de direcciones
+- **Integración con VS Code:** Instala la extensión "WSL" para editar archivos directamente
+- **Redireccionamiento de puertos:** Si quieres exponer WSL a tu red local, necesitas redirigir los puertos manualmente:
+  ```powershell
+  # Ejecutar como Administrador en PowerShell
+  netsh interface portproxy add v4tov4 listenport=80 listenaddress=0.0.0.0 connectport=80 connectaddress=$(wsl hostname -I)
+  netsh interface portproxy add v4tov4 listenport=443 listenaddress=0.0.0.0 connectport=443 connectaddress=$(wsl hostname -I)
+  ```
+
+---
+
+## 🏠 Servidor en casa / Detrás de NAT
+
+Ejecutar Nodyx en una máquina en casa (detrás de tu router) requiere algunos pasos adicionales.
+
+### Paso 1 — Encuentra tu IP pública
+
+Ve a [whatismyip.com](https://whatismyip.com) — esta es la IP que ve el mundo exterior.
+
+> ⚠️ **Problema:** La mayoría de ISP domésticos asignan **IPs dinámicas** — tu IP pública puede cambiar. Solución: usa un servicio DDNS.
+
+### Paso 2 — Configura DDNS (si no tienes IP estática)
+
+Un servicio DDNS (DNS Dinámico) asocia un nombre de host a tu IP actual y se actualiza automáticamente.
+
+**Opciones gratuitas:**
+- [DuckDNS](https://www.duckdns.org) — completamente gratuito, sencillo y fiable
+- [No-IP](https://noip.com) — plan gratuito disponible
+- [Dynu](https://dynu.com) — plan gratuito disponible
+
+**Ejemplo con DuckDNS:**
+1. Regístrate en duckdns.org
+2. Crea un subdominio (ej. `mi-comunidad.duckdns.org`)
+3. Instala el cliente de actualización automática en tu servidor:
+   ```bash
+   # Añadir al crontab (se actualiza cada 5 minutos)
+   */5 * * * * curl -s "https://www.duckdns.org/update?domains=mi-comunidad&token=TU_TOKEN&ip=" > /dev/null
+   ```
+
+### Paso 3 — Redireccionamiento de puertos en tu router
+
+Necesitas redirigir el tráfico desde tu router hacia tu servidor. El procedimiento varía según el modelo de router.
+
+**Pasos generales:**
+1. Entra en el panel de administración de tu router (normalmente `http://192.168.1.1` o `http://192.168.0.1`)
+2. Busca la sección **Redireccionamiento de puertos** o **NAT**
+3. Añade estas reglas:
+
+| Puerto externo | Protocolo | IP interna | Puerto interno |
+|---|---|---|---|
+| 80 | TCP | `IP_LOCAL_DE_TU_SERVIDOR` | 80 |
+| 443 | TCP | `IP_LOCAL_DE_TU_SERVIDOR` | 443 |
+| 3478 | TCP+UDP | `IP_LOCAL_DE_TU_SERVIDOR` | 3478 |
+| 49152–65535 | UDP | `IP_LOCAL_DE_TU_SERVIDOR` | 49152–65535 |
+
+> 💡 **Encontrar la IP local de tu servidor:**
+> ```bash
+> ip addr show | grep 'inet ' | grep -v '127.0.0.1'
+> # Normalmente algo como 192.168.1.42
+> ```
+
+> 💡 **Asigna una IP local fija a tu servidor:** En los ajustes de tu router, busca **Reserva de IP estática** o **Asignación de dirección fija**. Vincula la dirección MAC de tu servidor a una IP local fija (ej. `192.168.1.100`) para que nunca cambie.
+
+### Paso 4 — CGNAT (NAT de nivel de operador)
+
+Algunos ISP usan CGNAT — tu conexión doméstica comparte una IP pública con cientos de otros clientes. En este caso, el redireccionamiento de puertos es **imposible**.
+
+**Cómo saber si estás detrás de CGNAT:**
+```bash
+# La IP WAN de tu router (en el panel de administración) vs tu IP pública (whatismyip.com)
+# Si son diferentes → estás detrás de CGNAT
+```
+
+**Soluciones si estás detrás de CGNAT:**
+1. **Pide a tu ISP** una IP pública real (a veces gratuita, a veces por unos €/mes)
+2. **Usa un VPS barato como relay** — ejecuta Nginx en el VPS y tuneliza el tráfico a tu servidor doméstico vía SSH:
+   ```bash
+   # En tu servidor doméstico (crea un túnel inverso)
+   ssh -R 80:localhost:80 -R 443:localhost:443 usuario@IP_VPS -N
+   ```
+3. **Usa Cloudflare Tunnel** — gratuito, sin redireccionamiento de puertos, sin VPS (pero Cloudflare ve tu tráfico)
+
+---
+
+## 🚇 Alojar en casa sin abrir puertos
+
+¿Quieres ejecutar Nodyx en una Raspberry Pi (o un PC viejo) en casa, pero no quieres — o no puedes — abrir los puertos 80/443 en tu router? Sin problema, hay soluciones gratuitas y sencillas.
+
+### ¿Por qué hacen falta puertos? (explicación para principiantes)
+
+Imagina tu servidor como una casa. Para que visitantes de todo el mundo puedan llamar a tu timbre, necesitas:
+1. Que tu casa tenga una **dirección visible** (IP pública)
+2. Que la **puerta esté abierta** (puertos 80 y 443 redirigidos desde tu router a tu servidor)
+
+Si no quieres abrir esas puertas, usas un **túnel** — un intermediario que recibe a los visitantes por ti y los deja entrar por una entrada de servicio que tú controlas, sin exponer tu casa directamente.
+
+> ⚠️ **Importante:** Sin HTTPS, **las salas de voz no funcionarán** — los navegadores se niegan a acceder al micrófono/cámara en HTTP sin cifrar. Es necesaria una solución con túnel para usar todas las funciones de Nodyx.
+
+---
+
+### ⚡ Solución 0 — Nodyx Relay *(nueva recomendación — sin requisitos previos)*
+
+**Nodyx Relay** es la solución integrada de Nodyx. Sin cuenta de terceros, sin dominio, sin puertos abiertos.
+
+| | Nodyx Relay | Cloudflare Tunnel |
+|---|---|---|
+| Cuenta de terceros necesaria | ❌ No | ✅ Cloudflare |
+| Dominio necesario | ❌ No | ✅ Sí (~€1/año) |
+| URL que obtienes | `mi-comunidad.nodyx.org` | `mi-comunidad.midominio.com` |
+| Incluido en `install.sh` | ✅ Sí (opción 2) | 🔧 Script separado |
+| Código abierto | ✅ Sí | ❌ No |
+
+**Cómo activarlo:** durante la instalación con `install.sh`, elige simplemente la opción `[2] Nodyx Relay`. Eso es todo.
+
+> 📖 [→ Guía completa de Nodyx Relay](RELAY.md)
+
+---
+
+### 🌩️ Solución 1 — Cloudflare Tunnel *(alternativa si ya tienes un dominio en CF)*
+
+Cloudflare Tunnel crea una conexión **saliente** desde tu servidor hacia los servidores de Cloudflare. Sin puertos que abrir. Cloudflare recibe a los visitantes y los reenvía a tu servidor a través de este túnel.
+
+**Lo que necesitas:**
+- Una cuenta gratuita de Cloudflare → [dash.cloudflare.com](https://dash.cloudflare.com)
+- Un dominio (~$1/año en [Porkbun](https://porkbun.com) o [Namecheap](https://namecheap.com))
+
+> 💡 ¿Sin dominio? Nodyx te da uno gratis: durante la instalación, tu instancia obtiene automáticamente un subdominio **`mi-comunidad.nodyx.org`**. Sin necesidad de comprar nada.
+
+---
+
+> 🚀 **¡`install_tunnel.sh` automatiza toda la configuración!**
+>
+> Una vez lista tu cuenta de Cloudflare y tu dominio **(solo el Paso 1 de abajo)**, ejecuta simplemente:
+>
+> ```bash
+> curl -fsSL https://raw.githubusercontent.com/Pokled/Nodyx/main/install_tunnel.sh -o install_tunnel.sh
+> sudo bash install_tunnel.sh
+> ```
+>
+> El script se encarga de todo:
+> - Detecta la arquitectura de tu servidor (arm64, amd64…)
+> - Instala Nodyx completamente (PostgreSQL, Redis, coturn, PM2…)
+> - Descarga e instala `cloudflared`
+> - Te guía paso a paso por el inicio de sesión en Cloudflare (una URL que abrir en el navegador)
+> - Crea el túnel, genera `config.yml` y registra el DNS automáticamente
+> - Instala el servicio systemd y verifica que todo funciona
+>
+> **Los pasos 2–9 de abajo son solo de referencia** — útiles para entender qué está pasando, pero no hace falta ejecutarlos manualmente.
+
+---
+
+#### Paso 1 — Crea una cuenta en Cloudflare
+
+1. Ve a [dash.cloudflare.com](https://dash.cloudflare.com) y crea una cuenta gratuita
+2. Haz clic en **"Add a site"** e introduce tu dominio
+3. Elige el plan **Free** ($0/mes)
+4. Cloudflare te da dos **servidores DNS** (ej. `aria.ns.cloudflare.com`)
+5. Ve al panel de tu registrador (donde compraste el dominio) y reemplaza los servidores DNS por los de Cloudflare
+6. Espera entre 5 y 30 minutos a que se propague (Cloudflare te avisará por correo)
+
+#### Paso 2 — Instala `cloudflared` en tu servidor
+
+En tu Raspberry Pi / servidor Ubuntu/Debian:
+
+```bash
+# Descarga cloudflared (comprueba tu arquitectura: arm64 para Raspberry Pi 4, amd64 para PC)
+# Raspberry Pi 4 (arm64):
+curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64 \
+     -o /usr/local/bin/cloudflared
+chmod +x /usr/local/bin/cloudflared
+
+# PC normal (amd64):
+curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
+     -o /usr/local/bin/cloudflared
+chmod +x /usr/local/bin/cloudflared
+
+# Verifica que funciona:
+cloudflared --version
+```
+
+#### Paso 3 — Inicia sesión en Cloudflare
+
+```bash
+cloudflared tunnel login
+```
+
+👆 Este comando muestra una URL. **Cópiala** y ábrela en tu navegador. Inicia sesión en tu cuenta de Cloudflare y autoriza el acceso. Un archivo de certificado se descarga automáticamente en tu servidor (en `~/.cloudflared/cert.pem`).
+
+#### Paso 4 — Crea el túnel
+
+```bash
+# Sustituye "mi-comunidad" por el nombre que quieras
+cloudflared tunnel create mi-comunidad
+```
+
+Esto crea un archivo de configuración en `~/.cloudflared/`. Anota el **ID del túnel** que aparece (ej. `6ff42ae2-765d-4adf-8112-31c55c1551ef`).
+
+#### Paso 5 — Configura el túnel
+
+Crea el archivo de configuración:
+
+```bash
+nano ~/.cloudflared/config.yml
+```
+
+Pega este contenido (sustituye `ID_DEL_TÚNEL` por tu ID del Paso 4, y `midominio.com` por tu dominio):
+
+```yaml
+tunnel: ID_DEL_TÚNEL
+credentials-file: /root/.cloudflared/ID_DEL_TÚNEL.json
+
+ingress:
+  # El frontend (interfaz web)
+  - hostname: midominio.com
+    service: http://localhost:4173
+  # La API del backend
+  - hostname: api.midominio.com
+    service: http://localhost:3000
+  # Ruta por defecto (obligatoria)
+  - service: http_status:404
+```
+
+#### Paso 6 — Crea las entradas DNS
+
+```bash
+# Apunta midominio.com al túnel
+cloudflared tunnel route dns mi-comunidad midominio.com
+
+# Apunta api.midominio.com al túnel
+cloudflared tunnel route dns mi-comunidad api.midominio.com
+```
+
+Estos comandos crean los registros DNS en Cloudflare automáticamente. No hace falta tocar el panel DNS manualmente.
+
+#### Paso 7 — Inicia el túnel (prueba)
+
+```bash
+cloudflared tunnel run mi-comunidad
+```
+
+Si todo funciona, verás `INF Connection established` en los logs. Abre `https://midominio.com` en tu navegador — ¡Nodyx debería aparecer!
+
+#### Paso 8 — Inicia el túnel automáticamente al arrancar
+
+Para que el túnel arranque solo cuando tu servidor se reinicie:
+
+```bash
+# Instala cloudflared como servicio del sistema
+cloudflared service install
+
+# Activa e inicia el servicio
+systemctl enable cloudflared
+systemctl start cloudflared
+
+# Comprueba que está funcionando
+systemctl status cloudflared
+```
+
+#### Paso 9 — Configura Nodyx para usar este dominio
+
+Durante la instalación, introduce tu dominio `midominio.com` cuando el instalador lo pida. Caddy se configurará, pero con Cloudflare Tunnel puedes **desactivar Caddy** (Cloudflare gestiona el HTTPS):
+
+```bash
+systemctl stop caddy
+systemctl disable caddy
+```
+
+Luego configura Nodyx para escuchar en HTTP (no HTTPS) en localhost — el túnel de Cloudflare se encarga del cifrado.
+
+> 💡 **Sobre las salas de voz:** Cloudflare Tunnel no soporta UDP, así que **las salas de voz usarán tu relay TURN** en la IP de tu servidor. Para que funcione, el puerto **3478 UDP** debe estar abierto en tu router. Es el único puerto estrictamente necesario para la voz. Si no puedes abrirlo, la voz seguirá funcionando pero en modo relay TCP (latencia ligeramente mayor).
+
+---
+
+### 🦎 Solución 2 — Tailscale Funnel *(gratis, sin dominio)*
+
+Tailscale Funnel expone tu servidor a internet a través de la red de Tailscale, sin abrir puertos. Obtienes una URL HTTPS gratuita del tipo `https://miserv.tail1234.ts.net`.
+
+**Lo que necesitas:**
+- Una cuenta gratuita de Tailscale → [tailscale.com](https://tailscale.com)
+
+#### Paso 1 — Instala Tailscale
+
+```bash
+curl -fsSL https://tailscale.com/install.sh | sh
+```
+
+#### Paso 2 — Inicia sesión
+
+```bash
+tailscale up
+```
+
+Aparece un enlace → ábrelo en tu navegador e inicia sesión en tu cuenta de Tailscale.
+
+#### Paso 3 — Activa Funnel
+
+```bash
+# Expone el frontend (puerto 4173) a internet
+tailscale funnel 4173
+```
+
+Tailscale te da una URL HTTPS pública (ej. `https://miserv.tail1234.ts.net`). Usa esta URL durante la instalación de Nodyx cuando te pida el dominio.
+
+> ⚠️ **Limitaciones de Tailscale Funnel:** La URL gratuita es en `.ts.net` (no personalizable sin suscripción) y el ancho de banda está limitado en el plan gratuito. Adecuado para una comunidad pequeña o para pruebas.
+
+---
+
+### 🖥️ Solución 3 — Un VPS pequeño *(la más sencilla y fiable)*
+
+Siendo honestos, para una comunidad seria accesible 24/7, **un VPS es la mejor opción**. Cuesta menos que una suscripción a Netflix y evita todos estos líos con túneles.
+
+| Proveedor | Precio/mes | Especificaciones | Ideal para |
+|---|---|---|---|
+| [Hetzner](https://hetzner.com/cloud) | €3,29 | 2 vCPU, 4 GB RAM | ✅ Comunidad pequeña (recomendado) |
+| [Hetzner](https://hetzner.com/cloud) | €5,39 | 2 vCPU, 8 GB RAM | ✅ Comunidad activa |
+| [OVH VPS](https://ovhcloud.com/en/vps/) | €3,99 | 1 vCPU, 2 GB RAM | ✅ Principiante, servidor UE |
+| [Scaleway](https://scaleway.com) | €3,60 | 2 vCPU, 2 GB RAM | ✅ Centro de datos Francia/Europa |
+
+Con un VPS:
+- IP pública fija incluida
+- Puertos 80/443 abiertos por defecto
+- `bash install.sh` y listo en 10 minutos
+- Disponibilidad 24/7 garantizada
+
+---
+
+
+
+## 🔒 Detrás de una VPN o WireGuard
+
+### Ejecutar Nodyx detrás de una VPN tradicional (NordVPN, ExpressVPN, etc.)
+
+Si tu servidor se conecta a una VPN (poco habitual, pero posible), todo el tráfico saliente pasa por la VPN. Esto crea dos problemas:
+- Tu servidor TURN anuncia la IP de la VPN, no la IP real de tu servidor
+- Let's Encrypt no puede llegar a tu servidor para la verificación HTTP
+
+**Solución:** Configura la VPN para excluir el tráfico local y no enrutar los servicios públicos del servidor a través de la VPN.
+
+En la mayoría de los casos, **no ejecutes una VPN personal en la misma máquina que Nodyx**. Úsala solo en los dispositivos cliente.
+
+---
+
+### Malla P2P con WireGuard (Federación Nodyx — Fase 3)
+
+> 🔭 **Esto llegará en la Fase 3** — los nodos Nodyx formarán automáticamente una malla WireGuard, haciendo la red verdaderamente descentralizada y resiliente.
+
+Hoy en día, cada instancia de Nodyx es independiente. En el futuro, las instancias se conectarán mediante túneles WireGuard para:
+- Compartir datos de federación (directorio de instancias)
+- Enrutar tráfico entre comunidades
+- Hacer la red resiliente ante fallos individuales
+
+**Si ya ejecutas WireGuard en tu servidor** (ej. como VPN personal o entre servidores), ten cuidado:
+
+1. **Asegúrate de que los servicios de Nodyx escuchan en la interfaz correcta** — el script escucha en `0.0.0.0` por defecto (todas las interfaces), lo cual es correcto
+2. **Reglas del firewall** — UFW está configurado para permitir los puertos necesarios en todas las interfaces. Si usas WireGuard con enrutamiento estricto, puede que necesites añadir reglas para la interfaz WireGuard (`wg0`) manualmente:
+   ```bash
+   sudo ufw allow in on wg0 to any port 3478
+   ```
+3. **IP externa del TURN** — `install.sh` detecta automáticamente tu IP pública a través de `api.ipify.org`. Si tu servidor enruta el tráfico saliente por WireGuard, esto podría devolver la IP del par WireGuard en lugar de la IP real de tu servidor. Corrígelo:
+   ```bash
+   # Edita /etc/turnserver.conf
+   # Cambia external-ip= por tu IP pública real
+   sudo systemctl restart coturn
+   ```
+
+---
+
+## ❌ Errores comunes y soluciones
+
+### 🔴 "Address already in use" en el puerto 80 o 443
+
+Otro servicio está usando el puerto (normalmente Apache u otra instancia de Nginx).
+
+```bash
+# Encontrar qué usa el puerto 80
+sudo lsof -i :80
+sudo lsof -i :443
+
+# Detener Apache si está presente
+sudo systemctl stop apache2
+sudo systemctl disable apache2
+
+# Luego reiniciar Caddy
+sudo systemctl restart caddy
+```
+
+---
+
+### 🔴 El dominio no resuelve / El certificado SSL falla
+
+Caddy intenta obtener un certificado SSL de Let's Encrypt al arrancar. Si tu dominio aún no apunta al servidor, esto falla.
+
+```bash
+# Comprobar si tu dominio resuelve a tu servidor
+dig +short tudominio.com
+# Debería devolver la IP de tu servidor
+
+# Revisar los logs de Caddy para ver errores
+sudo journalctl -u caddy -f
+
+# Forzar a Caddy a reintentar
+sudo systemctl restart caddy
+```
+
+> ⏳ **El DNS tarda en propagarse por la red** — si acabas de cambiar el DNS, espera entre 5 y 30 minutos e inténtalo de nuevo.
+
+---
+
+### 🔴 El backend no arranca (puerto 3000)
+
+Consulta los logs de PM2:
+
+```bash
+pm2 logs nodyx-core --lines 50
+```
+
+Causas frecuentes:
+- **Contraseña de base de datos incorrecta** — comprueba `/opt/nodyx/nodyx-core/.env`
+- **PostgreSQL no está en ejecución** — `sudo systemctl start postgresql`
+- **Redis no está en ejecución** — `sudo systemctl start redis-server`
+- **Puerto 3000 ya en uso** — `sudo lsof -i :3000`
+
+---
+
+### 🔴 Las salas de voz muestran "Relay (TURN)" en lugar de "P2P" para algunos usuarios
+
+Esto es **normal y esperado**. Los usuarios detrás de NAT (redes corporativas, 4G, algunos ISP) no pueden establecer conexiones P2P directas. El relay TURN es la alternativa — funciona correctamente, simplemente usa el ancho de banda de tu servidor.
+
+El P2P real solo funciona cuando ambos usuarios tienen IPs públicas accesibles o tipos de NAT compatibles.
+
+---
+
+### 🔴 El relay TURN no funciona en absoluto (las salas de voz fallan completamente)
+
+```bash
+# Comprobar que coturn está en ejecución
+sudo systemctl status coturn
+
+# Revisar los logs de coturn
+tail -f /var/log/coturn.log
+
+# Probar la conectividad TURN (desde tu máquina local)
+# Usa https://webrtc.github.io/samples/src/content/peerconnection/trickle-ice/
+# Introduce: turn:IP_DE_TU_SERVIDOR:3478 / usuario: nodyx / credencial: TU_CREDENCIAL
+```
+
+> 💡 **Usuarios de Cloudflare:** Si tu dominio está proxificado por Cloudflare, el puerto 3478 no funcionará a través del nombre de dominio. `install.sh` usa la **dirección IP directa** de tu servidor para la URL TURN (`turn:IP:3478`) para evitar esto automáticamente.
+
+---
+
+### 🔴 "Failed to fetch" al subir avatar o banner
+
+Comprueba que Caddy enruta `/uploads/*` al puerto 3000:
+
+```bash
+cat /etc/caddy/Caddyfile
+# Debería contener: reverse_proxy /uploads/* localhost:3000
+```
+
+---
+
+### 🔴 El frontend muestra una página en blanco o errores de SvelteKit
+
+```bash
+pm2 logs nodyx-frontend --lines 50
+```
+
+Causas frecuentes:
+- La compilación del frontend falló — recompila: `cd /opt/nodyx/nodyx-frontend && npm run build && pm2 restart nodyx-frontend`
+- `PUBLIC_API_URL` incorrecto en `.env` — debe ser `https://tudominio.com` (sin `/api/v1`)
+
+---
+
+## 🎛️ Tras la instalación
+
+### Primer acceso
+
+1. Abre `https://tudominio.com` en tu navegador
+2. Inicia sesión con las credenciales de administrador que estableciste durante la instalación
+3. Eres el **propietario** de la comunidad — tienes acceso completo al panel de administración
+
+### Panel de administración
+
+Accede a él desde el menú → **Admin** (visible solo para propietarios y administradores).
+
+Desde el panel de administración puedes:
+- Subir el logo y el banner de la comunidad
+- Crear categorías del foro
+- Crear salas de voz
+- Gestionar miembros (ascender, expulsar, asignar rangos)
+- Configurar la descripción de la comunidad
+
+### Invita a tus primeros miembros
+
+Comparte la URL de tu instancia. Los nuevos usuarios pueden registrarse en `https://tudominio.com/auth/register`.
+
+Para ascender a alguien a moderador o administrador:
+1. Panel de administración → **Miembros**
+2. Encuentra al usuario → **Editar rol**
+3. Elige: `miembro`, `moderador` o `administrador`
+
+---
+
+## 💡 Trucos y consejos
+
+### Comandos útiles
+
+```bash
+# Ver el estado de todos los servicios
+pm2 list
+
+# Ver logs del backend (en tiempo real)
+pm2 logs nodyx-core
+
+# Ver logs del frontend
+pm2 logs nodyx-frontend
+
+# Reiniciar todo
+pm2 restart all
+
+# Recompilar y reiniciar tras una actualización
+cd /opt/nodyx/nodyx-core && npm run build && pm2 restart nodyx-core
+cd /opt/nodyx/nodyx-frontend && npm run build && pm2 restart nodyx-frontend
+
+# Comprobar Caddy (HTTPS/proxy)
+sudo systemctl status caddy
+sudo journalctl -u caddy -f
+
+# Comprobar coturn (relay de voz)
+sudo systemctl status coturn
+tail -f /var/log/coturn.log
+
+# Comprobar el uso del disco
+df -h
+
+# Comprobar el uso de memoria
+free -h
+
+# Ver quién está conectado por SSH
+who
+```
+
+### Protege tu servidor
+
+```bash
+# Cambiar el puerto SSH (opcional, reduce el ruido)
+# Edita /etc/ssh/sshd_config → Port 2222
+sudo systemctl restart sshd
+
+# Deshabilitar el acceso root por SSH (usa un usuario normal + sudo)
+# Edita /etc/ssh/sshd_config → PermitRootLogin no
+
+# Comprobar fail2ban (bloquea intentos de fuerza bruta)
+sudo apt install -y fail2ban
+sudo systemctl enable fail2ban --now
+```
+
+### Copias de seguridad
+
+```bash
+# Copia de seguridad de la base de datos PostgreSQL
+sudo -u postgres pg_dump nodyx > /backup/nodyx_$(date +%Y%m%d).sql
+
+# Copia de seguridad de los archivos subidos (avatares, banners)
+tar -czf /backup/uploads_$(date +%Y%m%d).tar.gz /opt/nodyx/nodyx-core/uploads/
+
+# Automatizar con una tarea cron diaria
+crontab -e
+# Añadir: 0 3 * * * sudo -u postgres pg_dump nodyx > /backup/nodyx_$(date +%Y%m%d).sql
+```
+
+### Actualizar Nodyx
+
+```bash
+cd /opt/nodyx
+git pull
+
+# Recompilar el backend
+cd nodyx-core && npm install && npm run build && pm2 restart nodyx-core
+
+# Recompilar el frontend
+cd ../nodyx-frontend && npm install && npm run build && pm2 restart nodyx-frontend
+```
+
+> 💡 **Las migraciones se aplican automáticamente** — el backend ejecuta las nuevas migraciones SQL al arrancar.
+
+---
+
+## 🗑️ Desinstalación completa
+
+Si quieres eliminar Nodyx completamente de tu servidor:
+
+```bash
+# 1. Detener y eliminar los procesos PM2
+pm2 delete nodyx-core nodyx-frontend
+pm2 save
+
+# 2. Eliminar el arranque automático de PM2
+pm2 unstartup systemd
+
+# 3. Eliminar el directorio de Nodyx
+rm -rf /opt/nodyx
+
+# 4. Eliminar la base de datos y el usuario de PostgreSQL
+sudo -u postgres psql -c "DROP DATABASE IF EXISTS nodyx;"
+sudo -u postgres psql -c "DROP ROLE IF EXISTS nodyx_user;"
+
+# 5. Eliminar la configuración de Caddy
+sudo rm -f /etc/caddy/Caddyfile
+sudo systemctl restart caddy
+
+# 6. Detener y deshabilitar coturn
+sudo systemctl stop coturn
+sudo systemctl disable coturn
+sudo rm -f /etc/turnserver.conf
+
+# 7. Eliminar las reglas del firewall (opcional)
+sudo ufw --force reset
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+sudo ufw allow ssh
+sudo ufw --force enable
+
+# 8. Eliminar el archivo de credenciales
+rm -f /root/nodyx-credentials.txt
+```
+
+> ⚠️ **Los archivos subidos** (avatares, banners, etc.) están en `/opt/nodyx/nodyx-core/uploads/`. Haz una copia de seguridad antes de eliminar si quieres conservar los archivos de los usuarios.
+
+### Desinstalar paquetes del sistema (opcional)
+
+Solo hazlo si instalaste estos paquetes exclusivamente para Nodyx:
+
+```bash
+# Eliminar coturn
+sudo apt-get remove --purge -y coturn
+
+# Eliminar Caddy
+sudo apt-get remove --purge -y caddy
+sudo rm -f /etc/apt/sources.list.d/caddy-stable.list
+
+# Eliminar Redis (solo si ningún otro servicio lo usa)
+sudo apt-get remove --purge -y redis-server
+
+# Eliminar PostgreSQL (PELIGRO: elimina todas las bases de datos de este servidor)
+# sudo apt-get remove --purge -y postgresql postgresql-contrib
+# sudo rm -rf /var/lib/postgresql/
+
+# Eliminar Node.js
+# sudo apt-get remove --purge -y nodejs
+```
+
+---
+
+## 🆘 ¿Sigues atascado?
+
+- Consulta los [Issues abiertos](https://github.com/Pokled/Nodyx/issues)
+- Abre una [Discusión](https://github.com/Pokled/Nodyx/discussions)
+- Lee la [documentación de arquitectura](./ARCHITECTURE.md) para entender cómo encajan las piezas
+
+---
+
+*Guía de instalación de Nodyx — v0.4.1 — marzo 2026*

--- a/docs/es/MANIFESTO.md
+++ b/docs/es/MANIFESTO.md
@@ -1,0 +1,147 @@
+# NODYX — Manifiesto
+### Versión 1.0 — La base inmutable
+
+---
+
+> *"Internet no fue inventada para vigilarnos.
+> Fue inventada para unirnos."*
+
+---
+
+## Por qué existe Nodyx
+
+Hubo un tiempo en que internet pertenecía a sus habitantes.
+
+Instalabas TeamSpeak en un PC viejo, abrías un foro phpBB un domingo por la tarde, compartías archivos por FTP sin pedirle permiso a nadie. Las comunidades nacían libremente, vivían en sus propios servidores, morían si así lo decidían. Nadie era dueño de su contenido. Nadie podía cerrarlas.
+
+Entonces llegaron las plataformas centralizadas. Discord, Facebook, Slack. Decían: *"Con nosotros es más sencillo."* Y era verdad. Así que la gente los siguió.
+
+¿El precio? Invisible al principio. Luego cada vez más opaco.
+
+Hoy millones de comunidades están encerradas en plataformas herméticas. Sus debates, sus tutoriales, su conocimiento colectivo — invisibles para Google, inaccesibles sin cuenta, condenadas a desaparecer el día que la plataforma cambie sus condiciones o cierre sus puertas. Discord mató sin querer una parte de internet. No por malicia. Por centralización.
+
+**Nodyx nació para arreglarlo.**
+
+---
+
+## Qué es Nodyx
+
+Nodyx es una plataforma de comunicación comunitaria descentralizada, de código abierto y libre.
+
+Es el foro de los años 2000 que no ha envejecido, pero ha madurado. Es Ventrilo con cifrado. Es phpBB con una interfaz de 2026. Es TeamSpeak sin servidor propietario. Es un lugar donde una comunidad puede vivir, crear, compartir y crecer — en sus propios términos, en sus propias máquinas.
+
+Nodyx está hecho de bloques modulares. Cualquiera puede añadirlos, modificarlos y compartirlos. Nodyx hace por las comunidades digitales lo que los CMS hicieron por los sitios web.
+
+La red de Nodyx son las propias personas. No los centros de datos. No los accionistas. Las personas.
+
+---
+
+## Qué no es Nodyx
+
+Nodyx no es una empresa.
+Nodyx no es una criptomoneda.
+Nodyx no es vigilancia disfrazada de servicio gratuito.
+Nodyx no es una herramienta para extremistas violentos, terroristas o depredadores.
+Nodyx no está en venta.
+
+---
+
+## Los principios fundadores
+
+Estos principios no son orientaciones. Son el contrato entre Nodyx y sus usuarios. Cada decisión técnica, cada funcionalidad, cada plugin debe alinearse con ellos. Sin excepción.
+
+### 1. Privacidad por arquitectura, no por promesa
+
+El cifrado no es opcional. Está integrado en el corazón de la red. Ningún dato personal pasa por un servidor central. WireGuard protege los intercambios. Los tokens autentican sin identificar. Lo que escribes te pertenece. Lo que compartes te pertenece.
+
+### 2. El contenido indexable como derecho, no como privilegio
+
+Los foros públicos de Nodyx son visibles para Google, Perplexity y todos los motores de búsqueda. El conocimiento de la comunidad pertenece a internet. Una respuesta útil no debería morir detrás de un muro de inicio de sesión.
+
+### 3. El autoalojamiento como libertad fundamental
+
+Cualquiera puede alojar una instancia de Nodyx en cualquier servidor. Una Raspberry Pi en el salón. Un VPS de €3/mes. Un servidor empresarial. Nodyx no le pide permiso a nadie.
+
+### 4. Transparencia total de código abierto
+
+El código es público. Auditable. Con posibilidad de fork. Si mañana una autoridad, una empresa o cualquier entidad exige añadir una puerta trasera en el código oficial, la comunidad tiene el derecho y el deber de hacer un fork del proyecto y continuar sin ella. Este manifiesto es el permiso explícito para hacerlo.
+
+**Nodyx nunca contendrá una puerta trasera. Jamás.**
+
+### 5. La modularidad como respeto a los colaboradores
+
+Nodyx es un núcleo rodeado de plugins. El núcleo es estable, documentado, protegido. Los plugins son el espacio de juego de la comunidad. Un desarrollador en solitario, un estudiante, un entusiasta — todos pueden contribuir sin necesidad de entender todo el proyecto. Eso es el código abierto real.
+
+### ⚠️ Regla absoluta — Intangibilidad del núcleo
+
+**El núcleo de Nodyx no puede ser modificado por nadie, por ningún motivo, sin la validación explícita del círculo fundador del proyecto.**
+
+El núcleo contiene el alma del proyecto: el protocolo de red, el sistema de cifrado, la arquitectura de plugins, la gestión de identidades. Son los cimientos sobre los que todo reposa.
+
+Los colaboradores de la comunidad trabajan **alrededor** del núcleo, nunca dentro de él.
+Los plugins extienden Nodyx. No lo modifican.
+Los temas visten a Nodyx. No lo transforman.
+
+Cualquier Pull Request que toque el núcleo será rechazado sin discusión si no ha sido iniciado o validado por los mantenedores fundadores. Esto no es autoritarismo. Es responsabilidad.
+
+### 6. Las personas antes que la tecnología
+
+Nodyx no existe para ser técnicamente impresionante. Existe para que las personas puedan encontrarse, crear juntas y ayudarse mutuamente. Si una tecnología compleja puede ser reemplazada por algo más sencillo que hace lo mismo, elegimos lo sencillo. Siempre.
+
+### 7. La moderación como responsabilidad comunitaria
+
+Cada instancia de Nodyx es responsable de su comunidad. Los administradores de la instancia tienen las herramientas para moderar. La IA integrada (opcional) puede ayudar. Pero la responsabilidad no puede delegarse en un algoritmo. Las personas deciden.
+
+Nodyx condena sin ambigüedad cualquier uso de la plataforma con fines terroristas, explotación infantil, acoso organizado o cualquier actividad ilegal. La descentralización no es un escudo para los criminales. Es una protección para las personas honestas.
+
+---
+
+## Visión a largo plazo
+
+Dentro de 10 años, queremos que un joven de 15 años pueda instalar Nodyx en un PC viejo y lanzar su comunidad de gaming en 15 minutos. Sin pagar. Sin dar su identidad. Sin depender de nadie.
+
+Queremos que el conocimiento de esa comunidad sea visible en Google. Que dentro de 5 años, alguien que busque "cómo hacer X en Godot" llegue a un hilo de Nodyx y encuentre la respuesta.
+
+Queremos que clubes deportivos, artistas, desarrolladores, asociaciones y empresas tengan todos su hogar digital. Ligero, funcional, privado y verdaderamente suyo.
+
+Queremos devolver a internet su alma.
+
+---
+
+## Cláusula de supervivencia
+
+Si algún día Nodyx, bajo cualquier presión — legal, comercial, política — traiciona uno de estos principios fundadores, este manifiesto autoriza explícitamente a cualquier miembro de la comunidad a:
+
+- Hacer un fork del proyecto con un nombre diferente
+- Tomar la totalidad del código bajo la licencia AGPL-3.0
+- Continuar Nodyx en el espíritu de este manifiesto
+
+**Nodyx pertenece a su comunidad. No a sus creadores.**
+
+---
+
+## Para los colaboradores
+
+Si estás leyendo estas líneas y quieres contribuir, bienvenido.
+
+No necesitas ser un experto. Necesitas compartir esta visión. Lo demás se aprende.
+
+Lee `ARCHITECTURE.md` para entender las decisiones técnicas.
+Lee `CONTRIBUTING.md` para aprender cómo participar.
+Lee `ROADMAP.md` para saber hacia dónde vamos.
+
+Y si crees que nos equivocamos en algo, dilo. Eso también es el código abierto.
+
+---
+
+*Este manifiesto es la BIBLIA del proyecto Nodyx.*
+*Cada decisión debe alinearse con él.*
+*Puede evolucionar, pero nunca ser traicionado.*
+
+**Última actualización:** febrero de 2026
+**Versión:** 1.0
+**Licencia:** AGPL-3.0
+
+---
+
+*"La red es la gente."*

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -1,0 +1,266 @@
+# NODYX
+
+> *"La red es la gente."*
+
+**Nodyx** es una plataforma de comunicación comunitaria descentralizada, de código abierto y libre.
+
+Es el internet de los años 2000 reconstruido con las herramientas de 2026.
+
+---
+
+## Por qué existe Nodyx
+
+Discord, Facebook y las grandes plataformas han encerrado a millones de comunidades en plataformas herméticas.
+Debates, tutoriales, conocimiento colectivo — invisibles para Google, inaccesibles sin cuenta, condenados a desaparecer el día que la plataforma cierre.
+
+**Nodyx lo soluciona.**
+
+- Foros públicos **indexados por todos los motores de búsqueda** (Google, Bing, Brave, Qwant...)
+- Reacciones, agradecimientos, etiquetas, búsqueda de texto completo
+- **Chat** comunitario en tiempo real (Socket.IO)
+- **Voz** + compartir pantalla (WebRTC P2P)
+- **Autoalojable** en cualquier servidor
+- **Red P2P** — los usuarios son la red
+- **Código abierto** — AGPL-3.0
+
+---
+
+## Una instancia = una comunidad
+
+Nodyx no se despliega como plataforma multicomunitaria.
+**Cada instalación de Nodyx es una comunidad soberana**, configurada vía `.env`:
+
+```env
+NODYX_COMMUNITY_NAME=Linux y Código Abierto
+NODYX_COMMUNITY_DESCRIPTION=La comunidad hispanohablante de software libre.
+NODYX_COMMUNITY_LANGUAGE=es
+NODYX_COMMUNITY_COUNTRY=ES
+NODYX_COMMUNITY_SLUG=linux
+```
+
+Las instancias se descubren entre sí a través del **nodyx-directory** — el registro global *(Fase 2)*.
+
+---
+
+## Estado del proyecto
+
+**v2.0.0 — Comunicaciones privadas y soberanas**
+
+```
+Foro                        ✓  Categorías, hilos, publicaciones, reacciones, agradecimientos, etiquetas
+Búsqueda de texto completo  ✓  PostgreSQL tsvector/GIN, extractos resaltados
+Panel de administración     ✓  Panel, miembros, rangos, bloqueos, moderación
+SEO                         ✓  Sitemap, RSS, robots.txt, JSON-LD, URLs canónicas
+Chat en tiempo real         ✓  Socket.IO — canales, respuestas, anclados, previsualizaciones, @menciones
+Salas de voz                ✓  Malla WebRTC P2P — silenciar, sin sonido, PTT, filtro de ruido
+Compartir pantalla          ✓  Compartir pantalla WebRTC + grabación de clips
+P2P DataChannels            ✓  Escritura instantánea, reacciones optimistas, transferencia de archivos
+NodyxCanvas                 ✓  Pizarra colaborativa P2P en salas de voz
+Notificaciones              ✓  respuesta, agradecimiento, @mención — insignia, centro, purga auto 30d
+Mensajes directos           ✓  MDs 1:1 — cifrado E2E (ECDH P-256 + AES-256-GCM + capa ESY)
+  ↳ Escudo E2E              ✓  Indicador en vivo (verde/naranja), tooltip de huella ESY
+  ↳ Animación de barbarización ✓  Cifrado visualizado — glifos se mezclan y revelan en tiempo real
+  ↳ Editar y eliminar       ✓  Edición inline con recifrado, eliminación en tiempo real para todos
+Encuestas                   ✓  Elección / planificación / clasificación — en chat y foro
+Sistema de bloqueo          ✓  Bloqueo de usuario, IP y email
+Biblioteca de recursos      ✓  Marcos, banners, insignias, pegatinas, sonidos, temas, fuentes
+Temas de perfil             ✓  6 preajustes, CSS por usuario en toda la app, editor en vivo
+UI móvil                    ✓  Navegación inferior, drawer de chat, voz en móvil
+Calendario / Eventos        ✓  CRUD, RSVP, mapas OSM, portada, fragmentos enriquecidos
+Búsqueda global             ✓  Índice FTS entre instancias, UI /discover
+Federación                  ✓  Directorio de instancias, Galaxy Bar (selector multi-instancia)
+Protocolo Gossip            ✓  Indexación de eventos/hilos entre instancias
+Nodyx Signet                ✓  PWA de autenticación ECDSA P-256 sin contraseña
+2FA (TOTP + Signet)         ✓  TOTP RFC 6238 + Signet como 2.º factor, cadena de prioridad
+nodyx-relay                 ✓  Túnel TCP en Rust — servidor en casa, sin puertos abiertos
+nodyx-turn                  ✓  STUN/TURN en Rust — reemplaza coturn, voz a través de VPNs
+Suite honeypot              ✓  Tarpit, archivos canario, logins falsos, píxel, huella, honeytokens, slowloris
+Hub Olimpo                  ✓  Centro de control de seguridad — panel en vivo, recolección de credenciales, lista negra distribuida
+```
+
+---
+
+## Instalación
+
+### Opción A — Docker (recomendado)
+
+El método más sencillo. Requiere Docker Desktop o Docker Engine.
+
+```bash
+git clone https://github.com/Pokled/Nodyx
+cd Nodyx/nodyx-core
+cp .env.example .env
+# Edita .env con la información de tu comunidad
+docker-compose up -d
+```
+
+La API arranca en `http://localhost:3000`
+
+---
+
+### Opción B — Windows Server sin Docker (PowerShell Easy-Install)
+
+Un script de PowerShell automatiza la instalación completa en menos de 15 minutos:
+Node.js, PostgreSQL, Redis, configuración de la base de datos, migraciones y registro como servicio de Windows.
+
+```powershell
+# Ejecuta PowerShell como Administrador, luego:
+.\scripts\Install-Nodyx.ps1
+
+# O con una ruta de instalación personalizada:
+.\scripts\Install-Nodyx.ps1 -NodyxPath "D:\Apps\Nodyx"
+```
+
+El script instala y configura automáticamente:
+- **Chocolatey** (gestor de paquetes para Windows)
+- **Node.js LTS** + **PostgreSQL 16** + **Redis**
+- **NSSM** para registrar Nodyx como servicio de Windows (arranque automático)
+- Regla de firewall para el puerto de la API
+
+---
+
+### Opción C — Instalación manual (Linux/Mac/Windows)
+
+**Requisitos previos:** Node.js 20+, PostgreSQL 16+, Redis 7+
+
+```bash
+git clone https://github.com/Pokled/Nodyx
+cd Nodyx/nodyx-core
+npm install
+cp .env.example .env
+```
+
+Edita `.env` con tus datos, luego crea la base de datos:
+
+```sql
+-- Como superusuario de PostgreSQL
+CREATE ROLE nodyx_user LOGIN PASSWORD 'tu_contraseña';
+CREATE DATABASE nodyx OWNER nodyx_user;
+GRANT ALL PRIVILEGES ON DATABASE nodyx TO nodyx_user;
+```
+
+Aplica las migraciones:
+
+```bash
+# Linux/Mac (autenticación peer o por contraseña)
+PGPASSWORD=tu_contraseña psql -U nodyx_user -d nodyx -f src/migrations/001_initial.sql
+# Las migraciones se aplican automáticamente al arrancar — no se necesita SQL manual
+
+# Windows
+$env:PGPASSWORD="tu_contraseña"
+& "C:\Program Files\PostgreSQL\16\bin\psql.exe" -U nodyx_user -d nodyx -f src\migrations\001_initial.sql
+# Las migraciones se aplican automáticamente al arrancar — no se necesita SQL manual
+```
+
+Arrancar:
+
+```bash
+npm run dev       # desarrollo (ts-node, puerto 3000)
+npm run build     # compilación TypeScript
+npm start         # producción (node dist/)
+```
+
+---
+
+## Proxy inverso HTTPS — Caddy (recomendado)
+
+[Caddy](https://caddyserver.com) es un proxy inverso que gestiona automáticamente los certificados SSL a través de Let's Encrypt. Sin configuración SSL manual.
+
+```bash
+# Instalar Caddy
+choco install caddy       # Windows
+apt install caddy         # Debian/Ubuntu
+brew install caddy        # macOS
+
+# Ejecutar con la configuración de ejemplo (desde la raíz del repo)
+caddy run --config nodyx-core/scripts/Caddyfile.example
+```
+
+Un ejemplo está disponible en [`nodyx-core/scripts/Caddyfile.example`](../../nodyx-core/scripts/Caddyfile.example).
+
+---
+
+## Variables de entorno
+
+Consulta [`nodyx-core/.env.example`](../../nodyx-core/.env.example) para la lista completa.
+
+| Variable | Obligatoria | Descripción |
+|---|---|---|
+| `NODYX_COMMUNITY_NAME` | Sí | Nombre visible de la comunidad |
+| `NODYX_COMMUNITY_SLUG` | Sí | Identificador de URL (letras minúsculas, guiones) |
+| `NODYX_COMMUNITY_LANGUAGE` | No | Idioma (por defecto: `en`) |
+| `JWT_SECRET` | Sí | Secreto JWT — **32+ caracteres aleatorios en producción** |
+| `DB_HOST` / `DB_PORT` / `DB_NAME` | Sí | Conexión PostgreSQL |
+| `DB_USER` / `DB_PASSWORD` | Sí | Credenciales PostgreSQL |
+| `REDIS_HOST` / `REDIS_PORT` | No | Redis (por defecto: `localhost:6379`) |
+| `PORT` | No | Puerto de la API (por defecto: `3000`) |
+| `NODE_ENV` | No | `development` o `production` |
+
+---
+
+## Stack tecnológico
+
+| Capa | Tecnología |
+|---|---|
+| API | TypeScript + Fastify |
+| Base de datos | PostgreSQL 16 |
+| Caché / Limitación de peticiones | Redis 7 |
+| Búsqueda de texto completo | PostgreSQL tsvector + GIN |
+| Frontend | SvelteKit + Tailwind v4 |
+| Editor | Tiptap (WYSIWYG) |
+| P2P | WebRTC DataChannels + nodyx-relay (Rust) |
+
+---
+
+## Cuentas de demostración
+
+Tras `npm run seed`:
+
+| Email | Contraseña | Rol |
+|---|---|---|
+| `bob@nodyx.demo` | `demo1234` | miembro |
+| `charlie@nodyx.demo` | `demo1234` | propietario (gaming) |
+
+---
+
+## Documentación
+
+- [ROADMAP.md](./ROADMAP.md) — El camino hacia la visión completa
+- [ARCHITECTURE.md](./ARCHITECTURE.md) — Cómo está construido Nodyx
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — Cómo contribuir
+- [MANIFESTO.md](./MANIFESTO.md) — Los principios fundadores
+
+---
+
+## Contribuir
+
+Nodyx pertenece a su comunidad. Todas las contribuciones son bienvenidas.
+
+Lee [CONTRIBUTING.md](./CONTRIBUTING.md) antes de empezar.
+
+```
+nodyx-plugins/    →  Crear plugins
+nodyx-themes/     →  Crear temas
+i18n/             →  Traducir a tu idioma
+nodyx-docs/       →  Mejorar la documentación
+```
+
+---
+
+## Licencia
+
+AGPL-3.0 — El código pertenece a su comunidad.
+
+Si Nodyx traiciona sus principios, el Manifiesto autoriza explícitamente
+a cualquiera a hacer un fork del proyecto y continuar.
+
+---
+
+## Supervisora jefa
+
+**Iris** — Aprueba cada commit desde el 18 de febrero de 2026. 🐱
+
+---
+
+*Nacido el 18 de febrero de 2026 a las 23:37.*
+*"Haz un fork si te traicionamos."*

--- a/docs/es/RELAY.md
+++ b/docs/es/RELAY.md
@@ -1,0 +1,294 @@
+# ⚡ Nodyx Relay — Instala sin dominio ni puertos abiertos
+
+> **El problema:** Quieres alojar Nodyx en casa — en una Raspberry Pi, un PC viejo, tu router doméstico — pero no tienes dominio y tu ISP bloquea los puertos entrantes.
+>
+> **La solución:** Nodyx Relay. Un binario Rust de 9 MB que establece una conexión **saliente** hacia nuestra infraestructura, haciendo tu instancia accesible en `mi-comunidad.nodyx.org` — sin ninguna configuración.
+
+---
+
+## Tabla de contenidos
+
+- [Cómo funciona](#-cómo-funciona)
+- [Requisitos](#-requisitos)
+- [Instalación](#-instalación)
+- [Comparativa con otros métodos](#-comparativa-con-otros-métodos)
+- [Verificar que el túnel está activo](#-verificar-que-el-túnel-está-activo)
+- [Solución de problemas](#-solución-de-problemas)
+- [Preguntas frecuentes](#-preguntas-frecuentes)
+- [Para los curiosos — Arquitectura técnica](#-para-los-curiosos--arquitectura-técnica)
+
+---
+
+## 🔌 Cómo funciona
+
+```
+                    Tu máquina (en casa)
+                    ┌────────────────────────────────┐
+                    │  nodyx-core (puerto 3000)      │
+                    │  nodyx-frontend (puerto 4173)  │
+                    │  Caddy (puerto 80, local)      │
+                    │                                │
+                    │  nodyx-relay-client  ──────────┼──── conexión TCP saliente ───►
+                    └────────────────────────────────┘                               │
+                                                                                     │
+                                                              relay.nodyx.org:7443
+                                                              ┌────────────────────────────┐
+                                                              │  nodyx-relay-server        │
+                                                              │                            │
+                    ◄─────── HTTPS via Caddy ───────────────  │  *.nodyx.org → :7001   │
+                    Navegador → mi-comunidad.nodyx.org      └────────────────────────────┘
+```
+
+1. **Ejecutas `bash install.sh`** y eliges la opción `[2] Nodyx Relay`
+2. **`nodyx-relay-client`** arranca como servicio systemd en tu máquina
+3. Establece una **conexión TCP saliente** (puerto 7443) hacia `relay.nodyx.org` — igual que abrir una web, no como abrir un puerto
+4. Cuando alguien visita `mi-comunidad.nodyx.org`, la petición HTTPS llega a nuestro VPS, el servidor relay la enruta a través del túnel y tu máquina responde
+5. **Tu máquina no tiene ningún puerto abierto.** Tu router no tiene nada que redirigir. Tu ISP solo ve tráfico saliente.
+
+---
+
+## 📋 Requisitos
+
+| Elemento | ¿Obligatorio? | Notas |
+|---|---|---|
+| Dominio propio | ❌ No | El relay proporciona `mi-comunidad.nodyx.org` gratis |
+| Puertos 80/443 abiertos | ❌ No | El relay solo usa tráfico **saliente** |
+| Cuenta en Cloudflare | ❌ No | Independencia total |
+| Conexión a internet | ✅ Sí | Cualquier conexión funciona (fibra, 4G, satélite) |
+| SO Linux de 64 bits | ✅ Sí | Ubuntu 22.04/24.04, Debian 11/12, Raspberry Pi OS 64-bit |
+| Arquitectura | ✅ `x86_64` o `aarch64` | PC/VPS o Raspberry Pi 3/4/5 |
+
+> 💡 **Raspberry Pi 4, 8 GB RAM, Ubuntu Server 24.04 (arm64):** probado y validado en condiciones reales — 1 de marzo de 2026.
+
+---
+
+## 🚀 Instalación
+
+### Método 1 — Instalador interactivo (recomendado)
+
+```bash
+git clone https://github.com/Pokled/Nodyx.git && cd Nodyx && sudo bash install.sh
+```
+
+Cuando el instalador pregunte por el modo de red, elige **`2`**:
+
+```
+  Modo de conexión de red
+  ┌─ [1] Dominio propio  — requiere puertos 80/443 abiertos
+  ├─ [2] Nodyx Relay     — recomendado — sin puertos, sin dominio (RPi, servidor en casa, ...)
+  └─ [3] sslip.io auto   — dominio automático gratuito, requiere puertos abiertos
+
+  ? Elección [1/2/3] (por defecto: 2 — Nodyx Relay):
+```
+
+**El instalador se encarga de todo:**
+- Descarga el binario `nodyx-relay` (amd64 o arm64 detectado automáticamente)
+- Registra tu identificador en el directorio de nodyx.org
+- Crea e inicia el servicio systemd `nodyx-relay-client`
+- Configura Caddy en modo HTTP local (sin puertos que abrir)
+
+**Resultado:** `mi-comunidad.nodyx.org` disponible en ~5 minutos.
+
+---
+
+### Método 2 — Solo el binario (instalación existente)
+
+Si ya tienes una instancia de Nodyx y solo quieres añadir el relay:
+
+```bash
+# 1. Descarga el binario
+ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+sudo curl -L "https://github.com/Pokled/Nodyx/releases/download/v0.1.0-relay/nodyx-relay-linux-${ARCH}" \
+  -o /usr/local/bin/nodyx-relay
+sudo chmod +x /usr/local/bin/nodyx-relay
+
+# 2. Verifica
+nodyx-relay --version
+
+# 3. Crea el servicio (sustituye TU_IDENTIFICADOR y TU_TOKEN por tus valores reales)
+sudo tee /etc/systemd/system/nodyx-relay-client.service > /dev/null <<EOF
+[Unit]
+Description=Nodyx Relay Client
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/nodyx-relay client \
+  --server relay.nodyx.org:7443 \
+  --slug TU_IDENTIFICADOR \
+  --token TU_TOKEN \
+  --local-port 80
+Restart=on-failure
+RestartSec=5s
+User=root
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now nodyx-relay-client
+```
+
+> 💡 Tu token está disponible en `/root/nodyx-credentials.txt` si usaste `install.sh`, o en la respuesta JSON de la API de registro de nodyx.org.
+
+---
+
+## ⚖️ Comparativa con otros métodos
+
+| Método | Dominio necesario | Puertos a abrir | Cuenta de terceros | Dependencia |
+|---|---|---|---|---|
+| **Nodyx Relay** ⭐ | ❌ No | ❌ No | ❌ No | Solo nuestra infraestructura |
+| VPS + dominio propio | ✅ Sí (~€1/año) | ✅ 80, 443 | ❌ No | Ninguna |
+| sslip.io auto | ❌ No | ✅ 80, 443 | ❌ No | Ninguna |
+| Cloudflare Tunnel | ✅ Sí (dominio CF) | ❌ No | ✅ Cloudflare | Cloudflare |
+| Tailscale + Funnel | ❌ No | ❌ No | ✅ Tailscale | Tailscale |
+| Ngrok | ❌ No | ❌ No | ✅ Ngrok | Ngrok |
+
+> **Filosofía de Nodyx:** El relay es código abierto, autoalojado en nuestro propio VPS, y puede ser sustituido por un relay comunitario. Cero dependencia de empresas de terceros.
+
+---
+
+## 🔍 Verificar que el túnel está activo
+
+```bash
+# Estado del servicio
+sudo systemctl status nodyx-relay-client
+
+# Logs en directo
+sudo journalctl -u nodyx-relay-client -f
+
+# Lo que deberías ver en los logs:
+# → Connected to relay.nodyx.org:7443
+# → Registered as slug "mi-comunidad" — OK
+# → Forwarding GET / → HTTP 200
+```
+
+**Desde el exterior:**
+
+```bash
+curl -I https://mi-comunidad.nodyx.org/
+# HTTP/2 200
+```
+
+---
+
+## 🔧 Solución de problemas
+
+### El servicio no arranca
+
+```bash
+sudo journalctl -u nodyx-relay-client --no-pager -n 50
+```
+
+| Error | Causa | Solución |
+|---|---|---|
+| `Connection refused` | relay.nodyx.org inaccesible | Comprueba tu conexión a internet |
+| `Registration rejected: Invalid slug or token` | Token incorrecto | Comprueba `/root/nodyx-credentials.txt` |
+| `Binary not found` | Binario no instalado | Reinstala con `install.sh` o el Método 2 |
+| `Address already in use` (puerto 80) | Otro servicio escuchando en :80 | `sudo ss -tlnp \| grep :80` |
+
+### La reconexión no funciona
+
+El cliente relay se reconecta automáticamente con retroceso exponencial (1s → 2s → 4s → máx. 30s). Si la conexión se cae (corte de internet, reinicio del servidor relay), se recupera sola. No tienes que hacer nada.
+
+### Mi instancia no es accesible desde internet
+
+1. Comprueba que el servicio está en ejecución: `systemctl is-active nodyx-relay-client`
+2. Comprueba que Caddy está en ejecución: `systemctl is-active caddy`
+3. Comprueba que nodyx-core está en ejecución: `pm2 status nodyx-core`
+4. Prueba en local: `curl http://localhost/api/v1/instance/info`
+
+### Reiniciar manualmente
+
+```bash
+sudo systemctl restart nodyx-relay-client
+```
+
+---
+
+## ❓ Preguntas frecuentes
+
+**P: ¿Mis datos pasan por vuestro servidor?**
+
+Sí, las peticiones HTTP pasan por `relay.nodyx.org`. Pero el contenido permanece cifrado TLS de extremo a extremo (HTTPS entre el navegador y nuestro servidor Caddy). No almacenamos el contenido de las peticiones. Los datos de tu comunidad (publicaciones, mensajes, archivos) permanecen **exclusivamente en tu máquina**.
+
+**P: ¿Qué pasa si nodyx.org no está disponible?**
+
+Tu instancia local sigue funcionando con normalidad. Solo se interrumpe el acceso desde internet a través de `mi-comunidad.nodyx.org`. Si tienes tu propio dominio, puedes cambiar a él en cualquier momento.
+
+**P: ¿Funcionan las salas de voz en modo Relay?**
+
+Las salas de voz usan WebRTC, que requiere un servidor TURN para atravesar el NAT. En modo Relay, coturn no está instalado (los puertos UDP necesarios no están abiertos). Las llamadas de voz entre miembros en la misma red local funcionarán. Para llamadas entre redes distintas, se necesita un servidor TURN externo — esto es lo que resolverá la **Fase 3.0-B (nodyx-turn)** de forma integrada.
+
+**P: ¿Es gratuito el relay?**
+
+Sí, sin límites durante el periodo beta. Nos reservamos el derecho de introducir límites razonables si el uso se vuelve excesivo (ancho de banda > varios TB/mes por instancia, por ejemplo). El relay es código abierto — puedes alojar el tuyo propio.
+
+**P: ¿Cómo cambio mi identificador?**
+
+El identificador se registra en el momento de la instalación. Para cambiarlo, contacta con el soporte de nodyx.org o elimina y vuelve a registrar tu instancia.
+
+**P: ¿Funciona el relay con Docker?**
+
+Sí. El binario `nodyx-relay client` puede ejecutarse fuera del contenedor Docker — simplemente apunta `--local-port` al puerto expuesto por tu contenedor (por defecto 80).
+
+---
+
+## 🏗️ Para los curiosos — Arquitectura técnica
+
+### El servidor relay (nodyx.org)
+
+```
+Puerto 7443 (TCP público)
+└── Acepta conexiones de los clientes relay
+    └── Autentica mediante token (tabla directory_instances en PostgreSQL)
+    └── Registra identificador → TunnelHandle (DashMap en memoria)
+
+Puerto 7001 (HTTP, solo local — recibe peticiones de Caddy)
+└── Extrae el identificador de la cabecera Host
+    ├── Identificador con túnel activo → reenvía por el túnel TCP
+    ├── Identificador en BD con URL → redirección 302
+    └── Identificador desconocido → 404
+```
+
+### El cliente relay (tu máquina)
+
+```
+nodyx-relay client
+└── Conexión TCP a relay.nodyx.org:7443
+    └── Envía: Register { slug, token }
+    └── Recibe: ServerMessage::Request { id, method, path, headers, body_b64 }
+        └── Ejecuta: reqwest → http://127.0.0.1:80{path}
+        └── Envía: ClientMessage::Response { id, status, headers, body_b64 }
+    └── Reconexión automática si se desconecta
+```
+
+### Protocolo de transporte
+
+Mensajes JSON enmarcados con un prefijo de longitud de 4 bytes en big-endian:
+
+```
+[ 4 bytes: longitud (u32 big-endian) ][ payload JSON ]
+```
+
+Tamaño máximo de trama: 16 MB.
+
+### Repositorio
+
+El código fuente de `nodyx-relay` está en el mismo repositorio que Nodyx:
+
+```
+nodyx-p2p/
+└── crates/
+    └── nodyx-relay/
+        └── src/
+            ├── main.rs          — CLI (clap)
+            ├── protocol.rs      — tipos + enmarcado
+            ├── server/          — servidor relay (VPS)
+            └── client/          — cliente relay (tu máquina)
+```
+
+---
+
+*Versión 1.0 — 1 de marzo de 2026*
+*Validado en Raspberry Pi 4 (arm64), Ubuntu Server 24.04, sin puertos abiertos.*

--- a/docs/es/ROADMAP.md
+++ b/docs/es/ROADMAP.md
@@ -1,0 +1,777 @@
+# NODYX — Hoja de ruta
+### Versión 2.4 — Sistema de copias de seguridad + Modo de mantenimiento en vivo
+
+---
+
+> *"Un proyecto que intenta hacerlo todo a la vez no hace nada bien."*
+> La hoja de ruta de Nodyx se basa en una regla simple:
+> cada fase debe funcionar perfectamente antes de pasar a la siguiente.
+
+---
+
+## ESTADO ACTUAL — Mayo 2026
+
+| Fase | Título | Estado |
+|---|---|---|
+| **Fase 1** | Foro MVP + Admin | ✅ Completa |
+| **Fase 2** | Chat en tiempo real + Directorio + Identidad de red | ✅ Completa |
+| **Fase 2.5** | Personalización de comunidad + Federación ligera | ✅ Completa |
+| **Fase 3** | Infraestructura P2P + Base en Rust | ✅ Completa |
+| **Fase 4** | Enriquecimiento de la plataforma (v1.4 → v1.8) | ✅ Completa |
+| **Fase 4.5** | Refuerzo de seguridad (v1.8.2) | ✅ Completa |
+| **Fase 4.6** | Defensa activa y seguridad en tiempo de ejecución (v1.9.0) | ✅ Completa |
+| **Fase 4.7** | 2FA — TOTP + Nodyx Signet como 2.º factor (v1.9.1) | ✅ Completa |
+| **Fase 4.8** | Estabilidad en producción y refuerzo entre runtimes (v1.9.3) | ✅ Completa |
+| **Fase 4.9** | Aislamiento de procesos, cobertura de tests y CI (v1.9.4) | ✅ Completa |
+| **Fase 4.10** | Perfil vivo + Rediseño del foro (v1.9.5) | ✅ Completa |
+| **Fase 4.11** | Comunicaciones privadas y soberanas — MDs E2E (v2.0) | ✅ Completa |
+| **Fase 4.12** | Constructor de página de inicio + SDK de widgets (v2.1) | ✅ Completa |
+| **Fase 4.13** | NodyxCanvas — Actualización mayor (v2.2) | ✅ Completa |
+| **Fase 4.14** | Reproductor multimedia universal + Catálogo del constructor + Refuerzo de túneles (v2.3) | ✅ Completa |
+| **Fase 4.15** | Sistema de copias de seguridad Fase 1 + Modo de mantenimiento en vivo (v2.4) | ✅ Completa |
+| Fase 5 | Móvil + Nodos + Reacciones + Importación de Discord | 🔨 En curso |
+| **Fase Horizonte** | NODYX-ETHER — Soberanía de la capa física | 🌌 Visión |
+| **Fase Radio** | NODYX-RADIO — Radio por internet + red publicitaria cooperativa | 📻 Visión |
+
+---
+
+## FASE 1 — Foro MVP + Admin ✅ COMPLETA
+### Objetivo: Una comunidad puede instalar, configurar y vivir en Nodyx
+
+### 1.1 Backend del foro
+- [x] Migración SQL inicial (users, communities, categories, threads, posts)
+- [x] Migración 002 — user_profiles (bio, avatar, tags, links, campos sociales)
+- [x] Migración 003 — grades (grades, community_grades, community_members.grade_id)
+- [x] Migración 004 — social links (github, youtube, twitter, instagram, website)
+- [x] Migración 005 — categories.parent_id (categorías infinitas, CTE recursivo)
+- [x] Migración 006 — threads.is_featured (artículos destacados)
+- [x] Migración 007 — post_reactions + post_thanks (reacciones emoji + karma)
+- [x] Migración 008 — tags + thread_tags (etiquetas por comunidad)
+- [x] Migración 009 — search_vector + GIN triggers (búsqueda de texto completo)
+- [x] Migración 010 — notifications (thread_reply, post_thanks, mention)
+- [x] Ruta POST /api/v1/auth/register
+- [x] Ruta POST /api/v1/auth/login + logout
+- [x] Ruta GET  /api/v1/communities + /communities/:slug
+- [x] Ruta POST /api/v1/communities/:slug/members (unirse/salir)
+- [x] Rutas del foro (categorías, hilos, publicaciones) — CRUD completo
+- [x] Edición del título del hilo (autor + mods)
+- [x] Reacciones emoji en publicaciones (6 emojis, alternancia)
+- [x] Botón de agradecimiento (+5 karma al autor, 1 por usuario/publicación)
+- [x] Etiquetas de hilos (el admin las crea, se seleccionan al crear)
+- [x] Búsqueda de texto completo en PostgreSQL (ts_headline, filtro por comunidad)
+- [x] Notificaciones (respuesta, agradecimiento recibido, @mención)
+- [x] Middleware de autenticación JWT
+- [x] Middleware de limitación de peticiones Redis
+- [x] Validación Zod en todas las rutas
+- [x] Seguimiento de usuarios "en línea" — heartbeat Redis TTL 900s
+- [x] Rutas de instancia — /instance/info, /instance/categories, /instance/threads/recent
+- [x] Rutas de administración — estadísticas, miembros, hilos (anclar/bloquear/eliminar), categorías, etiquetas
+
+### 1.2 SEO e indexación
+- [x] Rutas del foro renderizadas como HTML estático (SvelteKit SSR)
+- [x] Metaetiquetas dinámicas (title, description, og:*)
+- [x] Sitemap.xml automático
+- [x] robots.txt configurable
+- [x] Feed RSS
+- [x] Schema.org JSON-LD (Forum, DiscussionForumPosting)
+- [x] llms.txt (para agentes de IA)
+
+### 1.3 Frontend
+- [x] SvelteKit inicializado + Tailwind v4
+- [x] Página de inicio = comunidad de la instancia (NODYX_COMMUNITY_NAME vía .env)
+- [x] Árbol de categorías recursivo (CategoryTree.svelte)
+- [x] Página de lista de categorías + hilos (con etiquetas)
+- [x] Página de hilo + publicaciones + formulario de respuesta
+- [x] Editor WYSIWYG (Tiptap — negrita, código, tablas, imágenes, iframes)
+- [x] Formulario de registro / inicio de sesión
+- [x] Perfiles de usuario completos (bio, etiquetas, enlaces, widget de GitHub)
+- [x] Sistema de rangos (CRUD admin + insignia de color)
+- [x] Directorio de instancias (/communities — impulsado por nodyx.org)
+- [x] Panel de administración completo (/admin — 9 páginas incluyendo Etiquetas)
+- [x] Barra de navegación adaptativa (búsqueda, campana de notificaciones, enlace Admin)
+- [x] Página /search — pestañas Hilos/Publicaciones, extractos resaltados
+- [x] Página /notifications — lista + marcar como leído + sondeo cada 30s
+
+### 1.4 Autoalojamiento
+- [x] `install.sh` — instalador de VPS en un clic (puertos 80/443, Let's Encrypt vía Caddy, PM2, coturn, PostgreSQL, Redis)
+- [x] `install_tunnel.sh` — instalador para servidor en casa vía Cloudflare Tunnel (sin puertos abiertos, Raspberry Pi)
+- [x] docker-compose.yml (Nodyx + PostgreSQL + Redis)
+- [x] Dockerfile multietapa
+- [x] Script de seed (datos de demostración)
+- [x] Script PowerShell "Nodyx-Easy-Install" — automatiza Node/PostgreSQL/Redis en Windows Server sin Docker
+- [x] Comprobación de salud visual post-instalación (spinner braille, puntuación PASS/WARN/FAIL)
+- [x] Documentación de instalación en 15 minutos
+- [x] Guía completa de nombres de dominio (DOMAIN.md — tipos, compatibilidad, preguntas frecuentes)
+- [x] .env.example documentado
+
+### Criterios de éxito de la Fase 1 ✅
+Un usuario no desarrollador puede:
+1. Instalar Nodyx en su servidor en menos de 15 minutos ✅
+2. Configurar su instancia a través del instalador interactivo ✅
+3. Crear categorías, hilos y etiquetas ✅
+4. Gestionar su comunidad a través del panel de administración ✅
+5. Aparecer en los motores de búsqueda (Google, Bing, Brave, Qwant...) ✅
+
+---
+
+## FASE 2 — Chat en tiempo real + Directorio + Identidad de red ✅ COMPLETA
+### Objetivo: Los miembros se comunican en directo, el directorio es real, cada instancia tiene su URL
+
+### 2.1 Chat en tiempo real ✅
+- [x] WebSocket (Socket.io) integrado en Fastify v5
+- [x] Canales de texto configurables por el administrador
+- [x] Notificaciones en tiempo real (WebSocket — sustituye el sondeo cada 30s)
+- [x] Historial de mensajes persistido en PostgreSQL
+
+### 2.2 nodyx.org — Directorio ✅
+- [x] Servicio de directorio global real — API de registro de instancias
+- [x] Página /communities alimentada por el directorio real (fin del mock)
+- [x] Registro automático de la instancia en el primer arranque
+- [x] Ping automático cada 5 minutos (contador de miembros en vivo, estadísticas de conexión)
+
+### 2.3 Identidad de red — `mi-comunidad.nodyx.org` ✅
+- [x] Cada instancia elige un identificador único en la instalación
+- [x] El identificador se reserva con el directorio de nodyx.org (API REST)
+- [x] DNS wildcard `*.nodyx.org` gestionado por nuestro Cloudflare
+- [x] Caddy enruta `mi-comunidad.nodyx.org → IP del nodo` (Certificado de origen de Cloudflare)
+- [x] El administrador no tiene que configurar DNS — URL limpia en 1 clic
+
+### 2.4 Salas de voz — Capa de red ✅
+- [x] Servidor coturn (STUN/TURN) configurado e iniciado por `install.sh`
+- [x] Señalización WebRTC vía Socket.io (`src/socket/voice.ts`)
+- [x] VoicePanel.svelte — barra flotante + controles de micrófono/cámara/pantalla compartida
+- [x] VoiceSettings.svelte — cadena AudioContext configurable
+- [x] MediaCenter.svelte — compartir pantalla + clips
+
+---
+
+## FASE 2.5 — Personalización de comunidad + Federación ligera ✅ COMPLETA
+### Objetivo: Cada instancia es única, y las instancias pueden compartir sus creaciones
+
+### v0.6 — Biblioteca de recursos y Jardín de funciones ✅
+
+- [x] Migración 017 — `community_assets` (marcos, banners, insignias, pegatinas, avatares, fondos)
+- [x] Migración 018 — `user_equipped_assets` (ranuras de personalización de perfil)
+- [x] Migración 019 — `feature_seeds` (propuestas de funciones)
+- [x] Migración 020 — `user_seed_balance` (3 semillas/semana por usuario)
+- [x] Ruta `POST /api/v1/assets` — subida multipart con compresión Sharp (WebP)
+- [x] CRUD completo + like + equipar/desequipar rutas para recursos de comunidad
+- [x] `assetService.ts` — miniaturas automáticas, redimensionado, gestión de ranuras
+- [x] Página `/library` — galería de recursos con filtros de categoría/etiqueta/popularidad
+- [x] Página `/library/[id]` — detalle de recurso con like, equipar, botón Whisper
+- [x] Rutas `/api/v1/garden` — propuestas + votación con semillas + cambio de estado (admin)
+- [x] Página `/garden` — lista de propuestas, votación visual con contador de semillas
+- [x] Perfil de usuario — mostrar recursos equipados (marco, banner, insignia, fondo)
+- [x] `/users/me/edit` — gestionar ranuras de recursos en tu propio perfil
+
+### v0.7 — Recursos federados + Whispers ✅
+
+- [x] Migración 021 — `directory_assets` (instantánea de recursos federados de otras instancias)
+- [x] Migración 022 — `whisper_rooms` + `whisper_messages` (salas efímeras)
+- [x] Ruta `POST /api/directory/assets` — enviar recursos al registro (token Bearer)
+- [x] Ruta `GET /api/directory/assets/search` — búsqueda pública en múltiples instancias
+- [x] Planificador — envía recursos a `nodyx.org` cada hora
+- [x] Planificador — limpia salas whisper caducadas cada 10 minutos
+- [x] Pestaña "🌐 Todas las instancias" en `/library` — recursos federados del directorio
+- [x] Rutas `/api/v1/whispers` — crear, obtener, eliminar salas efímeras
+- [x] Socket.IO — eventos `whisper:*` (unirse, salir, mensaje, escribiendo, historial, caducado)
+- [x] Página `/whisper/[id]` — sala whisper en tiempo real (estilo iMessage, TTL visible)
+- [x] Botón "🤫 Whisper" en páginas de recursos — creación de sala contextual
+- [x] Botón "🔗 Compartir" — copia enlace con feedback "✅ Copiado!"
+- [x] `linkify.ts` — URLs clicables en chat (`linkifyHtml`) y whispers (`linkifyText`)
+
+---
+
+## FASE 3 — Infraestructura P2P + Base en Rust ✅ COMPLETA
+### Objetivo: Liberarse de las dependencias de red de terceros. Construir el núcleo descentralizado.
+
+> *"P2P es el alma. Rust es el cuerpo."*
+>
+> Nodyx no reemplazará Node.js ni SvelteKit — hacen su trabajo perfectamente.
+> Rust vendrá **por debajo**, invisible para el usuario, para gestionar las partes
+> que JavaScript no puede hacer bien: redes de bajo nivel, cifrado, WireGuard, DHT.
+> La capa Rust se comunica con nodyx-core vía un socket Unix local — simple y desacoplado.
+
+---
+
+### 3.0 — `nodyx-p2p`: La base en Rust ✅ COMPLETA
+
+#### ¿Por qué Rust aquí?
+
+Hoy, un usuario sin dominio y sin puertos abiertos debe:
+1. Crear una cuenta de Cloudflare
+2. Añadir su dominio a Cloudflare (requiere tener uno, ~$1/año)
+3. Configurar `cloudflared` manualmente o vía `install_tunnel.sh`
+
+Demasiada fricción. Y más importante: **es una dependencia de un servicio de terceros**,
+contraria a la filosofía de Nodyx.
+
+La capa Rust resuelve esto de forma radical y progresiva.
+
+#### Arquitectura
+
+```
+nodyx-frontend (SvelteKit) ──────────────────────┐
+nodyx-core    (Fastify/Node.js) ─────────────────┤
+                                                  │ IPC (Unix socket)
+                                                  ▼
+                                    ┌─────────────────────┐
+                                    │     nodyx-p2p       │
+                                    │       (Rust)        │
+                                    │                     │
+                                    │  ┌───────────────┐  │
+                                    │  │ Relay Client  │  │
+                                    │  │ (TCP/tokio)   │  │
+                                    │  └───────────────┘  │
+                                    │  ┌───────────────┐  │
+                                    │  │ STUN/TURN     │  │
+                                    │  │ (reemplaza    │  │
+                                    │  │  coturn)      │  │
+                                    │  └───────────────┘  │
+                                    │  ┌───────────────┐  │
+                                    │  │ DHT Kademlia  │  │
+                                    │  │ + WireGuard   │  │
+                                    │  │ (red en malla │  │
+                                    │  │  entre nodos) │  │
+                                    │  └───────────────┘  │
+                                    └─────────────────────┘
+```
+
+#### Fase 3.0-A — `nodyx-relay-client` ✅ VALIDADA — 1 de marzo de 2026
+
+> Reemplaza `install_tunnel.sh` + Cloudflare Tunnel. Sin dominio. Sin puertos abiertos.
+> **Probado en condiciones reales: Raspberry Pi 4, sin puertos abiertos, sin cuenta de Cloudflare.**
+
+- [x] Binario Rust estático (9MB) — `tokio` + `hyper` + `tokio-postgres` + `clap` + `dashmap`
+- [x] Conexión TCP saliente a `relay.nodyx.org:7443` (nuestra infraestructura)
+- [x] Reenvío HTTP bidireccional (enmarcado JSON, prefijo de longitud de 4 bytes)
+- [x] Registro automático de `mi-comunidad.nodyx.org` sin DNS ni cuenta de CF
+- [x] Reconexión automática con retroceso exponencial (1s → 2s → 4s → máx. 30s)
+- [x] GitHub Release `v0.1.1-relay` — binarios amd64 + arm64 (fix: gestión de peticiones concurrentes)
+- [x] Integración en `install.sh`: opción 2 "Nodyx Relay (recomendado)"
+- [x] Servicio systemd en el cliente (`nodyx-relay-client.service`)
+
+**Resultado para el usuario:** `bash install.sh` → elige "Relay" → obtiene `mi-comunidad.nodyx.org` **sin ninguna configuración de red**.
+
+#### Fase 3.0-B — Nodos P2P en el navegador (WebRTC DataChannels) ✅ POC VALIDADO — 2 de marzo de 2026
+
+> Los navegadores de los usuarios se convierten en nodos relay activos.
+> Comunicación directa entre pares sin intermediario de servidor.
+> **Reutiliza la señalización existente de `voice.ts`** — sin nueva infraestructura de servidor.
+
+**Enfoque:** DataChannels WebRTC nativos + señalización Socket.IO existente (patrón voice.ts)
+**No en este POC:** libp2p (excesivo), DHT (2027+)
+
+**v0.8 — POC dos navegadores ✅:**
+- [x] Añadir eventos `p2p:offer`, `p2p:answer`, `p2p:ice` a `voice.ts` (3 líneas — mismo patrón que `voice:offer/answer/ice`)
+- [x] Crear `nodyx-frontend/src/lib/p2p.ts` — gestor RTCPeerConnection + DataChannel
+- [x] Descubrimiento de pares vía Socket.IO existente (handshake educado/maleducado — un único iniciador)
+- [x] Usar el coturn propio de la instancia (ya instalado) — sin STUN de terceros
+- [x] Manejador `ondatachannel` en el lado del receptor (crítico — sin él, el receptor nunca recibe el canal)
+- [x] Indicador UI "⚡ P2P · N" en la cabecera del canal de texto (amarillo cuando activo, gris pulsante al conectar)
+- [x] Test validado: dos navegadores, DataChannel directo confirmado, mensajes sin pasar por el servidor
+
+**Resultado para el usuario:** unirse a cualquier canal de texto → el indicador ⚡ P2P aparece automáticamente cuando otro miembro está presente. Sin configuración.
+
+**v0.9 — Malla 1-N ✅ ENTREGADO — 2 de marzo de 2026:**
+- [x] Gestionar múltiples conexiones de pares simultáneas (Map de RTCPeerConnections — ya en p2p.ts)
+- [x] Indicadores de escritura P2P instantáneos (~1–5ms, puntos animados estilo Discord)
+- [x] Reacciones optimistas + animación pop con físicas de muelle (llega antes del roundtrip al servidor)
+- [x] Fallback elegante si WebRTC falla (timeout ICE 12s, toast sutil, flags _hadAttempt/_hadSuccess)
+- [x] Transferencia de recursos entre pares (chunks de 32 KB, protocolo p2p:asset:*, store p2pAssetPeers, botón ⚡ amarillo)
+
+#### Fase 3.0-C — `nodyx-turn` (reemplaza coturn) ✅ VALIDADA — 4 de marzo de 2026 / Actualizada el 8 de marzo de 2026
+
+> coturn es un proyecto C de los años 2000. Complejo de configurar, gran superficie de ataque.
+> **Reemplazado por un binario Rust de 2,9 MB — sin dependencias, credenciales dinámicas.**
+
+- [x] Servidor STUN/TURN en Rust — RFC 5389 (STUN) + RFC 5766 (TURN)
+- [x] Credenciales basadas en tiempo HMAC-SHA1 (username={expires}:{userId})
+- [x] MESSAGE-INTEGRITY en todas las respuestas de éxito TURN (RFC 5389 §10.3) — requerido para relay en Firefox/Chrome
+- [x] **TURN-over-TCP (RFC 6062)** — TCP:3478 junto a UDP:3478, registro de asignaciones compartido
+- [x] Enmarcado RFC 4571 (prefijo de longitud de 2 bytes big-endian por mensaje TCP)
+- [x] Abstracción `ResponseSink` — todos los manejadores TURN independientes del transporte (UDP y TCP unificados)
+- [x] Limitador de velocidad UDP por IP (30 pkt/seg) + cuotas de asignación (MAX_LIFETIME=300s) + mapa de bloqueo
+- [x] Binario estático de 2,9 MB, integrado en `install.sh`, servicio systemd
+- [x] Validado: STUN Binding Request → 0x0101 Binding Success ✅
+- [x] **Voz — Failover a relay**: cambia automáticamente a `iceTransportPolicy: relay` tras pérdida de paquetes alta sostenida (>25% × 3 sondeos)
+- [x] **Voz — Optimización Opus**: 32 kbps por defecto, DTX desactivado, mono, FEC activado — optimizado para enlaces VPN/con pérdidas
+
+#### Fase 3.0-D — Núcleo `nodyx-p2p` (visión a largo plazo 2027-2028)
+
+> El núcleo distribuido. Cuando un nodo quiere contactar con otro directamente, sin pasar por nosotros.
+> Red inmortal: cada dato replicado en 3+ nodos, autocurativo.
+
+- [ ] Kademlia DHT (vía `libp2p`) — descubrimiento de pares sin servidor central
+- [ ] WireGuard (vía `wireguard-rs`) — túnel directo cifrado entre instancias voluntarias
+- [ ] ICE/STUN nativo — NAT traversal sin coturn para conexiones P2P
+- [ ] API IPC expuesta a nodyx-core: `relay.register(slug)`, `peer.connect(slug)`, `network.peers()`
+- [ ] Protocolo Gossip — propagación natural del estado por la red
+- [ ] CRDTs — datos distribuidos sin conflictos (como contadores, presencia)
+- [ ] Factor de replicación 3 — autocurativo si un nodo cae
+- [ ] Si `nodyx.org` no está disponible, los nodos se encuentran vía DHT (resiliencia)
+
+---
+
+### 3.1 — Salas de voz — Interfaz y modos avanzados
+*(capa de red ya en marcha — Fase 2.4)*
+
+- [x] Barra lateral VoicePanel — panel izquierdo en posición fija con lista de participantes (diseño Galaxy Bar)
+- [x] Panel de interacción con miembros en voz — clic en cualquier miembro → estadísticas de red en tiempo real (RTT / jitter / pérdida de paquetes) + control de volumen
+- [x] Panel de automonitorización — clic en ti mismo → medidor de nivel de audio en vivo, insignias de estado silenciado / sin sonido / PTT
+- [x] Popup VoiceSettings — modal grande en posición fija (360px), escapa el desbordamiento de la barra lateral con superposición de fondo
+- [x] Botones de interacción por par — enlace de perfil, Mensaje directo, compartir archivos + Mini-juego (próximamente)
+- [ ] Modo anfiteatro — difusión 1→N (9 a 25+ personas, vídeo en "pantalla")
+- [ ] Nodos como servicio — una Raspberry Pi puede convertirse en relay multimedia para aliviar el servidor principal
+
+#### v1.0 — Mesa colaborativa ⏳ PLANIFICADA
+*(base P2P DataChannels operativa — v0.9)*
+
+> *La sala de voz se convierte en un espacio vivo: jugar, trabajar, escuchar música, compartir archivos — todo en una ventana. El primero self-hosted de código abierto en combinar los cuatro casos de uso.*
+
+**Base visual**
+- [ ] Mesa oval SVG — avatares posicionados en elipse (yo = siempre abajo, algoritmo `getAvatarPositions`)
+- [ ] Zona central despejada (arrastrar y soltar, mismo plano SVG)
+- [ ] Clic en avatar → menú contextual (whisper, perfil, desafío, silenciar)
+- [ ] Protocolo `table:*` en DataChannels (estado, evento, objeto:mover/añadir/eliminar)
+- [ ] Árbitro anfitrión — fuente única de verdad, elección automática cuando el anfitrión sale
+- [ ] Persistencia del estado en BD (instantánea cada 30s) + restauración al reconectar
+- [ ] Ondas de audio en avatares (AnalyserNode + propiedad CSS personalizada `--voice-intensity`)
+
+**Archivos y presencia**
+- [ ] Arrastrar y soltar archivo → compartido en la mesa para todos (temporal)
+- [ ] Anclar 📎 — el archivo permanece visible aunque el propietario esté desconectado
+- [ ] Arrastrar archivo sobre avatar → abre un Whisper con el archivo adjunto
+- [ ] Estados de presencia: 🎙️ en voz / 🪑 en la mesa / 🎮 en partida
+
+**Widgets**
+- [ ] Giro aleatorio "¿Quién empieza?" (animación CSS, resultado visible para todos)
+- [ ] Temporizador compartido — Pomodoro / Blitz / Personalizado (AudioContext para sonido final)
+- [ ] Marcador de sesión persistente
+- [ ] Modo escenario — "Tomar la palabra" (votación rápida, micrófono prioritario, otros -20dB)
+- [ ] Modo espectador — miembros del foro observan sin participar (sala Socket.IO separada)
+- [ ] Historial de sesión exportable (texto o PDF)
+
+**Jukebox colaborativo**
+- [ ] Reproductor Web Audio API (reproducir/pausar/siguiente) — sincronización P2P, calidad original, sin compresión
+- [ ] Volumen individual (GainNode + localStorage, nunca se emite a otros)
+- [ ] Carátula: etiquetas ID3 → MusicBrainz → Apple iTunes → caché IndexedDB
+- [ ] Listas de reproducción colaborativas guardadas en BD
+- [ ] Votos 👍👎 + cola de prioridad inteligente
+- [ ] Fundido cruzado entre pistas (dos GainNodes superpuestos)
+- [ ] Reacciones con código de tiempo (estilo SoundCloud) — almacenadas en BD, reaparecen al reproducir de nuevo
+- [ ] Temporizador de sueño con fundido progresivo
+
+**Plantillas y plugins**
+- [ ] Selector de plantillas (el anfitrión elige, emite `table:theme:set` a todos)
+- [ ] 3 plantillas oficiales: Brasserie de Nuit, Table de Feutre, Pierre & Braise
+- [ ] Sistema de plugins `plugins/table-templates/` — primer ejemplo para desarrolladores de la comunidad
+
+**Juegos (progresión secuencial)**
+- [ ] Dados RPG (d4–d100) — animación CSS 3D + historial de tiradas visible para todos
+- [ ] Ajedrez — `chess.js` + tablero SVG + sincronización de estado FEN vía DataChannel
+- [ ] Póker — máquina de estados + cifrado AES-GCM de mano por jugador
+- [ ] RPG / Warhammer — mapa hexagonal, fichas (recursos de la Biblioteca), niebla de guerra *(largo plazo)*
+
+### 3.2 — Red en malla entre instancias
+*(depende de la Fase 3.0-C)*
+
+- [ ] Malla WireGuard entre instancias voluntarias — túnel cifrado de extremo a extremo
+- [ ] DHT para descubrimiento de pares sin servidor central
+- [ ] Protocolo Gossip — sincronización ligera de metadatos entre nodos
+- [ ] Directorio de copias de seguridad distribuido — si `nodyx.org` cae, los nodos mantienen el directorio
+- [ ] Transición automática a conexión P2P directa cuando esté disponible
+- [ ] Federación ligera — un miembro de la comunidad A puede interactuar con la comunidad B
+
+---
+
+## FASE 4 — Enriquecimiento de la plataforma (v1.4 → v1.8) ✅ COMPLETA
+### Objetivo: Nodyx se convierte en la plataforma de comunidad completa
+
+**Entregado:**
+- [x] **NodyxCanvas** (v0.9) — pizarra colaborativa P2P en salas de voz (CRDT LWW, cursores reactivos a la voz, exportación PNG)
+- [x] **Sistema de temas de perfil** (v1.0) — 6 preajustes integrados (Défaut, Minuit, Forêt, Chaleur, Rose, Verre), motor de variables CSS (`--p-bg`, `--p-card-bg`, `--p-accent`…), editor en vivo con selectores de color, propagación a toda la app (nav, barras laterales, fondo)
+- [x] **UI adaptable a móvil** (v1.0) — drawer de canales de chat, barra de navegación inferior, VoicePanel accesible en móvil, páginas de foro + admin responsivas
+- [x] **Biblioteca de recursos 12 MB** (v1.0) — ampliado desde 5 MB, directrices de diseño de subida por tipo
+- [x] **Chat — Sistema de respuesta/cita** (v1.1) — reply_to_id en mensajes, barra de vista previa en el campo de entrada, cita inline en el mensaje
+- [x] **Chat — Mensajes anclados** (v1.1) — banner fijo en la cabecera del canal, anclar/desanclar por admin
+- [x] **Chat — Previsualizaciones de enlaces** (v1.1) — despliegue Open Graph en el servidor, caché Redis 1h, tarjetas de vista previa bajo los mensajes
+- [x] **Chat — Insignia de mención** (v1.1) — burbuja roja en el icono de Chat cuando se @menciona, separada de la campana de notificaciones
+- [x] **Presencia — Estado de usuario personalizado** (v1.1) — emoji + texto, 8 preajustes, almacenado en Redis 24h, visible en la barra lateral
+- [x] **Presencia — Lista de miembros desconectados** (v1.1) — sección desplegable en la barra lateral, avatares en escala de grises
+- [x] **Plugins** (v1.1) — base `plugins/` con 3 plantillas de mesa oficiales (Brasserie de Nuit, Table de Feutre, Pierre & Braise)
+- [x] **Mensajes directos (MDs)** (v1.2) — conversaciones privadas 1:1, `dm_conversations` + `dm_messages`, insignia de no leídos, Socket.IO `dm:send/typing/read`
+- [x] **Encuestas** (v1.2) — en chat (botón 📊) y foro (creación de hilo + independiente), 3 tipos: elección / planificación / clasificación, resultados Socket.IO en tiempo real
+- [x] **Sistema de bloqueo** (v1.2) — bloqueo de IP, bloqueo de email, aplicación multicapa (registro, inicio de sesión, middleware), UI de administración
+- [x] **nodyx-turn — TURN-over-TCP** (v1.3) — RFC 6062, TCP:3478, bypass de VPN/firewall para voz
+- [x] **nodyx-turn — fix MESSAGE-INTEGRITY** (v1.3) — RFC 5389 §10.3, el relay ahora funciona en Firefox, Chrome, todos los clientes WebRTC
+- [x] **Voz — Failover a relay** (v1.3) — reinicia ICE automáticamente con `iceTransportPolicy: relay` tras 3 sondeos consecutivos con alta pérdida
+- [x] **Voz — Opus optimizado** (v1.3) — 32 kbps por defecto, DTX desactivado, mono, FEC activado
+- [x] **Calendario de eventos** (v1.6) — CRUD completo, RSVP, subida de portada, páginas `/calendar` + `/calendar/[id]` + edición, `can_manage` (autor O mod/admin), sanitize-html extendido
+- [x] **Protocolo Gossip** (v1.6) — `announceEventsToDirectory()` cada 10 min, `/discover` multitipo (comunidades + hilos + eventos)
+- [x] **Búsqueda global basada en Gossip** (v1.5) — `network_index` FTS GIN PostgreSQL, `announceThreadsToDirectory()`, `/discover` con barra de búsqueda y tarjetas entre instancias, opt-in `NODYX_GLOBAL_INDEXING=true`
+- [x] **Admin — Panel de control enriquecido** (v1.7) — estadísticas extendidas (eventos/encuestas/recursos/chat/MDs), doble gráfico de actividad de 7 días (publicaciones + nuevos miembros), top 5 colaboradores, registros recientes
+- [x] **Anuncios del sistema** (v1.7) — banners con código de color (6 variantes) creados por el admin, descartables por el usuario, caducidad opcional, vista previa — `/admin/announcements`
+- [x] **Registro de moderación** (v1.7) — trazabilidad de 11 tipos de acciones de administración, filtros de acción/actor, paginación — `/admin/audit-log`
+- [x] **Sistema de tareas ligero** (v1.8) — tableros Kanban de comunidad, columnas configurables, tarjetas con asignado/fecha límite/prioridad, arrastrar y soltar HTML5 nativo, `/tasks`
+
+---
+
+## FASE 4.5 — Refuerzo de seguridad ✅ COMPLETA
+### Objetivo: Reforzar cada superficie de ataque antes de que la Fase 5 abra la plataforma a un uso más amplio
+
+> *"Desplegado rápido. Ahora hagámoslo a prueba de balas."*
+> Auditoría de seguridad completa realizada en marzo de 2026 — antes de iniciar cualquier trabajo de la Fase 5.
+
+### Alcance y resultados de la auditoría
+
+- **38 vulnerabilidades** identificadas y corregidas en toda la base de código
+- Cero errores de compilación TypeScript tras todas las correcciones
+- Todas las correcciones desplegadas en producción sin tiempo de inactividad
+
+### Categorías de vulnerabilidades corregidas
+
+**Inyección SQL**
+- [x] `gardenService` — consultas parametrizadas en lugar de interpolación de cadenas directa
+- [x] Rutas de `notifications` — todos los filtros dinámicos reforzados
+
+**JWT**
+- [x] Ataque de confusión de algoritmo — `algorithms: ['HS256']` explícito aplicado en todas las llamadas a `jwt.verify()`
+
+**SSRF / DNS Rebinding**
+- [x] Despliegue Open Graph (`chat:unfurl`) — lista de bloqueo de rangos de IP privadas (RFC 1918 + loopback + link-local), verificación de resolución de hostname antes de fetch
+
+**Socket.IO IDOR**
+- [x] `chat:react` — verificación de propiedad/membresía antes de aplicar la reacción
+- [x] `chat:delete` — validación de autor o admin, sin eliminación entre canales
+- [x] `voice:stats` — membresía de canal verificada antes de exponer estadísticas de pares
+- [x] Eventos `jukebox` — membresía de sala aplicada en todas las acciones sobre la cola
+
+**Inyección CSS / XSS**
+- [x] Temas de perfil — valores de variables CSS saneados, sin `url()` / `expression()` / `javascript:` permitidos
+- [x] Inyección CSS de fuentes — valores de `font-family` restringidos a lista de permitidos
+- [x] URLs de GIFs — validación de esquema + lista de dominios permitidos antes de renderizar
+
+**Autenticación**
+- [x] Limitación de velocidad en el registro — endpoint de registro de Nodyx Signet protegido
+- [x] Limpieza de sesión al cerrar sesión — JWT invalidado en Redis al cerrar sesión explícitamente
+- [x] Validación del asignado — el asignado de una tarea debe ser miembro de la comunidad
+
+**Criptografía / Entrada**
+- [x] Validación RIFF WebP — las subidas de recursos verifican los bytes mágicos antes del procesamiento con Sharp
+- [x] Inyección de cabeceras SMTP — eliminación de saltos de línea en todas las cabeceras de email proporcionadas por el usuario
+
+---
+
+## FASE 4.6 — Defensa activa y seguridad en tiempo de ejecución ✅ COMPLETA
+### Objetivo: Convertir la plataforma en un defensor activo — detectar, disuadir y alertar en tiempo real
+
+> *"El mejor cortafuegos es el que piensa."*
+> La Fase 4.6 construye sobre el refuerzo estático de la 4.5 con sistemas de seguridad dinámicos en tiempo de ejecución.
+
+- [x] **Honeypot** — más de 25 rutas de escáner atrapadas (`.env`, `.git`, `wp-admin`, `phpmyadmin`, shells, copias de seguridad…); tarpit 3–7s; geolocalización; scare page; registro en BD + bloqueo automático de fail2ban
+- [x] **fail2ban** — 5 jaulas: SSH, reincidentes SSH (permanente), fuerza bruta de autenticación HTTP, honeypot (7 días), lista negra permanente
+- [x] **`nodyx-auth.log`** — la ruta de autenticación ahora alimenta la jaula de fail2ban en cada inicio de sesión fallido
+- [x] **Lista negra de IP permanente** — jaula `nodyx-permban` (`bantime = -1`) + BD `ip_bans` para actores maliciosos conocidos
+- [x] **Monitorización de seguridad en Discord** — embeds en tiempo real para hits de honeypot, fuerza bruta, inicio de sesión de admin, detección de nueva IP, nuevos registros
+- [x] **Argon2id** — nuevo estándar de hash de contraseñas (OWASP 2026); hashes bcrypt migrados transparentemente en el próximo inicio de sesión
+- [x] **Anti-spam de chat** — limitador de velocidad de ventana deslizante dual (ráfaga + sostenido); UI de espera en el cliente
+- [x] **Filtro de contenido** — símbolos nazi/de odio (6 puntos de código Unicode), lista de imágenes permitidas (solo Tenor/Giphy), lista de dominios bloqueados configurable
+- [x] **Escaneo NSFW opcional** — `nsfwjs` + TensorFlow.js en la subida de imágenes (`NSFW_SCAN=true`)
+- [x] **Limitación de velocidad de subida** — 10 subidas / 10 minutos / usuario
+- [x] **Verificación de email** — obligatoria cuando SMTP está configurado; inicio de sesión bloqueado para cuentas no verificadas
+- [x] **Rotación de logs** — rotación diaria, retención de 90 días, comprimidos
+- [x] **Píxel de seguimiento** (v1.9.2) — PNG transparente 1×1 incrustado en la scare page; registrado en `honeypot_pixel_hits`; alerta de Discord en visitas repetidas (umbral >30s)
+- [x] **Trampas de recolección de credenciales** (v1.9.2) — 12 rutas de inicio de sesión muestran un formulario de inicio de sesión de WordPress falso convincente; credenciales registradas; embed de Discord "🔑 Credential Harvest"
+- [x] **Archivos canario** (v1.9.2) — 11 patrones de archivo sirven credenciales falsas realistas; PRNG determinista por IP; embed de Discord "📄 Canary"
+- [x] **Huella de canvas** (v1.9.2) — JS del navegador en la scare page envía hash de huella a `/_hp_fp`; Discord "🔍 Fingerprint Reconnu" si visitas > 1
+- [x] **Honeytokens** (v1.9.2) — 3 enlaces invisibles + 1 casi invisible en el HTML de la scare page; clic → Discord "🎯 HONEYTOKEN CLICKED"
+- [x] **Slowloris inverso** (v1.9.2) — `reply.hijack()` transmite la scare page byte a byte; mantiene ocupados los hilos del atacante 45–90s
+- [x] **Hub Olimpo** (v1.9.2) — centro de control de seguridad: estadísticas globales, cronología de 48h, IPs principales, panel de trampas activas, tabla de recolección de credenciales enmascarada, lista de atacantes recurrentes
+
+---
+
+## FASE 4.7 — Autenticación de dos factores ✅ COMPLETA
+### Objetivo: Añadir un segundo factor fuerte sin sacrificar la experiencia de usuario
+
+> *"Algo que sabes + algo que tienes."*
+> La Fase 4.7 añade 2FA criptográfico sobre el sistema de autenticación existente, con Nodyx Signet como opción premium.
+
+- [x] **TOTP (RFC 6238)** — compatible con cualquier app de autenticación (Google Authenticator, Aegis, Bitwarden); configuración con código QR; confirmación de 6 dígitos; sesión pendiente de 5 min respaldada por Redis
+- [x] **2FA vía Nodyx Signet** — si el usuario tiene un dispositivo Signet registrado, Signet se usa como 2.º factor (ECDSA P-256 > secreto TOTP compartido)
+- [x] **Cadena de prioridad** — Signet > TOTP > inicio de sesión directo; el sistema selecciona automáticamente el factor más fuerte disponible
+- [x] **UI de configuración** — activar/desactivar 2FA con visualización de código QR y flujo de confirmación
+- [x] **UI de inicio de sesión** — segundo paso fluido: campo de código TOTP o pantalla de espera de Signet activada automáticamente
+- [x] **Reconstrucción PWA de Nodyx Signet** — marcadores de posición obsoletos `nexusnode.app` reemplazados por `nodyx.org`
+
+---
+
+## FASE 4.8 — Estabilidad en producción y refuerzo entre runtimes ✅ COMPLETA
+### Objetivo: Hacer Nodyx imperturbable — cada estado compartido entre runtimes coherente, cada escenario de fallo gestionado
+
+> *"Un sistema es tan estable como su suposición más débil."*
+> La Fase 4.8 es una auditoría quirúrgica completa de toda la pila.
+
+- [x] **Auditoría de keyPrefix Redis — Node.js** — `ioredis keyPrefix: 'nodyx:'` es la única fuente de verdad; todos los prefijos `nodyx:` manuales eliminados
+- [x] **Auditoría de keyPrefix Redis — Rust** — Rust no tiene ioredis keyPrefix; las 11 claves compartidas llevan prefijo `nodyx:` manual
+- [x] **Coherencia de bloqueo entre runtimes** — los bloqueos establecidos por Node.js o Rust son ahora visibles para ambos runtimes
+- [x] **Limitación de velocidad entre runtimes** — los límites de inicio de sesión/registro/reset/reenvío de verificación ahora se comparten
+- [x] **Contador de miembros en línea corregido** — el panel de administración siempre mostraba 0 (Rust escaneaba `heartbeat:*` en lugar de `nodyx:heartbeat:*`)
+- [x] **Invalidación de sesión al cambiar contraseña** — el índice `user_sessions:{id}` ahora es coherente entre ambos runtimes
+- [x] **Timeouts de fetch del planificador** — `AbortSignal.timeout()` añadido a las 4 llamadas HTTP salientes anteriormente sin guardia
+- [x] **Caddy — Failover a Rust** — todos los bloques `localhost:3100` cambiados a `lb_policy first` + `fail_duration 30s`
+- [x] **install.sh — versión centralizada** — variable única `NODYX_VERSION` usada de forma coherente
+- [x] **install.sh — Caddyfile generado reforzado** — cabeceras de seguridad, bloque honeypot y `header_up -X-Forwarded-For` en todas las rutas API
+- [x] **Guardias de memoria PM2** — `max_memory_restart` añadido a los 4 procesos (512M core, 256M frontend, 256M hub, 128M docs)
+- [x] **Rotación de logs** — `/etc/logrotate.d/nodyx-auth` — diaria, retención de 30 días, comprimidos
+- [x] **Renombrado systemd** — descripción de `nodyx-relay.service` y `SyslogIdentifier` actualizados a `nodyx-relay`
+
+**Validación:** 63/63 tests Node.js en verde · Build Rust 0 errores · Caddy validate OK
+
+---
+
+## FASE 4.9 — Aislamiento de procesos, cobertura de tests y CI ✅ COMPLETA
+### Objetivo: Cero procesos root, cobertura de tests completa en ambos runtimes, pipeline CI reproducible
+
+- [x] **Aislamiento de procesos — User=nodyx** — Todos los procesos de la aplicación se ejecutan ahora como el usuario de sistema dedicado `nodyx`
+- [x] **Restricción de permisos de archivo** — `nodyx-frontend/.env` y `nodyx-hub/.env` cambiados de 644 a `root:nodyx 640`
+- [x] **Suite de tests Node.js — 181/181** — 6 nuevos archivos de test que cubren módulos, encuestas, búsqueda, notificaciones, wiki, middleware
+- [x] **Suite de tests Rust — 18/18** — Primeros tests Rust escritos para `nodyx-server`: `error.rs` (11 tests) + `extractors.rs` (7 tests)
+- [x] **Bloqueo de dependencias críticas** — paquetes sensibles a la seguridad fijados a versiones exactas en `nodyx-core/package.json`
+- [x] **Pipeline CI reforzado** — GitHub Actions actualizado: dos trabajos paralelos (`test-node`, `test-rust`), caché npm, verificación de tipos `npx tsc --noEmit` antes de vitest
+- [x] **Brecha de migración cerrada** — `052_placeholder.sql` añadido para cerrar la brecha de secuencia entre 051 y 053
+
+**Validación:** 181/181 tests Node.js en verde · 18/18 tests Rust en verde · TypeScript 0 errores · Todos los servicios activos como usuario nodyx
+
+---
+
+## FASE 4.10 — Perfil vivo + Rediseño del foro ✅ COMPLETA (v1.9.5)
+### Objetivo: Perfiles dinámicos, un foro que parece una plataforma seria
+
+- [x] **Banner generativo** — SVG Lissajous único por nombre de usuario, hash FNV-1a determinista, compatible con SSR, animado vía `animateTransform`
+- [x] **Anillos de reputación** — 3 anillos SVG concéntricos animados (Longevidad / Calidad / Compromiso), tooltips, enlace a `/reputation`
+- [x] **Mapa de calor de actividad** — cuadrícula 53×7 estilo GitHub, estadísticas de racha + récord, tooltip en posición fija
+- [x] **Endpoint de actividad** — `GET /api/v1/users/:username/activity` (UNION publicaciones + hilos, ventana de 365 días)
+- [x] **Hero parallax** — el banner se desplaza al 35% de la velocidad de la página, limitado a 60px
+- [x] **Arcos de avatar** — 3 círculos SVG giratorios vía `animateTransform` + pulso de brillo
+- [x] **Línea de tiempo** — hitos temporales + umbrales de XP en la parte inferior del perfil
+- [x] **Página `/reputation`** — documentación completa de la fórmula transparente (Longevidad, Calidad con decaimiento λ, Compromiso)
+- [x] **Eliminar avatar / eliminar banner** — limpia tanto `banner_url` como `banner_asset_id` atómicamente
+- [x] **Rediseño del foro** — diseño plano, sin `rounded-*` (excepto avatares), contenido a ancho completo
+
+---
+
+## FASE 4.11 — Comunicaciones privadas y soberanas ✅ COMPLETA (v2.0)
+### Objetivo: MDs que ningún servidor puede leer — ni siquiera el tuyo
+
+- [x] **Par de claves ECDH P-256** — generado en el navegador, clave privada almacenada como `CryptoKey` no extraíble en IndexedDB, nunca sale del cliente
+- [x] **Cifrado AES-256-GCM** — IV aleatorio de 12 bytes por mensaje, texto cifrado autenticado almacenado en la base de datos
+- [x] **Capa ESY Barbare** — segunda capa de ofuscación por instancia sobre AES-GCM (tabla de permutación de bytes + ruido PRNG xorshift32, N rondas). El servidor solo ve base64 opaco
+- [x] **`instance.esy`** — generado una vez por instancia, con huella digital (`SHA-256` truncado), servido vía `/api/v1/instance/esy-public`
+- [x] **Escudo E2E** en la cabecera de MD — punto verde pulsante (ambos activos), naranja (parcial), huella ESY al pasar el ratón
+- [x] **Animación de barbarización** — el remitente ve el texto difuminarse durante el cifrado, el receptor ve la burbuja descifrarse en tiempo real (350ms)
+- [x] **Edición de mensajes con recifrado** — editar un mensaje E2E recifra con la cadena completa ECDH + AES + ESY
+- [x] **Eliminación en tiempo real** — borrado suave propagado instantáneamente a todos los participantes vía Socket.IO
+- [x] **Rediseño de MDs a ancho completo** — diseño dividido con glassmorphism, burbujas agrupadas estilo iMessage
+- [x] **Fix AudioContext** — contexto compartido único para todo el VAD de pares (límite de Chrome de 6 contextos por origen)
+
+---
+
+## FASE 4.12 — Constructor de página de inicio + SDK de widgets ✅ COMPLETA (v2.1)
+### Objetivo: Cada comunidad obtiene su propia página de inicio totalmente personalizable
+
+- [x] **Constructor de página de inicio** — editor de administración con arrastrar y soltar, 11 zonas de diseño (banner, hero, barra de estadísticas, principal, barra lateral, mitad ×2, trío ×3, pie ×4)
+- [x] **Registro de plugins** — cada widget nativo es un archivo autocontenido, sin cambios en el núcleo para añadir nuevos
+- [x] **4 widgets nativos Fase 1** — Hero Banner (variantes en vivo/evento/noche), Barra de estadísticas (contadores animados), Tarjeta de unirse, Banner de anuncio
+- [x] **Reglas de visibilidad** — audiencia por widget (todos / invitados / miembros) + fechas de inicio/fin programadas
+- [x] **Tienda de widgets** — instala widgets externos vía subida de `.zip` (barra de progreso XHR, validación de 4 pasos, lista blanca de extracción)
+- [x] **Cargador dinámico de widgets** — Web Components cargados en tiempo de ejecución, sin rebuild, sin despliegue
+- [x] **SDK de widgets** — Custom Elements JS simples (Shadow DOM), esquema `manifest.json` → campos de configuración generados automáticamente en el constructor
+- [x] **Widget de demostración: Reproductor de vídeo** — YouTube / Vimeo / MP4 con vista previa, visor de código fuente, instalable con un clic
+
+---
+
+## FASE 4.13 — Actualización mayor de NodyxCanvas ✅ COMPLETA (v2.2)
+### Objetivo: Convertir la pizarra colaborativa en un espacio de trabajo creativo completo
+
+> *"De una herramienta de dibujo básica a una plataforma de colaboración asíncrona real."*
+> El canvas fue reescrito desde cero con 4 componentes UI dedicados, 11 herramientas de dibujo,
+> una pila undo/redo persistente y un chat por tablero — todo sincronizado vía CRDT Socket.IO.
+
+### 4.13.1 — Arquitectura UI (Sprint A)
+
+- [x] **4 componentes dedicados** — CanvasLeftToolbar (selector de herramientas), CanvasTopBar (opciones contextuales), CanvasBottomBar (deshacer/zoom/cuadrícula), CanvasRightPanel (participantes + chat)
+- [x] **CanvasLeftToolbar** — selector de herramientas vertical con atajos de teclado (V/P/T/N/R/C/S/A/X/I/F/E)
+- [x] **CanvasTopBar** — controles contextuales por herramienta: pluma, texto, nota adhesiva, rectángulo/círculo, forma, flecha, conector
+- [x] **CanvasBottomBar** — botones Deshacer / Rehacer, Zoom− / % / Zoom+ / Restablecer, alternar cuadrícula (G), alternar ajuste
+- [x] **CanvasRightPanel** — panel derecho desplegable: lista de participantes con avatar real, indicador de herramienta en vivo, punto de color; chat en tiempo real por tablero con burbujas estilo iMessage
+- [x] **Atajos de teclado completos** — V P T N R C S A X I F E G + Ctrl+Z / Ctrl+Y / Ctrl+Shift+Z + Supr + Escape
+- [x] **Renderizado portal** — canvas montado en `document.body` vía `use:portal`, bypasea `position:fixed` roto por `transform` CSS
+- [x] **Avatares de usuario reales** — el panel de participantes muestra los avatares reales de los usuarios con fallback a iniciales
+- [x] **Deshacer / Rehacer** — pila de 50 ops `UndoOp { id, before, after }` por sesión. Fix de bug CRDT LWW timestamp
+- [x] **Ajuste a cuadrícula** — `snapV(v) = snapEnabled ? Math.round(v / 28) * 28 : v`, aplicado en creación + movimiento + redimensionado
+- [x] **Renderizado de texto enriquecido** — negrita/cursiva vía `ctx.font`, subrayado + tachado dibujados manualmente, ajuste de palabras con `buildTextLines()`
+
+### 4.13.2 — Nuevas herramientas (Sprint B)
+
+- [x] **Formas avanzadas** — triángulo, diamante, estrella (5 puntas), hexágono, nube — dibujadas vía `Path2D`, relleno + trazo + etiqueta opcional interior
+- [x] **Conectores** — líneas rectas / bezier / en ángulo, `startCap` y `endCap` independientes (flecha/punto/ninguno), estilo sólido/discontinuo/punteado, creación en 2 clics
+- [x] **Marcos / Secciones** — regiones rectangulares con nombre, borde discontinuo + relleno semitransparente + etiqueta superior; campo de nombre inline al crear
+- [x] **Inserción de imágenes** — arrastrar y soltar desde el escritorio o selector de archivos → subida multipart a `/api/v1/assets`, caché asíncrono, tamaño proporcional (máx. 400px)
+- [x] **Barra de herramientas conectada** — CanvasLeftToolbar y CanvasTopBar actualizados para herramientas de forma, conector, marco e imagen
+
+### 4.13.3 — Asas de redimensionado (Fase 1.1)
+
+- [x] **8 asas de redimensionado** — esquinas (nw/ne/sw/se) + puntos medios (n/s/e/w) renderizados en espacio de pantalla tras la transformación del canvas, tamaño fijo de 5px a cualquier zoom
+- [x] **Elementos soportados** — rect, circle, shape, frame, image, sticky
+- [x] **Redimensionado en vivo** — `applyResize()` actualiza x/y/w/h durante el arrastre, tamaño mínimo 12px, compatible con ajuste
+- [x] **Deshacer/rehacer** — ops de redimensionado añadidas a la pila de deshacer, restauradas vía CRDT con timestamp actualizado
+
+### 4.13.4 — Correcciones de bugs
+
+- [x] **Fix CRDT undo** — `undo()` ahora restaura `{ ...entry.before, ts: Date.now() }` en lugar de `entry.before` directamente — evita el rechazo silencioso por la verificación LWW
+- [x] **Orden de campos en subida de imágenes** — campos de texto (`name`, `asset_type`) añadidos antes del archivo en FormData para que `@fastify/multipart` pueda leerlos del stream antes del binario
+- [x] **Estructura HTML** — superposición del nombre del marco correctamente colocada dentro del div del contenedor central
+## FASE 5 — Móvil + Nodos + Reacciones
+### Objetivo: Nodyx en el bolsillo de todos, con conocimiento estructurado
+
+- [ ] **Reacciones en MDs** — reacciones emoji en mensajes privados
+- [ ] **Importación de Discord** — importación masiva de canales, hilos, reacciones y avatares desde una exportación de servidor de Discord
+- [ ] **Bio enriquecida en Markdown** — editor TipTap en la bio del perfil
+- [ ] **Backend del sistema Gracias** — tabla `thanks`, puntuación Q real con decaimiento λ (`e^{-λt}`)
+- [ ] **Tarjeta de perfil compartible** — `/users/:username/card` imagen SSR (avatar + anillos + estadísticas), meta OG
+- [ ] **Nodos** (SPEC 013) — conocimiento estructurado duradero, Anchors, validado por la comunidad vía Garden
+- [ ] **Sistema de módulos** — 26 módulos activables desde el panel de administración (estilo CMS)
+- [ ] **Móvil — iOS** vía Capacitor
+- [ ] **Móvil — Android** vía Capacitor
+- [ ] **Escritorio** vía Tauri (.exe/.app/.sh ~10MB, independiente)
+- [ ] **Migración a Rust** — crate `nodyx-server` Axum reemplazando nodyx-core progresivamente (directorio → auth → búsqueda → usuarios → foros → Socket.IO)
+- [ ] **NodyxPoints** — sistema de reputación comunitaria entre instancias
+- [ ] **Insignias y niveles**
+- [ ] **Galaxy Bar** — selector de múltiples instancias, SSO descentralizado, notificaciones bioluminiscentes
+- [ ] **API pública documentada** para desarrolladores de terceros
+
+---
+
+## REGLAS DEL ROADMAP
+
+1. No empezar una fase sin que la anterior esté estable y en uso
+2. No romper lo que funciona — proponer alternativas (ej. Relay vs CF Tunnel vs puertos abiertos)
+3. La complejidad está oculta: el usuario ve un botón, la capa Rust gestiona la complejidad
+4. Cada añadido debe ser coherente con el aspecto descentralizado y soberano
+5. El núcleo se mantiene simple. La complejidad va a los plugins.
+6. La comunidad puede votar para repriorizar fases futuras
+
+---
+
+## LO QUE NUNCA ESTARÁ EN EL ROADMAP
+
+- Publicidad
+- Venta de datos
+- Funciones que requieran un **servidor central obligatorio** (`nodyx.org` es opcional — sin él, la instancia sigue siendo completamente funcional en su propio dominio)
+- Puertas traseras de cualquier tipo
+- Dependencia permanente de un servicio propietario de terceros
+- Reemplazar Node.js o SvelteKit por Rust (cada herramienta en su lugar)
+
+---
+
+## FASE HORIZONTE — NODYX-ETHER
+### La capa física. La última frontera.
+
+> *"Las ondas de radio no necesitan permiso."*
+
+Nodyx descentraliza la capa de aplicación.
+Pero seguimos dependiendo de una cosa: la infraestructura física de internet.
+Cables de fibra controlados por los ISP. Satélites controlados por corporaciones.
+
+**NODYX-ETHER descentraliza la propia capa física.**
+
+El puente que lo hace posible: los **CRDTs**.
+Ya en Nodyx (NodyxCanvas). Ya en producción.
+El mismo CRDT que sincroniza el trazo de una pizarra puede sincronizar una publicación del foro
+sobre un enlace LoRa a 250 bps — incluso con un retraso de 2 horas.
+
+```
+Capa 1 — Malla local      LoRa / Wi-Fi ad-hoc   0–50 km      sin infraestructura
+Capa 2 — Radio regional   HF / NVIS             500–3000 km  rebote ionosférico
+Capa 3 — Ionosfera        HF onda corta         Global       sin cables, sin satélites
+```
+
+```
+nodyx-p2p/
+└── nodyx-ether/          ← espacio de trabajo futuro
+    ├── nodyx-modem/      ← módem software (codificación HF / LoRa en Rust)
+    ├── nodyx-mesh/       ← relay en malla LoRa / Wi-Fi ad-hoc
+    └── nodyx-sync/       ← serialización de deltas CRDT (Cap'n Proto / FlatBuffers)
+```
+
+**nodyx-relay se convierte en un orquestador multirruta:**
+`ethernet → wifi-mesh → lora → hf-radio` — fallback automático, el CRDT gestiona la convergencia.
+
+**Lo que esto significa en la práctica:**
+Una comunidad en una zona de desastre. La fibra cortada. El 4G destruido.
+Una Raspberry Pi con batería. Un módulo LoRa en el tejado. 55€ en total.
+La comunidad continúa. Los anuncios llegan. La gente sabe quién está vivo.
+
+**Eso es soberanía.**
+
+Esta no es una función para mañana. Es una **llamada a los colaboradores:**
+→ Radioaficionados, makers de LoRa, contribuidores de Meshtastic, desarrolladores de Rust embebido.
+→ La arquitectura está aquí. La base CRDT está desplegada.
+→ La capa de radio espera las manos adecuadas.
+
+→ **[Especificación completa: docs/ideas/NODYX-ETHER.md](../ideas/NODYX-ETHER.md)**
+
+---
+
+## FASE RADIO — NODYX-RADIO
+### La radio por internet que por fin tiene una razón de existir.
+
+> *"50.000 operadores de radio por internet emitiendo al vacío. Nodyx es la señal de vuelta."*
+
+El problema que nadie resolvió: más de 100.000 emisoras de radio por internet existían en su apogeo.
+Menos del 5% tenía más de 10 oyentes simultáneos.
+No porque los programas fueran malos. Porque no había estructura para convertir oyentes simultáneos en una comunidad.
+
+**Las emisoras que sobrevivieron** tenían una capa de comunidad estructuralmente unida.
+**Las emisoras que murieron** tenían audiencia pero no comunidad.
+
+La inversión que Nodyx hace posible:
+```
+Emisoras muertas  :  emiten → esperan tener comunidad
+Emisoras vivas    :  comunidad → emiten como expresión
+```
+
+**Una instancia de Nodyx ES la capa de comunidad.** Una emisora que usa Nodyx obtiene:
+- Foro (archivos, debates, notas del programa — indexados por todos los motores de búsqueda)
+- Chat en vivo (los oyentes reaccionan en tiempo real durante las emisiones)
+- Salas de voz (estudio abierto, backstage, preguntas y respuestas con oyentes)
+- Jardín (la comunidad vota los próximos programas)
+
+**La red publicitaria cooperativa — el modelo económico que faltaba:**
+
+Una emisora pequeña con 80 oyentes no puede negociar con los anunciantes sola.
+Pero 200 emisoras Nodyx-Radio con 80 oyentes cada una = **16.000 oyentes locales**.
+Un panadero, artesano o evento local puede pagar por ese alcance.
+
+```
+nodyx.org/radio
+  → red publicitaria cooperativa
+  → anunciantes locales/regionales contratan cuñas de audio
+  → cuñas distribuidas a emisoras de la región objetivo
+  → reparto de ingresos: 80% emisora / 20% infraestructura nodyx.org
+```
+
+Sin seguimiento. Sin perfilado de usuarios. Solo segmentación geográfica.
+El panadero del pueblo financia la radio del pueblo que funciona en una Raspberry Pi del pueblo.
+**El dinero se queda local. La infraestructura sigue siendo libre.**
+
+Surgirán nuevas emisoras porque por fin tienen una comunidad.
+Y porque por fin pueden sostenerse.
+
+→ **[Visión completa: docs/ideas/NODYX-RADIO.md](../ideas/NODYX-RADIO.md)**
+
+---
+
+*Versión 2.2 — marzo de 2026*
+*"P2P es el alma. Rust es el cuerpo. La radio es la resiliencia. La comunidad es la razón."*

--- a/docs/es/THANKS.md
+++ b/docs/es/THANKS.md
@@ -1,0 +1,46 @@
+# GRACIAS — Nodyx existe gracias a vosotros
+
+> *"Si he visto más lejos, es porque estoy subido a hombros de gigantes."*
+> — Isaac Newton
+
+Nodyx no inventó nada. Nodyx ensambló, con respeto y gratitud,
+el trabajo de miles de desarrolladores que eligieron la libertad frente a la propiedad.
+
+---
+
+## 🔧 Herramientas que impulsan Nodyx
+
+| Proyecto | Función | Licencia |
+|---------|------|---------|
+| **Node.js** | Base de ejecución | MIT |
+| **TypeScript** | Lenguaje del proyecto | Apache 2.0 |
+| **Fastify** | Motor de la API | MIT |
+| **PostgreSQL** | Base de datos principal | PostgreSQL |
+| **Redis** | Memoria en caché | BSD |
+| **Meilisearch** | Búsqueda y SEO | MIT |
+| **SvelteKit** | Interfaz de usuario | MIT |
+| **Tauri** | Escritorio nativo | MIT / Apache 2.0 |
+| **Capacitor** | Móvil nativo | MIT |
+| **WireGuard** | Túnel cifrado | GPL v2 |
+| **Docker** | Despliegue portable | Apache 2.0 |
+| **Ollama** | IA local | MIT |
+| **Socket.io** | Eventos en tiempo real | MIT |
+| **Git** | Historia del proyecto | GPL v2 |
+
+---
+
+## 💜 Menciones especiales
+
+**Linux** — Sin ti nada de esto existiría.
+
+**Internet** — Fuiste inventada para unirnos.
+Nodyx se asegura de que siga siendo así.
+
+## 😺 Supervisora jefa
+
+**Iris** — Por asegurarse de que el desarrollador se mantuviera concentrado.
+
+---
+
+*Nodyx es libre porque estos proyectos fueron libres antes que él.*
+*AGPL-3.0 — El código pertenece a su comunidad.*


### PR DESCRIPTION
Full Spanish translation of the Nodyx documentation — 9 documents, 
~2900 lines total.

## Documents translated

| File | Lines | Notes |
|---|---|---|
| `docs/es/INSTALL.md` | 970 | PM2 memory table included from EN (not in FR) |
| `docs/es/RELAY.md` | 294 | |
| `docs/es/DOMAIN.md` | 207 | Added sslip.io explanation (not in EN/FR) |
| `docs/es/CONTRIBUTING.md` | 204 | |
| `docs/es/MANIFESTO.md` | 147 | |
| `docs/es/EMAIL.md` | 143 | |
| `docs/es/ROADMAP.md` | 777 | |
| `docs/es/THANKS.md` | 44 | |
| `docs/es/README.md` | 266 | |

## Translation decisions

- Informal register (tuteo) — consistent with FR
- 'Voice channels' → 'salas de voz' (following FR 'salons vocaux')
- 'slug' → 'identificador de URL' + example 'mi-comunidad'
- 'private silos' → 'plataformas herméticas' (clearer in Spanish)
- 'merge' → 'fusionar' (GitHub ES standard)
- Technical terms kept in English where standard (drawer, scare page, 
  embeds, Whisper, cooldown, CRDT, DHT, WebRTC, honeypot...)
- French theme names kept as-is (Défaut, Minuit...) — hardcoded in app

## Intentional improvements over EN/FR originals

- INSTALL.md: 'invisible → heavier' corrected to 'invisible → cada vez 
  más opaco' (conceptually consistent; fits the theme of platform opacity)
- MANIFESTO.md: 'private silos' → 'plataformas herméticas' (removes 
  redundancy — a silo is private by definition)
- MANIFESTO.md: 'condemned' → 'condenadas' (gender agreement with 
  'comunidades')
- DOMAIN.md: added sslip.io explanation note (service less known to 
  Spanish-speaking audience)

## Reviewed by

Native Spanish speaker (Spain) — reviewed line by line.