### PR TITLE
feat(streamer): playlists Soundboard, overlay playlist OBS et tab Scènes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,15 +29,15 @@ Caddyfile.dev
 ecosystem.config.js
 nodyx-core/turn-server.js
 
-# Uploads utilisateurs (données personnelles)
-nodyx-core/uploads/avatars/*
-nodyx-core/uploads/banners/*
-nodyx-core/uploads/logos/*
-nodyx-core/uploads/assets/*
-nodyx-core/uploads/fonts/*
-!nodyx-core/uploads/avatars/.gitkeep
-!nodyx-core/uploads/banners/.gitkeep
-!nodyx-core/uploads/logos/.gitkeep
+# Uploads utilisateurs (données personnelles) : tout le contenu, quel que soit
+# le sous-dossier (posts, audio_thumbs, inline_images et tout futur type),
+# sauf les .gitkeep qui préservent l'arborescence.
+nodyx-core/uploads/**
+!nodyx-core/uploads/*/
+!nodyx-core/uploads/*/.gitkeep
+
+# Backups locaux (archives tar.gz du Backup System)
+nodyx-core/backups/
 
 # Hub runtime files
 nodyx-hub/.env

--- a/docs/fr/streamer-hub/scenes-obs.md
+++ b/docs/fr/streamer-hub/scenes-obs.md
@@ -1,0 +1,117 @@
+# Scènes OBS — Compositeur visuel Nodyx
+
+Le tab **Scènes** du Streamer Hub permet de composer visuellement les scènes que tu utilises dans OBS sans avoir à les configurer manuellement dans OBS. Tu poses tes sources (caméra, alerts, ticker, playlist, etc.) sur un canvas 1920×1080 à l'écran, et tu retrouves la même mise en page côté OBS.
+
+> **Note Phase A.** Le compositeur stocke les scènes côté Nodyx. La synchronisation directe avec OBS via WebSocket (Phase B+) viendra plus tard : aujourd'hui tu poses ta composition dans Nodyx, tu copies les URLs d'overlay et tu reproduis les positions à la main dans OBS. Ce sera entièrement automatique quand le bridge sera activé.
+
+## Layout général
+
+Le tab reprend le layout d'OBS pour que tu ne perdes pas tes repères :
+
+```
+┌───────────────────────────────┬────────────┐
+│                               │            │
+│      Canvas preview 16:9      │  Contrôles │
+│                               │            │
+├──────────┬──────────┬─────────┤            │
+│  Scènes  │  Sources │  Mixer  │            │
+└──────────┴──────────┴─────────┴────────────┘
+```
+
+- **Canvas** (haut, large) : preview 16:9, scalé à la largeur disponible. Référence pixel = 1920×1080.
+- **Scènes** : liste de tes scènes Nodyx (Dev, Discussion, Chill…). Boutons `＋ − dupliquer` style OBS.
+- **Sources** : sources de la scène active, triées par ordre Z (devant → arrière). Boutons `＋ −`.
+- **Audio Mixer** : sliders de volume des sources audio. *Phase B (à venir)*.
+- **Contrôles** : `Start Streaming`, `Start Recording`, `Studio Mode`. *Phase C (à venir, via OBS WebSocket)*.
+- **Propriétés** (panneau droit) : édition de la source sélectionnée (nom, X/Y, largeur, hauteur, URL, etc.).
+
+## Créer une scène
+
+1. Clique sur le bouton `＋` en bas de la colonne **Scènes**.
+2. Saisis un nom (ex : `Dev`, `Discussion`, `Pause`, `BRB`).
+3. `Entrée` pour valider.
+
+Le nom doit être unique pour ton compte. Pour repartir d'une scène existante, sélectionne-la et clique sur l'icône **dupliquer** : tu obtiens `Dev (copie)` avec exactement la même composition.
+
+## Ajouter une source
+
+1. Sélectionne la scène cible dans la colonne **Scènes**.
+2. Clique sur `＋` en bas de la colonne **Sources**.
+3. Choisis un type dans le catalogue :
+   - **📹 Source vidéo** : webcam, capture jeu ou image. Placeholder en Phase A ; la vraie source OBS sera liée en Phase B.
+   - **🔔 Alert Box** : notifications follow / sub / raid / cheer.
+   - **📰 Event Ticker** : bandeau d'events qui défile.
+   - **🎵 Playlist** : musique d'ambiance en autoplay loop (voir [Soundboard & Playlists](soundboard.md)).
+   - **🔊 Soundboard OSD** : carte affichée quand un son du Stream Deck joue.
+   - **🎯 Goal Bar** : barre d'objectif (followers, subs…).
+   - **🏆 Leaderboard** : top viewers, chat ou donateurs.
+   - **🎬 Clips Player** : lecteur de top clips déclenchable depuis le Deck.
+   - **🌐 Browser Source** : n'importe quelle URL HTTPS (widget externe).
+
+La source apparaît centrée sur le canvas avec sa taille par défaut. Tu peux ensuite la déplacer ou la redimensionner.
+
+## Manipuler une source
+
+### Sélection
+Clique sur la source dans le canvas ou dans la liste **Sources**. La source sélectionnée est encadrée d'une bordure rouge OBS-style avec 8 poignées de redimensionnement.
+
+### Déplacement
+Drag le centre de la source. Le mouvement **se magnétise** aux bords du canvas et au centre (X et Y), comme OBS.
+
+### Redimensionnement
+Drag une des 8 poignées rouges :
+- 4 poignées d'angle (`↖ ↗ ↘ ↙`) : redimensionnement libre 2D.
+- 4 poignées de bord (`↑ ↓ ← →`) : un seul axe.
+
+La taille reste clampée au canvas (impossible de déborder).
+
+### Visibilité et verrouillage (style OBS)
+Dans la liste **Sources** :
+- L'icône **œil** masque la source du canvas sans la supprimer (utile pour tester une compo).
+- L'icône **cadenas** empêche le drag/resize accidentel sur le canvas (souvent utile pour la caméra une fois bien réglée).
+
+### Ordre Z (devant / derrière)
+Survole une source dans la liste et utilise les chevrons `↑ ↓` pour la déplacer dans la pile. OBS et Nodyx affichent les sources de fond en bas et les sources de premier plan en haut.
+
+### Suppression
+Sélectionne et clique sur `−` en bas de la liste **Sources**. La source est retirée de la scène (les autres scènes ne sont pas touchées).
+
+## Propriétés détaillées
+
+Quand une source est sélectionnée, le panneau **Propriétés** (à droite) permet d'ajuster :
+- **Nom affiché** : étiquette de la source (visible dans la liste et le canvas).
+- **X / Y / Largeur / Hauteur** : pixels absolus (référentiel 1920×1080).
+- Selon le type :
+  - **Browser Source** : URL (HTTPS uniquement, validée côté backend).
+  - **Source vidéo** : type visé (webcam / capture / image) pour la liaison Phase B.
+  - Pour les overlays Nodyx (alert, ticker, playlist…) : le token d'overlay et la config seront éditables dans une prochaine itération.
+
+## Sauvegarde
+
+Tout est sauvegardé automatiquement, **debounced à 400 ms** après ta dernière action. Tu vois "sauvegardé à l'instant" en haut à droite quand le PATCH a réussi.
+
+Si la sauvegarde échoue (réseau, conflit), un toast rouge s'affiche. Réessaye en bougeant la source de 1 pixel.
+
+## Roadmap
+
+| Phase | Contenu | État |
+|-------|---------|------|
+| **A** | Canvas WYSIWYG + scènes côté Nodyx + génération d'URLs | ✅ Disponible |
+| **B** | Connexion OBS WebSocket en lecture seule (import des scènes OBS) | À venir |
+| **C** | Sync bidirectionnelle (drag/resize Nodyx → OBS en live), Audio Mixer et Contrôles activés | À venir |
+| **D** | Auto-installer : Nodyx recrée toutes les Browser Sources dans OBS depuis tes scènes | À venir |
+| **E** | Actions Stream Deck dédiées OBS (scene switch, source toggle, stream start) | À venir |
+
+## FAQ
+
+**Q. Pourquoi la Browser Source apparaît seulement comme un placeholder ?**
+Le canvas Nodyx ne rend pas encore le contenu vivant des sources (iframe live) pour rester rapide à manipuler. Tu vois l'emprise (position + taille), pas le contenu. Le rendu fidèle viendra en Phase B avec le bridge OBS qui peut envoyer des screenshots de la scène réelle.
+
+**Q. Puis-je avoir plusieurs Audio Mixer ?**
+Le mixer est une vue agrégée des sources audio toutes scènes confondues côté OBS. Il sera unique et persistant en Phase B.
+
+**Q. Que se passe-t-il si je supprime une scène utilisée par mon Stream Deck ?**
+Les boutons "Démarrer playlist X" du Deck restent attachés à la playlist, pas à la scène Nodyx. Tu peux supprimer / renommer / réorganiser tes scènes sans casser tes boutons.
+
+**Q. La Phase B sera-t-elle compatible avec mon OBS ?**
+Oui, si tu es sur OBS 28 ou plus récent. Le plugin OBS WebSocket 5.x est intégré nativement depuis cette version. Pas d'install supplémentaire à prévoir.

--- a/nodyx-core/src/migrations/100_streamer_audio_playlists.sql
+++ b/nodyx-core/src/migrations/100_streamer_audio_playlists.sql
@@ -1,0 +1,42 @@
+-- ─── Streamer Hub — Soundboard playlists ────────────────────────────────────
+-- Un streamer veut grouper ses sons par contexte (intro, discussion, dev,
+-- hype, jingles…) plutôt que de tout avoir dans une liste plate. On stocke
+-- les playlists séparément des tracks, avec une table de jonction
+-- streamer_audio_playlist_tracks (migration 101). Un track peut appartenir
+-- à plusieurs playlists (un même jingle d'intro peut être dans "Intro" et
+-- "Favoris").
+--
+-- Visibilité :
+--   - 'private' : visible uniquement par le propriétaire (admin) (défaut)
+--   - 'public'  : exposée sur la page publique /soundboard pour les viewers
+--                 (filtres par playlist en pills au-dessus de la lib)
+--
+-- color : hex #RRGGBB optionnel, utilisé pour l'accent visuel de la pill
+-- (admin sidebar + page publique). NULL = défaut violet Nodyx.
+--
+-- position : tri manuel des playlists dans la sidebar admin. Pas d'unique
+-- car le réordonnage côté UI peut temporairement créer des doublons avant
+-- la mise à jour finale par lots.
+
+CREATE TABLE IF NOT EXISTS streamer_audio_playlists (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name          VARCHAR(100) NOT NULL,
+  description   TEXT,
+  color         VARCHAR(7) CHECK (color IS NULL OR color ~ '^#[0-9a-fA-F]{6}$'),
+  visibility    TEXT NOT NULL DEFAULT 'private' CHECK (visibility IN ('private', 'public')),
+  position      INTEGER NOT NULL DEFAULT 0,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (owner_user_id, name)
+);
+
+-- Sidebar admin : liste des playlists d'un owner, triées par position.
+CREATE INDEX IF NOT EXISTS idx_streamer_audio_playlists_owner
+  ON streamer_audio_playlists (owner_user_id, position ASC);
+
+-- Page publique : récupération rapide des playlists publiques d'un owner.
+-- Index partiel pour ne pas peser quand 95% des playlists sont privées.
+CREATE INDEX IF NOT EXISTS idx_streamer_audio_playlists_public
+  ON streamer_audio_playlists (owner_user_id, position ASC)
+  WHERE visibility = 'public';

--- a/nodyx-core/src/migrations/101_streamer_audio_playlist_tracks.sql
+++ b/nodyx-core/src/migrations/101_streamer_audio_playlist_tracks.sql
@@ -1,0 +1,27 @@
+-- ─── Streamer Hub — Playlist tracks (jonction many-to-many) ──────────────────
+-- Lien entre playlists et tracks. Un track peut être dans plusieurs playlists
+-- (ex: jingle "Bonjour" dans "Intro" ET "Favoris"). Pas de cascade vers la
+-- track elle-même : retirer un track d'une playlist ne supprime pas le track
+-- de la bibliothèque, et vice-versa.
+--
+-- position : ordre du track dans la playlist (drag-to-reorder côté UI admin).
+-- Pas d'unique sur (playlist_id, position) pour permettre des swaps en 2 temps
+-- sans contrainte intermédiaire violée. La cohérence est garantie par les
+-- requêtes UPDATE batch côté service.
+
+CREATE TABLE IF NOT EXISTS streamer_audio_playlist_tracks (
+  playlist_id UUID NOT NULL REFERENCES streamer_audio_playlists(id) ON DELETE CASCADE,
+  track_id    UUID NOT NULL REFERENCES streamer_audio_library(id)   ON DELETE CASCADE,
+  position    INTEGER NOT NULL DEFAULT 0,
+  added_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (playlist_id, track_id)
+);
+
+-- Lecture des tracks d'une playlist dans l'ordre (filtre admin + page publique).
+CREATE INDEX IF NOT EXISTS idx_streamer_audio_playlist_tracks_order
+  ON streamer_audio_playlist_tracks (playlist_id, position ASC);
+
+-- Lecture des playlists auxquelles appartient un track donné (pour afficher
+-- "ce track est dans X playlists" dans l'éditeur de track).
+CREATE INDEX IF NOT EXISTS idx_streamer_audio_playlist_tracks_track
+  ON streamer_audio_playlist_tracks (track_id);

--- a/nodyx-core/src/migrations/102_streamer_obs_scenes.sql
+++ b/nodyx-core/src/migrations/102_streamer_obs_scenes.sql
@@ -1,0 +1,53 @@
+-- ─── Streamer Hub — Scènes OBS pilotées depuis Nodyx ────────────────────────
+-- Permet au streamer de composer ses scènes (Dev, Discussion, Chill...) dans
+-- un canvas WYSIWYG Nodyx au lieu de configurer OBS directement. Une scène
+-- Nodyx = un layout 1920x1080 contenant N "sources" (overlays Nodyx ou URLs
+-- Browser libres) positionnées et redimensionnées.
+--
+-- Phase A (cette migration) : les scènes sont stockées côté Nodyx. Le streamer
+-- les compose visuellement, génère les URLs d'overlay et les colle dans OBS.
+-- Phase B/C plus tard : un bridge OBS WebSocket synchronisera ces scènes
+-- automatiquement dans OBS (Add Browser Source, Set Transform, Switch Scene).
+--
+-- Format de layout (JSONB) :
+--   {
+--     "sources": [
+--       {
+--         "id":       "src_xxx",
+--         "type":     "alert_box" | "ticker" | "playlist" | "soundboard_osd"
+--                   | "goal_bar" | "leaderboard" | "clips_player"
+--                   | "browser_source" | "placeholder_video",
+--         "label":    "Alerte follow",
+--         "x":        0..1920,
+--         "y":        0..1080,
+--         "w":        1..1920,
+--         "h":        1..1080,
+--         "z":        ordre de stack (0 = fond, N = devant),
+--         "visible":  bool,
+--         "locked":   bool,
+--         "config":   {} (varie par type : overlayToken, playlistId, url, etc.)
+--       }
+--     ]
+--   }
+--
+-- `placeholder_video` représente les sources vidéo OBS (webcam, capture jeu)
+-- qu'on ne pilote pas en Phase A : on les laisse manipulables en position/taille
+-- pour la maquette, et plus tard OBS-bridge les liera aux vraies sources.
+
+CREATE TABLE IF NOT EXISTS streamer_obs_scenes (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name          VARCHAR(80) NOT NULL,
+  color         VARCHAR(7) CHECK (color IS NULL OR color ~ '^#[0-9a-fA-F]{6}$'),
+  layout        JSONB NOT NULL DEFAULT '{"sources":[]}'::jsonb,
+  position      INTEGER NOT NULL DEFAULT 0,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (owner_user_id, name)
+);
+
+-- Sidebar admin : liste des scènes d'un owner, triées par position. Pas
+-- d'unique sur position : un réordonnage peut temporairement créer des
+-- doublons avant la mise à jour finale par lots (cf. reorderScenes service).
+CREATE INDEX IF NOT EXISTS idx_streamer_obs_scenes_owner
+  ON streamer_obs_scenes (owner_user_id, position ASC);

--- a/nodyx-core/src/routes/streamer.ts
+++ b/nodyx-core/src/routes/streamer.ts
@@ -81,6 +81,7 @@ import { getClipMp4Url } from '../services/streamer/twitchClipExtraction'
 import {
   createOverlay,
   findOverlayByToken,
+  findOverlayByOwnerAndType,
   isOverlayType,
   listOverlays,
   revokeOverlay,
@@ -147,6 +148,32 @@ import {
   setViewerQueueEnabled,
   QUEUE_LIMITS,
 } from '../services/streamer/soundboardQueueService'
+
+import {
+  listPlaylistsForOwner,
+  listPublicPlaylists,
+  getPlaylist,
+  createPlaylist,
+  updatePlaylist,
+  deletePlaylist,
+  reorderPlaylists,
+  addTrackToPlaylist,
+  removeTrackFromPlaylist,
+  reorderTracksInPlaylist,
+  listTracksInPlaylist,
+  listPlaylistIdsForTrack,
+  type PlaylistVisibility,
+  type UpdatePlaylistInput,
+} from '../services/streamer/audioPlaylistService'
+import {
+  listScenesForOwner,
+  getScene,
+  createScene,
+  updateScene,
+  deleteScene,
+  duplicateScene,
+  reorderScenes,
+} from '../services/streamer/obsScenesService'
 
 // ── Helpers env ──────────────────────────────────────────────────────────────
 
@@ -1319,6 +1346,183 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
     },
   )
 
+  // Liste des playlists auxquelles appartient un track donné. Sert au popover
+  // "ajouter à playlist" depuis la ligne d'un track : on coche/décoche pour
+  // savoir d'un coup d'œil dans quelles playlists ce son est déjà.
+  server.get<{ Params: { id: string } }>(
+    '/audio-library/:id/playlists',
+    { preHandler: adminOnly },
+    async (request, reply) => {
+      const t = await getTrack(request.params.id)
+      if (!t) return reply.code(404).send({ ok: false, error: 'not_found' })
+      if (t.ownerUserId !== request.user!.userId) {
+        return reply.code(403).send({ ok: false, error: 'forbidden' })
+      }
+      const playlistIds = await listPlaylistIdsForTrack(request.params.id)
+      return { ok: true, playlistIds }
+    },
+  )
+
+  // ── Soundboard playlists (admin CRUD + tracks management) ──────────────
+  // Permet au streamer de grouper ses sons par contexte (intro, dev, hype...).
+  // Voir migrations 100 + 101 et audioPlaylistService.
+
+  server.get('/audio-library/playlists', { preHandler: adminOnly }, async (request) => {
+    const playlists = await listPlaylistsForOwner(request.user!.userId)
+    return { playlists }
+  })
+
+  server.post<{ Body: { name?: string; description?: string; color?: string; visibility?: string } }>(
+    '/audio-library/playlists',
+    { preHandler: adminOnly },
+    async (request, reply) => {
+      const b = request.body
+      const name = (b?.name ?? '').trim()
+      if (!name) return reply.code(400).send({ ok: false, error: 'name_required' })
+      const visibility: PlaylistVisibility = b?.visibility === 'public' ? 'public' : 'private'
+      try {
+        const playlist = await createPlaylist({
+          ownerUserId: request.user!.userId,
+          name,
+          description: b?.description,
+          color:       b?.color,
+          visibility,
+        })
+        return reply.send({ ok: true, playlist })
+      } catch (err) {
+        const msg = (err as { message?: string }).message ?? 'unknown'
+        if (msg === 'playlist_name_taken') return reply.code(409).send({ ok: false, error: msg })
+        return reply.code(500).send({ ok: false, error: msg })
+      }
+    },
+  )
+
+  server.get<{ Params: { id: string } }>(
+    '/audio-library/playlists/:id',
+    { preHandler: adminOnly },
+    async (request, reply) => {
+      const p = await getPlaylist(request.params.id)
+      if (!p) return reply.code(404).send({ ok: false, error: 'not_found' })
+      if (p.ownerUserId !== request.user!.userId && p.visibility !== 'public') {
+        return reply.code(403).send({ ok: false, error: 'forbidden' })
+      }
+      const tracks = await listTracksInPlaylist(p.id)
+      return { ok: true, playlist: p, tracks }
+    },
+  )
+
+  server.patch<{ Params: { id: string }; Body: UpdatePlaylistInput }>(
+    '/audio-library/playlists/:id',
+    { preHandler: adminOnly },
+    async (request, reply) => {
+      const existing = await getPlaylist(request.params.id)
+      if (!existing) return reply.code(404).send({ ok: false, error: 'not_found' })
+      if (existing.ownerUserId !== request.user!.userId) {
+        return reply.code(403).send({ ok: false, error: 'forbidden' })
+      }
+      try {
+        const playlist = await updatePlaylist(request.params.id, request.body ?? {})
+        return { ok: true, playlist }
+      } catch (err) {
+        const msg = (err as { message?: string }).message ?? 'unknown'
+        if (msg === 'playlist_name_taken') return reply.code(409).send({ ok: false, error: msg })
+        return reply.code(500).send({ ok: false, error: msg })
+      }
+    },
+  )
+
+  server.delete<{ Params: { id: string } }>(
+    '/audio-library/playlists/:id',
+    { preHandler: adminOnly },
+    async (request, reply) => {
+      const ok = await deletePlaylist(request.params.id, request.user!.userId)
+      if (!ok) return reply.code(404).send({ ok: false, error: 'not_found_or_forbidden' })
+      return { ok: true }
+    },
+  )
+
+  // Réordonner la sidebar des playlists.
+  server.post<{ Body: { ids?: string[] } }>(
+    '/audio-library/playlists/reorder',
+    { preHandler: adminOnly },
+    async (request, reply) => {
+      const ids = Array.isArray(request.body?.ids) ? request.body!.ids : []
+      if (ids.length === 0) return reply.code(400).send({ ok: false, error: 'ids_required' })
+      await reorderPlaylists(request.user!.userId, ids)
+      return { ok: true }
+    },
+  )
+
+  // Ajouter un track à une playlist (idempotent côté service).
+  server.post<{ Params: { id: string }; Body: { trackId?: string } }>(
+    '/audio-library/playlists/:id/tracks',
+    { preHandler: adminOnly },
+    async (request, reply) => {
+      const existing = await getPlaylist(request.params.id)
+      if (!existing) return reply.code(404).send({ ok: false, error: 'not_found' })
+      if (existing.ownerUserId !== request.user!.userId) {
+        return reply.code(403).send({ ok: false, error: 'forbidden' })
+      }
+      const trackId = (request.body?.trackId ?? '').toString()
+      if (!trackId) return reply.code(400).send({ ok: false, error: 'track_id_required' })
+      const added = await addTrackToPlaylist(request.params.id, trackId)
+      return { ok: true, added }
+    },
+  )
+
+  // Retirer un track d'une playlist.
+  server.delete<{ Params: { id: string; trackId: string } }>(
+    '/audio-library/playlists/:id/tracks/:trackId',
+    { preHandler: adminOnly },
+    async (request, reply) => {
+      const existing = await getPlaylist(request.params.id)
+      if (!existing) return reply.code(404).send({ ok: false, error: 'not_found' })
+      if (existing.ownerUserId !== request.user!.userId) {
+        return reply.code(403).send({ ok: false, error: 'forbidden' })
+      }
+      const removed = await removeTrackFromPlaylist(request.params.id, request.params.trackId)
+      return { ok: removed }
+    },
+  )
+
+  // Réordonner les tracks dans une playlist.
+  server.post<{ Params: { id: string }; Body: { trackIds?: string[] } }>(
+    '/audio-library/playlists/:id/reorder-tracks',
+    { preHandler: adminOnly },
+    async (request, reply) => {
+      const existing = await getPlaylist(request.params.id)
+      if (!existing) return reply.code(404).send({ ok: false, error: 'not_found' })
+      if (existing.ownerUserId !== request.user!.userId) {
+        return reply.code(403).send({ ok: false, error: 'forbidden' })
+      }
+      const ids = Array.isArray(request.body?.trackIds) ? request.body!.trackIds : []
+      if (ids.length === 0) return reply.code(400).send({ ok: false, error: 'track_ids_required' })
+      await reorderTracksInPlaylist(request.params.id, ids)
+      return { ok: true }
+    },
+  )
+
+  // POST /audio-library/playlists/overlay-token — admin — récupère (ou crée
+  // si absent) le token d'overlay "playlist" du streamer. Un seul token par
+  // owner, partagé entre toutes ses playlists. L'URL finale OBS prend la
+  // playlist_id en query : /overlay/playlist/<token>?id=<playlistId>.
+  server.post(
+    '/audio-library/playlists/overlay-token',
+    { preHandler: adminOnly },
+    async (request, reply) => {
+      let overlay = await findOverlayByOwnerAndType(request.user!.userId, 'playlist')
+      if (!overlay) {
+        overlay = await createOverlay({
+          overlayType: 'playlist',
+          label:       'Playlist (OBS)',
+          config:      {},
+          createdBy:   request.user!.userId,
+        })
+      }
+      return reply.send({ ok: true, token: overlay.token })
+    },
+  )
+
   // ── Soundboard public (page viewers) ────────────────────────────────────
   // Route PUBLIQUE (pas d'auth). Renvoie la biblio publique du streamer
   // principal + le now-playing depuis Redis. Pollée toutes les 2s par la
@@ -1329,14 +1533,28 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
     const streamers = await listStreamers('twitch').catch(() => [])
     const owner = streamers[0]
     if (!owner?.userId) {
-      return reply.send({ ok: true, streamer: null, tracks: [], nowPlaying: null, queue: [], queueEnabled: false })
+      return reply.send({
+        ok: true, streamer: null, tracks: [], nowPlaying: null,
+        queue: [], queueEnabled: false, playlists: [],
+      })
     }
 
-    const [tracks, queue, queueEnabled] = await Promise.all([
+    const [tracks, queue, queueEnabled, playlists] = await Promise.all([
       listPublicTracks(owner.userId).catch(() => []),
       listSoundboardQueue(owner.userId).catch(() => []),
       isViewerQueueEnabled(owner.userId).catch(() => true),
+      listPublicPlaylists(owner.userId).catch(() => []),
     ])
+
+    // Pour chaque playlist publique, on récupère la liste ordonnée de ses
+    // tracks (juste les ids ici, le viewer aura les détails depuis `tracks`
+    // côté frontend via un map id → track). Évite de dupliquer la payload.
+    const playlistsWithTracks = await Promise.all(
+      playlists.map(async (p) => {
+        const items = await listTracksInPlaylist(p.id).catch(() => [])
+        return { ...p, trackIds: items.map(t => t.id) }
+      }),
+    )
 
     let nowPlaying: unknown = null
     try {
@@ -1354,6 +1572,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
       nowPlaying,
       queue,
       queueEnabled,
+      playlists: playlistsWithTracks,
     })
   })
 
@@ -1516,6 +1735,108 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         ipAddress: request.ip,
         metadata:  { rewardId: request.params.id },
       })
+      return reply.send({ ok: true })
+    },
+  )
+
+  // ── Scènes OBS (compositeur visuel Nodyx) ──────────────────────────────
+  // CRUD pour les scènes du canvas WYSIWYG. Une scène = un layout 1920x1080
+  // contenant N sources positionnées. Phase A : maquette + génération d'URLs
+  // d'overlay. Phase B+ : sync avec OBS via WebSocket.
+
+  server.get('/obs/scenes', { preHandler: adminOnly }, async (request) => {
+    const scenes = await listScenesForOwner(request.user!.userId)
+    return { ok: true, scenes }
+  })
+
+  server.post<{ Body: { name?: string; color?: string | null; layout?: unknown } }>(
+    '/obs/scenes',
+    { preHandler: adminOnly },
+    async (request, reply) => {
+      const name = (request.body?.name ?? '').trim()
+      if (!name) return reply.code(400).send({ ok: false, error: 'name_required' })
+      try {
+        const scene = await createScene({
+          ownerUserId: request.user!.userId,
+          name,
+          color:       request.body?.color ?? null,
+          layout:      request.body?.layout,
+        })
+        return reply.send({ ok: true, scene })
+      } catch (err) {
+        if ((err as Error).message === 'scene_name_taken') {
+          return reply.code(409).send({ ok: false, error: 'scene_name_taken' })
+        }
+        throw err
+      }
+    },
+  )
+
+  server.get<{ Params: { id: string } }>(
+    '/obs/scenes/:id',
+    { preHandler: adminOnly },
+    async (request, reply) => {
+      const scene = await getScene(request.params.id)
+      if (!scene) return reply.code(404).send({ ok: false, error: 'not_found' })
+      if (scene.ownerUserId !== request.user!.userId) {
+        return reply.code(403).send({ ok: false, error: 'forbidden' })
+      }
+      return reply.send({ ok: true, scene })
+    },
+  )
+
+  server.patch<{ Params: { id: string }; Body: { name?: string; color?: string | null; layout?: unknown } }>(
+    '/obs/scenes/:id',
+    { preHandler: adminOnly },
+    async (request, reply) => {
+      const existing = await getScene(request.params.id)
+      if (!existing) return reply.code(404).send({ ok: false, error: 'not_found' })
+      if (existing.ownerUserId !== request.user!.userId) {
+        return reply.code(403).send({ ok: false, error: 'forbidden' })
+      }
+      try {
+        const scene = await updateScene(request.params.id, {
+          name:   request.body?.name,
+          color:  request.body?.color,
+          layout: request.body?.layout,
+        })
+        return reply.send({ ok: true, scene })
+      } catch (err) {
+        if ((err as Error).message === 'scene_name_taken') {
+          return reply.code(409).send({ ok: false, error: 'scene_name_taken' })
+        }
+        throw err
+      }
+    },
+  )
+
+  server.delete<{ Params: { id: string } }>(
+    '/obs/scenes/:id',
+    { preHandler: adminOnly },
+    async (request, reply) => {
+      const ok = await deleteScene(request.params.id, request.user!.userId)
+      if (!ok) return reply.code(404).send({ ok: false, error: 'not_found_or_forbidden' })
+      return reply.send({ ok: true })
+    },
+  )
+
+  server.post<{ Params: { id: string } }>(
+    '/obs/scenes/:id/duplicate',
+    { preHandler: adminOnly },
+    async (request, reply) => {
+      const scene = await duplicateScene(request.params.id, request.user!.userId)
+      if (!scene) return reply.code(404).send({ ok: false, error: 'not_found_or_forbidden' })
+      return reply.send({ ok: true, scene })
+    },
+  )
+
+  server.post<{ Body: { sceneIds?: string[] } }>(
+    '/obs/scenes/reorder',
+    { preHandler: adminOnly },
+    async (request, reply) => {
+      const ids = Array.isArray(request.body?.sceneIds) ? request.body!.sceneIds : []
+      if (ids.length === 0) return reply.code(400).send({ ok: false, error: 'scene_ids_required' })
+      await reorderScenes(request.user!.userId, ids)
       return reply.send({ ok: true })
     },
   )
@@ -1698,6 +2019,37 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
       },
     })
   })
+
+  // GET /overlay/playlist/:token/:playlistId — token-gated — payload pour la
+  // page d'overlay OBS qui lit une playlist en autoplay loop. Le token EST
+  // l'auth (créé pour le streamer, type 'playlist'). On vérifie que la
+  // playlist appartient bien au même owner pour empêcher un token qui se
+  // baladerait de jouer les playlists d'un autre streamer.
+  server.get<{ Params: { token: string; playlistId: string } }>(
+    '/overlay/playlist/:token/:playlistId',
+    async (request, reply) => {
+      const overlay = await findOverlayByToken(request.params.token)
+      if (!overlay || overlay.overlayType !== 'playlist' || !overlay.createdBy) {
+        return reply.code(404).send({ ok: false, error: 'not_found' })
+      }
+      const pl = await getPlaylist(request.params.playlistId)
+      if (!pl) return reply.code(404).send({ ok: false, error: 'playlist_not_found' })
+      if (pl.ownerUserId !== overlay.createdBy) {
+        return reply.code(403).send({ ok: false, error: 'cross_owner_forbidden' })
+      }
+      const tracks = await listTracksInPlaylist(pl.id)
+      return reply.send({
+        ok: true,
+        playlist: {
+          id:          pl.id,
+          name:        pl.name,
+          description: pl.description,
+          color:       pl.color,
+        },
+        tracks,
+      })
+    },
+  )
 
   // GET /stats  — admin only — totaux + séries journalières des events EventSub
   // sur les N derniers jours (default 7, max 30). Sert à alimenter les sparklines

--- a/nodyx-core/src/services/streamer/audioPlaylistService.ts
+++ b/nodyx-core/src/services/streamer/audioPlaylistService.ts
@@ -1,0 +1,308 @@
+// ─── Streamer Hub — Soundboard playlists service ────────────────────────────
+// CRUD playlists + gestion des tracks (add/remove/reorder). Les playlists
+// permettent au streamer de grouper ses sons par contexte (intro, dev,
+// discussion, hype...) au lieu d'une liste plate. Un track peut être dans
+// plusieurs playlists, et les playlists ont leur propre visibilité (publique
+// = exposée sur /soundboard pour les viewers, privée = admin only).
+//
+// Lien avec audioLibraryService : les playlists pointent vers des tracks
+// via streamer_audio_playlist_tracks. Si un track est supprimé, ON DELETE
+// CASCADE le retire de toutes les playlists automatiquement.
+
+import { db } from '../../config/database'
+import type { AudioTrack } from './audioLibraryService'
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type PlaylistVisibility = 'private' | 'public'
+
+export interface AudioPlaylist {
+  id:           string
+  ownerUserId:  string
+  name:         string
+  description:  string | null
+  color:        string | null
+  visibility:   PlaylistVisibility
+  position:     number
+  trackCount:   number
+  createdAt:    Date
+  updatedAt:    Date
+}
+
+interface AudioPlaylistRow {
+  id:             string
+  owner_user_id:  string
+  name:           string
+  description:    string | null
+  color:          string | null
+  visibility:     PlaylistVisibility
+  position:       number
+  track_count:    string             // pg COUNT() retourne en string
+  created_at:     Date
+  updated_at:     Date
+}
+
+function rowToPlaylist(r: AudioPlaylistRow): AudioPlaylist {
+  return {
+    id:           r.id,
+    ownerUserId:  r.owner_user_id,
+    name:         r.name,
+    description:  r.description,
+    color:        r.color,
+    visibility:   r.visibility,
+    position:     r.position,
+    trackCount:   parseInt(r.track_count, 10) || 0,
+    createdAt:    r.created_at,
+    updatedAt:    r.updated_at,
+  }
+}
+
+const SELECT_COLS = `
+  p.id, p.owner_user_id, p.name, p.description, p.color,
+  p.visibility, p.position, p.created_at, p.updated_at,
+  (SELECT COUNT(*)::text FROM streamer_audio_playlist_tracks pt WHERE pt.playlist_id = p.id) AS track_count
+`
+
+// ── List / get ─────────────────────────────────────────────────────────────
+
+export async function listPlaylistsForOwner(ownerUserId: string): Promise<AudioPlaylist[]> {
+  const r = await db.query<AudioPlaylistRow>(
+    `SELECT ${SELECT_COLS} FROM streamer_audio_playlists p
+     WHERE p.owner_user_id = $1
+     ORDER BY p.position ASC, p.created_at ASC`,
+    [ownerUserId],
+  )
+  return r.rows.map(rowToPlaylist)
+}
+
+// Pour la page publique /soundboard : retourne uniquement les playlists
+// publiques d'un owner, dans l'ordre choisi par celui-ci.
+export async function listPublicPlaylists(ownerUserId: string): Promise<AudioPlaylist[]> {
+  const r = await db.query<AudioPlaylistRow>(
+    `SELECT ${SELECT_COLS} FROM streamer_audio_playlists p
+     WHERE p.owner_user_id = $1 AND p.visibility = 'public'
+     ORDER BY p.position ASC, p.created_at ASC`,
+    [ownerUserId],
+  )
+  return r.rows.map(rowToPlaylist)
+}
+
+export async function getPlaylist(id: string): Promise<AudioPlaylist | null> {
+  const r = await db.query<AudioPlaylistRow>(
+    `SELECT ${SELECT_COLS} FROM streamer_audio_playlists p WHERE p.id = $1`,
+    [id],
+  )
+  return r.rows[0] ? rowToPlaylist(r.rows[0]) : null
+}
+
+// ── Create / update / delete ───────────────────────────────────────────────
+
+export interface CreatePlaylistInput {
+  ownerUserId:  string
+  name:         string
+  description?: string
+  color?:       string
+  visibility?:  PlaylistVisibility
+}
+
+export async function createPlaylist(input: CreatePlaylistInput): Promise<AudioPlaylist | null> {
+  // Position = max actuel + 1 pour mettre la nouvelle playlist en fin de liste.
+  const maxR = await db.query<{ max_pos: number | null }>(
+    `SELECT MAX(position) AS max_pos FROM streamer_audio_playlists WHERE owner_user_id = $1`,
+    [input.ownerUserId],
+  )
+  const nextPos = (maxR.rows[0]?.max_pos ?? -1) + 1
+
+  try {
+    const r = await db.query<{ id: string }>(
+      `INSERT INTO streamer_audio_playlists
+         (owner_user_id, name, description, color, visibility, position)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id`,
+      [
+        input.ownerUserId,
+        input.name.slice(0, 100),
+        input.description?.slice(0, 500) ?? null,
+        input.color ?? null,
+        input.visibility ?? 'private',
+        nextPos,
+      ],
+    )
+    return getPlaylist(r.rows[0].id)
+  } catch (err) {
+    const msg = (err as { message?: string }).message ?? ''
+    if (msg.includes('duplicate key') && msg.includes('owner_user_id_name_key')) {
+      // Nom déjà pris pour cet owner. On laisse remonter pour que la route
+      // renvoie une 409 explicite.
+      throw new Error('playlist_name_taken')
+    }
+    throw err
+  }
+}
+
+export interface UpdatePlaylistInput {
+  name?:        string
+  description?: string | null
+  color?:       string | null
+  visibility?:  PlaylistVisibility
+}
+
+export async function updatePlaylist(id: string, patch: UpdatePlaylistInput): Promise<AudioPlaylist | null> {
+  const sets: string[] = []
+  const vals: unknown[] = []
+  let idx = 1
+  const push = (col: string, v: unknown): void => { sets.push(`${col} = $${idx++}`); vals.push(v) }
+
+  if (patch.name        !== undefined) push('name',        patch.name.slice(0, 100))
+  if (patch.description !== undefined) push('description', patch.description?.slice(0, 500) ?? null)
+  if (patch.color       !== undefined) push('color',       patch.color)
+  if (patch.visibility  !== undefined) push('visibility',  patch.visibility)
+
+  if (sets.length === 0) return getPlaylist(id)
+
+  sets.push(`updated_at = NOW()`)
+  vals.push(id)
+  try {
+    await db.query(
+      `UPDATE streamer_audio_playlists SET ${sets.join(', ')} WHERE id = $${idx}`,
+      vals,
+    )
+  } catch (err) {
+    const msg = (err as { message?: string }).message ?? ''
+    if (msg.includes('duplicate key') && msg.includes('owner_user_id_name_key')) {
+      throw new Error('playlist_name_taken')
+    }
+    throw err
+  }
+  return getPlaylist(id)
+}
+
+export async function deletePlaylist(id: string, ownerUserId: string): Promise<boolean> {
+  const r = await db.query(
+    `DELETE FROM streamer_audio_playlists WHERE id = $1 AND owner_user_id = $2`,
+    [id, ownerUserId],
+  )
+  return (r.rowCount ?? 0) > 0
+}
+
+// Réordonne la sidebar des playlists. ids = ordre désiré, on les remet de
+// 0 à N-1. Filtre côté caller pour ne pas accepter des ids d'autres owners.
+export async function reorderPlaylists(ownerUserId: string, ids: string[]): Promise<void> {
+  if (ids.length === 0) return
+  await db.query('BEGIN')
+  try {
+    for (let i = 0; i < ids.length; i++) {
+      await db.query(
+        `UPDATE streamer_audio_playlists
+           SET position = $1, updated_at = NOW()
+         WHERE id = $2 AND owner_user_id = $3`,
+        [i, ids[i], ownerUserId],
+      )
+    }
+    await db.query('COMMIT')
+  } catch (err) {
+    await db.query('ROLLBACK').catch(() => {})
+    throw err
+  }
+}
+
+// ── Tracks management ──────────────────────────────────────────────────────
+
+// Ajoute un track à une playlist. Position = fin de liste (max + 1).
+// Idempotent : si déjà présent, no-op silencieux (pas d'erreur).
+export async function addTrackToPlaylist(playlistId: string, trackId: string): Promise<boolean> {
+  const maxR = await db.query<{ max_pos: number | null }>(
+    `SELECT MAX(position) AS max_pos FROM streamer_audio_playlist_tracks WHERE playlist_id = $1`,
+    [playlistId],
+  )
+  const nextPos = (maxR.rows[0]?.max_pos ?? -1) + 1
+
+  const r = await db.query(
+    `INSERT INTO streamer_audio_playlist_tracks (playlist_id, track_id, position)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (playlist_id, track_id) DO NOTHING`,
+    [playlistId, trackId, nextPos],
+  )
+  return (r.rowCount ?? 0) > 0
+}
+
+export async function removeTrackFromPlaylist(playlistId: string, trackId: string): Promise<boolean> {
+  const r = await db.query(
+    `DELETE FROM streamer_audio_playlist_tracks WHERE playlist_id = $1 AND track_id = $2`,
+    [playlistId, trackId],
+  )
+  return (r.rowCount ?? 0) > 0
+}
+
+// Réordonne les tracks dans une playlist. Même pattern que reorderPlaylists.
+export async function reorderTracksInPlaylist(playlistId: string, trackIds: string[]): Promise<void> {
+  if (trackIds.length === 0) return
+  await db.query('BEGIN')
+  try {
+    for (let i = 0; i < trackIds.length; i++) {
+      await db.query(
+        `UPDATE streamer_audio_playlist_tracks
+           SET position = $1
+         WHERE playlist_id = $2 AND track_id = $3`,
+        [i, playlistId, trackIds[i]],
+      )
+    }
+    await db.query('COMMIT')
+  } catch (err) {
+    await db.query('ROLLBACK').catch(() => {})
+    throw err
+  }
+}
+
+// Liste les tracks d'une playlist, dans l'ordre, avec les colonnes complètes
+// du track (joint avec streamer_audio_library + community_assets pour les
+// file_path/mime_type, comme fait audioLibraryService).
+export async function listTracksInPlaylist(playlistId: string): Promise<AudioTrack[]> {
+  const r = await db.query(
+    `SELECT
+       l.id, l.owner_user_id, l.asset_id, l.visibility,
+       l.title, l.artist, l.album, l.duration_ms, l.thumbnail_url,
+       l.volume_default::text AS volume_default,
+       l.fade_in_ms, l.fade_out_ms, l.loop, l.royalty_free, l.tags,
+       l.created_at, l.updated_at,
+       a.file_path, a.mime_type
+     FROM streamer_audio_playlist_tracks pt
+     JOIN streamer_audio_library l ON l.id = pt.track_id
+     JOIN community_assets a ON a.id = l.asset_id
+     WHERE pt.playlist_id = $1
+     ORDER BY pt.position ASC, pt.added_at ASC`,
+    [playlistId],
+  )
+  // On reformatage minimal en AudioTrack pour matcher la shape attendue.
+  return r.rows.map((row): AudioTrack => ({
+    id:             row.id,
+    ownerUserId:    row.owner_user_id,
+    assetId:        row.asset_id,
+    visibility:     row.visibility,
+    title:          row.title,
+    artist:         row.artist,
+    album:          row.album,
+    durationMs:     row.duration_ms,
+    thumbnailUrl:   row.thumbnail_url,
+    fileUrl:        `/uploads/${row.file_path}`,
+    mimeType:       row.mime_type,
+    volumeDefault:  parseFloat(row.volume_default) || 1,
+    fadeInMs:       row.fade_in_ms,
+    fadeOutMs:      row.fade_out_ms,
+    loop:           row.loop,
+    royaltyFree:    row.royalty_free,
+    tags:           row.tags ?? [],
+    createdAt:      row.created_at,
+    updatedAt:      row.updated_at,
+  }))
+}
+
+// Liste les ids des playlists auxquelles appartient un track donné. Utile
+// pour afficher "ce track est dans 3 playlists" dans l'éditeur de track.
+export async function listPlaylistIdsForTrack(trackId: string): Promise<string[]> {
+  const r = await db.query<{ playlist_id: string }>(
+    `SELECT playlist_id FROM streamer_audio_playlist_tracks WHERE track_id = $1`,
+    [trackId],
+  )
+  return r.rows.map(x => x.playlist_id)
+}

--- a/nodyx-core/src/services/streamer/deckService.ts
+++ b/nodyx-core/src/services/streamer/deckService.ts
@@ -17,7 +17,20 @@ export type DeckActionType =
   | 'stop_audio'
   | 'pause_audio'
   | 'navigate_page'
+  | 'playlist_control'
   | 'noop'
+
+// Sous-commandes d'un bouton 'playlist_control'. 'play' optionnellement avec
+// playlistId pour switcher l'overlay sur cette playlist en un clic ; sans id,
+// reprend simplement la lecture en cours.
+export type PlaylistControlCmd =
+  | 'play'         // démarre / reprend (si playlistId fourni, switche dessus)
+  | 'pause'
+  | 'toggle'       // bascule play/pause (le plus utile au quotidien)
+  | 'skip'         // suivant
+  | 'prev'         // précédent
+  | 'stop'         // arrêt + reset cursor
+  | 'volume'       // ajuste le volume (delta négatif/positif ou absolu via mode)
 
 export interface DeckButton {
   id:        string
@@ -42,6 +55,13 @@ export type DeckActionPayload =
   | { type: 'stop_audio' }
   | { type: 'pause_audio' }
   | { type: 'navigate_page';    targetPageId?: string; pageJump?: 'next' | 'prev' | 'home' }
+  | {
+      type:        'playlist_control'
+      cmd:         PlaylistControlCmd
+      playlistId?: string          // requis pour 'play' switch, optionnel pour le reste
+      volumeMode?: 'delta' | 'absolute'  // pour 'volume' uniquement
+      volumeValue?: number               // delta [-1,1] ou absolu [0,1]
+    }
 
 export interface DeckPage {
   id:      string
@@ -109,8 +129,14 @@ function isValidActionType(t: unknown): t is DeckActionType {
   return (
     t === 'top_clips' || t === 'vod_marker' || t === 'chat_message' ||
     t === 'trigger_command' || t === 'play_audio' || t === 'stop_audio' ||
-    t === 'pause_audio' || t === 'navigate_page' || t === 'noop'
+    t === 'pause_audio' || t === 'navigate_page' ||
+    t === 'playlist_control' || t === 'noop'
   )
+}
+
+function isValidPlaylistCmd(c: unknown): c is PlaylistControlCmd {
+  return c === 'play' || c === 'pause' || c === 'toggle' ||
+         c === 'skip' || c === 'prev'  || c === 'stop' || c === 'volume'
 }
 
 function isValidPageJump(j: unknown): j is 'next' | 'prev' | 'home' {
@@ -181,6 +207,19 @@ function sanitizeButton(raw: unknown): DeckButton | null {
       const targetPageId = typeof rawAction.targetPageId === 'string' ? rawAction.targetPageId.slice(0, 64) : undefined
       const pageJump     = isValidPageJump(rawAction.pageJump) ? rawAction.pageJump : undefined
       action = { type: 'navigate_page', targetPageId, pageJump }
+      break
+    }
+    case 'playlist_control': {
+      const cmd = isValidPlaylistCmd(rawAction.cmd) ? rawAction.cmd : 'toggle'
+      const playlistId = typeof rawAction.playlistId === 'string' && rawAction.playlistId.length > 0
+        ? rawAction.playlistId.slice(0, 64)
+        : undefined
+      const volumeMode = rawAction.volumeMode === 'absolute' ? 'absolute' as const
+                       : rawAction.volumeMode === 'delta'    ? 'delta'    as const
+                       : undefined
+      const rawVol = Number(rawAction.volumeValue)
+      const volumeValue = Number.isFinite(rawVol) ? Math.max(-1, Math.min(1, rawVol)) : undefined
+      action = { type: 'playlist_control', cmd, playlistId, volumeMode, volumeValue }
       break
     }
     default:
@@ -487,6 +526,37 @@ export async function executeAction(action: DeckActionPayload, triggeredBy: stri
       // Navigation pilotée par le mobile (le client intercepte avant d'appeler
       // le backend). Si on arrive ici, c'est un fallback : ack vide.
       return { ok: true, message: '' }
+    }
+
+    case 'playlist_control': {
+      // Tous les overlays playlist du streamer écoutent la room
+      // `playlist:<ownerUserId>`. On émet la commande dessus, l'overlay
+      // l'applique localement (play/pause/skip/volume/switch). En l'absence
+      // d'overlay connecté, no-op silencieux comme pour audio:play.
+      const [{ listStreamers }, { io }] = await Promise.all([
+        import('./tokenService'),
+        import('../../socket/io'),
+      ])
+      const streamers = await listStreamers('twitch').catch(() => [])
+      const ownerUserId = streamers[0]?.userId
+      if (!ownerUserId || !io) return { ok: false, message: 'Stream non lié' }
+
+      io.of('/overlay').to(`playlist:${ownerUserId}`).emit('playlist:control', {
+        cmd:         action.cmd,
+        playlistId:  action.playlistId,
+        volumeMode:  action.volumeMode,
+        volumeValue: action.volumeValue,
+      })
+
+      const label = action.cmd === 'play'   ? '▶ Playlist'
+                  : action.cmd === 'pause'  ? '⏸ Pause'
+                  : action.cmd === 'toggle' ? '⏯ Toggle'
+                  : action.cmd === 'skip'   ? '⏭ Suivant'
+                  : action.cmd === 'prev'   ? '⏮ Précédent'
+                  : action.cmd === 'stop'   ? '⏹ Stop'
+                  : '🔊 Volume'
+      console.log(`[deck] playlist_control ${action.cmd} (by ${triggeredBy})`)
+      return { ok: true, message: label }
     }
   }
 }

--- a/nodyx-core/src/services/streamer/obsScenesService.ts
+++ b/nodyx-core/src/services/streamer/obsScenesService.ts
@@ -1,0 +1,360 @@
+// ─── Streamer Hub — Scènes OBS pilotées depuis Nodyx ─────────────────────────
+// Service CRUD pour les scènes du compositeur visuel. Une scène = un layout
+// 1920x1080 contenant N sources positionnées (overlays Nodyx ou URLs Browser
+// libres). Le streamer compose visuellement dans le hub puis colle les URLs
+// dans OBS (Phase A), ou laisse Nodyx pousser tout via OBS WebSocket (Phase B+).
+//
+// Voir migration 102_streamer_obs_scenes.sql pour la shape DB et le format
+// JSONB du layout. Le sanitize ci-dessous est l'unique point d'entrée qui
+// décide ce qui rentre en DB : si un client envoie un layout farfelu, on le
+// nettoie avant persistence (pas d'XSS sur les URLs Browser, pas de tailles
+// négatives, etc.).
+
+import { randomBytes } from 'node:crypto'
+import { db } from '../../config/database'
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+// Types de sources qu'on peut placer dans une scène. Mappés 1:1 sur les
+// overlays Nodyx token-gated, plus 'browser_source' (URL libre) et
+// 'placeholder_video' (cam/capture jeu : on les positionne en Phase A,
+// elles seront liées aux vraies sources OBS en Phase B/C).
+export type ObsSceneSourceType =
+  | 'alert_box'
+  | 'ticker'
+  | 'playlist'
+  | 'soundboard_osd'
+  | 'goal_bar'
+  | 'leaderboard'
+  | 'clips_player'
+  | 'stream_timer'
+  | 'browser_source'
+  | 'placeholder_video'
+
+const VALID_TYPES: ReadonlySet<ObsSceneSourceType> = new Set([
+  'alert_box', 'ticker', 'playlist', 'soundboard_osd',
+  'goal_bar', 'leaderboard', 'clips_player', 'stream_timer',
+  'browser_source', 'placeholder_video',
+])
+
+// Canvas de référence : 1920x1080 (16:9 1080p) côté backend. Le frontend
+// scale visuellement, mais on stocke en pixels absolus pour que Phase B
+// puisse pousser tel quel à OBS (qui travaille aussi en pixels absolus).
+export const CANVAS_WIDTH  = 1920
+export const CANVAS_HEIGHT = 1080
+
+export interface ObsSceneSource {
+  id:      string
+  type:    ObsSceneSourceType
+  label:   string
+  x:       number          // 0..CANVAS_WIDTH
+  y:       number          // 0..CANVAS_HEIGHT
+  w:       number          // 1..CANVAS_WIDTH
+  h:       number          // 1..CANVAS_HEIGHT
+  z:       number          // ordre de stack : plus grand = devant
+  visible: boolean
+  locked:  boolean
+  config:  Record<string, unknown>   // varie par type, validé client-side
+}
+
+// Fond de scène : couleur unie ou image (URL HTTPS), comme OBS qui laisse
+// poser une "Color Source" ou "Image Source" en arrière-plan. Optionnel :
+// si `kind = 'none'` la scène est transparente (sera composée sur l'OBS
+// canvas en Phase B+).
+export interface ObsSceneBackground {
+  kind:   'none' | 'color' | 'image'
+  color?: string       // hex #RRGGBB, requis si kind='color'
+  url?:   string       // URL HTTPS, requis si kind='image'
+}
+
+export interface ObsSceneLayout {
+  sources:     ObsSceneSource[]
+  background?: ObsSceneBackground
+}
+
+export interface ObsScene {
+  id:           string
+  ownerUserId:  string
+  name:         string
+  color:        string | null
+  layout:       ObsSceneLayout
+  position:     number
+  createdAt:    Date
+  updatedAt:    Date
+}
+
+interface ObsSceneRow {
+  id:             string
+  owner_user_id:  string
+  name:           string
+  color:          string | null
+  layout:         unknown
+  position:       number
+  created_at:     Date
+  updated_at:     Date
+}
+
+function rowToScene(r: ObsSceneRow): ObsScene {
+  return {
+    id:          r.id,
+    ownerUserId: r.owner_user_id,
+    name:        r.name,
+    color:       r.color,
+    layout:      sanitizeLayout(r.layout),
+    position:    r.position,
+    createdAt:   r.created_at,
+    updatedAt:   r.updated_at,
+  }
+}
+
+// ── Sanitize ───────────────────────────────────────────────────────────────
+
+function clampInt(v: unknown, lo: number, hi: number, fallback: number): number {
+  const n = Number(v)
+  if (!Number.isFinite(n)) return fallback
+  return Math.max(lo, Math.min(hi, Math.floor(n)))
+}
+
+// URL Browser Source : on accepte http/https uniquement. Pas de javascript:,
+// pas de data:, pas de file:. Tronquée à 2KB (raisonnable pour des URLs de
+// widget OBS classiques avec query params).
+function sanitizeBrowserUrl(raw: unknown): string {
+  if (typeof raw !== 'string') return ''
+  const trimmed = raw.trim().slice(0, 2000)
+  if (!/^https?:\/\//i.test(trimmed)) return ''
+  return trimmed
+}
+
+function sanitizeSourceConfig(type: ObsSceneSourceType, raw: unknown): Record<string, unknown> {
+  const r = (raw && typeof raw === 'object') ? raw as Record<string, unknown> : {}
+  switch (type) {
+    case 'alert_box':
+    case 'ticker':
+    case 'soundboard_osd':
+    case 'goal_bar':
+    case 'leaderboard':
+    case 'clips_player':
+    case 'stream_timer':
+      // Ces sources sont des overlays Nodyx token-gated. On garde
+      // l'overlayToken si fourni : le frontend résoudra l'URL preview à
+      // partir du token (et le bridge OBS Phase B+ poussera l'URL réelle).
+      return {
+        overlayToken: typeof r.overlayToken === 'string' ? r.overlayToken.slice(0, 64) : undefined,
+      }
+    case 'playlist':
+      return {
+        overlayToken: typeof r.overlayToken === 'string' ? r.overlayToken.slice(0, 64) : undefined,
+        playlistId:   typeof r.playlistId   === 'string' ? r.playlistId.slice(0, 64)   : undefined,
+        shuffle:      r.shuffle === true,
+        volume:       Number.isFinite(Number(r.volume)) ? Math.max(0, Math.min(1, Number(r.volume))) : undefined,
+      }
+    case 'browser_source':
+      return { url: sanitizeBrowserUrl(r.url) }
+    case 'placeholder_video':
+      // Hint visuel pour l'admin (cam / capture / image). On stocke juste un
+      // label de catégorie ; le bridge OBS choisira la vraie source plus tard.
+      return {
+        kind: r.kind === 'webcam' || r.kind === 'capture' || r.kind === 'image' ? r.kind : 'webcam',
+      }
+  }
+}
+
+function sanitizeSource(raw: unknown): ObsSceneSource | null {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  if (typeof r.type !== 'string' || !VALID_TYPES.has(r.type as ObsSceneSourceType)) return null
+  const type = r.type as ObsSceneSourceType
+
+  const x = clampInt(r.x, 0, CANVAS_WIDTH  - 1, 0)
+  const y = clampInt(r.y, 0, CANVAS_HEIGHT - 1, 0)
+  const w = clampInt(r.w, 1, CANVAS_WIDTH,  320)
+  const h = clampInt(r.h, 1, CANVAS_HEIGHT, 180)
+  const z = clampInt(r.z, 0, 999, 0)
+
+  const id      = typeof r.id    === 'string' && r.id.length > 0 ? r.id.slice(0, 64) : 'src_' + randomBytes(6).toString('hex')
+  const label   = typeof r.label === 'string' ? r.label.slice(0, 60) : ''
+  const visible = r.visible !== false
+  const locked  = r.locked  === true
+  const config  = sanitizeSourceConfig(type, r.config)
+
+  return { id, type, label, x, y, w, h, z, visible, locked, config }
+}
+
+function sanitizeBackground(raw: unknown): ObsSceneBackground | undefined {
+  if (!raw || typeof raw !== 'object') return undefined
+  const r = raw as Record<string, unknown>
+  const kind = r.kind === 'color' || r.kind === 'image' ? r.kind : 'none'
+  if (kind === 'none') return { kind: 'none' }
+  if (kind === 'color') {
+    const color = typeof r.color === 'string' && /^#[0-9a-fA-F]{6}$/.test(r.color) ? r.color : '#000000'
+    return { kind: 'color', color }
+  }
+  // image : URL HTTPS uniquement, même garde-fou que browser_source.
+  const url = typeof r.url === 'string' && /^https?:\/\//i.test(r.url.trim()) ? r.url.trim().slice(0, 2000) : ''
+  if (!url) return { kind: 'none' }
+  return { kind: 'image', url }
+}
+
+export function sanitizeLayout(raw: unknown): ObsSceneLayout {
+  if (!raw || typeof raw !== 'object') return { sources: [] }
+  const r = raw as Record<string, unknown>
+  const rawSources = Array.isArray(r.sources) ? r.sources : []
+  // Cap dur sur le nombre de sources par scène : 32 c'est large pour un
+  // streamer typique (5-10 sources/scène), évite un layout pathologique
+  // qui ralentirait le rendu preview iframes.
+  const sources = rawSources
+    .slice(0, 32)
+    .map(sanitizeSource)
+    .filter((s): s is ObsSceneSource => s !== null)
+  const background = sanitizeBackground(r.background)
+  return background ? { sources, background } : { sources }
+}
+
+// ── List / get ─────────────────────────────────────────────────────────────
+
+export async function listScenesForOwner(ownerUserId: string): Promise<ObsScene[]> {
+  const r = await db.query<ObsSceneRow>(
+    `SELECT id, owner_user_id, name, color, layout, position, created_at, updated_at
+       FROM streamer_obs_scenes
+      WHERE owner_user_id = $1
+      ORDER BY position ASC, created_at ASC`,
+    [ownerUserId],
+  )
+  return r.rows.map(rowToScene)
+}
+
+export async function getScene(id: string): Promise<ObsScene | null> {
+  const r = await db.query<ObsSceneRow>(
+    `SELECT id, owner_user_id, name, color, layout, position, created_at, updated_at
+       FROM streamer_obs_scenes WHERE id = $1`,
+    [id],
+  )
+  return r.rows[0] ? rowToScene(r.rows[0]) : null
+}
+
+// ── Create / update / delete ───────────────────────────────────────────────
+
+export interface CreateSceneInput {
+  ownerUserId: string
+  name:        string
+  color?:      string | null
+  layout?:     unknown
+}
+
+export async function createScene(input: CreateSceneInput): Promise<ObsScene | null> {
+  const maxR = await db.query<{ max_pos: number | null }>(
+    `SELECT MAX(position) AS max_pos FROM streamer_obs_scenes WHERE owner_user_id = $1`,
+    [input.ownerUserId],
+  )
+  const nextPos = (maxR.rows[0]?.max_pos ?? -1) + 1
+  const layout  = sanitizeLayout(input.layout)
+
+  try {
+    const r = await db.query<{ id: string }>(
+      `INSERT INTO streamer_obs_scenes (owner_user_id, name, color, layout, position)
+       VALUES ($1, $2, $3, $4::jsonb, $5)
+       RETURNING id`,
+      [
+        input.ownerUserId,
+        input.name.slice(0, 80),
+        input.color ?? null,
+        JSON.stringify(layout),
+        nextPos,
+      ],
+    )
+    return getScene(r.rows[0].id)
+  } catch (err) {
+    const msg = (err as { message?: string }).message ?? ''
+    if (msg.includes('duplicate key') && msg.includes('owner_user_id_name_key')) {
+      throw new Error('scene_name_taken')
+    }
+    throw err
+  }
+}
+
+export interface UpdateSceneInput {
+  name?:   string
+  color?:  string | null
+  layout?: unknown
+}
+
+export async function updateScene(id: string, patch: UpdateSceneInput): Promise<ObsScene | null> {
+  const sets: string[] = []
+  const vals: unknown[] = []
+  let idx = 1
+  const push = (col: string, v: unknown): void => { sets.push(`${col} = $${idx++}`); vals.push(v) }
+
+  if (patch.name   !== undefined) push('name',  patch.name.slice(0, 80))
+  if (patch.color  !== undefined) push('color', patch.color)
+  if (patch.layout !== undefined) push('layout', JSON.stringify(sanitizeLayout(patch.layout)))
+
+  if (sets.length === 0) return getScene(id)
+
+  sets.push(`updated_at = NOW()`)
+  vals.push(id)
+  try {
+    await db.query(
+      `UPDATE streamer_obs_scenes SET ${sets.join(', ')} WHERE id = $${idx}`,
+      vals,
+    )
+  } catch (err) {
+    const msg = (err as { message?: string }).message ?? ''
+    if (msg.includes('duplicate key') && msg.includes('owner_user_id_name_key')) {
+      throw new Error('scene_name_taken')
+    }
+    throw err
+  }
+  return getScene(id)
+}
+
+export async function deleteScene(id: string, ownerUserId: string): Promise<boolean> {
+  const r = await db.query(
+    `DELETE FROM streamer_obs_scenes WHERE id = $1 AND owner_user_id = $2`,
+    [id, ownerUserId],
+  )
+  return (r.rowCount ?? 0) > 0
+}
+
+// Duplique une scène (utile : "Nouvelle scène basée sur Dev"). Le nom est
+// suffixé par un compteur si "X (copie)" est déjà pris.
+export async function duplicateScene(id: string, ownerUserId: string): Promise<ObsScene | null> {
+  const src = await getScene(id)
+  if (!src || src.ownerUserId !== ownerUserId) return null
+  let candidate = `${src.name} (copie)`.slice(0, 80)
+  for (let i = 2; i < 99; i++) {
+    try {
+      return await createScene({
+        ownerUserId,
+        name:   candidate,
+        color:  src.color,
+        layout: src.layout,
+      })
+    } catch (err) {
+      if ((err as Error).message !== 'scene_name_taken') throw err
+      candidate = `${src.name} (copie ${i})`.slice(0, 80)
+    }
+  }
+  return null
+}
+
+// Réordonne les scènes dans la sidebar. Pattern transactionnel partagé avec
+// reorderPlaylists : on autorise des positions intermédiaires en doublon
+// pendant la séquence d'UPDATE pour éviter une contrainte tueuse.
+export async function reorderScenes(ownerUserId: string, ids: string[]): Promise<void> {
+  if (ids.length === 0) return
+  await db.query('BEGIN')
+  try {
+    for (let i = 0; i < ids.length; i++) {
+      await db.query(
+        `UPDATE streamer_obs_scenes
+            SET position = $1, updated_at = NOW()
+          WHERE id = $2 AND owner_user_id = $3`,
+        [i, ids[i], ownerUserId],
+      )
+    }
+    await db.query('COMMIT')
+  } catch (err) {
+    await db.query('ROLLBACK').catch(() => {})
+    throw err
+  }
+}

--- a/nodyx-core/src/services/streamer/overlayService.ts
+++ b/nodyx-core/src/services/streamer/overlayService.ts
@@ -17,9 +17,10 @@ export type OverlayType =
   | 'leaderboard'
   | 'clips_player'
   | 'soundboard'
+  | 'playlist'
 
 const VALID_TYPES: ReadonlySet<OverlayType> = new Set([
-  'alert_box', 'goal_bar', 'stream_timer', 'event_ticker', 'leaderboard', 'clips_player', 'soundboard',
+  'alert_box', 'goal_bar', 'stream_timer', 'event_ticker', 'leaderboard', 'clips_player', 'soundboard', 'playlist',
 ])
 
 // ── Soundboard ──────────────────────────────────────────────────────────────
@@ -506,6 +507,23 @@ export async function findOverlayByToken(token: string): Promise<OverlayRow | nu
   const r = await db.query<OverlayRowDb>(
     `SELECT * FROM streamer_overlays WHERE token = $1 AND revoked_at IS NULL LIMIT 1`,
     [token],
+  )
+  return r.rows[0] ? rowToPublic(r.rows[0]) : null
+}
+
+// Le premier overlay actif d'un type donné créé par un owner. Sert au pattern
+// "ensure" : l'overlay playlist est unique par streamer (un seul token, qui
+// permet d'embarquer N'IMPORTE laquelle de ses playlists via ?id=). On évite
+// ainsi de polluer la liste des overlays avec une entrée par playlist.
+export async function findOverlayByOwnerAndType(
+  ownerUserId: string,
+  overlayType: OverlayType,
+): Promise<OverlayRow | null> {
+  const r = await db.query<OverlayRowDb>(
+    `SELECT * FROM streamer_overlays
+     WHERE created_by = $1 AND overlay_type = $2 AND revoked_at IS NULL
+     ORDER BY created_at ASC LIMIT 1`,
+    [ownerUserId, overlayType],
   )
   return r.rows[0] ? rowToPublic(r.rows[0]) : null
 }

--- a/nodyx-core/src/socket/overlay.ts
+++ b/nodyx-core/src/socket/overlay.ts
@@ -50,6 +50,14 @@ export function registerOverlayNamespace(server: Server): void {
       socket.join(`soundboard:${createdBy}`)
     }
 
+    // Playlist : un overlay par scène OBS peut tourner en parallèle, tous
+    // dans la même room. Quand le streamer presse un bouton "playlist_control"
+    // sur son Deck, le service envoie un event `playlist:control` à cette
+    // room et chaque overlay applique localement (play/pause/skip/volume).
+    if (overlayType === 'playlist' && createdBy) {
+      socket.join(`playlist:${createdBy}`)
+    }
+
     // Trace last connection pour le debug admin ("dernière connexion OBS").
     touchOverlayLastSeen(overlayId).catch(() => {})
 

--- a/nodyx-frontend/src/lib/components/admin/DeckEditor.svelte
+++ b/nodyx-frontend/src/lib/components/admin/DeckEditor.svelte
@@ -385,6 +385,20 @@
 		})
 		: audioTracks)
 
+	// Playlists du streamer : utilisées par le picker du bouton
+	// playlist_control quand cmd='play' (sélection de la playlist à démarrer).
+	interface PlaylistLite { id: string; name: string; color: string | null; trackCount: number }
+	let playlistsList = $state<PlaylistLite[]>([])
+	async function loadPlaylistsList(): Promise<void> {
+		try {
+			const res = await apiFetch(fetch, '/streamer/audio-library/playlists', { headers: { Authorization: `Bearer ${token}` } })
+			if (res.ok) {
+				const d = await res.json() as { playlists: PlaylistLite[] }
+				playlistsList = d.playlists ?? []
+			}
+		} catch { /* silencieux : la liste reste vide, l'éditeur reste utilisable */ }
+	}
+
 	function audioPickerThumb(t: AudioTrackLite): string {
 		// Les thumbnails sont des URL relatives /uploads/... renvoyées par le backend.
 		// PUBLIC_API_URL pointe vers /api/v1, on remonte d'un cran.
@@ -460,7 +474,7 @@
 		flash(`Bouton déplacé sur "${target.name}".`, true)
 	}
 
