### PR TITLE
chore(security): rename CI JWT_SECRET placeholder for clarity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,14 @@ jobs:
 
       - name: Vitest — 181 tests attendus
         working-directory: nodyx-core
+        # Valeur factice, requise par le bootstrap backend qui refuse de
+        # démarrer sans JWT_SECRET >= 32 chars. La prod utilise son propre
+        # secret dans son .env, jamais dans le repo. Cette chaîne n'a
+        # aucun privilège : container CI éphémère, aucune DB derrière,
+        # aucun JWT forgé avec ça ne sera valide ailleurs que dans le
+        # runner GitHub jetable.
         env:
-          JWT_SECRET: ci-nodyx-test-secret-32chars-longok
+          JWT_SECRET: CI_PLACEHOLDER_NOT_A_REAL_SECRET_safe_to_be_public
           NODE_ENV: test
         run: npm test
 


### PR DESCRIPTION
## Pourquoi
Le nom \`ci-nodyx-test-secret-32chars-longok\` dans le workflow CI laissait penser que c'était un vrai secret en clair à la lecture rapide du fichier public, ce qui crée du doute pour qui regarde sans le contexte.

## Quoi
- Renommé en \`CI_PLACEHOLDER_NOT_A_REAL_SECRET_safe_to_be_public\` (50 chars, toujours au-dessus du minimum 32 requis par le bootstrap backend)
- Ajout d'un commentaire YAML au-dessus du bloc \`env\` qui explique pourquoi c'est en clair et pourquoi ce n'est pas un risque

## Pas un risque sécurité
- Container CI éphémère, détruit après chaque run
- Aucune DB ni système réel derrière
- Le vrai \`JWT_SECRET\` de prod est dans le \`.env\` du VPS, jamais dans le repo
- Pratique standard partout (Discord OSS, Strapi, Sentry, n8n)

## Test
Le bloc \`env\` est inchangé sauf le placeholder. Les 181 tests Vitest doivent passer comme avant.