### PR TITLE
fix(chat): mobile channel switch + remove duplicated sidebar

### DIFF
--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -871,8 +871,13 @@
 				</div>
 
 				<!-- COMMUNICATIONS -->
+				<!-- Mobile : masqué pour éviter la duplication avec ChannelSidebar (le drawer
+				     dédié au chat sur /chat). En mobile, la galaxy-sidebar = nav site + modules
+				     uniquement, ChannelSidebar = canaux. Évite les 2 hamburgers concurrents qui
+				     ouvrent 2 drawers avec les mêmes canaux + le bug de navigation des <a href>
+				     en mode déjà-sur-/chat. En desktop (≥ lg), comportement strictement inchangé. -->
 				{#if (layoutTextChannels.length > 0 && mods.chat !== false) || (layoutVoiceChannels.length > 0 && mods.voice !== false)}
-				<div>
+				<div class="hidden lg:block">
 					<p class="px-2 mb-1.5 text-[9px] uppercase tracking-[.2em] font-black"
 					   style="color: #374151">{tFn('nav.section.communications')}</p>
 					<div class="space-y-px">

--- a/nodyx-frontend/src/routes/chat/+page.svelte
+++ b/nodyx-frontend/src/routes/chat/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount, onDestroy, tick } from 'svelte';
+	import { onMount, onDestroy, tick, untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { browser } from '$app/environment';
 	import { page } from '$app/stores';
@@ -68,27 +68,32 @@
 	// ── State ─────────────────────────────────────────────────────────────────
 	let selectedChannel = $state<Channel | null>(null);
 
-	// Select channel from URL ?channel=id param, or default to first text channel
+	// Select channel from URL ?channel=id param, or default to first text channel.
+	// IMPORTANT : on utilise untrack() pour lire selectedChannel sans créer une
+	// dépendance réactive. Sinon, quand joinChannel() fait `selectedChannel = X`
+	// AVANT que goto() ait propagé la nouvelle URL, ce $effect re-fire avec
+	// selectedChannel.id à jour MAIS urlChannelId périmé, et déclenche un 2e
+	// joinChannel(ancien) qui annule le changement. Bug reproductible sur mobile
+	// où le timing de goto est plus lent que le state Svelte. Avec untrack le
+	// $effect ne fire QUE quand l'URL change réellement.
 	$effect(() => {
-		if (localChannels.length === 0) return;
 		const urlChannelId = $page.url.searchParams.get('channel');
-		if (urlChannelId) {
-			const found = localChannels.find((c: any) => c.id === urlChannelId);
-			if (found && found.id !== selectedChannel?.id) {
-				if (s) {
-					// Socket ready: use joinChannel so socket rooms + state are properly reset
-					joinChannel(found);
-				} else {
-					// Socket not yet ready: set selectedChannel so the connect handler
-					// can emit chat:join once the socket connects
-					selectedChannel = found;
+		untrack(() => {
+			if (localChannels.length === 0) return;
+			if (urlChannelId) {
+				const found = localChannels.find((c: any) => c.id === urlChannelId);
+				if (found && found.id !== selectedChannel?.id) {
+					if (s) {
+						joinChannel(found);
+					} else {
+						selectedChannel = found;
+					}
 				}
+			} else if (!selectedChannel) {
+				const def = localChannels.find((c: any) => c.type === 'text') ?? localChannels[0];
+				if (def) goto(`/chat?channel=${def.id}`, { replaceState: true });
 			}
-		} else if (!selectedChannel) {
-			const def = localChannels.find((c: any) => c.type === 'text') ?? localChannels[0];
-			// Navigate to default channel so URL stays in sync
-			if (def) goto(`/chat?channel=${def.id}`, { replaceState: true });
-		}
+		});
 	});
 	let messages        = $state<Message[]>([]);
 	// Ensure custom fonts are loaded whenever messages change


### PR DESCRIPTION
## Pourquoi

Deux bugs UX mobile distincts sur la page /chat, identifiés ensemble :

1. **2 sidebars superposées** : la galaxy-sidebar du layout contenait une section COMMUNICATIONS avec les canaux, en doublon avec ChannelSidebar. En mobile, 2 hamburgers ouvraient 2 drawers proposant la même chose.

2. **Tap sur un canal annulé** : sur le ChannelSidebar mobile, le tap sur un canal X déclenchait `joinChannel(X)` mais le canal redevenait l'ancien immédiatement. Race condition Svelte 5 + SvelteKit : le `` qui sync URL ↔ `selectedChannel` se ré-exécutait quand `selectedChannel` mutait, AVANT que `goto()` ait propagé la nouvelle URL, et appelait `joinChannel(ancien)` avec l'URL périmée.

## Quoi

- `+layout.svelte` : ajout de `class="hidden lg:block"` sur la section COMMUNICATIONS (1 classe, 5 lignes de commentaire). En desktop, comportement strictement inchangé.
- `chat/+page.svelte` : import `untrack` + wrap du contenu du `$effect` dans `untrack()` pour que ce dernier ne dépende plus réactivement de `selectedChannel` ni de `localChannels`. Il ne fire que quand l'URL change réellement.

## Test

Validé en condition réelle sur mobile : tap sur un canal change bien la vue. Desktop : aucun changement visuel ni comportemental.
