### PR TITLE
fix(installer): family-aware DNS check for dual-stack machines (closes #29)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -113,6 +113,21 @@ One merged PR = one star. Typos count. Translations count. Bug reports that turn
       <br/>
       <sub><strong>First external contributor 🏆</strong></sub>
     </td>
+    <td align="center" width="200">
+      <a href="https://github.com/schlaggi">
+        <img src="https://github.com/schlaggi.png?size=120" width="120" height="120" style="border-radius:50%;" alt="schlaggi"/>
+        <br/>
+        <sub><b>schlaggi</b></sub>
+      </a>
+      <br/>
+      <sub>🌟 × 1</sub>
+      <br/>
+      <sub><a href="https://github.com/Pokled/nodyx/issues/29">#29</a></sub>
+      <br/>
+      <sub><em>dual-stack DNS check IPv4/IPv6 family-aware</em></sub>
+      <br/>
+      <sub><strong>First dual-stack hunter 🌐</strong></sub>
+    </td>
   </tr>
 </table>
 
@@ -142,6 +157,7 @@ Sometimes a contribution isn't a PR. Sometimes it's just being there at exactly 
 
 | Contributor | Contribution | Type | Issue / PR | Fix / polish | Date |
 |---|---|---|---|---|---|
+| [@schlaggi](https://github.com/schlaggi) | Reported one-click installer false-positive DNS mismatch on dual-stack machines : `getent hosts` returns mixed-family (A or AAAA depending on `/etc/nsswitch.conf`), then the script compared the resolved IPv6 against the locally-detected IPv4 → bogus "mismatch", Let's Encrypt step refused to proceed. Fix : family-aware resolution via `getent ahostsv4` / `ahostsv6` + optional public IPv6 detection. | `bug(installer)` | [#29](https://github.com/Pokled/nodyx/issues/29) | _to fill on merge_ | 2026-05-18 |
 | [@naranco66](https://github.com/naranco66) | Full Spanish translation of the documentation : 9 documents, ~3000 lines, line-by-line native review (Spain). Includes thoughtful linguistic decisions (`"plataformas herméticas"` over literal `"silos privados"`, gender agreement on `"condenadas"`, sslip.io explanation for a Hispanic audience less familiar with the service). | `docs(es)` | [#28](https://github.com/Pokled/nodyx/pull/28) | [`0a6d74d`](https://github.com/Pokled/nodyx/commit/0a6d74d) | 2026-05-17 |
 | Yannick (nodyx.org member) | Created an account at the worst possible second of the very first prod backup test (between `pg_dump` at 21:00 and `pg_restore` at 21:17). The user row got wiped by the restore, which is what made it visible that `pg_dump` was capturing the system tables themselves (`backups`, `backup_audit_log`, `backup_settings`, `schema_migrations`) — meaning a restore was destroying the safety net created seconds earlier. Account recovered via CLI restore of the pre-restore snapshot. | `bug(backup)` | — | [`87696f6`](https://github.com/Pokled/nodyx/commit/87696f6) | 2026-05-06 |
 | [@lukasMega](https://github.com/lukasMega) | Reported docs search input losing focus on click (had to click twice), second-pass test of [`882099d`](https://github.com/Pokled/nodyx/commit/882099d) which triggered a full slug + UX audit : 108 broken TOC links, 60 leading-dash ids, 11 phantom entries from code-block comments | `bug(docs)` | [#12](https://github.com/Pokled/nodyx/discussions/12) | [`a429fa3`](https://github.com/Pokled/nodyx/commit/a429fa3) | 2026-05-02 |

--- a/install.sh
+++ b/install.sh
@@ -1775,25 +1775,54 @@ else
 fi
 
 # ── DNS pre-check (Let's Encrypt will fail if DNS doesn't point here) ───────
+# Family-aware : on compare A↔IPv4 et AAAA↔IPv6 séparément. Avant ce fix,
+# `getent hosts` retournait du mixed-family (A ou AAAA selon nsswitch.conf),
+# ce qui causait des faux mismatchs sur les machines dual-stack avec un
+# domaine résolvant à la fois A et AAAA (cf. issue #29).
 if ! $RELAY_MODE && ! $DOMAIN_IS_AUTO && [[ -n "${DOMAIN:-}" ]]; then
   info "$(printf "$(t dns_checking)" "${BOLD}" "${DOMAIN}" "${RESET}")"
-  _dns_ip=$(getent hosts "$DOMAIN" 2>/dev/null | awk '{print $1}' | head -1 || true)
-  if [[ -z "$_dns_ip" ]]; then
+
+  # Résoudre A et AAAA séparément. `ahostsv4` / `ahostsv6` sont fournis
+  # par glibc (Debian/Ubuntu/Fedora) et par musl (Alpine récent).
+  _dns_v4=$(getent ahostsv4 "$DOMAIN" 2>/dev/null | awk '{print $1}' | sort -u || true)
+  _dns_v6=$(getent ahostsv6 "$DOMAIN" 2>/dev/null | awk '{print $1}' | grep -v '^::1$' | sort -u || true)
+
+  # Détecter optionnellement l'IPv6 publique du serveur. Si pas d'IPv6,
+  # le curl -6 échoue silencieusement et _public_v6 reste vide.
+  _public_v6=$(curl -s --max-time 5 -6 https://api64.ipify.org 2>/dev/null || true)
+
+  # Match family-aware : OK si IPv4 publique ∈ A OU IPv6 publique ∈ AAAA.
+  _match=false
+  if [[ -n "$PUBLIC_IP"  && -n "$_dns_v4" ]] && grep -qFx "$PUBLIC_IP"  <<<"$_dns_v4"; then _match=true; fi
+  if [[ -n "$_public_v6" && -n "$_dns_v6" ]] && grep -qFx "$_public_v6" <<<"$_dns_v6"; then _match=true; fi
+
+  if [[ -z "$_dns_v4" && -z "$_dns_v6" ]]; then
     echo ""
     warn "$(printf "$(t dns_unresolved)" "${BOLD}" "${DOMAIN}" "${RESET}")"
     warn "$(t dns_le_will_fail)"
     echo -e "  ${CYAN}$(printf "$(t dns_set_a)" "${BOLD}" "${DOMAIN}" "${RESET}" "${CYAN}" "${PUBLIC_IP}" "${RESET}")"
     _confirm "$(t continue_q)" \
       || die "$(printf "$(t dns_fix_first)" "${DOMAIN}" "${PUBLIC_IP}")"
-  elif [[ "$_dns_ip" != "$PUBLIC_IP" ]]; then
+  elif ! $_match; then
     echo ""
-    warn "$(printf "$(t dns_mismatch)" "${BOLD}" "${DOMAIN}" "${RESET}" "${RED}" "${_dns_ip}" "${RESET}" "${PUBLIC_IP}")"
+    # Affichage : on remonte la première IP de la même famille que le
+    # serveur si possible, sinon ce qu'on a trouvé.
+    _shown_ip="${_dns_v4%%$'\n'*}"
+    [[ -z "$_shown_ip" ]] && _shown_ip="${_dns_v6%%$'\n'*}"
+    warn "$(printf "$(t dns_mismatch)" "${BOLD}" "${DOMAIN}" "${RESET}" "${RED}" "${_shown_ip}" "${RESET}" "${PUBLIC_IP}")"
     warn "$(t dns_le_mismatch_fail)"
     echo -e "  ${CYAN}$(t dns_update_a)${RESET}"
     _confirm "$(t continue_q)" \
       || die "$(printf "$(t dns_fix_correct)" "${DOMAIN}" "${PUBLIC_IP}")"
   else
-    ok "$(printf "$(t dns_ok)" "${DOMAIN}" "${_dns_ip}")"
+    # On affiche l'IP qui a matché, en priorité IPv4 si elle correspond.
+    _shown_ip="$PUBLIC_IP"
+    if [[ -n "$_dns_v4" ]] && grep -qFx "$PUBLIC_IP" <<<"$_dns_v4"; then
+      _shown_ip="$PUBLIC_IP"
+    elif [[ -n "$_public_v6" ]] && grep -qFx "$_public_v6" <<<"$_dns_v6"; then
+      _shown_ip="$_public_v6"
+    fi
+    ok "$(printf "$(t dns_ok)" "${DOMAIN}" "${_shown_ip}")"
   fi
 fi
 


### PR DESCRIPTION
## Context

Closes #29, reported by @schlaggi.

On a dual-stack machine (public IPv4 + IPv6) where the domain resolves both A and AAAA records, the one-click installer produced a false-positive DNS mismatch. The locally-detected public IPv4 (from `api.ipify.org`) was compared against an arbitrary single result from `getent hosts $DOMAIN | head -1` which, depending on `/etc/nsswitch.conf`, often returned the AAAA on recent Debian 13.

Result : the installer refused to proceed with Let's Encrypt, even when DNS was perfectly correct.

## Fix

Family-aware DNS resolution :

- `getent ahostsv4` for A records (IPv4 only)
- `getent ahostsv6` for AAAA records (IPv6 only, filters out `::1`)
- Optional detection of the public IPv6 via `curl -6 https://api64.ipify.org` (silent fail if no IPv6)
- Match succeeds if **either** the public IPv4 is in the A set **or** the public IPv6 is in the AAAA set. Either family is enough for Let's Encrypt's HTTP-01 challenge.

## Compatibility

- glibc (Debian, Ubuntu, Fedora) ✓
- musl (Alpine recent) ✓
- IPv4-only machines : behavior unchanged
- IPv6-only machines : now supported
- Domains with A only / AAAA only : correct behavior
- Translations `T_EN[dns_*]` / `T_FR[dns_*]` : unchanged, all existing keys reused. No i18n regression.

## Tests

- `bash -n install.sh` : ✓
- Unresolved domain (`*.invalid`) : returns empty v4 + v6, triggers `dns_unresolved` correctly
- Domain resolving on Cloudflare CDN (not matching local IP) : correctly flagged as mismatch (separate concern from this issue)
- schlaggi's scenario (dual-stack with A=local-v4 + AAAA=local-v6) : would match on v4 family alone, no more false mismatch

## Test plan

- [ ] Reviewer runs `bash -n install.sh`
- [ ] Reviewer tests on a dual-stack machine (or confirms by reading the diff that the family separation is correct)
- [ ] Reviewer verifies CONTRIBUTORS.md update for @schlaggi

## Author recognition

@schlaggi added to the Rookies in CONTRIBUTORS.md with the title **First dual-stack hunter 🌐**. First contribution to Nodyx, welcome aboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)