-	onMount(() => { loadClipsOverlays(); loadCustomCommands(); loadAudioTracks() })
+	onMount(() => { loadClipsOverlays(); loadCustomCommands(); loadAudioTracks(); loadPlaylistsList() })
 
 	function isCellOccupied(x: number, y: number, exceptId: string | null): boolean {
 		if (!currentPage) return false
@@ -972,6 +986,9 @@
 							<option value="stop_audio">⏹ Couper tous les sons</option>
 							<option value="pause_audio">⏸ Mettre en pause</option>
 						</optgroup>
+						<optgroup label="Playlist (overlay OBS)">
+							<option value="playlist_control">🎛 Contrôle playlist</option>
+						</optgroup>
 						<optgroup label="Navigation">
 							<option value="navigate_page">📑 Aller à une page</option>
 						</optgroup>
@@ -1110,6 +1127,73 @@
 					{:else if selected.action.type === 'pause_audio'}
 						<div class="mt-2 text-[10px] text-slate-400 bg-slate-900/40 border border-slate-700/60 rounded px-2 py-1.5 leading-snug">
 							Met en pause la piste en cours. Ré-appuyer sur le bouton Jouer la reprend.
+						</div>
+					{:else if selected.action.type === 'playlist_control'}
+						<!-- Picker commande playlist : pilote l'overlay OBS via socket.
+						     Seul 'play' nécessite une playlist cible (switch). Le reste
+						     agit sur la playlist en cours. -->
+						<div class="mt-2 space-y-2">
+							<div class="flex items-center gap-1.5">
+								<span class="text-[9px] uppercase font-semibold text-slate-500">Commande</span>
+								<Tooltip text="play = démarre / switche sur une playlist précise. toggle = bascule lecture / pause. skip/prev = changer de piste. stop = arrête et remet à zéro. volume = ajuste le volume de l'overlay."/>
+							</div>
+							<select value={selected.action.cmd ?? 'toggle'}
+								onchange={(e) => updateAction({ cmd: e.currentTarget.value as 'play' | 'pause' | 'toggle' | 'skip' | 'prev' | 'stop' | 'volume' })}
+								class="w-full rounded bg-slate-950 border border-slate-700/60 focus:border-purple-500/60 px-2 py-1 text-xs text-white outline-none">
+								<option value="play">▶ Démarrer une playlist (switch)</option>
+								<option value="toggle">⏯ Play / Pause (toggle)</option>
+								<option value="pause">⏸ Pause</option>
+								<option value="skip">⏭ Suivant</option>
+								<option value="prev">⏮ Précédent</option>
+								<option value="stop">⏹ Stop + reset</option>
+								<option value="volume">🔊 Ajuster le volume</option>
+							</select>
+
+							{#if selected.action.cmd === 'play'}
+								<label class="block">
+									<span class="text-[9px] uppercase font-semibold text-slate-500">Playlist à démarrer</span>
+									{#if playlistsList.length > 0}
+										<select value={selected.action.playlistId ?? ''}
+											onchange={(e) => updateAction({ playlistId: e.currentTarget.value || undefined })}
+											class="mt-0.5 w-full rounded bg-slate-950 border border-slate-700/60 px-2 py-1 text-xs text-white outline-none focus:border-purple-500/60">
+											<option value="">— Choisir une playlist —</option>
+											{#each playlistsList as p (p.id)}
+												<option value={p.id}>{p.name} ({p.trackCount})</option>
+											{/each}
+										</select>
+									{:else}
+										<div class="mt-0.5 text-[10px] text-amber-300 bg-amber-500/10 border border-amber-500/30 rounded px-2 py-1.5">
+											Aucune playlist. Crée-en dans le tab Soundboard.
+										</div>
+									{/if}
+								</label>
+							{:else if selected.action.cmd === 'volume'}
+								<div class="grid grid-cols-2 gap-2">
+									<label class="block">
+										<span class="text-[9px] uppercase font-semibold text-slate-500">Mode</span>
+										<select value={selected.action.volumeMode ?? 'delta'}
+											onchange={(e) => updateAction({ volumeMode: e.currentTarget.value as 'delta' | 'absolute' })}
+											class="mt-0.5 w-full rounded bg-slate-950 border border-slate-700/60 px-2 py-1 text-xs text-white outline-none focus:border-purple-500/60">
+											<option value="delta">Relatif (+/-)</option>
+											<option value="absolute">Absolu (0-100%)</option>
+										</select>
+									</label>
+									<label class="block">
+										<span class="text-[9px] uppercase font-semibold text-slate-500">Valeur</span>
+										<input type="number" step="0.05" min={selected.action.volumeMode === 'absolute' ? 0 : -1} max="1"
+											value={selected.action.volumeValue ?? (selected.action.volumeMode === 'absolute' ? 0.6 : 0.05)}
+											oninput={(e) => updateAction({ volumeValue: Math.max(-1, Math.min(1, parseFloat(e.currentTarget.value) || 0)) })}
+											class="mt-0.5 w-full rounded bg-slate-950 border border-slate-700/60 px-2 py-1 text-xs text-white outline-none focus:border-purple-500/60"/>
+									</label>
+								</div>
+								<div class="text-[10px] text-slate-500 leading-snug">
+									Ex : <span class="text-slate-300 font-mono">delta +0.05</span> = bouton « Volume +5% », <span class="text-slate-300 font-mono">absolu 0.0</span> = mute.
+								</div>
+							{:else}
+								<div class="text-[10px] text-slate-400 bg-slate-900/40 border border-slate-700/60 rounded px-2 py-1.5 leading-snug">
+									Cette commande agit sur l'overlay playlist actuellement actif dans OBS.
+								</div>
+							{/if}
 						</div>
 					{:else if selected.action.type === 'navigate_page'}
 						<div class="mt-2 space-y-2">

--- a/nodyx-frontend/src/lib/components/admin/OverlayManager.svelte
+++ b/nodyx-frontend/src/lib/components/admin/OverlayManager.svelte
@@ -7,6 +7,24 @@
 	import EventTickerConfigEditor from './EventTickerConfigEditor.svelte'
 	import LeaderboardConfigEditor from './LeaderboardConfigEditor.svelte'
 	import StreamTimerConfigEditor from './StreamTimerConfigEditor.svelte'
+	import PlaceInSceneModal       from './obs/PlaceInSceneModal.svelte'
+	import { focusSceneAfterNav, consumeFocusedOverlayToken } from './obs/sceneNav'
+	import { onDestroy }            from 'svelte'
+	import type { ObsSceneSourceType } from '$lib/types/obsScenes'
+
+	// Quels types d'overlay backend peuvent être placés dans une scène Nodyx.
+	// playlist nécessite une playlistId qu'on ne peut pas demander ici sans le
+	// contexte Soundboard, donc on le route via le tab Soundboard où le streamer
+	// aura le bon picker.
+	const SCENE_PLACEABLE: Partial<Record<string, ObsSceneSourceType>> = {
+		alert_box:    'alert_box',
+		event_ticker: 'ticker',
+		soundboard:   'soundboard_osd',
+		goal_bar:     'goal_bar',
+		leaderboard:  'leaderboard',
+		clips_player: 'clips_player',
+		stream_timer: 'stream_timer',
+	}
 
 	interface Props {
 		token: string
@@ -14,7 +32,7 @@
 
 	let { token }: Props = $props()
 
-	type OverlayType = 'alert_box' | 'goal_bar' | 'stream_timer' | 'event_ticker' | 'leaderboard' | 'clips_player' | 'soundboard'
+	type OverlayType = 'alert_box' | 'goal_bar' | 'stream_timer' | 'event_ticker' | 'leaderboard' | 'clips_player' | 'soundboard' | 'playlist'
 
 	type OverlayRow = {
 		id:           string
@@ -37,12 +55,20 @@
 		leaderboard:  { label: 'Leaderboard',  desc: 'Podium top 3 + liste rang 4-N. 4 catégories (subs/bits/raids/chatteurs) × 4 périodes. Mode récap fin de stream.', routeSlug: 'board', ready: true },
 		clips_player: { label: 'Clips Player', desc: 'Player full screen qui joue une session de clips (top chaine ou raider) déclenchée depuis Studio Live.', routeSlug: 'clips', ready: true },
 		soundboard:   { label: 'Soundboard',   desc: 'Joue les sons déclenchés depuis ton Stream Deck. OSD discrète (vignette + titre + progress) en coin d\'écran. Crée plusieurs overlays si tu veux le son sur plusieurs scènes OBS.', routeSlug: 'soundboard', ready: true },
+		playlist:     { label: 'Playlist',     desc: 'Lit une de tes playlists Soundboard en autoplay loop pour servir de musique d\'ambiance. URL par playlist via le tab Soundboard (icône 📺). Token partagé, paramètre ?id=… pour cibler la playlist.', routeSlug: 'playlist', ready: true },
 	}
 
 	let overlays    = $state<OverlayRow[]>([])
 	let loading     = $state(true)
 	let toast       = $state<{ text: string; ok: boolean } | null>(null)
 	let configOpen  = $state<Set<string>>(new Set())   // ids overlays dont le panneau config est déplié
+
+	// Modal "Placer dans une scène" : id overlay actif, null = fermé. On
+	// expose token+label+type pour que la modal puisse créer la source.
+	let placeOverlay = $state<OverlayRow | null>(null)
+	const placeSceneType = $derived<ObsSceneSourceType | null>(
+		placeOverlay ? SCENE_PLACEABLE[placeOverlay.overlayType] ?? null : null,
+	)
 
 	function toggleConfig(id: string): void {
 		const next = new Set(configOpen)
@@ -61,15 +87,57 @@
 	}
 
 	async function reload(): Promise<void> {
-		const res = await apiFetch(fetch, '/streamer/overlays', { headers: { Authorization: `Bearer ${token}` } })
-		if (res.ok) {
-			const data = await res.json() as { overlays: OverlayRow[] }
-			overlays = data.overlays
+		// Loading est garanti à false en sortie, peu importe ce qui foire :
+		// réseau coupé, token expiré, JSON invalide. Sans ce try/finally, un
+		// throw silencieux laissait l'UI en "Chargement…" éternellement.
+		try {
+			const res = await apiFetch(fetch, '/streamer/overlays', { headers: { Authorization: `Bearer ${token}` } })
+			if (res.ok) {
+				const data = await res.json() as { overlays: OverlayRow[] }
+				overlays = data.overlays
+			} else if (res.status === 401) {
+				flash('Session expirée. Recharge la page.', false)
+			} else {
+				flash(`Chargement des overlays impossible (HTTP ${res.status}).`, false)
+			}
+		} catch (err) {
+			console.warn('[overlay-manager] reload failed', err)
+			flash('Erreur réseau au chargement des overlays.', false)
+		} finally {
+			loading = false
 		}
-		loading = false
 	}
 
-	onMount(() => { reload() })
+	// Si l'utilisateur arrive ici via "Modifier les couleurs / sons" depuis
+	// le tab Scènes, on déplie le panneau config de l'overlay ciblé et on
+	// scroll dessus. Token plutôt qu'id car c'est ce que la scène stocke.
+	function focusOverlay(targetToken: string): void {
+		const target = overlays.find(o => o.token === targetToken)
+		if (!target) return
+		const next = new Set(configOpen)
+		next.add(target.id)
+		configOpen = next
+		setTimeout(() => {
+			const el = document.getElementById(`overlay-row-${target.id}`)
+			if (el && 'scrollIntoView' in el) el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+		}, 80)
+	}
+
+	function onFocusEvent(e: Event): void {
+		const detail = (e as CustomEvent<{ token: string }>).detail
+		if (detail?.token) focusOverlay(detail.token)
+	}
+
+	onMount(() => {
+		void reload().then(() => {
+			const t = consumeFocusedOverlayToken()
+			if (t) focusOverlay(t)
+		})
+		window.addEventListener('nodyx:focus-overlay', onFocusEvent)
+	})
+	onDestroy(() => {
+		window.removeEventListener('nodyx:focus-overlay', onFocusEvent)
+	})
 
 	async function create(): Promise<void> {
 		if (creating) return
@@ -106,8 +174,16 @@
 		} else flash('Révocation échouée.', false)
 	}
 
+	// Fallback safe pour un type d'overlay inconnu (ex : nouveau type ajouté
+	// backend mais pas encore listé dans TYPE_META). Évite le crash render
+	// global qui bloquait toute la liste à "Chargement…" jusqu'au refresh.
+	const UNKNOWN_META = { label: 'Overlay', desc: 'Type inconnu côté admin.', routeSlug: 'unknown', ready: false }
+	function metaFor(t: OverlayType | string): { label: string; desc: string; routeSlug: string; ready: boolean } {
+		return (TYPE_META as Record<string, typeof UNKNOWN_META>)[t] ?? UNKNOWN_META
+	}
+
 	function urlFor(o: OverlayRow): string {
-		const meta = TYPE_META[o.overlayType]
+		const meta = metaFor(o.overlayType)
 		// L'overlay tourne sur le frontend (route SvelteKit /overlay/...), donc
 		// on prend l'origin du navigateur. En SSR (jamais ce composant), fallback
 		// chaine vide pour ne pas crasher.
@@ -192,9 +268,9 @@
 			</div>
 		{:else}
 			{#each overlays as o (o.id)}
-				{@const meta = TYPE_META[o.overlayType]}
+				{@const meta = metaFor(o.overlayType)}
 				{@const url  = urlFor(o)}
-				<div class="rounded-lg border border-slate-700/60 bg-slate-950/40 p-4 space-y-3">
+				<div id="overlay-row-{o.id}" class="rounded-lg border border-slate-700/60 bg-slate-950/40 p-4 space-y-3 scroll-mt-4 transition-colors {configOpen.has(o.id) ? 'border-purple-500/50' : ''}">
 					<div class="flex items-start justify-between gap-3 flex-wrap">
 						<div class="flex items-center gap-2.5">
 							<span class="text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded bg-cyan-500/15 text-cyan-300 border border-cyan-500/30">
@@ -207,7 +283,17 @@
 								</div>
 							</div>
 						</div>
-						<div class="flex items-center gap-1.5">
+						<div class="flex items-center gap-1.5 flex-wrap">
+							{#if SCENE_PLACEABLE[o.overlayType]}
+								<button type="button" onclick={() => placeOverlay = o}
+									class="text-[11px] text-purple-200 hover:text-white border border-purple-500/40 hover:border-purple-500/70 bg-purple-500/15 hover:bg-purple-500/25 px-2.5 py-1 rounded transition-colors inline-flex items-center gap-1.5 font-medium">
+									<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+										<rect x="3" y="3" width="18" height="18" rx="2"/>
+										<path d="M9 9h6v6H9z"/>
+									</svg>
+									Placer dans une scène
+								</button>
+							{/if}
 							{#if o.overlayType === 'alert_box' || o.overlayType === 'goal_bar' || o.overlayType === 'event_ticker' || o.overlayType === 'leaderboard' || o.overlayType === 'stream_timer'}
 								<button type="button" onclick={() => toggleConfig(o.id)}
 									class="text-[11px] text-cyan-300 hover:text-cyan-200 border border-cyan-500/30 hover:border-cyan-500/50 px-2.5 py-1 rounded transition-colors inline-flex items-center gap-1">
@@ -257,3 +343,21 @@
 		</div>
 	</details>
 </section>
+
+{#if placeOverlay && placeSceneType}
+	<PlaceInSceneModal
+		{token}
+		sourceType={placeSceneType}
+		sourceLabel={placeOverlay.label?.trim() || metaFor(placeOverlay.overlayType).label}
+		sourceConfig={{ overlayToken: placeOverlay.token }}
+		onPlaced={(sceneId, _sceneName, _isNew) => {
+			// On redirige systématiquement vers la scène ciblée. L'utilisateur
+			// vient de faire un placement : la suite logique est de voir le
+			// résultat et positionner. Le toast aurait été ignoré au profit
+			// de la transition de tab.
+			placeOverlay = null
+			focusSceneAfterNav(sceneId)
+		}}
+		onClose={() => placeOverlay = null}
+	/>
+{/if}

--- a/nodyx-frontend/src/lib/components/admin/PlaylistSidebar.svelte
+++ b/nodyx-frontend/src/lib/components/admin/PlaylistSidebar.svelte
@@ -1,0 +1,435 @@
+<script lang="ts">
+	import { apiFetch } from '$lib/api'
+	import { browser } from '$app/environment'
+	import SendToDeckModal from './SendToDeckModal.svelte'
+	import PlaceInSceneModal from './obs/PlaceInSceneModal.svelte'
+	import { focusSceneAfterNav } from './obs/sceneNav'
+	import type { DeckButton } from '$lib/types/deck'
+
+	// Sidebar de gauche du tab Soundboard : liste les playlists du streamer,
+	// permet d'en créer/renommer/supprimer/réordonner et émet la sélection
+	// vers le parent pour filtrer la bibliothèque affichée à droite.
+	//
+	// "Toutes les pistes" = pseudo-playlist en haut, selectedId === null.
+
+	export type PlaylistVisibility = 'private' | 'public'
+
+	export interface Playlist {
+		id:          string
+		ownerUserId: string
+		name:        string
+		description: string | null
+		color:       string | null
+		visibility:  PlaylistVisibility
+		position:    number
+		trackCount:  number
+		createdAt:   string
+		updatedAt:   string
+	}
+
+	interface Props {
+		token:               string
+		playlists:           Playlist[]
+		selectedPlaylistId:  string | null
+		onSelectPlaylist:    (id: string | null) => void
+		onPlaylistsChanged:  () => void
+	}
+
+	let {
+		token,
+		playlists,
+		selectedPlaylistId,
+		onSelectPlaylist,
+		onPlaylistsChanged,
+	}: Props = $props()
+
+	let creating = $state(false)
+	let newName  = $state('')
+	let busy     = $state(false)
+	let editingId = $state<string | null>(null)
+	let editName  = $state('')
+	let editColor = $state('')
+	let editVisibility = $state<PlaylistVisibility>('private')
+
+	let toast = $state<{ text: string; ok: boolean } | null>(null)
+	function flash(text: string, ok: boolean): void {
+		toast = { text, ok }
+		if (browser) setTimeout(() => { toast = null }, 3000)
+	}
+
+	// Token d'overlay "playlist" du streamer, lazy-loaded au premier appel à
+	// copyOverlayUrl. Un seul token par streamer, partagé entre toutes ses
+	// playlists. L'URL OBS prend la playlist en query (?id=).
+	let overlayToken = $state<string | null>(null)
+
+	// Modal "Placer dans une scène" pour une playlist donnée. On charge le
+	// token overlay playlist (ensure) avant d'ouvrir le modal pour avoir une
+	// config valide à passer.
+	let placePlaylist = $state<Playlist | null>(null)
+	let placeOverlayToken = $state<string | null>(null)
+
+	async function openPlaceInScene(p: Playlist): Promise<void> {
+		const t = await ensureOverlayToken()
+		if (!t) { flash('Impossible de récupérer le token overlay.', false); return }
+		placeOverlayToken = t
+		placePlaylist = p
+	}
+
+	async function ensureOverlayToken(): Promise<string | null> {
+		if (overlayToken) return overlayToken
+		// Pas de Content-Type ici : Fastify rejette tout POST déclarant
+		// application/json sans body (FST_ERR_CTP_EMPTY_JSON_BODY). On envoie
+		// la requête nue, le backend n'attend rien dans le body.
+		const res = await apiFetch(fetch, '/streamer/audio-library/playlists/overlay-token', {
+			method:  'POST',
+			headers: { Authorization: `Bearer ${token}` },
+		})
+		if (!res.ok) return null
+		const d = await res.json() as { token: string }
+		overlayToken = d.token
+		return overlayToken
+	}
+
+	// SendToDeckModal : ouvert avec un buttonTemplate déjà prêt selon ce que
+	// l'admin a choisi. null = fermé.
+	let deckModalTemplate = $state<Omit<DeckButton, 'id' | 'x' | 'y' | 'w' | 'h'> | null>(null)
+	let deckModalTitle    = $state('')
+	let deckModalSubtitle = $state('')
+
+	function openDeckModalStartPlaylist(p: Playlist): void {
+		// Bouton "Démarrer la playlist X" : couleur dérivée de la playlist
+		// pour qu'on retrouve visuellement le bouton dans le deck.
+		const accent = (p.color ?? '#a78bfa').replace('#', '').toLowerCase()
+		deckModalTemplate = {
+			label:     p.name.slice(0, 40),
+			icon:      '🎵',
+			iconScale: 1,
+			gradient:  `${accent}/8b5cf6`,
+			action:    { type: 'playlist_control', cmd: 'play', playlistId: p.id },
+		}
+		deckModalTitle    = 'Ajouter au Stream Deck'
+		deckModalSubtitle = `▶ Démarrer "${p.name}"`
+	}
+
+	function openDeckModalGlobal(cmd: 'toggle' | 'skip' | 'prev' | 'stop', label: string, icon: string): void {
+		deckModalTemplate = {
+			label,
+			icon,
+			iconScale: 1.4,
+			gradient:  'minimal',
+			action:    { type: 'playlist_control', cmd },
+		}
+		deckModalTitle    = 'Ajouter au Stream Deck'
+		deckModalSubtitle = label
+	}
+
+	async function copyOverlayUrl(p: Playlist): Promise<void> {
+		if (!browser) return
+		const t = await ensureOverlayToken()
+		if (!t) { flash('Impossible de générer le lien.', false); return }
+		const url = `${window.location.origin}/overlay/playlist/${t}?id=${p.id}`
+		try {
+			await navigator.clipboard.writeText(url)
+			flash(`Lien overlay "${p.name}" copié.`, true)
+		} catch {
+			// Fallback : on affiche le lien dans une prompt pour permettre la copie manuelle.
+			window.prompt('Copie ce lien dans OBS Browser Source :', url)
+		}
+	}
+
+	async function createOne(): Promise<void> {
+		const name = newName.trim()
+		if (!name || busy) return
+		busy = true
+		try {
+			const res = await apiFetch(fetch, '/streamer/audio-library/playlists', {
+				method:  'POST',
+				headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+				body:    JSON.stringify({ name }),
+			})
+			if (res.ok) {
+				newName = ''
+				creating = false
+				onPlaylistsChanged()
+			} else if (res.status === 409) {
+				flash('Une playlist avec ce nom existe déjà.', false)
+			} else {
+				flash('Création échouée.', false)
+			}
+		} finally {
+			busy = false
+		}
+	}
+
+	function startEdit(p: Playlist): void {
+		editingId = p.id
+		editName = p.name
+		editColor = p.color ?? ''
+		editVisibility = p.visibility
+	}
+
+	function cancelEdit(): void { editingId = null }
+
+	async function saveEdit(): Promise<void> {
+		if (!editingId || busy) return
+		busy = true
+		try {
+			const body: Record<string, unknown> = {
+				name:       editName.trim(),
+				color:      editColor.trim() || null,
+				visibility: editVisibility,
+			}
+			const res = await apiFetch(fetch, `/streamer/audio-library/playlists/${editingId}`, {
+				method:  'PATCH',
+				headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+				body:    JSON.stringify(body),
+			})
+			if (res.ok) {
+				editingId = null
+				onPlaylistsChanged()
+			} else if (res.status === 409) {
+				flash('Ce nom est déjà pris par une autre playlist.', false)
+			} else {
+				flash('Mise à jour échouée.', false)
+			}
+		} finally {
+			busy = false
+		}
+	}
+
+	async function deleteOne(p: Playlist): Promise<void> {
+		const msg = p.trackCount > 0
+			? `Supprimer la playlist "${p.name}" ? Les ${p.trackCount} sons restent dans ta bibliothèque, ils sont juste retirés de cette playlist.`
+			: `Supprimer la playlist "${p.name}" ?`
+		if (!confirm(msg)) return
+		busy = true
+		try {
+			const res = await apiFetch(fetch, `/streamer/audio-library/playlists/${p.id}`, {
+				method:  'DELETE',
+				headers: { Authorization: `Bearer ${token}` },
+			})
+			if (res.ok) {
+				if (selectedPlaylistId === p.id) onSelectPlaylist(null)
+				onPlaylistsChanged()
+			} else {
+				flash('Suppression échouée.', false)
+			}
+		} finally {
+			busy = false
+		}
+	}
+</script>
+
+<aside class="border border-zinc-800 bg-zinc-900 flex flex-col min-h-[400px]">
+	<header class="px-4 py-3 border-b border-zinc-800 flex items-center justify-between gap-2">
+		<h3 class="text-xs uppercase tracking-wide font-medium text-zinc-400">Playlists</h3>
+		{#if !creating}
+			<button type="button" onclick={() => { creating = true; newName = '' }}
+				class="text-xs inline-flex items-center gap-1 bg-purple-500/15 hover:bg-purple-500/25 border border-purple-500/40 hover:border-purple-500/70 text-purple-100 px-2 py-1 rounded-sm transition-colors font-medium"
+				title="Créer une playlist">
+				<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
+				Nouvelle
+			</button>
+		{/if}
+	</header>
+
+	{#if toast}
+		<div class="mx-2 my-1.5 border-l-2 px-2 py-1.5 text-[11px] flex items-center gap-2 {toast.ok ? 'border-emerald-500 bg-emerald-500/5 text-emerald-200' : 'border-rose-500 bg-rose-500/5 text-rose-200'}">
+			{toast.text}
+		</div>
+	{/if}
+
+	{#if creating}
+		<div class="px-2 py-2 border-b border-zinc-800 bg-zinc-950/50 flex items-center gap-1.5">
+			<input type="text" bind:value={newName} maxlength="100" placeholder="Nom (ex: Intro, Dev, Chill...)"
+				onkeydown={(e) => { if (e.key === 'Enter') createOne(); if (e.key === 'Escape') creating = false }}
+				class="flex-1 bg-zinc-900 border border-zinc-800 focus:border-purple-500/60 focus:ring-1 focus:ring-purple-500/20 px-2 py-1 text-xs text-zinc-100 placeholder-zinc-600 outline-none rounded-sm transition-colors"
+				autofocus/>
+			<button type="button" onclick={createOne} disabled={busy || !newName.trim()}
+				class="text-xs bg-purple-500 hover:bg-purple-400 disabled:bg-zinc-800 disabled:text-zinc-500 text-white px-2 py-1 rounded-sm transition-colors font-medium">
+				Créer
+			</button>
+			<button type="button" onclick={() => creating = false}
+				class="text-xs text-zinc-500 hover:text-zinc-300 px-1 transition-colors" title="Annuler">✕</button>
+		</div>
+	{/if}
+
+	<ul class="flex-1 overflow-y-auto py-1">
+		<!-- Toutes les pistes : sélection par défaut, pas un vrai item DB -->
+		<li class="relative">
+			<button type="button" onclick={() => onSelectPlaylist(null)}
+				class="w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors text-left
+					{selectedPlaylistId === null ? 'bg-purple-500/15 text-zinc-100' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/40'}">
+				{#if selectedPlaylistId === null}
+					<span class="absolute left-0 w-0.5 h-6 bg-purple-500"></span>
+				{/if}
+				<svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+					<path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>
+				</svg>
+				<span class="flex-1 truncate">Toutes les pistes</span>
+			</button>
+		</li>
+
+		{#each playlists as p (p.id)}
+			{@const isSelected = selectedPlaylistId === p.id}
+			{@const accent = p.color ?? '#a78bfa'}
+			<li class="group relative">
+				{#if editingId === p.id}
+					<div class="px-2 py-2 bg-zinc-950/60 flex flex-col gap-1.5">
+						<input type="text" bind:value={editName} maxlength="100"
+							class="bg-zinc-900 border border-zinc-800 focus:border-purple-500/60 px-2 py-1 text-xs text-zinc-100 outline-none rounded-sm"/>
+						<div class="flex items-center gap-1.5">
+							<label class="cursor-pointer relative shrink-0" title="Couleur d'accent">
+								<span class="block w-5 h-5 rounded-full ring-1 ring-white/20"
+									style="background: {editColor || '#a78bfa'};"></span>
+								<input type="color" value={editColor || '#a78bfa'}
+									oninput={(e) => editColor = e.currentTarget.value}
+									class="absolute inset-0 opacity-0 cursor-pointer w-full h-full"/>
+							</label>
+							<select bind:value={editVisibility}
+								class="flex-1 bg-zinc-900 border border-zinc-800 px-1.5 py-1 text-[11px] text-zinc-100 outline-none rounded-sm">
+								<option value="private">Privée</option>
+								<option value="public">Publique</option>
+							</select>
+						</div>
+						<div class="flex items-center gap-1.5">
+							<button type="button" onclick={saveEdit} disabled={busy}
+								class="flex-1 text-[11px] bg-purple-500 hover:bg-purple-400 disabled:opacity-50 text-white px-2 py-1 rounded-sm transition-colors font-medium">
+								OK
+							</button>
+							<button type="button" onclick={cancelEdit}
+								class="text-[11px] bg-zinc-800 hover:bg-zinc-700 text-zinc-200 px-2 py-1 rounded-sm transition-colors">
+								Annuler
+							</button>
+						</div>
+					</div>
+				{:else}
+					<button type="button" onclick={() => onSelectPlaylist(p.id)}
+						class="w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors text-left
+							{isSelected ? 'bg-purple-500/15 text-zinc-100' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/40'}">
+						{#if isSelected}
+							<span class="absolute left-0 w-0.5 h-6 bg-purple-500"></span>
+						{/if}
+						<span class="w-2 h-2 rounded-full shrink-0 ring-1 ring-white/10" style="background: {accent};"></span>
+						<span class="flex-1 truncate" title={p.name}>{p.name}</span>
+						<span class="text-[10px] text-zinc-600 font-mono">{p.trackCount}</span>
+						{#if p.visibility === 'public'}
+							<span class="text-[9px] uppercase tracking-wider font-bold text-purple-300 bg-purple-500/15 px-1 rounded-sm" title="Visible sur la page publique">pub</span>
+						{/if}
+					</button>
+					<!-- Boutons d'action en hover. Le bouton OBS est mis en avant
+					     visuellement parce que c'est la feature la plus utile pour
+					     un streamer : un clic = URL prête-à-coller. -->
+					<div class="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity bg-zinc-900/95 backdrop-blur-sm pl-1.5">
+						<button type="button" onclick={() => copyOverlayUrl(p)}
+							class="p-1 rounded text-purple-300 hover:text-purple-100 hover:bg-purple-500/20"
+							title="Copier le lien overlay OBS de cette playlist">
+							<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+								<rect x="2" y="6" width="20" height="12" rx="2"/>
+								<polyline points="10 10 14 12 10 14 10 10" fill="currentColor"/>
+							</svg>
+						</button>
+						<button type="button" onclick={() => openPlaceInScene(p)}
+							class="p-1 rounded text-sky-300 hover:text-sky-100 hover:bg-sky-500/20"
+							title="Placer cette playlist dans une scène">
+							<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+								<rect x="3" y="3" width="18" height="18" rx="2"/>
+								<path d="M9 9h6v6H9z"/>
+							</svg>
+						</button>
+						<button type="button" onclick={() => openDeckModalStartPlaylist(p)}
+							class="p-1 rounded text-emerald-300 hover:text-emerald-100 hover:bg-emerald-500/20"
+							title="Créer un bouton Stream Deck qui démarre cette playlist">
+							<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+								<rect x="3" y="4" width="18" height="14" rx="2"/>
+								<polygon points="10 9 16 12 10 15 10 9" fill="currentColor"/>
+							</svg>
+						</button>
+						<button type="button" onclick={() => startEdit(p)}
+							class="p-1 rounded text-zinc-500 hover:text-zinc-100 hover:bg-zinc-800/60" title="Éditer">
+							<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+						</button>
+						<button type="button" onclick={() => deleteOne(p)}
+							class="p-1 rounded text-zinc-500 hover:text-rose-300 hover:bg-rose-900/40" title="Supprimer">
+							<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6"/></svg>
+						</button>
+					</div>
+				{/if}
+			</li>
+		{/each}
+
+		{#if playlists.length === 0 && !creating}
+			<li class="px-3 py-4 text-[11px] text-zinc-500 text-center leading-snug">
+				Aucune playlist. Crée-en pour organiser tes sons par contexte (Intro, Dev, Chill...).
+			</li>
+		{/if}
+	</ul>
+
+	{#if playlists.length > 0}
+		<footer class="border-t border-zinc-800 px-2 py-2 space-y-1.5">
+			<!-- Hint découvrabilité des actions hover. -->
+			<div class="text-[10px] text-zinc-600 leading-snug flex items-start gap-1.5 px-1">
+				<svg class="w-3 h-3 mt-0.5 shrink-0 text-purple-400/70" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+					<rect x="2" y="6" width="20" height="12" rx="2"/>
+					<polyline points="10 10 14 12 10 14 10 10" fill="currentColor"/>
+				</svg>
+				<span>Survole une playlist : <span class="text-purple-300">📺</span> URL OBS, <span class="text-sky-300">🎬</span> Placer en scène, <span class="text-emerald-300">▶</span> Bouton Deck.</span>
+			</div>
+
+			<!-- Boutons "globaux" : pilotent l'overlay courant peu importe la
+			     playlist active. À ajouter au Deck une fois pour toutes. -->
+			<div class="px-1 pt-1 border-t border-zinc-800/50">
+				<div class="text-[9px] uppercase tracking-wider font-medium text-zinc-500 mb-1">Contrôles Deck généraux</div>
+				<div class="grid grid-cols-2 gap-1">
+					<button type="button" onclick={() => openDeckModalGlobal('toggle', 'Play / Pause', '⏯')}
+						class="text-[11px] inline-flex items-center justify-center gap-1 bg-zinc-800/60 hover:bg-zinc-800 border border-zinc-800 hover:border-purple-500/40 text-zinc-300 hover:text-zinc-100 px-1.5 py-1 rounded-sm transition-colors"
+						title="Ajouter un bouton Play/Pause au Stream Deck">
+						<span>⏯</span> Play/Pause
+					</button>
+					<button type="button" onclick={() => openDeckModalGlobal('skip', 'Suivant', '⏭')}
+						class="text-[11px] inline-flex items-center justify-center gap-1 bg-zinc-800/60 hover:bg-zinc-800 border border-zinc-800 hover:border-purple-500/40 text-zinc-300 hover:text-zinc-100 px-1.5 py-1 rounded-sm transition-colors"
+						title="Ajouter un bouton Suivant au Stream Deck">
+						<span>⏭</span> Skip
+					</button>
+					<button type="button" onclick={() => openDeckModalGlobal('prev', 'Précédent', '⏮')}
+						class="text-[11px] inline-flex items-center justify-center gap-1 bg-zinc-800/60 hover:bg-zinc-800 border border-zinc-800 hover:border-purple-500/40 text-zinc-300 hover:text-zinc-100 px-1.5 py-1 rounded-sm transition-colors"
+						title="Ajouter un bouton Précédent au Stream Deck">
+						<span>⏮</span> Prev
+					</button>
+					<button type="button" onclick={() => openDeckModalGlobal('stop', 'Stop', '⏹')}
+						class="text-[11px] inline-flex items-center justify-center gap-1 bg-zinc-800/60 hover:bg-zinc-800 border border-zinc-800 hover:border-purple-500/40 text-zinc-300 hover:text-zinc-100 px-1.5 py-1 rounded-sm transition-colors"
+						title="Ajouter un bouton Stop au Stream Deck">
+						<span>⏹</span> Stop
+					</button>
+				</div>
+			</div>
+		</footer>
+	{/if}
+</aside>
+
+{#if deckModalTemplate}
+	<SendToDeckModal
+		{token}
+		title={deckModalTitle}
+		subtitle={deckModalSubtitle}
+		buttonTemplate={deckModalTemplate}
+		onClose={() => deckModalTemplate = null}
+		onPlaced={() => flash('Bouton ajouté au Stream Deck.', true)}
+	/>
+{/if}
+
+{#if placePlaylist && placeOverlayToken}
+	<PlaceInSceneModal
+		{token}
+		sourceType="playlist"
+		sourceLabel={placePlaylist.name}
+		sourceConfig={{ overlayToken: placeOverlayToken, playlistId: placePlaylist.id }}
+		onPlaced={(sceneId, _sceneName, _isNew) => {
+			// Redirection systématique : qu'on ait créé la scène ou utilisé
+			// une existante, le streamer veut voir le résultat.
+			placePlaylist = null
+			focusSceneAfterNav(sceneId)
+		}}
+		onClose={() => placePlaylist = null}
+	/>
+{/if}

--- a/nodyx-frontend/src/lib/components/admin/SoundLibraryPanel.svelte
+++ b/nodyx-frontend/src/lib/components/admin/SoundLibraryPanel.svelte
@@ -5,6 +5,7 @@
 	import { PUBLIC_API_URL } from '$env/static/public'
 	import Tooltip from '$lib/components/ui/Tooltip.svelte'
 	import SendToDeckModal from './SendToDeckModal.svelte'
+	import PlaylistSidebar, { type Playlist } from './PlaylistSidebar.svelte'
 
 	// Soundboard / bibliothèque audio : upload mp3/ogg/wav, extraction ID3 (titre,
 	// artiste, durée, cover art), preview, édition (volume défaut, fade in/out,
@@ -43,6 +44,20 @@
 	let tracks    = $state<AudioTrack[]>([])
 	let loading   = $state(true)
 	let uploading = $state(false)
+
+	// Playlists : sidebar gauche. selectedPlaylistId = null => "Toutes les pistes"
+	// (comportement par défaut, on affiche `tracks`). Sinon on charge les tracks
+	// de la playlist via /streamer/audio-library/playlists/:id et on les filtre.
+	let playlists          = $state<Playlist[]>([])
+	let selectedPlaylistId = $state<string | null>(null)
+	let playlistTracks     = $state<AudioTrack[]>([])
+	let playlistTracksLoading = $state(false)
+
+	// Popover "ajouter à une playlist" pour un track donné. trackId qu'on a
+	// ouvert + Set des playlist ids dans lesquelles ce track est déjà.
+	let playlistMenuTrackId = $state<string | null>(null)
+	let playlistMenuMembership = $state<Set<string>>(new Set())
+	let playlistMenuBusy = $state(false)
 	let uploadProgress = $state<{ done: number; total: number; current: string; failed: number }>({ done: 0, total: 0, current: '', failed: 0 })
 	let toast     = $state<{ text: string; ok: boolean } | null>(null)
 
@@ -147,7 +162,12 @@
 		return SOUND_GRADIENTS[h % SOUND_GRADIENTS.length]
 	}
 
-	const filtered = $derived(tracks.filter(t => {
+	// Source des pistes selon la sélection sidebar :
+	//   - null  => toutes les pistes de l'owner (full library)
+	//   - <id>  => uniquement les pistes de cette playlist (chargées séparément)
+	const baseTracks = $derived(selectedPlaylistId === null ? tracks : playlistTracks)
+
+	const filtered = $derived(baseTracks.filter(t => {
 		if (visibilityFilter !== 'all' && t.visibility !== visibilityFilter) return false
 		if (query.trim()) {
 			const q = query.trim().toLowerCase()
@@ -188,6 +208,102 @@
 			}
 		} finally {
 			loading = false
+		}
+	}
+
+	async function loadPlaylists(): Promise<void> {
+		const res = await apiFetch(fetch, '/streamer/audio-library/playlists', {
+			headers: { Authorization: `Bearer ${token}` },
+		})
+		if (res.ok) {
+			const d = await res.json() as { playlists: Playlist[] }
+			playlists = d.playlists ?? []
+		}
+	}
+
+	// Recharge les tracks de la playlist sélectionnée (si une l'est).
+	async function loadPlaylistTracks(playlistId: string): Promise<void> {
+		playlistTracksLoading = true
+		try {
+			const res = await apiFetch(fetch, `/streamer/audio-library/playlists/${playlistId}`, {
+				headers: { Authorization: `Bearer ${token}` },
+			})
+			if (res.ok) {
+				const d = await res.json() as { tracks: AudioTrack[] }
+				playlistTracks = d.tracks ?? []
+			} else {
+				playlistTracks = []
+			}
+		} finally {
+			playlistTracksLoading = false
+		}
+	}
+
+	function onSelectPlaylist(id: string | null): void {
+		selectedPlaylistId = id
+		stopPreview()
+		closePlaylistMenu()
+		if (id) loadPlaylistTracks(id)
+		else playlistTracks = []
+	}
+
+	async function onPlaylistsChanged(): Promise<void> {
+		await loadPlaylists()
+		// Si la playlist active a disparu (delete), on revient sur "Toutes".
+		if (selectedPlaylistId && !playlists.some(p => p.id === selectedPlaylistId)) {
+			selectedPlaylistId = null
+			playlistTracks = []
+		}
+	}
+
+	// Popover "ajouter à playlists" pour un track : charge ses playlists ids et
+	// ouvre le menu. Re-cliquer sur le même track ferme le menu.
+	async function openPlaylistMenu(trackId: string): Promise<void> {
+		if (playlistMenuTrackId === trackId) {
+			closePlaylistMenu()
+			return
+		}
+		playlistMenuTrackId = trackId
+		playlistMenuMembership = new Set()
+		const res = await apiFetch(fetch, `/streamer/audio-library/${trackId}/playlists`, {
+			headers: { Authorization: `Bearer ${token}` },
+		})
+		if (res.ok) {
+			const d = await res.json() as { playlistIds: string[] }
+			playlistMenuMembership = new Set(d.playlistIds ?? [])
+		}
+	}
+
+	function closePlaylistMenu(): void {
+		playlistMenuTrackId = null
+		playlistMenuMembership = new Set()
+	}
+
+	async function toggleTrackInPlaylist(trackId: string, playlistId: string): Promise<void> {
+		if (playlistMenuBusy) return
+		playlistMenuBusy = true
+		const isIn = playlistMenuMembership.has(playlistId)
+		try {
+			const url = `/streamer/audio-library/playlists/${playlistId}/tracks${isIn ? `/${trackId}` : ''}`
+			const res = await apiFetch(fetch, url, {
+				method:  isIn ? 'DELETE' : 'POST',
+				headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+				body:    isIn ? undefined : JSON.stringify({ trackId }),
+			})
+			if (res.ok) {
+				// Update optimiste du membership
+				const next = new Set(playlistMenuMembership)
+				if (isIn) next.delete(playlistId)
+				else      next.add(playlistId)
+				playlistMenuMembership = next
+				// Refresh des compteurs sidebar + tracks playlist active si concernée
+				loadPlaylists()
+				if (selectedPlaylistId === playlistId) loadPlaylistTracks(playlistId)
+			} else {
+				flash('Échec mise à jour playlist.', false)
+			}
+		} finally {
+			playlistMenuBusy = false
 		}
 	}
 
@@ -352,6 +468,7 @@
 
 	onMount(() => {
 		loadTracks()
+		loadPlaylists()
 		loadQueue()
 		// Poll la queue toutes les 4s pour voir les ajouts viewers arriver en
 		// quasi temps réel sans surcharger (l'admin reste connecté à ce panel
@@ -518,6 +635,20 @@
 			onchange={(e) => handleFiles((e.currentTarget as HTMLInputElement).files)} disabled={uploading}/>
 	</label>
 
+	<!-- Layout 2 colonnes : sidebar playlists | bibliothèque filtrée -->
+	<div class="grid grid-cols-1 lg:grid-cols-[240px_minmax(0,1fr)] gap-4 items-start">
+		<!-- Sidebar : navigation par playlist -->
+		<PlaylistSidebar
+			{token}
+			{playlists}
+			{selectedPlaylistId}
+			{onSelectPlaylist}
+			{onPlaylistsChanged}
+		/>
+
+		<!-- Colonne droite : filtres + biblio -->
+		<div class="space-y-3">
+
 	<!-- Filtres + recherche -->
 	<div class="flex items-center gap-2 flex-wrap">
 		<div class="flex items-center gap-1 bg-zinc-900 border border-zinc-800 p-0.5 rounded-sm">
@@ -540,16 +671,28 @@
 
 	<!-- Liste : grille tabulaire. -->
 	<div>
-		<div class="flex items-baseline justify-between mb-2">
-			<h3 class="text-xs uppercase tracking-wide font-medium text-zinc-500">Pistes</h3>
-			{#if filtered.length > 0}<span class="text-xs text-zinc-600">{filtered.length} / {tracks.length}</span>{/if}
+		<div class="flex items-baseline justify-between mb-2 gap-2">
+			<h3 class="text-xs uppercase tracking-wide font-medium text-zinc-500 truncate">
+				{#if selectedPlaylistId}
+					{@const p = playlists.find(x => x.id === selectedPlaylistId)}
+					{p?.name ?? 'Playlist'}
+				{:else}
+					Toutes les pistes
+				{/if}
+			</h3>
+			{#if filtered.length > 0}<span class="text-xs text-zinc-600 shrink-0">{filtered.length} / {baseTracks.length}</span>{/if}
 		</div>
 
-		{#if loading}
+		{#if loading || playlistTracksLoading}
 			<div class="border border-zinc-800 bg-zinc-900 px-4 py-6 text-sm text-zinc-500">Chargement…</div>
 		{:else if tracks.length === 0}
 			<div class="border border-dashed border-zinc-800 bg-zinc-900/50 px-4 py-8 text-center text-sm text-zinc-500">
 				Aucune piste. Dépose tes premiers fichiers audio ci-dessus pour démarrer.
+			</div>
+		{:else if selectedPlaylistId && baseTracks.length === 0}
+			<div class="border border-dashed border-zinc-800 bg-zinc-900/50 px-4 py-6 text-center text-sm text-zinc-500 leading-relaxed">
+				Playlist vide. Reviens sur <button type="button" onclick={() => onSelectPlaylist(null)} class="text-purple-300 hover:underline">Toutes les pistes</button>
+				et utilise l'icône <span class="text-zinc-300">≡</span> à côté de chaque son pour le ranger ici.
 			</div>
 		{:else if filtered.length === 0}
 			<div class="border border-dashed border-zinc-800 bg-zinc-900/50 px-4 py-6 text-center text-sm text-zinc-500">
@@ -558,7 +701,7 @@
 		{:else}
 			<div class="border border-zinc-800 bg-zinc-900">
 				<!-- Header colonnes : vignette | titre/artiste | durée | visibilité | actions -->
-				<div class="grid grid-cols-[56px_minmax(0,1fr)_80px_140px_260px] gap-4 px-4 py-2 border-b border-zinc-800 bg-zinc-950 text-[11px] uppercase tracking-wide font-medium text-zinc-500">
+				<div class="grid grid-cols-[56px_1fr_80px_140px_auto] gap-4 px-4 py-2 border-b border-zinc-800 bg-zinc-950 text-[11px] uppercase tracking-wide font-medium text-zinc-500">
 					<span></span>
 					<span>Titre</span>
 					<span>Durée</span>
@@ -567,7 +710,7 @@
 				</div>
 				<ul class="divide-y divide-zinc-800">
 					{#each filtered as t (t.id)}
-						<li class="grid grid-cols-[56px_minmax(0,1fr)_80px_140px_260px] gap-4 px-4 py-3 items-center {editingId === t.id ? 'bg-purple-500/[0.04] border-l-2 border-l-purple-500' : ''}">
+						<li class="grid grid-cols-[56px_1fr_80px_140px_auto] gap-4 px-4 py-3 items-center {editingId === t.id ? 'bg-purple-500/[0.04] border-l-2 border-l-purple-500' : ''}">
 							<!-- Col 1 : vignette / fallback -->
 							<div class="w-12 h-12 bg-zinc-950 border border-zinc-800 flex items-center justify-center overflow-hidden">
 								{#if t.thumbnailUrl}
@@ -605,7 +748,7 @@
 							</div>
 
 							<!-- Col 5 : actions -->
-							<div class="flex items-center gap-1.5 justify-end">
+							<div class="flex items-center gap-1.5 justify-end relative">
 								<button type="button" onclick={() => togglePreview(t)}
 									class="text-xs inline-flex items-center gap-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 hover:border-purple-500/60 hover:text-purple-200 text-zinc-100 px-2.5 py-1 rounded-sm transition-colors"
 									title={previewingId === t.id ? 'Arrêter' : 'Écouter'}>
@@ -623,6 +766,15 @@
 									<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
 									Deck
 								</button>
+								<!-- Bouton ouverture popover playlists pour ce track. -->
+								<button type="button" onclick={() => openPlaylistMenu(t.id)}
+									class="text-xs inline-flex items-center bg-zinc-800 hover:bg-zinc-700 border {playlistMenuTrackId === t.id ? 'border-purple-500/60 text-purple-200' : 'border-zinc-700 hover:border-purple-500/60 hover:text-purple-200'} text-zinc-100 px-2 py-1 rounded-sm transition-colors"
+									title="Ranger dans une playlist">
+									<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+										<line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="13" y2="18"/>
+										<polyline points="3 6 4 7 5 6"/><polyline points="3 12 4 13 5 12"/><polyline points="3 18 4 19 5 18"/>
+									</svg>
+								</button>
 								<button type="button" onclick={() => editingId === t.id ? cancelEdit() : startEdit(t)}
 									class="text-xs bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 hover:border-purple-500/60 hover:text-purple-200 text-zinc-100 px-2.5 py-1 rounded-sm transition-colors">
 									{editingId === t.id ? 'Fermer' : 'Éditer'}
@@ -637,6 +789,40 @@
 										<path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
 									</svg>
 								</button>
+
+								<!-- Popover playlists : ancré sous les actions, fermé par clic sur le même bouton. -->
+								{#if playlistMenuTrackId === t.id}
+									<div class="absolute top-full right-0 mt-1.5 z-20 w-64 bg-zinc-950 border border-zinc-800 shadow-xl rounded-sm overflow-hidden">
+										<div class="px-3 py-2 border-b border-zinc-800 flex items-center justify-between">
+											<span class="text-[11px] uppercase tracking-wide font-medium text-zinc-400">Playlists</span>
+											<button type="button" onclick={closePlaylistMenu} class="text-xs text-zinc-500 hover:text-zinc-300" title="Fermer">✕</button>
+										</div>
+										{#if playlists.length === 0}
+											<div class="px-3 py-3 text-[11px] text-zinc-500 text-center">
+												Aucune playlist. Crée-en une dans la sidebar à gauche.
+											</div>
+										{:else}
+											<ul class="max-h-56 overflow-y-auto py-1">
+												{#each playlists as p (p.id)}
+													{@const inIt = playlistMenuMembership.has(p.id)}
+													<li>
+														<button type="button" onclick={() => toggleTrackInPlaylist(t.id, p.id)} disabled={playlistMenuBusy}
+															class="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-left transition-colors {inIt ? 'text-zinc-100 bg-purple-500/10' : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/60'}">
+															<span class="w-3.5 h-3.5 rounded-sm border flex items-center justify-center shrink-0 {inIt ? 'bg-purple-500 border-purple-400' : 'border-zinc-600'}">
+																{#if inIt}
+																	<svg class="w-2.5 h-2.5 text-white" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>
+																{/if}
+															</span>
+															<span class="w-2 h-2 rounded-full shrink-0" style="background: {p.color ?? '#a78bfa'};"></span>
+															<span class="flex-1 truncate" title={p.name}>{p.name}</span>
+															<span class="text-[10px] text-zinc-600 font-mono">{p.trackCount}</span>
+														</button>
+													</li>
+												{/each}
+											</ul>
+										{/if}
+									</div>
+								{/if}
 							</div>
 						</li>
 
@@ -752,6 +938,9 @@
 			</div>
 		{/if}
 	</div>
+
+		</div><!-- /colonne droite -->
+	</div><!-- /grid 2 colonnes -->
 </section>
 
 {#if sendToDeckTrack}

--- a/nodyx-frontend/src/lib/components/admin/obs/AddSourceModal.svelte
+++ b/nodyx-frontend/src/lib/components/admin/obs/AddSourceModal.svelte
@@ -1,0 +1,410 @@
+<script lang="ts">
+	import { apiFetch } from '$lib/api'
+	import { SOURCE_TYPE_META, SOURCE_TYPE_ORDER, type ObsSceneSourceType } from '$lib/types/obsScenes'
+
+	// ─── Modal "+ Source" ───────────────────────────────────────────────────
+	// Flow en 2 étapes :
+	//   1. Catégorie : choix du type (placeholder vidéo, overlay Nodyx, URL libre).
+	//   2. Picker contextuel selon le type :
+	//        • overlays Nodyx → liste des overlays existants du type + bouton
+	//          "+ Créer un nouveau" qui POST /streamer/overlays et sélectionne
+	//          le nouveau dans la foulée.
+	//        • playlist → liste des playlists + auto-ensure du token overlay
+	//          playlist (un seul par streamer, partagé entre toutes les playlists).
+	//        • browser_source → saisie d'URL HTTPS.
+	//        • placeholder_video → pas d'étape 2, on ajoute direct.
+	//
+	// Objectif : tout converge vers les overlays/playlists déjà créés dans le
+	// hub. Pas de duplication, pas de re-saisie de tokens. La Phase B pourra
+	// pousser à OBS exactement le bon token sans devoir demander quoi que ce
+	// soit de plus à l'utilisateur.
+
+	// Mapping ObsSceneSourceType → OverlayType backend (slug envoyé à l'API).
+	// Pour les types qui mappent sur un overlay Nodyx token-gated.
+	type BackendOverlayType =
+		| 'alert_box' | 'event_ticker' | 'soundboard' | 'goal_bar'
+		| 'leaderboard' | 'clips_player' | 'playlist' | 'stream_timer'
+
+	const BACKEND_TYPE_FOR: Partial<Record<ObsSceneSourceType, BackendOverlayType>> = {
+		alert_box:      'alert_box',
+		ticker:         'event_ticker',
+		soundboard_osd: 'soundboard',
+		goal_bar:       'goal_bar',
+		leaderboard:    'leaderboard',
+		clips_player:   'clips_player',
+		playlist:       'playlist',
+		stream_timer:   'stream_timer',
+	}
+
+	interface Props {
+		token:   string
+		// Si fourni, on saute l'étape "choisir une catégorie" et on démarre
+		// directement sur le picker du type donné. Utilisé pour "Changer
+		// l'overlay/playlist" depuis le panneau Propriétés d'une source
+		// existante : le streamer ne veut pas re-choisir le type, juste
+		// l'overlay/playlist cible.
+		initialType?: ObsSceneSourceType
+		// Texte du header. Par défaut "Ajouter une source". En mode swap, le
+		// parent passe "Changer l'overlay" ou similaire pour ne pas induire
+		// en erreur.
+		title?:   string
+		onPick:  (type: ObsSceneSourceType, config: Record<string, unknown>, label: string) => void
+		onClose: () => void
+	}
+	let { token, initialType, title, onPick, onClose }: Props = $props()
+
+	type Step = 'category' | 'overlay-picker' | 'playlist-picker' | 'browser-url'
+	// Si initialType est fourni, on saute la catégorie. browser_source et
+	// placeholder_video sautent directement à leur étape dédiée.
+	const initialStep: Step =
+		!initialType                              ? 'category'
+		: initialType === 'browser_source'        ? 'browser-url'
+		: initialType === 'playlist'              ? 'playlist-picker'
+		: initialType === 'placeholder_video'     ? 'category'   // placeholder n'a pas d'étape 2
+		: 'overlay-picker'
+	let step = $state<Step>(initialStep)
+	let pickedType = $state<ObsSceneSourceType | null>(initialType ?? null)
+
+	// Auto-load la liste si on a démarré direct sur une étape 2.
+	$effect(() => {
+		if (!initialType) return
+		if (initialType === 'playlist') void loadPlaylistsAndToken()
+		else if (initialType !== 'browser_source' && initialType !== 'placeholder_video') {
+			void loadOverlaysFor(initialType)
+		}
+	})
+
+	// Picker overlay : état + liste + création inline.
+	interface OverlayRow {
+		id:          string
+		token:       string
+		overlayType: BackendOverlayType
+		label:       string | null
+	}
+	let overlays = $state<OverlayRow[]>([])
+	let overlaysLoading = $state(false)
+	let createOpen   = $state(false)
+	let createLabel  = $state('')
+	let createBusy   = $state(false)
+	let createError  = $state<string | null>(null)
+
+	// Picker playlist.
+	interface PlaylistRow { id: string; name: string; color: string | null; trackCount: number }
+	let playlists = $state<PlaylistRow[]>([])
+	let playlistOverlayToken = $state<string | null>(null)
+	let playlistLoading = $state(false)
+
+	// Browser URL.
+	let urlInput = $state('')
+
+	function pickCategory(type: ObsSceneSourceType): void {
+		pickedType = type
+		if (type === 'placeholder_video') {
+			// Ajouté direct, le streamer le configure côté Propriétés.
+			onPick(type, { kind: 'webcam' }, SOURCE_TYPE_META[type].label)
+			return
+		}
+		if (type === 'browser_source') {
+			step = 'browser-url'
+			return
+		}
+		if (type === 'playlist') {
+			step = 'playlist-picker'
+			void loadPlaylistsAndToken()
+			return
+		}
+		// Autres types mappent sur un overlay Nodyx → picker
+		step = 'overlay-picker'
+		void loadOverlaysFor(type)
+	}
+
+	async function loadOverlaysFor(type: ObsSceneSourceType): Promise<void> {
+		const backendType = BACKEND_TYPE_FOR[type]
+		if (!backendType) return
+		overlaysLoading = true
+		try {
+			const res = await apiFetch(fetch, '/streamer/overlays', { headers: { Authorization: `Bearer ${token}` } })
+			if (res.ok) {
+				const d = await res.json() as { overlays: OverlayRow[] }
+				overlays = (d.overlays ?? []).filter(o => o.overlayType === backendType)
+			}
+		} finally {
+			overlaysLoading = false
+		}
+	}
+
+	async function loadPlaylistsAndToken(): Promise<void> {
+		playlistLoading = true
+		try {
+			// Liste des playlists.
+			const r1 = await apiFetch(fetch, '/streamer/audio-library/playlists', { headers: { Authorization: `Bearer ${token}` } })
+			if (r1.ok) {
+				const d = await r1.json() as { playlists: PlaylistRow[] }
+				playlists = d.playlists ?? []
+			}
+			// Token overlay playlist : ensure (créé si pas encore).
+			const r2 = await apiFetch(fetch, '/streamer/audio-library/playlists/overlay-token', {
+				method:  'POST',
+				headers: { Authorization: `Bearer ${token}` },
+			})
+			if (r2.ok) {
+				const d = await r2.json() as { token: string }
+				playlistOverlayToken = d.token
+			}
+		} finally {
+			playlistLoading = false
+		}
+	}
+
+	async function createOverlay(): Promise<void> {
+		if (!pickedType || createBusy) return
+		const backendType = BACKEND_TYPE_FOR[pickedType]
+		if (!backendType) return
+		createBusy = true
+		createError = null
+		try {
+			const res = await apiFetch(fetch, '/streamer/overlays', {
+				method:  'POST',
+				headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+				body:    JSON.stringify({
+					overlayType: backendType,
+					label:       createLabel.trim() || null,
+				}),
+			})
+			if (res.ok) {
+				const d = await res.json() as { overlay: OverlayRow }
+				overlays = [d.overlay, ...overlays]
+				// Sélection automatique du nouveau pour ne pas obliger un 2e clic.
+				pickOverlay(d.overlay)
+			} else {
+				createError = `Création impossible (HTTP ${res.status}).`
+			}
+		} catch {
+			createError = 'Erreur réseau.'
+		} finally {
+			createBusy = false
+		}
+	}
+
+	function pickOverlay(o: OverlayRow): void {
+		if (!pickedType) return
+		const m = SOURCE_TYPE_META[pickedType]
+		onPick(pickedType, { overlayToken: o.token }, o.label?.trim() || m.label)
+	}
+
+	function pickPlaylist(p: PlaylistRow): void {
+		if (!playlistOverlayToken) return
+		onPick('playlist', {
+			overlayToken: playlistOverlayToken,
+			playlistId:   p.id,
+		}, p.name)
+	}
+
+	function confirmBrowserUrl(): void {
+		const url = urlInput.trim()
+		if (!/^https?:\/\//i.test(url)) {
+			urlInput = ''
+			return
+		}
+		// Le label par défaut = host de l'URL pour aider à s'y retrouver.
+		let host = 'Browser Source'
+		try { host = new URL(url).host } catch { /* keep fallback */ }
+		onPick('browser_source', { url }, host)
+	}
+
+	function back(): void {
+		// En mode swap (initialType fourni), il n'y a pas d'étape précédente :
+		// on ferme directement plutôt que de proposer un retour au catalogue
+		// qui n'aurait pas de sens.
+		if (initialType) { onClose(); return }
+		step = 'category'
+		pickedType = null
+		createOpen = false
+		createLabel = ''
+		createError = null
+		urlInput = ''
+	}
+</script>
+
+<div class="fixed inset-0 z-50 grid place-items-center p-4 bg-black/70 backdrop-blur-sm"
+	onclick={onClose}
+	onkeydown={(e) => { if (e.key === 'Escape') onClose() }}
+	role="dialog" aria-modal="true" tabindex="-1">
+	<div class="w-full max-w-2xl bg-zinc-950 border border-zinc-800 rounded-lg shadow-2xl"
+		onclick={(e) => e.stopPropagation()}
+		onkeydown={(e) => e.stopPropagation()}
+		role="document">
+		<header class="px-4 py-3 border-b border-zinc-800 flex items-center justify-between">
+			<div class="min-w-0">
+				<div class="text-xs uppercase tracking-widest font-semibold text-purple-300/80">{title ?? 'Ajouter une source'}</div>
+				<h3 class="text-base font-semibold text-zinc-100 mt-0.5 truncate">
+					{#if step === 'category'}Choisis un type
+					{:else if pickedType}{SOURCE_TYPE_META[pickedType].icon} {SOURCE_TYPE_META[pickedType].label}
+					{/if}
+				</h3>
+			</div>
+			<button type="button" onclick={onClose} class="text-zinc-500 hover:text-zinc-200 w-7 h-7 grid place-items-center shrink-0" title="Fermer">✕</button>
+		</header>
+
+		{#if step !== 'category' && !initialType}
+			<div class="px-4 pt-2">
+				<button type="button" onclick={back} class="text-xs text-zinc-500 hover:text-zinc-200 inline-flex items-center gap-1">
+					<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+						<polyline points="15 18 9 12 15 6"/>
+					</svg>
+					Retour au catalogue
+				</button>
+			</div>
+		{/if}
+
+		<!-- ── Étape 1 : catalogue catégories ──────────────────────────── -->
+		{#if step === 'category'}
+			<div class="p-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
+				{#each SOURCE_TYPE_ORDER as type (type)}
+					{@const m = SOURCE_TYPE_META[type]}
+					<button type="button" onclick={() => pickCategory(type)}
+						class="text-left flex items-start gap-3 p-3 rounded-md bg-zinc-900/60 border border-zinc-800 hover:bg-zinc-800/60 transition-colors group"
+						style="border-left: 3px solid #{m.accent};">
+						<span class="text-2xl leading-none mt-0.5">{m.icon}</span>
+						<div class="min-w-0 flex-1">
+							<div class="text-sm font-medium text-zinc-100">{m.label}</div>
+							<div class="text-[11px] text-zinc-500 mt-0.5 leading-snug">{m.description}</div>
+						</div>
+					</button>
+				{/each}
+			</div>
+			<footer class="px-4 py-2.5 border-t border-zinc-800 text-[11px] text-zinc-600 leading-snug">
+				La taille initiale est centrée sur le canvas. Tu pourras la repositionner / redimensionner après ajout.
+			</footer>
+
+		<!-- ── Étape 2A : picker overlay Nodyx ─────────────────────────── -->
+		{:else if step === 'overlay-picker' && pickedType}
+			<div class="p-4 space-y-3">
+				{#if overlaysLoading}
+					<div class="text-center text-xs text-zinc-500 py-6">Chargement…</div>
+				{:else if overlays.length === 0 && !createOpen}
+					<div class="rounded-md border border-dashed border-zinc-800 bg-zinc-900/40 px-4 py-5 text-center text-xs text-zinc-500 leading-snug">
+						Aucun overlay <span class="text-zinc-300">{SOURCE_TYPE_META[pickedType].label}</span> n'existe encore.<br/>
+						Crée-en un ci-dessous, il s'ajoutera à ta liste d'overlays.
+					</div>
+				{:else}
+					<div class="text-[10px] uppercase tracking-widest font-semibold text-zinc-500">Choisir un overlay existant</div>
+					<ul class="space-y-1.5 max-h-72 overflow-y-auto">
+						{#each overlays as o (o.id)}
+							<li>
+								<button type="button" onclick={() => pickOverlay(o)}
+									class="w-full text-left flex items-center gap-3 p-2.5 rounded-md bg-zinc-900/60 border border-zinc-800 hover:border-purple-500/60 hover:bg-purple-500/5 transition-colors">
+									<span class="w-1.5 h-1.5 rounded-full shrink-0" style="background: #{SOURCE_TYPE_META[pickedType].accent};"></span>
+									<div class="min-w-0 flex-1">
+										<div class="text-sm text-zinc-100 truncate">{o.label?.trim() || SOURCE_TYPE_META[pickedType].label}</div>
+										<div class="text-[10px] text-zinc-600 font-mono truncate" title={o.token}>token : {o.token.slice(0, 12)}…</div>
+									</div>
+									<svg class="w-3.5 h-3.5 text-zinc-600 shrink-0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"/></svg>
+								</button>
+							</li>
+						{/each}
+					</ul>
+				{/if}
+
+				<!-- Création inline d'un nouvel overlay du même type -->
+				<div class="border-t border-zinc-800 pt-3">
+					{#if !createOpen}
+						<button type="button" onclick={() => { createOpen = true; createLabel = '' }}
+							class="w-full inline-flex items-center justify-center gap-2 px-3 py-2 text-xs font-medium bg-purple-500/15 hover:bg-purple-500/25 border border-purple-500/40 hover:border-purple-500/70 text-purple-100 rounded-md transition-colors">
+							<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
+							Créer un nouvel overlay {SOURCE_TYPE_META[pickedType].label}
+						</button>
+					{:else}
+						<div class="space-y-2">
+							<label class="block">
+								<span class="text-[10px] uppercase tracking-wider font-semibold text-zinc-500">Label (optionnel)</span>
+								<input type="text" bind:value={createLabel} maxlength="60"
+									placeholder="ex : Alert principale"
+									onkeydown={(e) => { if (e.key === 'Enter') createOverlay() }}
+									class="mt-1 w-full bg-zinc-900 border border-zinc-800 focus:border-purple-500/60 px-3 py-1.5 text-xs text-zinc-100 outline-none rounded-sm"
+									autofocus/>
+							</label>
+							{#if createError}
+								<div class="text-[11px] text-rose-300 bg-rose-500/10 border border-rose-500/30 rounded-sm px-2 py-1.5">{createError}</div>
+							{/if}
+							<div class="flex items-center gap-2">
+								<button type="button" onclick={createOverlay} disabled={createBusy}
+									class="flex-1 text-xs font-medium bg-purple-500 hover:bg-purple-400 disabled:bg-zinc-800 disabled:text-zinc-500 text-white px-3 py-1.5 rounded-sm transition-colors">
+									{createBusy ? 'Création…' : 'Créer et ajouter'}
+								</button>
+								<button type="button" onclick={() => { createOpen = false; createError = null }}
+									class="text-xs bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-200 px-3 py-1.5 rounded-sm">
+									Annuler
+								</button>
+							</div>
+						</div>
+					{/if}
+				</div>
+			</div>
+
+		<!-- ── Étape 2B : picker playlist ──────────────────────────────── -->
+		{:else if step === 'playlist-picker'}
+			<div class="p-4 space-y-3">
+				{#if playlistLoading}
+					<div class="text-center text-xs text-zinc-500 py-6">Chargement…</div>
+				{:else if playlists.length === 0}
+					<div class="rounded-md border border-dashed border-zinc-800 bg-zinc-900/40 px-4 py-5 text-center text-xs text-zinc-500 leading-snug">
+						Aucune playlist. Crée-en une depuis le tab <span class="text-zinc-300">Soundboard</span>, elle apparaîtra ici.
+					</div>
+				{:else}
+					<div class="text-[10px] uppercase tracking-widest font-semibold text-zinc-500">Choisir une playlist</div>
+					<ul class="space-y-1.5 max-h-72 overflow-y-auto">
+						{#each playlists as p (p.id)}
+							<li>
+								<button type="button" onclick={() => pickPlaylist(p)} disabled={!playlistOverlayToken}
+									class="w-full text-left flex items-center gap-3 p-2.5 rounded-md bg-zinc-900/60 border border-zinc-800 hover:border-purple-500/60 hover:bg-purple-500/5 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+									<span class="w-2 h-2 rounded-full shrink-0" style="background: {p.color ?? '#a78bfa'};"></span>
+									<div class="min-w-0 flex-1">
+										<div class="text-sm text-zinc-100 truncate">{p.name}</div>
+										<div class="text-[10px] text-zinc-600 font-mono">{p.trackCount} piste{p.trackCount > 1 ? 's' : ''}</div>
+									</div>
+									<svg class="w-3.5 h-3.5 text-zinc-600 shrink-0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"/></svg>
+								</button>
+							</li>
+						{/each}
+					</ul>
+					<div class="text-[10px] text-zinc-600 leading-snug pt-1">
+						Le token overlay playlist est partagé entre toutes tes playlists. Tu peux l'éditer depuis le tab <span class="text-zinc-300">Overlays OBS</span> si besoin.
+					</div>
+				{/if}
+			</div>
+
+		<!-- ── Étape 2C : Browser Source URL libre ─────────────────────── -->
+		{:else if step === 'browser-url'}
+			<div class="p-5 space-y-3">
+				<div>
+					<div class="flex items-center gap-2 mb-2">
+						<span class="text-xl leading-none">🌐</span>
+						<div>
+							<div class="text-sm font-medium text-zinc-100">Browser Source</div>
+							<div class="text-[11px] text-zinc-500">N'importe quelle URL HTTPS (widget externe).</div>
+						</div>
+					</div>
+					<label class="block">
+						<span class="text-[10px] uppercase tracking-wider font-semibold text-zinc-500">URL</span>
+						<input type="url" bind:value={urlInput}
+							placeholder="https://..."
+							onkeydown={(e) => { if (e.key === 'Enter') confirmBrowserUrl() }}
+							class="mt-1 w-full bg-zinc-900 border border-zinc-800 focus:border-purple-500/60 focus:ring-1 focus:ring-purple-500/20 px-3 py-2 text-sm text-zinc-100 outline-none rounded-sm font-mono"
+							autofocus/>
+					</label>
+				</div>
+				<div class="flex items-center justify-end gap-2">
+					<button type="button" onclick={onClose}
+						class="text-xs bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-200 px-3 py-1.5 rounded-sm">
+						Annuler
+					</button>
+					<button type="button" onclick={confirmBrowserUrl} disabled={!/^https?:\/\//i.test(urlInput.trim())}
+						class="text-xs bg-purple-500 hover:bg-purple-400 disabled:bg-zinc-800 disabled:text-zinc-500 text-white px-4 py-1.5 rounded-sm font-medium">
+						Ajouter
+					</button>
+				</div>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/nodyx-frontend/src/lib/components/admin/obs/ObsScenesPanel.svelte
+++ b/nodyx-frontend/src/lib/components/admin/obs/ObsScenesPanel.svelte
@@ -1,0 +1,855 @@
+<script lang="ts">
+	import { apiFetch } from '$lib/api'
+	import { onMount, onDestroy } from 'svelte'
+	import SceneCanvas from './SceneCanvas.svelte'
+	import AddSourceModal from './AddSourceModal.svelte'
+	import { consumeFocusedSceneId, focusOverlayAfterNav } from './sceneNav'
+	import {
+		SOURCE_TYPE_META, FULL_SCENE_VIEWPORT_TYPES,
+		type ObsScene, type ObsSceneLayout, type ObsSceneSource,
+		type ObsSceneSourceType,
+	} from '$lib/types/obsScenes'
+
+	// ─── Streamer Hub → Scènes OBS (compositeur visuel) ─────────────────────
+	// Orchestrateur principal du tab "Scènes". Reproduit le layout d'OBS :
+	//   ┌────────────────────────┬──────────┐
+	//   │  Canvas preview 16:9   │ Contrôles│
+	//   ├─────┬─────┬────────────┤          │
+	//   │ Scn │ Src │ Audio Mix  │          │
+	//   └─────┴─────┴────────────┴──────────┘
+	// Avantage : le streamer qui connaît OBS retrouve immédiatement ses
+	// repères (Scenes en bas-gauche, Sources au centre, Mixer à droite,
+	// Controls à l'extrême droite). Adapté au style admin Nodyx (zinc/purple).
+	//
+	// Phase A : tout est stocké côté Nodyx, pas de sync OBS. Audio Mixer et
+	// Contrôles sont visibles mais marqués "via OBS bridge (à venir)" pour
+	// que l'utilisateur sache qu'ils seront activés en Phase B+.
+
+	interface Props {
+		token: string
+	}
+	let { token }: Props = $props()
+
+	let scenes      = $state<ObsScene[]>([])
+	let loading     = $state(true)
+	let activeId    = $state<string | null>(null)
+	let selectedSrc = $state<string | null>(null)
+	// Mode de rendu du canvas. 'live' affiche les iframes des overlays, 'wireframe'
+	// les placeholders rapides. Persisté en localStorage pour rester cohérent
+	// entre sessions (un user qui préfère wireframe ne veut pas re-toggle à
+	// chaque visite). Défaut 'live'.
+	let previewMode = $state<'live' | 'wireframe'>('live')
+
+	// Index des overlays et playlists pour résoudre dynamiquement le label
+	// affiché des sources d'une scène. Sans ça, le label de la source était
+	// figé à sa valeur au moment de l'ajout (ex "Alert Box"), et un renommage
+	// de l'overlay parent ne se reflétait pas dans le canvas.
+	interface OverlayLite  { id: string; token: string; label: string | null }
+	interface PlaylistLite { id: string; name: string }
+	let overlaysIndex  = $state<Map<string, OverlayLite>>(new Map())
+	let playlistsIndex = $state<Map<string, PlaylistLite>>(new Map())
+
+	async function loadOverlaysIndex(): Promise<void> {
+		try {
+			const res = await apiFetch(fetch, '/streamer/overlays', { headers: { Authorization: `Bearer ${token}` } })
+			if (res.ok) {
+				const d = await res.json() as { overlays: OverlayLite[] }
+				const map = new Map<string, OverlayLite>()
+				for (const o of d.overlays ?? []) map.set(o.token, o)
+				overlaysIndex = map
+			}
+		} catch { /* index restera vide : on retombera sur le label local de la source */ }
+	}
+	async function loadPlaylistsIndex(): Promise<void> {
+		try {
+			const res = await apiFetch(fetch, '/streamer/audio-library/playlists', { headers: { Authorization: `Bearer ${token}` } })
+			if (res.ok) {
+				const d = await res.json() as { playlists: PlaylistLite[] }
+				const map = new Map<string, PlaylistLite>()
+				for (const p of d.playlists ?? []) map.set(p.id, p)
+				playlistsIndex = map
+			}
+		} catch { /* idem */ }
+	}
+
+	// Label à afficher pour une source : priorité au nom vivant de l'overlay
+	// ou de la playlist parente, fallback sur le label stocké dans la source
+	// (utile si le parent est offline / supprimé), fallback final sur le type.
+	function displayLabelFor(s: ObsSceneSource): string {
+		const m = SOURCE_TYPE_META[s.type]
+		const tok = typeof s.config.overlayToken === 'string' ? s.config.overlayToken : null
+		if (s.type === 'playlist' && typeof s.config.playlistId === 'string') {
+			const p = playlistsIndex.get(s.config.playlistId)
+			if (p?.name) return p.name
+		}
+		if (tok) {
+			const o = overlaysIndex.get(tok)
+			if (o?.label?.trim()) return o.label.trim()
+		}
+		return (s.label?.trim() || m.label).slice(0, 60)
+	}
+	let creating    = $state(false)
+	let newName     = $state('')
+	let saving      = $state(false)
+	let lastSaveAt  = $state<number | null>(null)
+
+	// Pour éviter de spammer le PATCH layout pendant qu'on drag plusieurs
+	// fois d'affilée : on debounce 600ms après le dernier change. On garde
+	// aussi une trace du dernier layout poussé pour ne pas re-PATCH une
+	// scène qui n'a pas réellement bougé (sanitize backend peut renvoyer une
+	// version légèrement différente qui ressetterait scenes et redéclencherait
+	// les inputs réactifs).
+	let saveTimer: ReturnType<typeof setTimeout> | null = null
+	let saveInFlight = false
+	let pendingLayout: ObsSceneLayout | null = null
+	let lastPushedLayoutJson = ''
+
+	let toast = $state<{ text: string; ok: boolean } | null>(null)
+	function flash(text: string, ok: boolean): void {
+		toast = { text, ok }
+		setTimeout(() => { toast = null }, 3000)
+	}
+
+	// Modal "+ Source" : null = fermé.
+	let addSourceOpen = $state(false)
+	// Modal "Changer X" : si une source est en train d'être swap, on garde
+	// son id pour patcher la bonne au pick. null = modal swap fermé. Le
+	// $derived swappingSource est déclaré plus bas, après activeLayout.
+	let swapSourceId = $state<string | null>(null)
+
+	const activeScene = $derived<ObsScene | null>(scenes.find(s => s.id === activeId) ?? null)
+	const activeLayout = $derived<ObsSceneLayout>(activeScene?.layout ?? { sources: [] })
+	const swappingSource = $derived<ObsSceneSource | null>(
+		swapSourceId ? activeLayout.sources.find(s => s.id === swapSourceId) ?? null : null,
+	)
+	const selectedSource = $derived<ObsSceneSource | null>(
+		activeLayout.sources.find(s => s.id === selectedSrc) ?? null,
+	)
+	// Ordre d'affichage Sources list : z décroissant (devant → arrière), comme OBS.
+	const sourcesByZ = $derived<ObsSceneSource[]>(
+		[...activeLayout.sources].sort((a, b) => b.z - a.z),
+	)
+
+	// ── Chargement / sauvegarde scènes ─────────────────────────────────────
+
+	async function loadScenes(): Promise<void> {
+		loading = true
+		try {
+			const res = await apiFetch(fetch, '/streamer/obs/scenes', {
+				headers: { Authorization: `Bearer ${token}` },
+			})
+			if (res.ok) {
+				const d = await res.json() as { scenes: ObsScene[] }
+				scenes = d.scenes ?? []
+				// Priorité au focus posé par PlaceInSceneModal (création de scène
+				// depuis Overlays/Soundboard) : si un ID est en attente, on
+				// l'active. Sinon on garde la sélection courante, et à défaut
+				// on prend la première scène pour ne pas afficher un canvas
+				// vide au premier load.
+				const focused = consumeFocusedSceneId()
+				if (focused && scenes.some(s => s.id === focused)) {
+					activeId = focused
+					selectedSrc = null
+				} else if (!activeId && scenes.length > 0) {
+					activeId = scenes[0].id
+				}
+			}
+		} finally {
+			loading = false
+		}
+	}
+
+	// Quand le tab Scènes reste monté (l'utilisateur y était déjà), onMount
+	// ne re-tire pas. Le helper sceneNav broadcast un CustomEvent pour qu'on
+	// puisse capter le focus en live.
+	function onFocusEvent(e: Event): void {
+		const detail = (e as CustomEvent<{ sceneId: string }>).detail
+		if (!detail?.sceneId) return
+		// Si la scène est déjà chargée, on switche tout de suite. Sinon on
+		// reload puis on consomme l'id depuis le sessionStorage.
+		if (scenes.some(s => s.id === detail.sceneId)) {
+			activeId = detail.sceneId
+			selectedSrc = null
+		} else {
+			void loadScenes()
+		}
+	}
+
+	async function createScene(): Promise<void> {
+		const name = newName.trim()
+		if (!name || saving) return
+		saving = true
+		try {
+			const res = await apiFetch(fetch, '/streamer/obs/scenes', {
+				method:  'POST',
+				headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+				body:    JSON.stringify({ name }),
+			})
+			if (res.ok) {
+				const d = await res.json() as { scene: ObsScene }
+				scenes = [...scenes, d.scene]
+				activeId = d.scene.id
+				newName = ''
+				creating = false
+			} else if (res.status === 409) {
+				flash('Ce nom est déjà pris par une autre scène.', false)
+			} else {
+				flash('Création impossible.', false)
+			}
+		} finally {
+			saving = false
+		}
+	}
+
+	async function deleteScene(id: string): Promise<void> {
+		const s = scenes.find(x => x.id === id)
+		if (!s) return
+		if (!confirm(`Supprimer la scène "${s.name}" ?`)) return
+		const res = await apiFetch(fetch, `/streamer/obs/scenes/${id}`, {
+			method:  'DELETE',
+			headers: { Authorization: `Bearer ${token}` },
+		})
+		if (res.ok) {
+			scenes = scenes.filter(x => x.id !== id)
+			if (activeId === id) activeId = scenes[0]?.id ?? null
+		} else {
+			flash('Suppression échouée.', false)
+		}
+	}
+
+	async function duplicateScene(id: string): Promise<void> {
+		const res = await apiFetch(fetch, `/streamer/obs/scenes/${id}/duplicate`, {
+			method:  'POST',
+			headers: { Authorization: `Bearer ${token}` },
+		})
+		if (res.ok) {
+			const d = await res.json() as { scene: ObsScene }
+			scenes = [...scenes, d.scene]
+			activeId = d.scene.id
+			flash(`Scène dupliquée : "${d.scene.name}".`, true)
+		} else {
+			flash('Duplication échouée.', false)
+		}
+	}
+
+	async function persistLayout(layout: ObsSceneLayout): Promise<void> {
+		if (!activeId) return
+		const json = JSON.stringify(layout)
+		if (json === lastPushedLayoutJson) return       // rien de neuf à sauver
+		if (saveInFlight) {
+			// Un PATCH est déjà en vol : on garde le dernier layout désiré
+			// et on relancera dès qu'il revient. Ça évite N PATCH concurrents
+			// qui se télescopent dans le pool DB et l'event loop.
+			pendingLayout = layout
+			return
+		}
+		saveInFlight = true
+		lastPushedLayoutJson = json
+		try {
+			const res = await apiFetch(fetch, `/streamer/obs/scenes/${activeId}`, {
+				method:  'PATCH',
+				headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+				body:    JSON.stringify({ layout }),
+			})
+			if (res.ok) {
+				const d = await res.json() as { scene: ObsScene }
+				// On garde notre layout local (déjà à jour) plutôt que d'écraser
+				// avec la version backend, pour ne pas perturber les inputs en
+				// cours de saisie. On synchronise quand même les métadonnées
+				// (updatedAt, etc.).
+				scenes = scenes.map(s => s.id === d.scene.id ? { ...d.scene, layout: s.layout } : s)
+				lastSaveAt = Date.now()
+			} else {
+				flash('Sauvegarde échouée. Réessaye.', false)
+				lastPushedLayoutJson = ''       // pour réessayer la prochaine fois
+			}
+		} catch {
+			lastPushedLayoutJson = ''
+		} finally {
+			saveInFlight = false
+			// S'il y a eu d'autres changements pendant qu'on attendait, on flush
+			// maintenant (un seul PATCH supplémentaire avec la version la plus
+			// récente, pas la queue entière).
+			if (pendingLayout) {
+				const p = pendingLayout
+				pendingLayout = null
+				void persistLayout(p)
+			}
+		}
+	}
+
+	function applyLayoutChange(layout: ObsSceneLayout): void {
+		if (!activeScene) return
+		// Update local immédiat (UI fluide), persist debounced à 600ms.
+		scenes = scenes.map(s => s.id === activeScene.id ? { ...s, layout } : s)
+		if (saveTimer) clearTimeout(saveTimer)
+		saveTimer = setTimeout(() => { void persistLayout(layout) }, 600)
+	}
+
+	// ── Manipulation des sources ───────────────────────────────────────────
+
+	// Swap : on garde la position/taille/visibilité/lock/z de la source
+	// existante, on remplace juste le contenu (overlay token, playlist id,
+	// URL). Le label est mis à jour pour refléter le nouveau choix.
+	function swapSource(type: ObsSceneSourceType, config: Record<string, unknown>, label?: string): void {
+		if (!activeScene || !swappingSource) return
+		const m = SOURCE_TYPE_META[type]
+		const updated: ObsSceneSource = {
+			...swappingSource,
+			type,
+			label:  (label?.trim() || m.label).slice(0, 60),
+			config: config ?? {},
+		}
+		const layout: ObsSceneLayout = {
+			sources: activeLayout.sources.map(s => s.id === updated.id ? updated : s),
+		}
+		applyLayoutChange(layout)
+		swapSourceId = null
+	}
+
+	function addSource(type: ObsSceneSourceType, config: Record<string, unknown>, label?: string): void {
+		if (!activeScene) return
+		const m = SOURCE_TYPE_META[type]
+		const maxZ = activeLayout.sources.reduce((acc, s) => Math.max(acc, s.z), -1)
+		const newSrc: ObsSceneSource = {
+			id:      `src_${Math.random().toString(36).slice(2, 10)}`,
+			type,
+			label:   (label?.trim() || m.label).slice(0, 60),
+			x:       Math.round(((1920 - m.defaultW) / 2)),
+			y:       Math.round(((1080 - m.defaultH) / 2)),
+			w:       m.defaultW,
+			h:       m.defaultH,
+			z:       maxZ + 1,
+			visible: true,
+			locked:  false,
+			config:  config ?? {},
+		}
+		const layout: ObsSceneLayout = { sources: [...activeLayout.sources, newSrc] }
+		applyLayoutChange(layout)
+		selectedSrc = newSrc.id
+		addSourceOpen = false
+	}
+
+	function removeSource(id: string): void {
+		if (!activeScene) return
+		const layout: ObsSceneLayout = { sources: activeLayout.sources.filter(s => s.id !== id) }
+		applyLayoutChange(layout)
+		if (selectedSrc === id) selectedSrc = null
+	}
+
+	function toggleSourceVisible(id: string): void {
+		if (!activeScene) return
+		const layout: ObsSceneLayout = {
+			sources: activeLayout.sources.map(s => s.id === id ? { ...s, visible: !s.visible } : s),
+		}
+		applyLayoutChange(layout)
+	}
+
+	function toggleSourceLocked(id: string): void {
+		if (!activeScene) return
+		const layout: ObsSceneLayout = {
+			sources: activeLayout.sources.map(s => s.id === id ? { ...s, locked: !s.locked } : s),
+		}
+		applyLayoutChange(layout)
+	}
+
+	function moveSourceZ(id: string, dir: 'up' | 'down' | 'top' | 'bottom'): void {
+		if (!activeScene) return
+		const src = activeLayout.sources.find(s => s.id === id)
+		if (!src) return
+		const all = [...activeLayout.sources]
+		const maxZ = all.reduce((acc, s) => Math.max(acc, s.z), 0)
+		const minZ = all.reduce((acc, s) => Math.min(acc, s.z), 0)
+		const sorted = [...all].sort((a, b) => a.z - b.z)
+		const idx = sorted.findIndex(s => s.id === id)
+		let newZ = src.z
+		if (dir === 'top')    newZ = maxZ + 1
+		if (dir === 'bottom') newZ = minZ - 1
+		if (dir === 'up' && idx < sorted.length - 1) {
+			const next = sorted[idx + 1]
+			newZ = next.z
+			next.z = src.z
+		}
+		if (dir === 'down' && idx > 0) {
+			const prev = sorted[idx - 1]
+			newZ = prev.z
+			prev.z = src.z
+		}
+		const layout: ObsSceneLayout = {
+			sources: all.map(s => s.id === id ? { ...s, z: newZ } : sorted.find(x => x.id === s.id) ?? s),
+		}
+		applyLayoutChange(layout)
+	}
+
+	// Editeur de propriétés du source sélectionné : on patch un seul champ
+	// à la fois et on persist debounced via applyLayoutChange.
+	function patchSelected(patch: Partial<ObsSceneSource>): void {
+		if (!selectedSource || !activeScene) return
+		const layout: ObsSceneLayout = {
+			sources: activeLayout.sources.map(s => s.id === selectedSource.id ? { ...s, ...patch } : s),
+		}
+		applyLayoutChange(layout)
+	}
+
+	function fmtSavedAgo(ts: number | null): string {
+		if (!ts) return ''
+		const sec = Math.floor((Date.now() - ts) / 1000)
+		if (sec < 5)  return 'sauvegardé à l\'instant'
+		if (sec < 60) return `sauvegardé il y a ${sec}s`
+		return `sauvegardé il y a ${Math.floor(sec / 60)}min`
+	}
+
+	onMount(() => {
+		void loadScenes()
+		void loadOverlaysIndex()
+		void loadPlaylistsIndex()
+		window.addEventListener('nodyx:focus-scene', onFocusEvent)
+		try {
+			const v = localStorage.getItem('nodyx:scenes:preview-mode')
+			if (v === 'live' || v === 'wireframe') previewMode = v
+		} catch { /* localStorage indispo : on garde le défaut */ }
+	})
+
+	$effect(() => {
+		try { localStorage.setItem('nodyx:scenes:preview-mode', previewMode) } catch { /* noop */ }
+	})
+
+	// Patch du fond de scène : on regénère le layout en gardant les sources
+	// inchangées et on passe par le même flow debounced que les sources.
+	function setBackground(bg: { kind: 'none' | 'color' | 'image'; color?: string; url?: string } | undefined): void {
+		if (!activeScene) return
+		const layout: ObsSceneLayout = { sources: activeLayout.sources, ...(bg ? { background: bg } : {}) }
+		applyLayoutChange(layout)
+	}
+	onDestroy(() => {
+		window.removeEventListener('nodyx:focus-scene', onFocusEvent)
+	})
+</script>
+
+<section class="space-y-3">
+
+	<!-- Header : titre + état sauvegarde + lien doc -->
+	<header class="flex items-start justify-between gap-3 flex-wrap">
+		<div>
+			<h2 class="text-lg font-semibold text-zinc-100">Scènes OBS</h2>
+			<p class="text-sm text-zinc-500 mt-0.5">Compose la disposition de tes scènes. <span class="text-zinc-400">Phase A</span> : aperçu indicatif, le rendu final est celui d'OBS. <span class="text-zinc-600">Phase B (à venir)</span> : aperçu réel de la scène OBS via OBS WebSocket.</p>
+		</div>
+		{#if lastSaveAt}
+			<div class="text-[11px] text-zinc-500 flex items-center gap-1.5">
+				<span class="w-1.5 h-1.5 rounded-full bg-emerald-400/80"></span>
+				{fmtSavedAgo(lastSaveAt)}
+			</div>
+		{/if}
+	</header>
+
+	{#if toast}
+		<div class="border-l-2 px-3 py-2 text-sm flex items-center gap-2 {toast.ok ? 'border-emerald-500 bg-emerald-500/5 text-emerald-200' : 'border-rose-500 bg-rose-500/5 text-rose-200'}">
+			{toast.text}
+		</div>
+	{/if}
+
+	{#if loading}
+		<div class="border border-zinc-800 bg-zinc-900 px-4 py-10 text-sm text-zinc-500 text-center">Chargement…</div>
+	{:else}
+		<!-- Grille principale OBS-like : canvas en haut large + contrôles à
+		     droite ; 3 colonnes en bas (Scenes / Sources / Mixer). -->
+		<div class="grid grid-cols-[minmax(0,1fr)_240px] gap-3">
+			<!-- ── Colonne gauche : Canvas + 3 sous-colonnes ─────────────── -->
+			<div class="space-y-3 min-w-0">
+				<!-- Canvas preview -->
+				{#if activeScene}
+					<SceneCanvas
+						layout={activeLayout}
+						selectedId={selectedSrc}
+						onSelect={(id) => selectedSrc = id}
+						onChange={applyLayoutChange}
+						labelFor={displayLabelFor}
+						{previewMode}
+					/>
+					<!-- Toggle compact mode rendu sous le canvas : permet de basculer
+					     aperçu live (iframes) ↔ wireframe (placeholders rapides) sans
+					     quitter la scène. -->
+					<div class="flex items-center justify-end gap-2 text-[11px]">
+						<span class="text-zinc-500">Aperçu :</span>
+						<div class="inline-flex items-center bg-zinc-900 border border-zinc-800 rounded-sm p-0.5">
+							{#each (['live', 'wireframe'] as const) as m (m)}
+								<button type="button" onclick={() => previewMode = m}
+									class="px-2 py-0.5 rounded-sm transition-colors {previewMode === m ? 'bg-purple-500/15 text-purple-200' : 'text-zinc-400 hover:text-zinc-200'}">
+									{m === 'live' ? 'Live' : 'Wireframe'}
+								</button>
+							{/each}
+						</div>
+					</div>
+				{:else}
+					<div class="w-full aspect-video bg-zinc-950 border border-dashed border-zinc-800 flex flex-col items-center justify-center gap-2 text-zinc-500">
+						<svg class="w-12 h-12 opacity-50" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+							<rect x="3" y="3" width="18" height="18" rx="2"/>
+							<path d="M3 9h18M9 3v18"/>
+						</svg>
+						<div class="text-sm">Aucune scène. Crée-en une pour démarrer.</div>
+					</div>
+				{/if}
+
+				<!-- Trois sous-colonnes : Scenes / Sources / Audio Mixer -->
+				<div class="grid grid-cols-3 gap-3">
+					<!-- Scenes -->
+					<div class="border border-zinc-800 bg-zinc-900 flex flex-col">
+						<header class="px-3 py-2 border-b border-zinc-800 flex items-center justify-between">
+							<h3 class="text-[10px] uppercase tracking-widest font-semibold text-zinc-400">Scènes</h3>
+							<span class="text-[10px] text-zinc-600 font-mono">{scenes.length}</span>
+						</header>
+						<ul class="flex-1 min-h-[180px] max-h-[260px] overflow-y-auto">
+							{#each scenes as s (s.id)}
+								{@const isAct = activeId === s.id}
+								<li class="border-b border-zinc-800/60 last:border-0">
+									<button type="button" onclick={() => { activeId = s.id; selectedSrc = null }}
+										class="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-left transition-colors
+											{isAct ? 'bg-purple-500/15 text-zinc-100 border-l-2 border-l-purple-500'
+											       : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/40 border-l-2 border-transparent'}">
+										<span class="w-2 h-2 rounded-full shrink-0" style="background: {s.color ?? '#a78bfa'};"></span>
+										<span class="flex-1 truncate" title={s.name}>{s.name}</span>
+										<span class="text-[10px] text-zinc-600 font-mono">{s.layout.sources.length}</span>
+									</button>
+								</li>
+							{/each}
+							{#if scenes.length === 0 && !creating}
+								<li class="px-3 py-4 text-[11px] text-zinc-500 text-center leading-snug">
+									Crée ta première scène (ex : Dev, Discussion, Pause).
+								</li>
+							{/if}
+						</ul>
+						<!-- Boutons + - dupliquer style OBS -->
+						<footer class="border-t border-zinc-800 p-1 flex items-center gap-0.5">
+							{#if !creating}
+								<button type="button" onclick={() => { creating = true; newName = '' }}
+									class="w-6 h-6 grid place-items-center text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/60 rounded-sm" title="Nouvelle scène">
+									<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
+								</button>
+								<button type="button" onclick={() => activeId && deleteScene(activeId)} disabled={!activeId}
+									class="w-6 h-6 grid place-items-center text-zinc-400 hover:text-rose-300 hover:bg-rose-900/30 rounded-sm disabled:opacity-30" title="Supprimer la scène active">
+									<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M20 12H4"/></svg>
+								</button>
+								<button type="button" onclick={() => activeId && duplicateScene(activeId)} disabled={!activeId}
+									class="w-6 h-6 grid place-items-center text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/60 rounded-sm disabled:opacity-30" title="Dupliquer la scène active">
+									<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+										<rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+									</svg>
+								</button>
+							{:else}
+								<input type="text" bind:value={newName} maxlength="80" placeholder="Nom (ex : Dev)"
+									onkeydown={(e) => { if (e.key === 'Enter') createScene(); if (e.key === 'Escape') creating = false }}
+									class="flex-1 bg-zinc-950 border border-zinc-800 focus:border-purple-500/60 px-1.5 py-0.5 text-[11px] text-zinc-100 placeholder-zinc-600 outline-none rounded-sm" autofocus/>
+								<button type="button" onclick={createScene} disabled={saving || !newName.trim()}
+									class="text-[11px] bg-purple-500 hover:bg-purple-400 disabled:bg-zinc-800 disabled:text-zinc-500 text-white px-1.5 py-0.5 rounded-sm">OK</button>
+								<button type="button" onclick={() => creating = false}
+									class="text-[11px] text-zinc-500 hover:text-zinc-300 px-1">✕</button>
+							{/if}
+						</footer>
+					</div>
+
+					<!-- Sources de la scène active -->
+					<div class="border border-zinc-800 bg-zinc-900 flex flex-col">
+						<header class="px-3 py-2 border-b border-zinc-800 flex items-center justify-between">
+							<h3 class="text-[10px] uppercase tracking-widest font-semibold text-zinc-400">Sources</h3>
+							<span class="text-[10px] text-zinc-600 font-mono">{activeLayout.sources.length}</span>
+						</header>
+						<ul class="flex-1 min-h-[180px] max-h-[260px] overflow-y-auto">
+							{#each sourcesByZ as s (s.id)}
+								{@const m = SOURCE_TYPE_META[s.type]}
+								{@const isSel = selectedSrc === s.id}
+								<li class="border-b border-zinc-800/60 last:border-0 group">
+									<div class="flex items-center gap-1 px-2 py-1 text-xs transition-colors
+										{isSel ? 'bg-purple-500/15' : 'hover:bg-zinc-800/40'}">
+										<button type="button" onclick={() => toggleSourceVisible(s.id)}
+											class="w-5 h-5 grid place-items-center text-zinc-500 hover:text-zinc-200 shrink-0" title={s.visible ? 'Cacher' : 'Afficher'}>
+											{#if s.visible}
+												<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+											{:else}
+												<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+											{/if}
+										</button>
+										<button type="button" onclick={() => toggleSourceLocked(s.id)}
+											class="w-5 h-5 grid place-items-center text-zinc-500 hover:text-amber-300 shrink-0" title={s.locked ? 'Déverrouiller' : 'Verrouiller'}>
+											{#if s.locked}
+												<svg class="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M18 8h-1V6a5 5 0 0 0-10 0v2H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V10a2 2 0 0 0-2-2zM9 6a3 3 0 0 1 6 0v2H9V6z"/></svg>
+											{:else}
+												<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 9.9-1"/></svg>
+											{/if}
+										</button>
+										<button type="button" onclick={() => selectedSrc = s.id}
+											class="flex-1 flex items-center gap-1.5 min-w-0 text-left text-zinc-300 hover:text-zinc-100">
+											<span class="text-[14px] leading-none">{m.icon}</span>
+											<span class="truncate" title={displayLabelFor(s)}>{displayLabelFor(s)}</span>
+										</button>
+										<div class="hidden group-hover:flex items-center gap-0.5">
+											<button type="button" onclick={() => moveSourceZ(s.id, 'up')} class="w-5 h-5 grid place-items-center text-zinc-500 hover:text-zinc-200" title="Devant">
+												<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M18 15l-6-6-6 6"/></svg>
+											</button>
+											<button type="button" onclick={() => moveSourceZ(s.id, 'down')} class="w-5 h-5 grid place-items-center text-zinc-500 hover:text-zinc-200" title="Derrière">
+												<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M6 9l6 6 6-6"/></svg>
+											</button>
+											<button type="button" onclick={() => removeSource(s.id)} class="w-5 h-5 grid place-items-center text-zinc-500 hover:text-rose-300" title="Supprimer">
+												<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6"/></svg>
+											</button>
+										</div>
+									</div>
+								</li>
+							{/each}
+							{#if activeLayout.sources.length === 0 && activeScene}
+								<li class="px-3 py-4 text-[11px] text-zinc-500 text-center leading-snug">
+									Aucune source. Clique sur <span class="text-zinc-300">＋</span> ci-dessous pour ajouter une caméra, un overlay ou une URL.
+								</li>
+							{/if}
+						</ul>
+						<footer class="border-t border-zinc-800 p-1 flex items-center gap-0.5">
+							<button type="button" onclick={() => addSourceOpen = true} disabled={!activeScene}
+								class="w-6 h-6 grid place-items-center text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/60 rounded-sm disabled:opacity-30" title="Ajouter une source">
+								<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
+							</button>
+							<button type="button" onclick={() => selectedSrc && removeSource(selectedSrc)} disabled={!selectedSrc}
+								class="w-6 h-6 grid place-items-center text-zinc-400 hover:text-rose-300 hover:bg-rose-900/30 rounded-sm disabled:opacity-30" title="Supprimer la source sélectionnée">
+								<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M20 12H4"/></svg>
+							</button>
+						</footer>
+					</div>
+
+					<!-- Audio Mixer placeholder Phase A -->
+					<div class="border border-zinc-800 bg-zinc-900 flex flex-col">
+						<header class="px-3 py-2 border-b border-zinc-800 flex items-center justify-between">
+							<h3 class="text-[10px] uppercase tracking-widest font-semibold text-zinc-400">Audio Mixer</h3>
+							<span class="text-[9px] uppercase tracking-wider font-bold text-amber-300/80 bg-amber-500/10 px-1 rounded-sm">Phase B</span>
+						</header>
+						<div class="flex-1 min-h-[180px] flex flex-col items-center justify-center gap-2 px-3 py-4 text-center">
+							<svg class="w-8 h-8 text-zinc-700" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+								<rect x="4" y="2" width="6" height="20" rx="1"/><rect x="14" y="2" width="6" height="20" rx="1"/>
+								<line x1="7" y1="14" x2="7" y2="14"/><line x1="17" y1="8" x2="17" y2="8"/>
+							</svg>
+							<div class="text-[11px] text-zinc-500 leading-snug max-w-[20ch]">
+								Les sliders de volume des sources audio apparaîtront ici une fois Nodyx connecté à OBS.
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<!-- ── Colonne droite : Contrôles + Properties ───────────────── -->
+			<aside class="space-y-3 min-w-0">
+				<!-- Contrôles OBS (placeholders Phase A) -->
+				<div class="border border-zinc-800 bg-zinc-900">
+					<header class="px-3 py-2 border-b border-zinc-800 flex items-center justify-between">
+						<h3 class="text-[10px] uppercase tracking-widest font-semibold text-zinc-400">Contrôles</h3>
+						<span class="text-[9px] uppercase tracking-wider font-bold text-amber-300/80 bg-amber-500/10 px-1 rounded-sm">Phase C</span>
+					</header>
+					<div class="p-2 space-y-1.5">
+						<button type="button" disabled class="w-full inline-flex items-center justify-between gap-2 bg-zinc-800/40 border border-zinc-800 text-zinc-500 px-2.5 py-1.5 text-[11px] rounded-sm cursor-not-allowed">
+							<span class="inline-flex items-center gap-1.5"><span class="text-rose-400/60">●</span> Start Streaming</span>
+							<span class="text-[9px] uppercase font-mono">via OBS</span>
+						</button>
+						<button type="button" disabled class="w-full inline-flex items-center justify-between gap-2 bg-zinc-800/40 border border-zinc-800 text-zinc-500 px-2.5 py-1.5 text-[11px] rounded-sm cursor-not-allowed">
+							<span class="inline-flex items-center gap-1.5"><span class="text-zinc-500">⏺</span> Start Recording</span>
+							<span class="text-[9px] uppercase font-mono">via OBS</span>
+						</button>
+						<button type="button" disabled class="w-full inline-flex items-center justify-between gap-2 bg-zinc-800/40 border border-zinc-800 text-zinc-500 px-2.5 py-1.5 text-[11px] rounded-sm cursor-not-allowed">
+							<span class="inline-flex items-center gap-1.5"><span class="text-zinc-500">🎬</span> Studio Mode</span>
+							<span class="text-[9px] uppercase font-mono">via OBS</span>
+						</button>
+					</div>
+				</div>
+
+				<!-- Properties du source sélectionné OU panneau Scène si rien
+				     n'est sélectionné. Quand aucune source n'est ciblée, on
+				     propose le picker de fond de scène : couleur unie, image
+				     ou aucun (transparent, comme OBS Color/Image Source). -->
+				<div class="border border-zinc-800 bg-zinc-900">
+					<header class="px-3 py-2 border-b border-zinc-800 flex items-center justify-between">
+						<h3 class="text-[10px] uppercase tracking-widest font-semibold text-zinc-400">
+							{selectedSource ? 'Propriétés' : 'Scène'}
+						</h3>
+					</header>
+					<div class="p-2.5 space-y-2.5">
+						{#if !selectedSource}
+							{@const bg = activeLayout.background ?? { kind: 'none' as const }}
+							<div class="text-[10px] uppercase tracking-wider font-semibold text-zinc-500">Fond de scène</div>
+							<div class="grid grid-cols-3 gap-1 bg-zinc-950 border border-zinc-800 p-0.5 rounded-sm">
+								{#each [{ k: 'none', l: 'Aucun' }, { k: 'color', l: 'Couleur' }, { k: 'image', l: 'Image' }] as opt (opt.k)}
+									{@const isSel = bg.kind === opt.k}
+									<button type="button"
+										onclick={() => setBackground({
+											kind:  opt.k as 'none' | 'color' | 'image',
+											color: opt.k === 'color' ? (bg.color ?? '#0b0b0c') : undefined,
+											url:   opt.k === 'image' ? (bg.url   ?? '')        : undefined,
+										})}
+										class="text-[11px] px-2 py-1 rounded-sm transition-colors {isSel ? 'bg-purple-500/15 text-purple-200' : 'text-zinc-400 hover:text-zinc-200'}">
+										{opt.l}
+									</button>
+								{/each}
+							</div>
+
+							{#if bg.kind === 'color'}
+								<label class="flex items-center gap-2">
+									<input type="color" value={bg.color ?? '#0b0b0c'}
+										oninput={(e) => setBackground({ kind: 'color', color: e.currentTarget.value })}
+										class="w-8 h-8 bg-transparent border border-zinc-800 rounded cursor-pointer p-0"/>
+									<input type="text" value={bg.color ?? '#0b0b0c'} maxlength="7"
+										oninput={(e) => {
+											const v = e.currentTarget.value
+											if (/^#[0-9a-fA-F]{6}$/.test(v)) setBackground({ kind: 'color', color: v })
+										}}
+										class="flex-1 bg-zinc-950 border border-zinc-800 focus:border-purple-500/60 px-2 py-1 text-xs text-zinc-100 outline-none rounded-sm font-mono"/>
+								</label>
+							{:else if bg.kind === 'image'}
+								<label class="block">
+									<span class="text-[9px] uppercase font-semibold text-zinc-500">URL de l'image (HTTPS)</span>
+									<input type="url" value={bg.url ?? ''} placeholder="https://…"
+										oninput={(e) => setBackground({ kind: 'image', url: e.currentTarget.value })}
+										class="mt-0.5 w-full bg-zinc-950 border border-zinc-800 focus:border-purple-500/60 px-2 py-1 text-[11px] text-zinc-100 outline-none rounded-sm font-mono"/>
+								</label>
+								<div class="text-[10px] text-zinc-600 leading-snug">
+									L'image est affichée plein cadre derrière les sources (object-cover).
+								</div>
+							{:else}
+								<div class="text-[10px] text-zinc-500 leading-snug">
+									Aucun fond : la scène reste transparente. Choisis <span class="text-zinc-300">Couleur</span> pour un fond uni ou <span class="text-zinc-300">Image</span> pour un visuel.
+								</div>
+							{/if}
+
+							<div class="pt-2 border-t border-zinc-800 text-[11px] text-zinc-500 leading-snug">
+								Sélectionne une source dans le canvas ou la liste pour éditer sa position, sa taille ou son contenu.
+							</div>
+						{:else}
+							{@const m = SOURCE_TYPE_META[selectedSource.type]}
+							<!-- Header : on met en avant le nom vivant (super alerte,
+							     Pause, etc.) et on rappelle le type en sous-titre
+							     discret pour ne pas répéter Alert Box quand le
+							     streamer a donné un nom custom à son overlay. -->
+							<div class="flex items-center gap-2.5 min-w-0">
+								<span class="text-lg leading-none">{m.icon}</span>
+								<div class="min-w-0 flex-1">
+									<div class="text-sm font-semibold text-zinc-100 truncate" title={displayLabelFor(selectedSource)}>
+										{displayLabelFor(selectedSource)}
+									</div>
+									<div class="text-[10px] uppercase tracking-wider font-semibold" style="color: #{m.accent};">{m.label}</div>
+								</div>
+							</div>
+							<label class="block">
+								<span class="text-[9px] uppercase font-semibold text-zinc-500">Nom affiché</span>
+								<input type="text" value={selectedSource.label} maxlength="60"
+									oninput={(e) => patchSelected({ label: e.currentTarget.value })}
+									class="mt-0.5 w-full bg-zinc-950 border border-zinc-800 focus:border-purple-500/60 px-2 py-1 text-xs text-zinc-100 outline-none rounded-sm"/>
+							</label>
+							<div class="grid grid-cols-2 gap-2">
+								<label class="block">
+									<span class="text-[9px] uppercase font-semibold text-zinc-500">X</span>
+									<input type="number" value={selectedSource.x} min="0" max="1920"
+										oninput={(e) => patchSelected({ x: Math.max(0, Math.min(1920, parseInt(e.currentTarget.value) || 0)) })}
+										class="mt-0.5 w-full bg-zinc-950 border border-zinc-800 focus:border-purple-500/60 px-1.5 py-1 text-xs text-zinc-100 outline-none rounded-sm font-mono"/>
+								</label>
+								<label class="block">
+									<span class="text-[9px] uppercase font-semibold text-zinc-500">Y</span>
+									<input type="number" value={selectedSource.y} min="0" max="1080"
+										oninput={(e) => patchSelected({ y: Math.max(0, Math.min(1080, parseInt(e.currentTarget.value) || 0)) })}
+										class="mt-0.5 w-full bg-zinc-950 border border-zinc-800 focus:border-purple-500/60 px-1.5 py-1 text-xs text-zinc-100 outline-none rounded-sm font-mono"/>
+								</label>
+								<label class="block">
+									<span class="text-[9px] uppercase font-semibold text-zinc-500">Largeur</span>
+									<input type="number" value={selectedSource.w} min="1" max="1920"
+										oninput={(e) => patchSelected({ w: Math.max(1, Math.min(1920, parseInt(e.currentTarget.value) || 1)) })}
+										class="mt-0.5 w-full bg-zinc-950 border border-zinc-800 focus:border-purple-500/60 px-1.5 py-1 text-xs text-zinc-100 outline-none rounded-sm font-mono"/>
+								</label>
+								<label class="block">
+									<span class="text-[9px] uppercase font-semibold text-zinc-500">Hauteur</span>
+									<input type="number" value={selectedSource.h} min="1" max="1080"
+										oninput={(e) => patchSelected({ h: Math.max(1, Math.min(1080, parseInt(e.currentTarget.value) || 1)) })}
+										class="mt-0.5 w-full bg-zinc-950 border border-zinc-800 focus:border-purple-500/60 px-1.5 py-1 text-xs text-zinc-100 outline-none rounded-sm font-mono"/>
+								</label>
+							</div>
+							{#if selectedSource.type === 'browser_source'}
+								<label class="block">
+									<span class="text-[9px] uppercase font-semibold text-zinc-500">URL Browser Source</span>
+									<input type="url" value={typeof selectedSource.config.url === 'string' ? selectedSource.config.url : ''}
+										placeholder="https://…"
+										oninput={(e) => patchSelected({ config: { ...selectedSource.config, url: e.currentTarget.value } })}
+										class="mt-0.5 w-full bg-zinc-950 border border-zinc-800 focus:border-purple-500/60 px-2 py-1 text-[11px] text-zinc-100 outline-none rounded-sm font-mono"/>
+								</label>
+							{:else if typeof selectedSource.config.overlayToken === 'string' && selectedSource.config.overlayToken.length > 0}
+								<!-- Source liée à un overlay Nodyx : on offre des
+								     actions IN-PLACE plutôt que d'envoyer le streamer
+								     dans un autre tab. Le bouton "Changer..." rouvre
+								     le picker à l'étape adaptée (overlay du même type
+								     ou playlist) et permet de remplacer la cible en
+								     gardant la position/taille de la source. -->
+								<div class="rounded-sm border border-zinc-800 bg-zinc-950 px-2.5 py-2 space-y-1.5">
+									<div class="flex items-center justify-between gap-2">
+										<span class="text-[9px] uppercase tracking-wider font-semibold text-zinc-500">
+											{selectedSource.type === 'playlist' ? 'Playlist ciblée' : 'Overlay lié'}
+										</span>
+										<button type="button" onclick={() => { swapSourceId = selectedSource.id }}
+											class="text-[10px] font-medium text-purple-200 hover:text-purple-100 inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm bg-purple-500/15 hover:bg-purple-500/25 border border-purple-500/40">
+											<svg class="w-2.5 h-2.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
+											Changer
+										</button>
+									</div>
+									<div class="text-[11px] text-zinc-300 font-medium truncate" title={displayLabelFor(selectedSource)}>
+										{displayLabelFor(selectedSource)}
+									</div>
+								</div>
+								<!-- Lien secondaire vers la config viewer-facing de
+								     l'overlay (couleurs, sons, etc.). Navigation via
+								     le helper : pushState + hashchange dispatché manuel,
+								     + sessionStorage pour qu'OverlayManager ouvre pile
+								     la ligne de cet overlay au mount. -->
+								{#if selectedSource.type !== 'playlist'}
+									<button type="button"
+										onclick={() => focusOverlayAfterNav(selectedSource.config.overlayToken as string)}
+										class="text-[10px] text-zinc-500 hover:text-zinc-300 inline-flex items-center gap-1">
+										<svg class="w-2.5 h-2.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+											<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+										</svg>
+										Modifier les couleurs / sons de cet overlay
+									</button>
+								{/if}
+							{:else if selectedSource.type === 'placeholder_video'}
+								<label class="block">
+									<span class="text-[9px] uppercase font-semibold text-zinc-500">Type visé</span>
+									<select value={typeof selectedSource.config.kind === 'string' ? selectedSource.config.kind : 'webcam'}
+										onchange={(e) => patchSelected({ config: { ...selectedSource.config, kind: e.currentTarget.value } })}
+										class="mt-0.5 w-full bg-zinc-950 border border-zinc-800 focus:border-purple-500/60 px-2 py-1 text-[11px] text-zinc-100 outline-none rounded-sm">
+										<option value="webcam">📷 Webcam</option>
+										<option value="capture">🎮 Capture jeu</option>
+										<option value="image">🖼 Image / logo</option>
+									</select>
+								</label>
+								<div class="text-[10px] text-zinc-600 leading-snug">
+									La vraie source OBS sera liée ici quand le bridge OBS WebSocket sera activé (Phase B).
+								</div>
+							{/if}
+						{/if}
+					</div>
+				</div>
+			</aside>
+		</div>
+	{/if}
+</section>
+
+{#if addSourceOpen}
+	<AddSourceModal
+		{token}
+		onPick={(type, config, label) => addSource(type, config, label)}
+		onClose={() => addSourceOpen = false}
+	/>
+{/if}
+
+{#if swappingSource}
+	<!-- Mode swap : on rouvre le modal à l'étape adaptée au type courant.
+	     Le picker se charge de proposer la liste + "Créer un nouveau". Au
+	     pick, swapSource() met à jour la source SANS toucher la position. -->
+	<AddSourceModal
+		{token}
+		initialType={swappingSource.type}
+		title={swappingSource.type === 'playlist'
+			? 'Changer la playlist'
+			: `Changer l'overlay ${SOURCE_TYPE_META[swappingSource.type].label}`}
+		onPick={(type, config, label) => swapSource(type, config, label)}
+		onClose={() => swapSourceId = null}
+	/>
+{/if}

--- a/nodyx-frontend/src/lib/components/admin/obs/PlaceInSceneModal.svelte
+++ b/nodyx-frontend/src/lib/components/admin/obs/PlaceInSceneModal.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+	import { apiFetch } from '$lib/api'
+	import { onMount } from 'svelte'
+	import { SOURCE_TYPE_META, CANVAS_WIDTH, CANVAS_HEIGHT,
+		type ObsScene, type ObsSceneLayout, type ObsSceneSource, type ObsSceneSourceType } from '$lib/types/obsScenes'
+
+	// ─── Modal "Placer dans une scène" ──────────────────────────────────────
+	// Appelée depuis Overlays OBS et Soundboard pour rattacher un overlay ou
+	// une playlist à une scène existante (ou à une nouvelle). Le streamer reste
+	// sur son tab d'origine : pas de redirection vers Scènes, juste un toast
+	// de confirmation. C'est ce qui répare la sensation "tu es projeté ailleurs
+	// et tu te perds".
+	//
+	// Côté flow :
+	//   1. Liste des scènes existantes (créées par le streamer).
+	//   2. Option en bas : "+ Créer une nouvelle scène" inline.
+	//   3. Clic sur une scène → PATCH layout (ajoute la source au centre du
+	//      canvas avec la taille par défaut du type) → toast et fermeture.
+
+	interface Props {
+		token:      string
+		// Type de source à placer (ex : 'alert_box', 'playlist').
+		sourceType: ObsSceneSourceType
+		// Label par défaut (nom de l'overlay / playlist) pour identifier dans
+		// la liste Sources de la scène cible.
+		sourceLabel: string
+		// Config qui sera collée à la source (overlayToken, playlistId, etc.).
+		sourceConfig: Record<string, unknown>
+		// Le 3e arg signale si la scène vient d'être créée (true) ou si on
+		// a placé dans une scène existante (false). Les parents l'utilisent
+		// pour décider de naviguer vers Scènes (cas "nouvelle scène à
+		// travailler") ou de rester sur place (cas "rangement rapide").
+		onPlaced:   (sceneId: string, sceneName: string, isNew: boolean) => void
+		onClose:    () => void
+	}
+	let { token, sourceType, sourceLabel, sourceConfig, onPlaced, onClose }: Props = $props()
+
+	let scenes  = $state<ObsScene[]>([])
+	let loading = $state(true)
+	let busy    = $state(false)
+	let error   = $state<string | null>(null)
+
+	let creating  = $state(false)
+	let newName   = $state('')
+
+	async function loadScenes(): Promise<void> {
+		loading = true
+		try {
+			const res = await apiFetch(fetch, '/streamer/obs/scenes', { headers: { Authorization: `Bearer ${token}` } })
+			if (res.ok) {
+				const d = await res.json() as { scenes: ObsScene[] }
+				scenes = d.scenes ?? []
+			}
+		} finally {
+			loading = false
+		}
+	}
+
+	function buildNewSource(): ObsSceneSource {
+		const m = SOURCE_TYPE_META[sourceType]
+		return {
+			id:      `src_${Math.random().toString(36).slice(2, 10)}`,
+			type:    sourceType,
+			label:   (sourceLabel || m.label).slice(0, 60),
+			x:       Math.round((CANVAS_WIDTH  - m.defaultW) / 2),
+			y:       Math.round((CANVAS_HEIGHT - m.defaultH) / 2),
+			w:       m.defaultW,
+			h:       m.defaultH,
+			z:       0,    // placeholder ; on recalcule juste avant le PATCH
+			visible: true,
+			locked:  false,
+			config:  sourceConfig,
+		}
+	}
+
+	async function placeIn(scene: ObsScene): Promise<void> {
+		if (busy) return
+		busy = true
+		error = null
+		try {
+			// On récupère la version la plus à jour de la scène pour éviter
+			// d'écraser une modif faite ailleurs entre le load et le PATCH.
+			const fresh = await apiFetch(fetch, `/streamer/obs/scenes/${scene.id}`, {
+				headers: { Authorization: `Bearer ${token}` },
+			})
+			let liveLayout: ObsSceneLayout = scene.layout
+			if (fresh.ok) {
+				const d = await fresh.json() as { scene: ObsScene }
+				liveLayout = d.scene.layout
+			}
+			const maxZ = liveLayout.sources.reduce((acc, s) => Math.max(acc, s.z), -1)
+			const newSrc = { ...buildNewSource(), z: maxZ + 1 }
+			const layout: ObsSceneLayout = { sources: [...liveLayout.sources, newSrc] }
+
+			const res = await apiFetch(fetch, `/streamer/obs/scenes/${scene.id}`, {
+				method:  'PATCH',
+				headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+				body:    JSON.stringify({ layout }),
+			})
+			if (res.ok) {
+				onPlaced(scene.id, scene.name, false)
+			} else {
+				error = `Placement impossible (HTTP ${res.status}).`
+			}
+		} catch {
+			error = 'Erreur réseau.'
+		} finally {
+			busy = false
+		}
+	}
+
+	async function createAndPlace(): Promise<void> {
+		const name = newName.trim()
+		if (!name || busy) return
+		busy = true
+		error = null
+		try {
+			// On crée la scène avec la source déjà dedans pour éviter un
+			// 2e roundtrip réseau. Z = 0 (première source = au-dessus du fond).
+			const layout: ObsSceneLayout = { sources: [buildNewSource()] }
+			const res = await apiFetch(fetch, '/streamer/obs/scenes', {
+				method:  'POST',
+				headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+				body:    JSON.stringify({ name, layout }),
+			})
+			if (res.ok) {
+				const d = await res.json() as { scene: ObsScene }
+				onPlaced(d.scene.id, d.scene.name, true)
+			} else if (res.status === 409) {
+				error = 'Une scène a déjà ce nom.'
+			} else {
+				error = `Création impossible (HTTP ${res.status}).`
+			}
+		} catch {
+			error = 'Erreur réseau.'
+		} finally {
+			busy = false
+		}
+	}
+
+	onMount(() => { void loadScenes() })
+</script>
+
+<div class="fixed inset-0 z-50 grid place-items-center p-4 bg-black/70 backdrop-blur-sm"
+	onclick={onClose}
+	onkeydown={(e) => { if (e.key === 'Escape') onClose() }}
+	role="dialog" aria-modal="true" tabindex="-1">
+	<div class="w-full max-w-md bg-zinc-950 border border-zinc-800 rounded-lg shadow-2xl"
+		onclick={(e) => e.stopPropagation()}
+		onkeydown={(e) => e.stopPropagation()}
+		role="document">
+		<header class="px-4 py-3 border-b border-zinc-800 flex items-center justify-between">
+			<div class="min-w-0">
+				<div class="text-xs uppercase tracking-widest font-semibold text-purple-300/80">Placer dans une scène</div>
+				<h3 class="text-sm font-semibold text-zinc-100 mt-0.5 truncate">
+					{SOURCE_TYPE_META[sourceType].icon} {sourceLabel || SOURCE_TYPE_META[sourceType].label}
+				</h3>
+			</div>
+			<button type="button" onclick={onClose} class="text-zinc-500 hover:text-zinc-200 w-7 h-7 grid place-items-center shrink-0" title="Fermer">✕</button>
+		</header>
+
+		<div class="p-4 space-y-3">
+			{#if loading}
+				<div class="text-center text-xs text-zinc-500 py-6">Chargement…</div>
+			{:else if scenes.length === 0 && !creating}
+				<div class="rounded-md border border-dashed border-zinc-800 bg-zinc-900/40 px-4 py-5 text-center text-xs text-zinc-500 leading-snug">
+					Aucune scène. Crée-en une ci-dessous pour y placer cet élément.
+				</div>
+			{:else}
+				<div class="text-[10px] uppercase tracking-widest font-semibold text-zinc-500">Choisis une scène</div>
+				<ul class="space-y-1.5 max-h-64 overflow-y-auto">
+					{#each scenes as s (s.id)}
+						<li>
+							<button type="button" onclick={() => placeIn(s)} disabled={busy}
+								class="w-full text-left flex items-center gap-3 p-2.5 rounded-md bg-zinc-900/60 border border-zinc-800 hover:border-purple-500/60 hover:bg-purple-500/5 transition-colors disabled:opacity-50">
+								<span class="w-2 h-2 rounded-full shrink-0" style="background: {s.color ?? '#a78bfa'};"></span>
+								<div class="min-w-0 flex-1">
+									<div class="text-sm text-zinc-100 truncate">{s.name}</div>
+									<div class="text-[10px] text-zinc-600">{s.layout.sources.length} source{s.layout.sources.length > 1 ? 's' : ''}</div>
+								</div>
+								<svg class="w-3.5 h-3.5 text-zinc-600 shrink-0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"/></svg>
+							</button>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+
+			<!-- Création inline d'une nouvelle scène avec la source déjà dedans -->
+			<div class="border-t border-zinc-800 pt-3">
+				{#if !creating}
+					<button type="button" onclick={() => { creating = true; newName = '' }}
+						class="w-full inline-flex items-center justify-center gap-2 px-3 py-2 text-xs font-medium bg-purple-500/15 hover:bg-purple-500/25 border border-purple-500/40 hover:border-purple-500/70 text-purple-100 rounded-md transition-colors">
+						<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
+						Créer une nouvelle scène
+					</button>
+				{:else}
+					<div class="space-y-2">
+						<label class="block">
+							<span class="text-[10px] uppercase tracking-wider font-semibold text-zinc-500">Nom de la scène</span>
+							<input type="text" bind:value={newName} maxlength="80"
+								placeholder="ex : Dev, Discussion, Pause"
+								onkeydown={(e) => { if (e.key === 'Enter') createAndPlace() }}
+								class="mt-1 w-full bg-zinc-900 border border-zinc-800 focus:border-purple-500/60 px-3 py-1.5 text-xs text-zinc-100 outline-none rounded-sm"
+								autofocus/>
+						</label>
+						<div class="flex items-center gap-2">
+							<button type="button" onclick={createAndPlace} disabled={busy || !newName.trim()}
+								class="flex-1 text-xs font-medium bg-purple-500 hover:bg-purple-400 disabled:bg-zinc-800 disabled:text-zinc-500 text-white px-3 py-1.5 rounded-sm transition-colors">
+								{busy ? 'Création…' : 'Créer et placer'}
+							</button>
+							<button type="button" onclick={() => { creating = false; error = null }}
+								class="text-xs bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-200 px-3 py-1.5 rounded-sm">
+								Annuler
+							</button>
+						</div>
+					</div>
+				{/if}
+			</div>
+
+			{#if error}
+				<div class="text-[11px] text-rose-300 bg-rose-500/10 border border-rose-500/30 rounded-sm px-2 py-1.5">{error}</div>
+			{/if}
+		</div>
+	</div>
+</div>

--- a/nodyx-frontend/src/lib/components/admin/obs/SceneCanvas.svelte
+++ b/nodyx-frontend/src/lib/components/admin/obs/SceneCanvas.svelte
@@ -1,0 +1,358 @@
+<script lang="ts">
+	import { browser } from '$app/environment'
+	import {
+		CANVAS_WIDTH, CANVAS_HEIGHT, SOURCE_TYPE_META, FULL_SCENE_VIEWPORT_TYPES,
+		resolveSourceUrl,
+		type ObsSceneLayout, type ObsSceneSource,
+	} from '$lib/types/obsScenes'
+
+	// ─── Canvas scène OBS-like ──────────────────────────────────────────────
+	// Reproduit la zone preview d'OBS : fond noir 16:9, grille subtile, sources
+	// positionnées en pixels absolus (1920x1080) puis scaled visuellement. La
+	// sélection affiche les 8 poignées de resize style OBS (rouge ardent).
+	//
+	// Interactions :
+	//   • clic sur une source : sélection (par-dessus les autres)
+	//   • drag corps source : déplacement (snap aux bords + centre canvas)
+	//   • drag poignée : resize avec ratio libre, clampé au canvas
+	//   • clic hors source : désélection
+	//
+	// Le composant émet `onChange(layout)` à chaque modif persistante (fin de
+	// drag) pour que le parent puisse sauvegarder. Pendant un drag actif, on
+	// mute en local pour rester fluide à 60fps sans roundtrip réseau.
+
+	interface Props {
+		layout:        ObsSceneLayout
+		selectedId:    string | null
+		onSelect:      (id: string | null) => void
+		onChange:      (layout: ObsSceneLayout) => void
+		// Optionnel : résout le label affiché pour une source en fonction de
+		// l'overlay/playlist parent. Permet d'afficher "super alerte" plutôt
+		// que "Alert Box" quand le streamer a renommé l'overlay. Fallback
+		// sur le label stocké si non fourni.
+		labelFor?:     (s: ObsSceneSource) => string
+		// Mode rendu : 'live' affiche les iframes des overlays (preview
+		// fidèle), 'wireframe' garde les placeholders rapides (utile pour
+		// composer sans surcharger le CPU). Défaut 'live'.
+		previewMode?:  'live' | 'wireframe'
+	}
+
+	let { layout, selectedId, onSelect, onChange, labelFor, previewMode = 'live' }: Props = $props()
+
+	// Origin du navigateur pour construire les URLs des iframes. SSR-safe :
+	// vide tant qu'on n'est pas dans un browser, on cache les iframes.
+	const origin = $derived(browser ? window.location.origin : '')
+
+	// Réf au conteneur pour calculer le ratio pixel canvas → pixel écran.
+	// Recalculé sur ResizeObserver pour gérer redimensionnement de la fenêtre.
+	let stageEl: HTMLDivElement | null = null
+	let scale = $state(1)
+
+	function updateScale(): void {
+		if (!stageEl) return
+		const w = stageEl.clientWidth
+		scale = w > 0 ? w / CANVAS_WIDTH : 1
+	}
+
+	$effect(() => {
+		if (!stageEl) return
+		updateScale()
+		const obs = new ResizeObserver(updateScale)
+		obs.observe(stageEl)
+		return () => obs.disconnect()
+	})
+
+	// Le layout est immuable depuis l'extérieur, mais on a besoin de l'écrire
+	// pendant un drag. On garde une copie locale "dragLayout" qu'on flush au
+	// parent en fin d'interaction. Tant qu'aucun drag : on lit le prop.
+	let dragLayout = $state<ObsSceneLayout | null>(null)
+	const effectiveLayout = $derived<ObsSceneLayout>(dragLayout ?? layout)
+
+	// Sources triées par z pour l'ordre de stack (z bas = fond, z haut = devant).
+	const sortedSources = $derived<ObsSceneSource[]>(
+		[...effectiveLayout.sources].sort((a, b) => a.z - b.z),
+	)
+
+	// ── Drag/resize state ────────────────────────────────────────────────
+	type DragMode = null | 'move' | `resize-${'nw'|'n'|'ne'|'e'|'se'|'s'|'sw'|'w'}`
+	let dragMode  = $state<DragMode>(null)
+	let dragId    = $state<string | null>(null)
+	let dragStart = { mouseX: 0, mouseY: 0, x: 0, y: 0, w: 0, h: 0 }
+
+	function findSource(id: string): ObsSceneSource | null {
+		return effectiveLayout.sources.find(s => s.id === id) ?? null
+	}
+
+	// Le snap aux guides 0/centre/max donne ce feeling OBS où les bords se
+	// magnétisent. Tolérance en pixels CANVAS (8px = ~1% sur 1920).
+	const SNAP_TOLERANCE = 16
+	function snap(value: number, targets: number[]): number {
+		for (const t of targets) {
+			if (Math.abs(value - t) <= SNAP_TOLERANCE) return t
+		}
+		return value
+	}
+
+	function startMove(e: PointerEvent, src: ObsSceneSource): void {
+		if (src.locked) return
+		;(e.target as HTMLElement).setPointerCapture(e.pointerId)
+		dragMode  = 'move'
+		dragId    = src.id
+		dragStart = { mouseX: e.clientX, mouseY: e.clientY, x: src.x, y: src.y, w: src.w, h: src.h }
+		dragLayout = JSON.parse(JSON.stringify(layout))
+		onSelect(src.id)
+		e.stopPropagation()
+		e.preventDefault()
+	}
+
+	function startResize(e: PointerEvent, src: ObsSceneSource, handle: Exclude<DragMode, null | 'move'>): void {
+		if (src.locked) return
+		;(e.target as HTMLElement).setPointerCapture(e.pointerId)
+		dragMode  = handle
+		dragId    = src.id
+		dragStart = { mouseX: e.clientX, mouseY: e.clientY, x: src.x, y: src.y, w: src.w, h: src.h }
+		dragLayout = JSON.parse(JSON.stringify(layout))
+		onSelect(src.id)
+		e.stopPropagation()
+		e.preventDefault()
+	}
+
+	function onPointerMove(e: PointerEvent): void {
+		if (!dragMode || !dragId || !dragLayout) return
+		const dx = (e.clientX - dragStart.mouseX) / scale
+		const dy = (e.clientY - dragStart.mouseY) / scale
+
+		const idx = dragLayout.sources.findIndex(s => s.id === dragId)
+		if (idx < 0) return
+		const src = dragLayout.sources[idx]
+
+		if (dragMode === 'move') {
+			let nx = dragStart.x + dx
+			let ny = dragStart.y + dy
+			// Snap aux bords du canvas + centres (X et Y).
+			nx = snap(nx,                              [0, (CANVAS_WIDTH  - src.w) / 2, CANVAS_WIDTH  - src.w])
+			ny = snap(ny,                              [0, (CANVAS_HEIGHT - src.h) / 2, CANVAS_HEIGHT - src.h])
+			src.x = Math.max(0, Math.min(CANVAS_WIDTH  - src.w, Math.round(nx)))
+			src.y = Math.max(0, Math.min(CANVAS_HEIGHT - src.h, Math.round(ny)))
+		} else {
+			// Resize : ajuste x/y/w/h selon la poignée pressée.
+			let nx = dragStart.x
+			let ny = dragStart.y
+			let nw = dragStart.w
+			let nh = dragStart.h
+			const MIN = 24    // évite de réduire la source à 0 (perdue à l'œil)
+
+			if (dragMode.includes('e')) nw = Math.max(MIN, dragStart.w + dx)
+			if (dragMode.includes('s')) nh = Math.max(MIN, dragStart.h + dy)
+			if (dragMode.includes('w')) {
+				const nxRaw = dragStart.x + dx
+				const maxX  = dragStart.x + dragStart.w - MIN
+				nx = Math.min(maxX, Math.max(0, nxRaw))
+				nw = dragStart.w + (dragStart.x - nx)
+			}
+			if (dragMode.includes('n')) {
+				const nyRaw = dragStart.y + dy
+				const maxY  = dragStart.y + dragStart.h - MIN
+				ny = Math.min(maxY, Math.max(0, nyRaw))
+				nh = dragStart.h + (dragStart.y - ny)
+			}
+			// Clamp au canvas
+			if (nx + nw > CANVAS_WIDTH)  nw = CANVAS_WIDTH  - nx
+			if (ny + nh > CANVAS_HEIGHT) nh = CANVAS_HEIGHT - ny
+
+			src.x = Math.round(nx)
+			src.y = Math.round(ny)
+			src.w = Math.max(MIN, Math.round(nw))
+			src.h = Math.max(MIN, Math.round(nh))
+		}
+		// Trigger reactivity en cassant la référence
+		dragLayout = { sources: [...dragLayout.sources] }
+	}
+
+	function endDrag(e: PointerEvent): void {
+		if (!dragMode || !dragLayout) return
+		try { (e.target as HTMLElement).releasePointerCapture(e.pointerId) } catch { /* déjà release */ }
+		onChange(dragLayout)
+		dragLayout = null
+		dragMode = null
+		dragId = null
+	}
+
+	// Clic sur le stage sans toucher une source = désélection. Utilise le
+	// event target pour distinguer le stage vs un enfant.
+	function onStageClick(e: MouseEvent): void {
+		if (e.target === e.currentTarget) onSelect(null)
+	}
+
+	function metaFor(src: ObsSceneSource): typeof SOURCE_TYPE_META[keyof typeof SOURCE_TYPE_META] {
+		return SOURCE_TYPE_META[src.type]
+	}
+</script>
+
+<!-- Wrapper extérieur : noir + grid pattern pour évoquer le canvas OBS.
+     Le ratio 16:9 est maintenu via aspect-ratio CSS, scale calcule combien
+     1 pixel canvas vaut côté écran. -->
+<div bind:this={stageEl}
+	role="application"
+	tabindex="-1"
+	class="relative w-full aspect-video bg-black border border-zinc-800 overflow-hidden select-none cursor-default"
+	style="background-image:
+		linear-gradient(rgba(255,255,255,.04) 1px, transparent 1px),
+		linear-gradient(90deg, rgba(255,255,255,.04) 1px, transparent 1px);
+		background-size: {64 * scale}px {64 * scale}px;"
+	onclick={onStageClick}
+	onpointermove={onPointerMove}
+	onpointerup={endDrag}
+	onpointercancel={endDrag}>
+
+	<!-- Fond de scène (couleur unie ou image). On le dessine sous toutes
+	     les sources, au-dessus de la grille subtile : si l'utilisateur a
+	     posé un fond opaque, il masque la grille (comportement attendu). -->
+	{#if effectiveLayout.background && effectiveLayout.background.kind === 'color' && effectiveLayout.background.color}
+		<div class="absolute inset-0 pointer-events-none" style="background-color: {effectiveLayout.background.color}; z-index: 0;"></div>
+	{:else if effectiveLayout.background && effectiveLayout.background.kind === 'image' && effectiveLayout.background.url}
+		<img src={effectiveLayout.background.url} alt=""
+			class="absolute inset-0 w-full h-full object-cover pointer-events-none"
+			style="z-index: 0;"
+			loading="lazy"/>
+	{/if}
+
+	<!-- Repère "SAFE AREA" 5% sur les bords, hint subtil OBS-style. -->
+	<div class="absolute pointer-events-none border border-dashed border-white/5"
+		style="left: 5%; top: 5%; right: 5%; bottom: 5%; z-index: 1;"></div>
+
+	{#each sortedSources as src (src.id)}
+		{@const m = metaFor(src)}
+		{@const isSel = selectedId === src.id}
+		{@const liveUrl = previewMode === 'live' ? resolveSourceUrl(src, origin) : null}
+		<!-- Toutes les sources sont placables et resizables comme une Browser
+		     Source OBS classique. L'iframe rend dans le wrapper et le
+		     overflow:hidden coupe ce qui dépasse — au streamer de choisir le
+		     cadrage. Le drag/select reste sur le wrapper. -->
+		<div
+			role="button"
+			tabindex="0"
+			class="absolute group transition-shadow overflow-hidden {src.visible ? '' : 'opacity-30'}"
+			style="
+				left:   {(src.x / CANVAS_WIDTH)  * 100}%;
+				top:    {(src.y / CANVAS_HEIGHT) * 100}%;
+				width:  {(src.w / CANVAS_WIDTH)  * 100}%;
+				height: {(src.h / CANVAS_HEIGHT) * 100}%;
+				z-index: {src.z};
+			"
+			onpointerdown={(e) => startMove(e, src)}
+			onkeydown={(e) => { if (e.key === 'Enter') onSelect(src.id) }}>
+
+			{#if liveUrl}
+				<!-- Aperçu Phase A : l'iframe a une viewport CSS = la taille
+				     pixel de la source (src.w × src.h dans le repère
+				     1920×1080). On scale uniformément par canvas_scale pour
+				     adapter à la taille affichée du canvas. C'est l'approche
+				     la plus simple et la plus prévisible : ce que tu vois
+				     dans le canvas correspond à ce que rendrait une Browser
+				     Source OBS de cette taille. Le rendu n'est pas pixel-
+				     perfect pour les overlays Nodyx à CSS fixe (ils
+				     apparaissent à leur taille naturelle), mais le streamer
+				     compose visuellement et OBS gère le rendu final.
+				     L'aperçu réel et fidèle viendra en Phase B (OBS WebSocket
+				     + screenshots de la scène réelle). -->
+				<iframe
+					src={liveUrl}
+					title={labelFor ? labelFor(src) : (src.label || m.label)}
+					loading="lazy"
+					sandbox="allow-scripts allow-same-origin allow-popups"
+					class="absolute top-0 left-0 border-0 pointer-events-none bg-transparent"
+					style="
+						width:  {src.w}px;
+						height: {src.h}px;
+						transform: scale({scale});
+						transform-origin: top left;
+					"
+				></iframe>
+				<!-- Badge label en haut-gauche. Pour les overlays full-scene
+				     (pointer-events: none sur le wrapper), c'est l'unique zone
+				     cliquable pour sélectionner cette source depuis le canvas
+				     sans passer par la liste Sources. -->
+				<button type="button"
+					onclick={(e) => { e.stopPropagation(); onSelect(src.id) }}
+					class="absolute top-0 left-0 text-[9px] uppercase tracking-wider font-semibold px-1.5 py-0.5 hover:brightness-125 transition"
+					style="
+						color: #{m.accent};
+						background: rgba(0,0,0,0.55);
+						pointer-events: auto;
+						border: {isSel ? '1px solid rgba(239,68,68,0.95)' : '1px solid transparent'};
+					">
+					{labelFor ? labelFor(src) : (src.label || m.label)}
+				</button>
+			{:else}
+				<!-- Placeholder visuel par type : utilisé quand pas d'URL (overlay
+				     non lié, placeholder_video, mode wireframe). -->
+				<div class="absolute inset-0 flex flex-col items-center justify-center text-center px-2 py-2 backdrop-blur-[2px]"
+					style="background: rgba(0,0,0,0.35);
+						border: 1px solid #{m.accent}80;
+						box-shadow: inset 0 0 0 1px rgba(255,255,255,0.04);">
+					<div class="text-2xl mb-0.5 leading-none">{m.icon}</div>
+					<div class="text-[10px] uppercase tracking-wider font-semibold" style="color: #{m.accent};">
+						{labelFor ? labelFor(src) : (src.label || m.label)}
+					</div>
+				</div>
+			{/if}
+			{#if src.locked}
+				<div class="absolute top-1 right-1 text-[10px] text-amber-400 pointer-events-none" title="Verrouillée">🔒</div>
+			{/if}
+			{#if !src.visible}
+				<div class="absolute top-1 left-1 text-[10px] text-zinc-500 pointer-events-none" title="Cachée">⊘</div>
+			{/if}
+
+			<!-- Sélection OBS-style : bordure rouge ardent + poignées aux coins
+			     et milieux de bords. Les poignées sont des carrés de 8px (côté
+			     écran, donc fixes peu importe le zoom). -->
+			{#if isSel}
+				<div class="absolute inset-0 pointer-events-none ring-2 ring-red-500/95 ring-inset"></div>
+				{#if !src.locked}
+					{#each ['nw','n','ne','e','se','s','sw','w'] as h (h)}
+						<button type="button"
+							class="absolute w-2.5 h-2.5 bg-red-500 border border-white/80 shadow-md
+								{h === 'nw' || h === 'sw' ? 'left-0 -translate-x-1/2' : ''}
+								{h === 'ne' || h === 'se' ? 'right-0 translate-x-1/2' : ''}
+								{h === 'n'  ? 'left-1/2 -translate-x-1/2' : ''}
+								{h === 's'  ? 'left-1/2 -translate-x-1/2' : ''}
+								{h === 'w'  ? 'left-0 -translate-x-1/2 top-1/2 -translate-y-1/2' : ''}
+								{h === 'e'  ? 'right-0 translate-x-1/2 top-1/2 -translate-y-1/2' : ''}
+								{h === 'nw' || h === 'n' || h === 'ne' ? 'top-0 -translate-y-1/2' : ''}
+								{h === 'sw' || h === 's' || h === 'se' ? 'bottom-0 translate-y-1/2' : ''}
+								{h === 'nw' || h === 'se' ? 'cursor-nwse-resize' : ''}
+								{h === 'ne' || h === 'sw' ? 'cursor-nesw-resize' : ''}
+								{h === 'n'  || h === 's'  ? 'cursor-ns-resize' : ''}
+								{h === 'e'  || h === 'w'  ? 'cursor-ew-resize' : ''}
+							"
+							aria-label="Redimensionner ({h})"
+							onpointerdown={(e) => startResize(e, src, `resize-${h}` as Exclude<DragMode, null | 'move'>)}>
+						</button>
+					{/each}
+				{/if}
+			{:else}
+				<!-- Halo de hover discret pour suggérer qu'on peut cliquer -->
+				<div class="absolute inset-0 pointer-events-none ring-1 ring-white/0 group-hover:ring-white/30 transition"></div>
+			{/if}
+		</div>
+	{/each}
+
+	{#if effectiveLayout.sources.length === 0}
+		<div class="absolute inset-0 flex flex-col items-center justify-center gap-2 text-zinc-600 text-sm pointer-events-none">
+			<svg class="w-10 h-10 opacity-60" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+				<rect x="3" y="3" width="18" height="18" rx="2"/>
+				<path d="M9 9h6v6H9z"/>
+				<path d="M3 9h6M3 15h6M15 3v6M15 15v6"/>
+			</svg>
+			<div class="text-xs uppercase tracking-widest text-zinc-500">Canvas vide</div>
+			<div class="text-[11px] text-zinc-600 max-w-[24ch] text-center">Ajoute une source depuis la colonne de droite pour démarrer.</div>
+		</div>
+	{/if}
+
+	<!-- Resolution badge bas-droite : on est sur du 1920x1080 référence. Hint
+	     pour l'utilisateur qu'on raisonne en pixels OBS, pas en CSS responsive. -->
+	<div class="absolute bottom-1 right-1 text-[9px] font-mono text-white/30 bg-black/30 px-1 py-0.5 rounded-sm pointer-events-none">
+		{CANVAS_WIDTH}×{CANVAS_HEIGHT}
+	</div>
+</div>

--- a/nodyx-frontend/src/lib/components/admin/obs/sceneNav.ts
+++ b/nodyx-frontend/src/lib/components/admin/obs/sceneNav.ts
@@ -1,0 +1,93 @@
+// Petit helper de navigation vers le tab "Scènes" du Streamer Hub avec focus
+// sur une scène précise. Contournement nécessaire : le composant parent
+// (admin/streamer-hub/+page.svelte) a un $effect qui réécrit l'URL hash à
+// `#tab=X` à chaque changement d'activeTab, ce qui écrasait nos paramètres
+// additionnels (&scene=ID). On passe donc l'intent via sessionStorage, lu
+// par ObsScenesPanel.onMount qui set activeId puis nettoie la clé.
+
+const FOCUS_KEY = 'nodyx:focus-scene'
+const FOCUS_OVERLAY_KEY = 'nodyx:focus-overlay-token'
+
+// Navigation utilitaire vers un tab quelconque du Streamer Hub. Mêmes
+// garanties que focusSceneAfterNav : setTimeout pour laisser commit le
+// state appelant, pushState + dispatch manuel pour fire hashchange même
+// si le navigateur swallow l'assignment.
+function navigateToTab(tab: string): void {
+	if (typeof window === 'undefined') return
+	setTimeout(() => {
+		const target = `#tab=${tab}`
+		if (window.location.hash === target) return
+		try {
+			window.history.pushState(null, '', window.location.pathname + target)
+			window.dispatchEvent(new HashChangeEvent('hashchange', {
+				oldURL: window.location.href.replace(target, ''),
+				newURL: window.location.href,
+			}))
+		} catch {
+			window.location.hash = target
+		}
+	}, 0)
+}
+
+export function focusSceneAfterNav(sceneId: string): void {
+	if (typeof window === 'undefined') return
+	try { sessionStorage.setItem(FOCUS_KEY, sceneId) } catch { /* sessionStorage saturé : tant pis */ }
+	// On laisse Svelte commit le state update qui ferme le modal appelant
+	// avant de toucher au hash. Sans ce délai, certains navigateurs ne firent
+	// pas le hashchange (assignation au milieu d'une réaction DOM).
+	setTimeout(() => {
+		const target = '#tab=scenes'
+		const already = window.location.hash === target
+		if (!already) {
+			// pushState + dispatch manuel de hashchange : ceinture + bretelles.
+			// Si on était sur un autre tab, le parent réagit au hashchange et
+			// switch activeTab. Si l'utilisateur était déjà sur Scènes, le
+			// CustomEvent ci-dessous suffit (le panel reste monté).
+			try {
+				window.history.pushState(null, '', window.location.pathname + target)
+				window.dispatchEvent(new HashChangeEvent('hashchange', {
+					oldURL: window.location.href.replace(target, ''),
+					newURL: window.location.href,
+				}))
+			} catch {
+				// Fallback brutal si pushState/HashChangeEvent indisponibles.
+				window.location.hash = target
+			}
+		}
+		// Notifie aussi un panel déjà monté pour bouger l'activeId sans attendre
+		// un remount (cas "j'étais déjà sur le tab Scènes").
+		try { window.dispatchEvent(new CustomEvent('nodyx:focus-scene', { detail: { sceneId } })) } catch { /* noop */ }
+	}, 0)
+}
+
+export function consumeFocusedSceneId(): string | null {
+	if (typeof window === 'undefined') return null
+	try {
+		const v = sessionStorage.getItem(FOCUS_KEY)
+		if (v) sessionStorage.removeItem(FOCUS_KEY)
+		return v
+	} catch {
+		return null
+	}
+}
+
+// Navigation vers le tab Overlays OBS avec focus sur un overlay précis
+// (par token). Le composant OverlayManager lit la clé au mount et déplie
+// la config + scroll vers la ligne. Pattern symétrique à focusSceneAfterNav.
+export function focusOverlayAfterNav(overlayToken: string): void {
+	if (typeof window === 'undefined') return
+	try { sessionStorage.setItem(FOCUS_OVERLAY_KEY, overlayToken) } catch { /* tant pis */ }
+	try { window.dispatchEvent(new CustomEvent('nodyx:focus-overlay', { detail: { token: overlayToken } })) } catch { /* noop */ }
+	navigateToTab('overlays')
+}
+
+export function consumeFocusedOverlayToken(): string | null {
+	if (typeof window === 'undefined') return null
+	try {
+		const v = sessionStorage.getItem(FOCUS_OVERLAY_KEY)
+		if (v) sessionStorage.removeItem(FOCUS_OVERLAY_KEY)
+		return v
+	} catch {
+		return null
+	}
+}

--- a/nodyx-frontend/src/lib/types/deck.ts
+++ b/nodyx-frontend/src/lib/types/deck.ts
@@ -13,6 +13,10 @@ export type DeckActionType =
 	| 'stop_audio'
 	| 'pause_audio'
 	| 'navigate_page'
+	| 'playlist_control'
+
+export type PlaylistControlCmd =
+	| 'play' | 'pause' | 'toggle' | 'skip' | 'prev' | 'stop' | 'volume'
 
 export interface DeckAction {
 	type:          DeckActionType
@@ -34,6 +38,13 @@ export interface DeckAction {
 	// navigate_page : soit cible directe, soit jump relatif. Géré client-side.
 	targetPageId?: string
 	pageJump?:     'next' | 'prev' | 'home'
+	// playlist_control : pilote l'overlay playlist OBS via socket. `cmd`
+	// requis ; `playlistId` seulement pour 'play' (switch). `volumeMode` +
+	// `volumeValue` pour 'volume'.
+	cmd?:          PlaylistControlCmd
+	playlistId?:   string
+	volumeMode?:   'delta' | 'absolute'
+	volumeValue?:  number
 }
 
 export interface DeckButton {

--- a/nodyx-frontend/src/lib/types/obsScenes.ts
+++ b/nodyx-frontend/src/lib/types/obsScenes.ts
@@ -1,0 +1,217 @@
+// Types partagés Streamer Hub → Scènes OBS. Miroir des types du service
+// backend `obsScenesService.ts`. Définis ici pour éviter la divergence entre
+// les sous-composants (ScenesPanel, SceneCanvas, AddSourceModal).
+
+export type ObsSceneSourceType =
+	| 'alert_box'
+	| 'ticker'
+	| 'playlist'
+	| 'soundboard_osd'
+	| 'goal_bar'
+	| 'leaderboard'
+	| 'clips_player'
+	| 'stream_timer'
+	| 'browser_source'
+	| 'placeholder_video'
+
+// Canvas de référence en pixels absolus (1920x1080 = 16:9 1080p). Le canvas
+// frontend est scalé visuellement mais on stocke et on raisonne en pixels
+// pour que le bridge OBS WebSocket (Phase B+) puisse pousser tel quel.
+export const CANVAS_WIDTH  = 1920
+export const CANVAS_HEIGHT = 1080
+
+export interface ObsSceneSource {
+	id:      string
+	type:    ObsSceneSourceType
+	label:   string
+	x:       number
+	y:       number
+	w:       number
+	h:       number
+	z:       number
+	visible: boolean
+	locked:  boolean
+	// Config dépendante du type (overlayToken, url, playlistId, kind, etc.).
+	// Validée backend dans sanitizeSourceConfig.
+	config:  Record<string, unknown>
+}
+
+export interface ObsSceneBackground {
+	kind:   'none' | 'color' | 'image'
+	color?: string
+	url?:   string
+}
+
+export interface ObsSceneLayout {
+	sources:     ObsSceneSource[]
+	background?: ObsSceneBackground
+}
+
+export interface ObsScene {
+	id:          string
+	ownerUserId: string
+	name:        string
+	color:       string | null
+	layout:      ObsSceneLayout
+	position:    number
+	createdAt:   string
+	updatedAt:   string
+}
+
+// Métadonnées d'affichage par type de source : utilisé pour le catalogue
+// "+ Source" et pour le rendu placeholder dans le canvas. Choix de couleurs
+// cohérent avec le reste de l'admin (accents par catégorie).
+export interface SourceTypeMeta {
+	label:       string
+	description: string
+	icon:        string         // emoji ou symbole
+	accent:      string         // hex sans #, pour les badges/bordures
+	defaultW:    number
+	defaultH:    number
+}
+
+// Tailles par défaut = taille NATURELLE du contenu rendu par chaque overlay
+// (la taille à laquelle son CSS interne est designé). La source apparaît
+// ainsi à la taille où le contenu est lisible. Si le streamer agrandit, le
+// contenu suit (scale OBS-style). S'il rétrécit, ça compresse. Pour les
+// overlays qui ont un sélecteur de position interne (timer, alert), la
+// position interne reste éditable via leur config, indépendamment de la
+// taille de la source dans la scène.
+export const SOURCE_TYPE_META: Record<ObsSceneSourceType, SourceTypeMeta> = {
+	alert_box: {
+		label:       'Alert Box',
+		description: 'Notifications follow / sub / raid / cheer.',
+		icon:        '🔔',
+		accent:      'f59e0b',
+		defaultW:    640, defaultH: 200,
+	},
+	ticker: {
+		label:       'Event Ticker',
+		description: 'Bandeau d\'events qui défile.',
+		icon:        '📰',
+		accent:      '38bdf8',
+		defaultW:    1920, defaultH: 60,
+	},
+	playlist: {
+		label:       'Playlist',
+		description: 'Musique d\'ambiance en autoplay loop.',
+		icon:        '🎵',
+		accent:      'a78bfa',
+		defaultW:    360, defaultH: 90,
+	},
+	soundboard_osd: {
+		label:       'Soundboard OSD',
+		description: 'Carte affichée quand un son du Stream Deck joue.',
+		icon:        '🔊',
+		accent:      'c084fc',
+		defaultW:    340, defaultH: 90,
+	},
+	goal_bar: {
+		label:       'Goal Bar',
+		description: 'Barre d\'objectif (followers, subs, etc.).',
+		icon:        '🎯',
+		accent:      '34d399',
+		defaultW:    420, defaultH: 60,
+	},
+	leaderboard: {
+		label:       'Leaderboard',
+		description: 'Top viewers, chat ou donateurs.',
+		icon:        '🏆',
+		accent:      'fbbf24',
+		defaultW:    320, defaultH: 280,
+	},
+	clips_player: {
+		label:       'Clips Player',
+		description: 'Lecteur de top clips déclenchable au Deck.',
+		icon:        '🎬',
+		accent:      'f472b6',
+		defaultW:    640, defaultH: 360,
+	},
+	stream_timer: {
+		label:       'Stream Timer',
+		description: 'Chrono du stream en cours, format réglable.',
+		icon:        '⏱',
+		accent:      '60a5fa',
+		defaultW:    280, defaultH: 70,
+	},
+	browser_source: {
+		label:       'Browser Source',
+		description: 'N\'importe quelle URL (widget externe).',
+		icon:        '🌐',
+		accent:      '94a3b8',
+		defaultW:    480, defaultH: 270,
+	},
+	placeholder_video: {
+		label:       'Source vidéo',
+		description: 'Webcam, capture jeu ou image (sera liée à OBS plus tard).',
+		icon:        '📹',
+		accent:      'ef4444',
+		defaultW:    1920, defaultH: 1080,
+	},
+}
+
+// Set des types qui doivent toujours être rendus avec une viewport iframe
+// full-scene (1920×1080). Pour ceux-là, le placement dans la scène n'est
+// qu'une bounding box de scale : l'overlay se positionne lui-même.
+export const FULL_SCENE_VIEWPORT_TYPES = new Set<ObsSceneSourceType>([
+	'alert_box', 'ticker', 'playlist', 'soundboard_osd',
+	'goal_bar', 'leaderboard', 'clips_player', 'stream_timer',
+])
+
+// Slug de route SvelteKit côté frontend pour chaque type d'overlay Nodyx.
+// Sert à construire l'URL preview iframe dans le canvas Scènes. null = pas
+// d'URL native (browser_source utilise sa propre URL, placeholder_video n'a
+// pas de rendu live, juste un emplacement réservé).
+const ROUTE_SLUG: Partial<Record<ObsSceneSourceType, string>> = {
+	alert_box:      'alert',
+	ticker:         'ticker',
+	soundboard_osd: 'soundboard',
+	goal_bar:       'goal',
+	leaderboard:    'board',
+	clips_player:   'clips',
+	stream_timer:   'timer',
+	playlist:       'playlist',
+}
+
+// Construit l'URL d'aperçu live pour une source. Retourne null si la source
+// n'a pas (ou pas encore) tout ce qu'il faut pour afficher quelque chose
+// (ex : pas d'overlayToken sur une alert_box). Le caller dessine alors le
+// placeholder visuel.
+export function resolveSourceUrl(
+	source: ObsSceneSource,
+	origin: string,
+): string | null {
+	const m = SOURCE_TYPE_META[source.type]
+	if (source.type === 'browser_source') {
+		const url = typeof source.config.url === 'string' ? source.config.url : ''
+		return url || null
+	}
+	if (source.type === 'placeholder_video') return null
+	const slug = ROUTE_SLUG[source.type]
+	const token = typeof source.config.overlayToken === 'string' ? source.config.overlayToken : ''
+	if (!slug || !token) return null
+	const base = `${origin.replace(/\/+$/, '')}/overlay/${slug}/${token}`
+	if (source.type === 'playlist' && typeof source.config.playlistId === 'string') {
+		return `${base}?id=${encodeURIComponent(source.config.playlistId)}`
+	}
+	// Hint sous-utilisé pour l'instant : on passera `preview=1` plus tard
+	// pour que les overlays sachent qu'ils tournent dans l'éditeur (skip
+	// son, désactiver socket coûteux, etc.).
+	void m
+	return base
+}
+
+// Ordre d'affichage dans le catalogue "+ Source". Les types les plus
+// communs en premier, le browser libre et le placeholder vidéo à la fin.
+export const SOURCE_TYPE_ORDER: ObsSceneSourceType[] = [
+	'placeholder_video',
+	'alert_box',
+	'ticker',
+	'playlist',
+	'soundboard_osd',
+	'goal_bar',
+	'leaderboard',
+	'clips_player',
+	'stream_timer',
+	'browser_source',
+]

--- a/nodyx-frontend/src/routes/admin/streamer-hub/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/streamer-hub/+page.svelte
@@ -15,6 +15,7 @@
 	import DeckPanel          from '$lib/components/admin/DeckPanel.svelte'
 	import SoundLibraryPanel  from '$lib/components/admin/SoundLibraryPanel.svelte'
 	import OverlayManager     from '$lib/components/admin/OverlayManager.svelte'
+	import ObsScenesPanel     from '$lib/components/admin/obs/ObsScenesPanel.svelte'
 	import type { PageData } from './$types'
 
 	let { data }: { data: PageData } = $props()
@@ -152,13 +153,14 @@
 	// récompenses / overlays / audience / config. Synchronisation #hash dans
 	// l'URL pour deep-link (ex: /admin/streamer-hub#tab=studio). Si pas
 	// connecté, on force "config" pour que l'utilisateur voie le bouton Connect.
-	type TabId = 'overview' | 'studio' | 'rewards' | 'overlays' | 'bot' | 'deck' | 'sounds' | 'audience' | 'config'
+	type TabId = 'overview' | 'studio' | 'rewards' | 'overlays' | 'scenes' | 'bot' | 'deck' | 'sounds' | 'audience' | 'config'
 
 	const TABS: Array<{ id: TabId; label: string; iconPath: string; soon?: boolean }> = [
 		{ id: 'overview', label: 'Vue d\'ensemble', iconPath: 'M3 7a4 4 0 014-4h10a4 4 0 014 4v10a4 4 0 01-4 4H7a4 4 0 01-4-4V7z M9 9h6v6H9z' },
 		{ id: 'studio',   label: 'Studio Live',     iconPath: 'M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z' },
 		{ id: 'rewards',  label: 'Récompenses',     iconPath: 'M12 8v13m0-13V6a2 2 0 112 2h-2zm0 0V5.5A2.5 2.5 0 109.5 8H12zM5 21h14a2 2 0 002-2v-9a2 2 0 00-2-2H5a2 2 0 00-2 2v9a2 2 0 002 2z' },
 		{ id: 'overlays', label: 'Overlays OBS',    iconPath: 'M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z' },
+		{ id: 'scenes',   label: 'Scènes',           iconPath: 'M3 7a2 2 0 012-2h14a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V7zM9 5v14M3 11h6M3 15h6' },
 		{ id: 'bot',      label: 'Bot Chat',         iconPath: 'M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z' },
 		{ id: 'deck',     label: 'Stream Deck',      iconPath: 'M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z' },
 		{ id: 'sounds',   label: 'Soundboard',       iconPath: 'M9 18V5l12-2v13 M9 18a3 3 0 11-6 0 3 3 0 016 0zM21 16a3 3 0 11-6 0 3 3 0 016 0z' },
@@ -637,6 +639,11 @@
 	<!-- ══ Tab: Overlays OBS ═══════════════════════════════════════════════ -->
 	{#if isConnected && activeTab === 'overlays'}
 		<OverlayManager token={pageToken} />
+	{/if}
+
+	<!-- ══ Tab: Scènes (compositeur OBS-like) ════════════════════════════ -->
+	{#if isConnected && activeTab === 'scenes'}
+		<ObsScenesPanel token={pageToken} />
 	{/if}
 
 	<!-- ══ Tab: Bot Chat (sous-nav Timers / Commandes) ═══════════════════ -->

--- a/nodyx-frontend/src/routes/overlay/playlist/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/playlist/[token]/+page.svelte
@@ -1,0 +1,446 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte'
+	import { browser } from '$app/environment'
+	import { page } from '$app/state'
+	import { PUBLIC_API_URL } from '$env/static/public'
+
+	// ─── Overlay Playlist (OBS browser source) ──────────────────────────────
+	// Lit une playlist du streamer en autoplay loop pour servir de musique
+	// de fond ou d'ambiance sur une scène OBS. Une URL par playlist, à coller
+	// dans une Browser Source.
+	//
+	// URL :
+	//   /overlay/playlist/<token>?id=<playlistId>[&shuffle=1][&ui=mini|hidden][&volume=0-1]
+	//
+	// Le token est le token d'overlay "playlist" du streamer (un seul par
+	// streamer, partagé entre toutes ses playlists). La playlist ciblée est
+	// passée en query : on peut donc avoir 5 Browser Sources OBS (une par
+	// scène) qui pointent toutes vers le même token avec des id différents.
+	//
+	// Pas de socket ici : c'est de la lecture en boucle, le streamer édite
+	// la playlist côté admin et l'overlay reflète au prochain cycle (ou au
+	// prochain refresh OBS s'il est impatient).
+
+	interface Track {
+		id:            string
+		title:         string
+		artist:        string | null
+		thumbnailUrl:  string | null
+		fileUrl:       string
+		mimeType:      string
+		durationMs:    number | null
+		volumeDefault: number
+		fadeInMs:      number
+		fadeOutMs:     number
+		loop:          boolean
+	}
+
+	interface Playlist {
+		id:          string
+		name:        string
+		description: string | null
+		color:       string | null
+	}
+
+	type UiMode = 'mini' | 'hidden'
+
+	const token = $derived(page.params.token ?? '')
+
+	// Lecture sûre des query params : page.url peut être stale en SSR, on
+	// lit côté client uniquement.
+	let playlistId = $state('')
+	let shuffle    = $state(false)
+	let ui         = $state<UiMode>('mini')
+	let volume     = $state(0.6)
+
+	let status     = $state<'loading' | 'ready' | 'empty' | 'invalid' | 'error'>('loading')
+	let playlist   = $state<Playlist | null>(null)
+	let tracks     = $state<Track[]>([])
+	let order      = $state<number[]>([])      // ordre courant (indices dans `tracks`)
+	let cursor     = $state(0)                 // position dans `order`
+	let progressMs = $state(0)
+	let durationMs = $state(0)
+	let needsClick = $state(false)             // autoplay bloqué par browser policy
+	let lastError  = $state<string | null>(null)
+
+	// État réactif pour l'OSD : on met à jour le current à chaque changement
+	// de cursor pour que la carte affiche le bon titre.
+	const current = $derived<Track | null>(
+		tracks.length > 0 && order.length > 0 ? tracks[order[cursor]] ?? null : null,
+	)
+
+	let audioEl: HTMLAudioElement | null = null
+	let progressTimer: ReturnType<typeof setInterval> | null = null
+	let refreshTimer:  ReturnType<typeof setInterval> | null = null
+	let socket: { disconnect: () => void } | null = null
+	let paused = $state(false)
+
+	// Toast OSD éphémère affiché en haut au reçu d'une commande Deck (skip,
+	// pause, volume...). Confirme visuellement la prise en compte côté streamer
+	// sans polluer la scène longtemps.
+	let cmdToast = $state<string | null>(null)
+	let cmdToastTimer: ReturnType<typeof setTimeout> | null = null
+	function flashCmd(text: string): void {
+		cmdToast = text
+		if (cmdToastTimer) clearTimeout(cmdToastTimer)
+		cmdToastTimer = setTimeout(() => { cmdToast = null }, 1800)
+	}
+
+	function absoluteUrl(rel: string): string {
+		if (!rel) return ''
+		if (rel.startsWith('http')) return rel
+		const base = PUBLIC_API_URL.replace(/\/api\/v1\/?$/, '')
+		return `${base}${rel}`
+	}
+
+	function fmtTime(ms: number): string {
+		const total = Math.max(0, Math.round(ms / 1000))
+		const m = Math.floor(total / 60)
+		const s = total % 60
+		return `${m}:${s.toString().padStart(2, '0')}`
+	}
+
+	// Mélange Fisher-Yates des indices [0..n-1].
+	function shuffleOrder(n: number): number[] {
+		const arr = Array.from({ length: n }, (_, i) => i)
+		for (let i = arr.length - 1; i > 0; i--) {
+			const j = Math.floor(Math.random() * (i + 1))
+			;[arr[i], arr[j]] = [arr[j], arr[i]]
+		}
+		return arr
+	}
+
+	function rebuildOrder(): void {
+		const n = tracks.length
+		if (n === 0) { order = []; cursor = 0; return }
+		order = shuffle ? shuffleOrder(n) : Array.from({ length: n }, (_, i) => i)
+		cursor = 0
+	}
+
+	async function load(): Promise<void> {
+		if (!token || !playlistId) { status = 'invalid'; return }
+		try {
+			const res = await fetch(
+				`${PUBLIC_API_URL}/api/v1/streamer/overlay/playlist/${token}/${playlistId}`,
+			)
+			if (res.status === 404) { status = 'invalid'; return }
+			if (!res.ok) { status = 'error'; return }
+			const data = await res.json() as { ok: boolean; playlist: Playlist; tracks: Track[] }
+			playlist = data.playlist
+			tracks   = data.tracks ?? []
+			if (tracks.length === 0) { status = 'empty'; return }
+			rebuildOrder()
+			status = 'ready'
+		} catch {
+			status = 'error'
+		}
+	}
+
+	// Lance la lecture du track à la position `cursor` dans `order`.
+	function playCurrent(): void {
+		if (!browser || !audioEl || !current) return
+		try {
+			audioEl.src    = absoluteUrl(current.fileUrl)
+			audioEl.volume = effectiveVolume()
+			audioEl.loop   = false      // on enchaîne nous-mêmes (loop playlist != loop track)
+			paused = false
+			const p = audioEl.play()
+			if (p && typeof p.catch === 'function') {
+				p.catch(() => { needsClick = true })
+			}
+		} catch {
+			needsClick = true
+		}
+	}
+
+	function effectiveVolume(): number {
+		const v = volume * (current?.volumeDefault ?? 1)
+		return Math.max(0, Math.min(1, v))
+	}
+
+	function applyVolume(): void {
+		if (audioEl) audioEl.volume = effectiveVolume()
+	}
+
+	function advance(): void {
+		if (order.length === 0) return
+		cursor = (cursor + 1) % order.length
+		// Au tour suivant, si shuffle, on rebrasse pour éviter de retomber
+		// toujours sur le même premier élément en repassant à 0.
+		if (cursor === 0 && shuffle) order = shuffleOrder(tracks.length)
+		playCurrent()
+	}
+
+	function onEnded(): void { advance() }
+
+	function onTimeUpdate(): void {
+		if (!audioEl) return
+		progressMs = Math.floor(audioEl.currentTime * 1000)
+		durationMs = Math.floor((audioEl.duration || 0) * 1000)
+	}
+
+	function onError(): void {
+		// On skip le track fautif après un court délai pour éviter une boucle
+		// serrée si tous les fichiers sont KO.
+		lastError = current?.title ?? 'erreur lecture'
+		setTimeout(advance, 800)
+	}
+
+	// Déclenche la première lecture après un click utilisateur (preview OBS).
+	function startFromClick(): void {
+		needsClick = false
+		playCurrent()
+	}
+
+	onMount(() => {
+		if (!browser) return
+		// Parse query
+		const params = page.url.searchParams
+		playlistId = params.get('id') ?? ''
+		shuffle    = params.get('shuffle') === '1' || params.get('shuffle') === 'true'
+		const uiQ  = params.get('ui')
+		if (uiQ === 'hidden' || uiQ === 'mini') ui = uiQ
+		const volQ = Number(params.get('volume'))
+		if (Number.isFinite(volQ) && volQ >= 0 && volQ <= 1) volume = volQ
+
+		audioEl = new Audio()
+		audioEl.preload = 'auto'
+		audioEl.crossOrigin = 'anonymous'
+		audioEl.addEventListener('ended', onEnded)
+		audioEl.addEventListener('timeupdate', onTimeUpdate)
+		audioEl.addEventListener('error', onError)
+
+		// Watchdog : si le track n'a pas avancé depuis 3s ET pas en pause →
+		// on force advance pour éviter un freeze sur un fichier corrompu.
+		progressTimer = setInterval(() => {
+			if (!audioEl || audioEl.paused) return
+			// rien à faire ici en V1, on laisse onTimeUpdate gérer
+		}, 500)
+
+		// Refresh des tracks toutes les 60s : permet au streamer d'ajouter/
+		// retirer un son sans redémarrer l'overlay OBS. On garde le cursor
+		// courant si le track joué existe encore (par id), sinon on relance.
+		refreshTimer = setInterval(async () => {
+			if (status !== 'ready' || !playlistId) return
+			const playingId = current?.id ?? null
+			const prevIds = tracks.map(t => t.id).join(',')
+			await load()
+			if (status !== 'ready') return
+			const newIds = tracks.map(t => t.id).join(',')
+			if (newIds === prevIds) return       // pas de changement, on laisse jouer
+			// Si le track en cours est toujours là, on positionne le cursor dessus
+			// sans interrompre la lecture. Sinon on enchaîne sur le suivant.
+			const idx = playingId ? tracks.findIndex(t => t.id === playingId) : -1
+			if (idx >= 0) {
+				const newCursor = order.indexOf(idx) >= 0 ? order.indexOf(idx) : 0
+				cursor = newCursor
+			} else {
+				advance()
+			}
+		}, 60_000)
+
+		load().then(() => {
+			if (status === 'ready') playCurrent()
+		})
+
+		// Socket /overlay : reçoit les commandes émises par le Stream Deck quand
+		// le streamer presse un bouton 'playlist_control'. La même connexion sert
+		// à tous les overlays playlist du streamer (room playlist:<owner>), donc
+		// si plusieurs Browser Sources OBS pointent ici, elles reçoivent toutes
+		// la commande en parallèle (comportement voulu : OBS coupe l'audio des
+		// sources cachées, mais les états restent cohérents au switch de scène).
+		void openSocket()
+	})
+
+	async function openSocket(): Promise<void> {
+		try {
+			const { io } = await import('socket.io-client')
+			const s = io(`${PUBLIC_API_URL}/overlay`, {
+				auth:       { token },
+				transports: ['polling', 'websocket'],
+				path:       '/socket.io/',
+			})
+			s.on('playlist:control', (payload: {
+				cmd:         'play' | 'pause' | 'toggle' | 'skip' | 'prev' | 'stop' | 'volume'
+				playlistId?: string
+				volumeMode?: 'delta' | 'absolute'
+				volumeValue?: number
+			}) => { void handleControl(payload) })
+			socket = s
+		} catch {
+			// pas de socket = pas grave, l'overlay continue à jouer en autoplay
+			// loop sans pouvoir être piloté à distance.
+		}
+	}
+
+	async function handleControl(p: {
+		cmd:         'play' | 'pause' | 'toggle' | 'skip' | 'prev' | 'stop' | 'volume'
+		playlistId?: string
+		volumeMode?: 'delta' | 'absolute'
+		volumeValue?: number
+	}): Promise<void> {
+		if (!audioEl) return
+		switch (p.cmd) {
+			case 'play': {
+				if (p.playlistId && p.playlistId !== playlistId) {
+					// Switch sur une autre playlist : reload + autoplay
+					playlistId = p.playlistId
+					await load()
+					if (status === 'ready') playCurrent()
+					flashCmd(`▶ ${playlist?.name ?? 'Playlist'}`)
+				} else if (audioEl.paused) {
+					audioEl.play().catch(() => {})
+					paused = false
+					flashCmd('▶ Reprise')
+				} else if (status !== 'ready') {
+					// Pas de track joué (overlay venait juste d'être ouvert sans
+					// autoplay), on relance.
+					playCurrent()
+					flashCmd('▶ Lecture')
+				}
+				break
+			}
+			case 'pause': {
+				audioEl.pause()
+				paused = true
+				flashCmd('⏸ Pause')
+				break
+			}
+			case 'toggle': {
+				if (audioEl.paused) {
+					audioEl.play().catch(() => {})
+					paused = false
+					flashCmd('▶ Reprise')
+				} else {
+					audioEl.pause()
+					paused = true
+					flashCmd('⏸ Pause')
+				}
+				break
+			}
+			case 'skip': {
+				advance()
+				flashCmd('⏭ Suivant')
+				break
+			}
+			case 'prev': {
+				if (order.length === 0) break
+				cursor = (cursor - 1 + order.length) % order.length
+				playCurrent()
+				flashCmd('⏮ Précédent')
+				break
+			}
+			case 'stop': {
+				audioEl.pause()
+				audioEl.currentTime = 0
+				cursor = 0
+				paused = true
+				flashCmd('⏹ Stop')
+				break
+			}
+			case 'volume': {
+				const val = Number.isFinite(p.volumeValue) ? Number(p.volumeValue) : 0
+				if (p.volumeMode === 'absolute') {
+					volume = Math.max(0, Math.min(1, val))
+				} else {
+					volume = Math.max(0, Math.min(1, volume + val))
+				}
+				applyVolume()
+				flashCmd(`🔊 ${Math.round(volume * 100)}%`)
+				break
+			}
+		}
+	}
+
+	onDestroy(() => {
+		if (progressTimer)  clearInterval(progressTimer)
+		if (refreshTimer)   clearInterval(refreshTimer)
+		if (cmdToastTimer)  clearTimeout(cmdToastTimer)
+		if (socket) { socket.disconnect(); socket = null }
+		if (audioEl) {
+			audioEl.removeEventListener('ended', onEnded)
+			audioEl.removeEventListener('timeupdate', onTimeUpdate)
+			audioEl.removeEventListener('error', onError)
+			audioEl.pause()
+			audioEl.src = ''
+			audioEl = null
+		}
+	})
+
+	const pct = $derived(durationMs > 0 ? Math.min(100, (progressMs / durationMs) * 100) : 0)
+	const accent = $derived(playlist?.color ?? '#a78bfa')
+</script>
+
+<svelte:head>
+	<title>{playlist?.name ?? 'Playlist'} — Overlay</title>
+	<style>
+		html, body { background: transparent !important; margin: 0; padding: 0; }
+	</style>
+</svelte:head>
+
+{#if cmdToast}
+	<!-- Toast Deck : commande prise en compte, affiché 1.8s. Bandeau haut-droite
+	     pour ne pas se confondre avec l'OSD courante bas-droite. -->
+	<div class="fixed top-3 right-3 px-3 py-1.5 rounded-md bg-purple-950/85 backdrop-blur-md border border-purple-500/60 text-purple-100 text-xs font-medium shadow-2xl pointer-events-none">
+		{cmdToast}
+	</div>
+{/if}
+
+{#if needsClick}
+	<!-- Preview : OBS autorise l'autoplay, mais en navigateur il faut un click.
+	     On affiche une bannière cliquable seulement quand l'autoplay a échoué. -->
+	<button type="button" onclick={startFromClick}
+		class="fixed inset-0 grid place-items-center bg-black/40 backdrop-blur-sm cursor-pointer">
+		<div class="px-5 py-3 rounded-lg bg-zinc-900/90 border border-zinc-700 text-zinc-100 text-sm font-medium shadow-2xl">
+			▶ Cliquer pour démarrer
+		</div>
+	</button>
+{/if}
+
+{#if status === 'invalid'}
+	<div class="fixed top-3 left-3 px-3 py-1.5 rounded-md bg-rose-950/85 border border-rose-700 text-rose-100 text-xs font-medium">
+		Lien d'overlay invalide ou playlist supprimée.
+	</div>
+{:else if status === 'error'}
+	<div class="fixed top-3 left-3 px-3 py-1.5 rounded-md bg-rose-950/85 border border-rose-700 text-rose-100 text-xs font-medium">
+		Erreur de chargement.
+	</div>
+{:else if status === 'empty'}
+	<div class="fixed top-3 left-3 px-3 py-1.5 rounded-md bg-amber-950/85 border border-amber-700 text-amber-100 text-xs font-medium">
+		Playlist vide. Ajoute des sons depuis l'admin.
+	</div>
+{:else if status === 'ready' && current && ui === 'mini'}
+	<!-- OSD minimaliste, bas-droite, transparent : adapté à une Browser Source
+	     OBS de 360x90 (recommandé). On ne dessine rien d'autre pour ne pas
+	     polluer la scène. -->
+	<div class="fixed bottom-3 right-3 flex items-center gap-3 px-3 py-2 rounded-lg
+		bg-zinc-950/80 backdrop-blur-md border border-zinc-800/80 shadow-2xl
+		text-zinc-100 max-w-[360px]"
+		style="border-left: 3px solid {accent};">
+		<!-- Pochette -->
+		<div class="w-11 h-11 rounded bg-zinc-950 border border-zinc-800 overflow-hidden shrink-0 grid place-items-center">
+			{#if current.thumbnailUrl}
+				<img src={absoluteUrl(current.thumbnailUrl)} alt="" class="w-full h-full object-cover"/>
+			{:else}
+				<svg class="w-4 h-4 text-zinc-600" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+					<path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>
+				</svg>
+			{/if}
+		</div>
+		<!-- Texte + barre -->
+		<div class="min-w-0 flex-1">
+			<div class="flex items-baseline gap-2 mb-0.5">
+				<span class="text-[9px] uppercase tracking-widest font-bold" style="color: {accent};">{paused ? '⏸' : '▶'} {playlist?.name ?? ''}</span>
+			</div>
+			<div class="text-sm font-medium truncate" title={current.title}>{current.title}</div>
+			<div class="text-[11px] text-zinc-400 truncate flex items-center gap-1.5">
+				<span class="truncate">{current.artist ?? '—'}</span>
+				<span class="text-zinc-600 font-mono shrink-0">· {fmtTime(progressMs)} / {fmtTime(durationMs)}</span>
+			</div>
+			<!-- Barre de progression -->
+			<div class="mt-1 h-0.5 bg-zinc-800 rounded-full overflow-hidden">
+				<div class="h-full transition-[width] duration-200" style="width: {pct}%; background: {accent};"></div>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/nodyx-frontend/src/routes/soundboard/+page.svelte
+++ b/nodyx-frontend/src/routes/soundboard/+page.svelte
@@ -52,11 +52,25 @@
 		source:       'web' | 'chat'
 	}
 
+	// Une playlist publique = méta + liste ordonnée des ids des tracks qu'elle
+	// contient. Les détails de chaque track sont dans `tracks` (on évite de
+	// dupliquer la payload côté API).
+	interface PublicPlaylist {
+		id:          string
+		name:        string
+		description: string | null
+		color:       string | null
+		trackCount:  number
+		trackIds:    string[]
+	}
+
 	let streamer     = $state<Streamer | null>(null)
 	let tracks       = $state<Track[]>([])
 	let nowPlaying   = $state<NowPlaying | null>(null)
 	let queue        = $state<QueueEntry[]>([])
 	let queueEnabled = $state(true)
+	let playlists    = $state<PublicPlaylist[]>([])
+	let selectedPlaylistId = $state<string | null>(null)
 	let loading      = $state(true)
 	let pollTimer: ReturnType<typeof setInterval> | null = null
 
@@ -117,12 +131,19 @@
 				nowPlaying: NowPlaying | null
 				queue?: QueueEntry[]
 				queueEnabled?: boolean
+				playlists?: PublicPlaylist[]
 			}
 			streamer     = data.streamer
 			tracks       = data.tracks ?? []
 			nowPlaying   = data.nowPlaying ?? null
 			queue        = data.queue ?? []
 			queueEnabled = data.queueEnabled !== false
+			playlists    = data.playlists ?? []
+			// Si la playlist active vient d'être dépubliée/supprimée côté streamer,
+			// on retombe gracieusement sur "Toutes".
+			if (selectedPlaylistId && !playlists.some(p => p.id === selectedPlaylistId)) {
+				selectedPlaylistId = null
+			}
 		} finally {
 			loading = false
 		}
@@ -180,12 +201,23 @@
 		previewingId = null
 	}
 
+	// Sélection playlist (null = toutes les pistes). Si une playlist est active,
+	// on borne la base aux trackIds de cette playlist en respectant leur ordre,
+	// puis on applique la recherche par-dessus.
+	const baseTracks = $derived.by(() => {
+		if (!selectedPlaylistId) return tracks
+		const pl = playlists.find(p => p.id === selectedPlaylistId)
+		if (!pl) return tracks
+		const map = new Map(tracks.map(t => [t.id, t]))
+		return pl.trackIds.map(id => map.get(id)).filter((t): t is Track => !!t)
+	})
+
 	const filtered = $derived(query.trim()
-		? tracks.filter(t => {
+		? baseTracks.filter(t => {
 			const q = query.trim().toLowerCase()
 			return t.title.toLowerCase().includes(q) || (t.artist ?? '').toLowerCase().includes(q)
 		})
-		: tracks)
+		: baseTracks)
 
 	const nowProgressPct = $derived(
 		nowPlaying?.durationMs && nowPlaying.durationMs > 0
@@ -333,7 +365,7 @@
 		<section>
 			<div class="flex items-baseline justify-between gap-3 flex-wrap mb-3">
 				<h2 class="text-xs uppercase tracking-widest font-medium text-zinc-400">Bibliothèque</h2>
-				<span class="text-[10px] text-zinc-600">{filtered.length} / {tracks.length} son{tracks.length > 1 ? 's' : ''}</span>
+				<span class="text-[10px] text-zinc-600">{filtered.length} / {baseTracks.length} son{baseTracks.length > 1 ? 's' : ''}</span>
 			</div>
 
 			{#if loading}
@@ -345,6 +377,33 @@
 					<div class="text-[11px] text-zinc-600">Si tu es l'admin, passe quelques pistes en <span class="font-mono text-zinc-400">visibility: public</span> depuis le tab Soundboard.</div>
 				</div>
 			{:else}
+				<!-- Pills playlists : visible uniquement quand le streamer a au moins
+				     une playlist publique. Sinon on garde l'UI plate d'avant. -->
+				{#if playlists.length > 0}
+					<div class="flex items-center gap-1.5 flex-wrap mb-3">
+						<button type="button" onclick={() => selectedPlaylistId = null}
+							class="text-xs px-2.5 py-1 rounded-full border transition-colors {selectedPlaylistId === null
+								? 'bg-purple-500/20 border-purple-500/60 text-purple-100 font-medium'
+								: 'bg-zinc-900 border-zinc-800 text-zinc-400 hover:text-zinc-100 hover:border-zinc-700'}">
+							Tout
+							<span class="ml-1 text-[10px] {selectedPlaylistId === null ? 'text-purple-300' : 'text-zinc-600'}">{tracks.length}</span>
+						</button>
+						{#each playlists as p (p.id)}
+							{@const isOn = selectedPlaylistId === p.id}
+							{@const accent = p.color ?? '#a78bfa'}
+							<button type="button" onclick={() => selectedPlaylistId = p.id}
+								class="text-xs inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border transition-colors {isOn
+									? 'border-purple-500/60 text-zinc-100 font-medium'
+									: 'bg-zinc-900 border-zinc-800 text-zinc-400 hover:text-zinc-100 hover:border-zinc-700'}"
+								style={isOn ? `background: color-mix(in srgb, ${accent} 22%, transparent);` : ''}>
+								<span class="w-2 h-2 rounded-full" style="background: {accent};"></span>
+								<span class="truncate max-w-[120px]" title={p.name}>{p.name}</span>
+								<span class="text-[10px] {isOn ? 'text-zinc-300' : 'text-zinc-600'}">{p.trackCount}</span>
+							</button>
+						{/each}
+					</div>
+				{/if}
+
 				<div class="relative mb-4">
 					<svg class="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
 						<circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>

--- a/nodyx-frontend/svelte.config.js
+++ b/nodyx-frontend/svelte.config.js
@@ -32,6 +32,7 @@ const config = {
                 'font-src':     ['self', 'data:', 'https://fonts.gstatic.com'],
                 'connect-src':  ['self', 'wss:', 'https:'],
                 'frame-src':    [
+                    'self',   // requis pour le canvas Scènes admin qui embarque les /overlay/<type>/<token> en iframe preview
                     'https://www.youtube.com',
                     'https://youtube.com',
                     'https://www.youtube-nocookie.com',


### PR DESCRIPTION
## Summary

Sprint Streamer Hub complet, déjà déployé et validé en prod sur nodyx.org (v2.7.0), committé ici a posteriori.

### 🎵 Playlists Soundboard
Demande d'un streamer : organiser ses sons par contexte (Intro, Dev, Discussion, Pause...) au lieu d'une liste plate.
- Migrations 100-101 (playlists + jonction many-to-many, un track peut être dans plusieurs playlists)
- Sidebar admin (CRUD, copie URL OBS, bouton Deck, placement en scène), popover "ranger dans une playlist" par track
- Pills de filtre sur la page publique /soundboard pour les playlists publiques

### 📺 Overlay playlist + contrôle Stream Deck
- Type d'overlay `playlist` : un token par streamer, URL par playlist via `?id=` → une Browser Source OBS par scène
- Page /overlay/playlist/[token] : autoplay loop, shuffle/volume/ui en query, refresh 60s sans couper la lecture
- Action Deck `playlist_control` (play/pause/toggle/skip/prev/stop/volume) → room socket `playlist:<owner>`, toast OSD sur l'overlay

### 🎬 Scènes OBS — Phase A
Compositeur visuel qui reprend le layout d'OBS pour garder les repères du streamer.
- Migration 102 + service avec sanitize complet du layout JSONB (1920×1080, cap 32 sources, URLs https only)
- Canvas drag/resize poignées rouges OBS-style, snap, aperçu live des overlays en iframe (toggle live/wireframe), fond couleur/image
- Catalogue de sources branché sur les overlays/playlists existants (création inline), "Placer dans une scène" depuis Overlays OBS et Soundboard
- Phase B prévue : aperçu réel via OBS WebSocket (documenté dans la doc FR incluse)

### 🧹 Hygiène
- `.gitignore` : exclusion généralisée de `nodyx-core/uploads/**` et `nodyx-core/backups/`
- CSP `frame-src 'self'` (svelte.config.js, la config Caddy live a été patchée en parallèle)

## Test plan

- [x] tsc backend clean, 364/364 tests Vitest verts
- [x] svelte-check 0 erreur
- [x] dist recompilé byte-identique au build prod (parité prouvée)
- [x] Smoke prod : routes admin 401, /soundboard/public expose les playlists, overlay playlist SSR 200, CSP frame-src 'self' active
- [x] Validation manuelle par Jonathan en prod tout au long du sprint
- [ ] CI verte