### PR TITLE
docs: explain the PostgreSQL 16 choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ One command. Your server. Forever.
 |---|---|
 | Backend API | **TypeScript** + **Fastify v5** + Socket.IO, `nodyx-core/` |
 | Frontend | **SvelteKit 5** + Tailwind v4 + TipTap editor, `nodyx-frontend/` |
-| Database | **PostgreSQL 16** (FTS, migrations) + **Redis 7** (sessions, presence) |
+| Database | **PostgreSQL 16** (FTS, migrations) + **Redis 7** (sessions, presence) <sup>[¹](docs/en/ARCHITECTURE.md#why-postgresql-16-and-not-17-or-18)</sup> |
 | Voice relay | **nodyx-turn**, Rust STUN/TURN (replaces coturn, 2.9 MB binary) |
 | P2P tunneling | **nodyx-relay**, Rust TCP tunnel (home server, no open ports) |
 | Real-time | WebRTC P2P mesh + Socket.IO fallback |

--- a/docs/en/ARCHITECTURE.md
+++ b/docs/en/ARCHITECTURE.md
@@ -62,6 +62,23 @@ All routes start with `/api/v1/`
 
 ## 3. POSTGRESQL DATA MODEL
 
+### Why PostgreSQL 16 (and not 17 or 18)
+
+Nodyx ships with **PostgreSQL 16**. This is a deliberate choice, not a lag.
+
+**Why 16 is the right baseline for Nodyx today:**
+
+- **It's what Ubuntu 24.04 LTS ships by default.** `apt install postgresql` on a fresh Ubuntu 24.04 server installs PG 16. Picking the distro default keeps `install.sh` short, predictable, and free of third-party PPAs that admins might not trust. Less moving parts at install time means fewer breakages on real-world VPSes.
+- **Upstream support runs until November 2028.** PostgreSQL has a 5-year support window per major version. PG 16 is supported with security and bug fixes for 2+ more years. We are not on a deprecated version.
+- **Nodyx uses zero features specific to PG 17 or 18.** Our migrations rely on standard SQL plus widely-available extras: `JSONB`, `UUID`, `tsvector` full-text search, `CREATE INDEX CONCURRENTLY`, partial indexes, `IF NOT EXISTS` everywhere. These have been stable since PG 12+. We would gain literally nothing functional by upgrading.
+- **The performance and feature gains from 17/18 don't apply at our scale.** Improvements like streaming I/O, logical replication slot sync, or vectorized JSON path are aimed at multi-terabyte deployments or replication-heavy architectures. A Nodyx instance is "one community on one VPS" — these gains don't move the needle.
+
+**When we will migrate:**
+
+The plan is to skip PG 17 and move directly to **PG 18** once Ubuntu 26.04 LTS ships it as the default (expected mid-2026). At that point the installer will update transparently for new installs, and we will provide a documented `pg_upgradecluster` path for existing instances. Until then, **staying on PG 16 is the boring, reliable, recommended choice**.
+
+If you need PG 18 today for a specific reason (e.g. you are integrating Nodyx with another stack that requires it), you can add the official PostgreSQL APT repository and migrate manually with `pg_upgradecluster`. Open a thread on the forum if you want a walkthrough.
+
 ### Main tables
 
 ```sql

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -58,7 +58,7 @@ Une commande. Votre serveur. Pour toujours.
 |---|---|
 | API Backend | **TypeScript** + **Fastify v5** + Socket.IO, `nodyx-core/` |
 | Frontend | **SvelteKit 5** + Tailwind v4 + éditeur TipTap, `nodyx-frontend/` |
-| Base de données | **PostgreSQL 16** (FTS, migrations) + **Redis 7** (sessions, présence) |
+| Base de données | **PostgreSQL 16** (FTS, migrations) + **Redis 7** (sessions, présence) <sup>[¹](../en/ARCHITECTURE.md#why-postgresql-16-and-not-17-or-18)</sup> |
 | Relais voix | **nodyx-turn**, STUN/TURN en Rust (remplace coturn, binaire de 2,9 Mo) |
 | Tunnel P2P | **nodyx-relay**, tunnel TCP Rust (serveur domestique, sans ports ouverts) |
 | Temps réel | Maillage P2P WebRTC + fallback Socket.IO |

--- a/install.sh
+++ b/install.sh
@@ -1930,6 +1930,24 @@ chown -R nodyx:nodyx /home/nodyx/.pm2
 # ═══════════════════════════════════════════════════════════════════════════════
 #  POSTGRESQL
 # ═══════════════════════════════════════════════════════════════════════════════
+#
+# Why PostgreSQL 16 and not the latest (17 or 18) ?
+#   On Ubuntu 24.04 LTS, `apt install postgresql` installs PG 16 by default
+#   from the official Ubuntu repos. We DELIBERATELY stick to the distro default
+#   instead of pinning a newer version via the apt.postgresql.org PPA :
+#     - Less moving parts at install time = fewer surprises on real VPSes
+#     - PG 16 is supported by upstream until November 2028 (5-year window)
+#     - Nodyx uses zero features specific to PG 17/18 ; our migrations only
+#       rely on standard SQL + JSONB, UUID, tsvector, partial indexes,
+#       CREATE INDEX CONCURRENTLY — all stable since PG 12+
+#     - The perf gains in PG 17/18 (streaming I/O, JSON path vectorization)
+#       target multi-TB workloads, not a per-instance community platform
+#   The plan is to skip PG 17 and adopt PG 18 once Ubuntu 26.04 LTS ships it
+#   as the default. Details in docs/en/ARCHITECTURE.md § 3.
+#
+# Detect installed PostgreSQL version below — we accept whatever the distro
+# offers, including newer if the admin installed a PPA on their own.
+# ═══════════════════════════════════════════════════════════════════════════════
 step "$(t step_pg)"
 
 # Detect installed PostgreSQL version (needed for the versioned service name)


### PR DESCRIPTION
Documents pourquoi Nodyx tourne sur PostgreSQL 16 et pas PG 17/18, pour que la question ait une réponse écrite la prochaine fois qu'un contributeur ou un admin se la pose.

## Où c'est ajouté

- `docs/en/ARCHITECTURE.md § 3` : section "Why PostgreSQL 16 (and not 17 or 18)" avec les 4 vraies raisons + plan de migration future
- `README.md` (EN) : footnote ¹ sur la ligne Database qui pointe vers la section
- `docs/fr/README.md` : même footnote
- `install.sh` : bloc de commentaire pédagogique au-dessus de la section POSTGRESQL pour les admins qui lisent le script directement

## Pourquoi cette PR

Question récurrente en vocal / DM. On la remet une fois pour toutes dans le code, plus besoin d'y revenir.