### PR TITLE
feat(forum): ancres de sommaire dans les posts

### DIFF
--- a/nodyx-core/src/routes/forums.ts
+++ b/nodyx-core/src/routes/forums.ts
@@ -71,6 +71,12 @@ const ALLOWED_ATTRS: sanitizeHtml.IOptions['allowedAttributes'] = {
   '*':      ['class', 'data-align', 'data-type'],
   'span':   ['class', 'style', 'data-align', 'data-type'],
   'p':      ['class', 'style', 'data-align', 'data-type'],
+  // id sur les titres : permet les sommaires à ancres (#section) dans les
+  // posts longs façon documentation. Pas d'id ailleurs pour limiter le
+  // risque de collision avec les éléments de l'app (DOM clobbering).
+  'h2':     ['class', 'id', 'style', 'data-align', 'data-type'],
+  'h3':     ['class', 'id', 'data-align', 'data-type'],
+  'h4':     ['class', 'id', 'data-align', 'data-type'],
   'a':      ['href', 'target', 'rel'],
   'img':    ['src', 'alt', 'width', 'height'],
   'iframe': ['src', 'width', 'height', 'frameborder', 'allowfullscreen', 'allow'],

--- a/nodyx-frontend/src/app.css
+++ b/nodyx-frontend/src/app.css
@@ -78,6 +78,13 @@ select option {
 }
 
 /* ── Titres ───────────────────────────────────────────────────────────────── */
+/* Ancres de sommaire (#id) : décale le point d'arrivée du scroll pour que le
+   titre ciblé ne se retrouve pas masqué sous le header sticky. */
+.nodyx-prose h2[id],
+.nodyx-prose h3[id],
+.nodyx-prose h4[id] {
+    scroll-margin-top: 5rem;
+}
 .nodyx-prose h1,
 .nodyx-content .tiptap h1 {
     font-size: 1.5rem; font-weight: 700; color: white;


### PR DESCRIPTION
## Summary
- Autorise `id` sur h2/h3/h4 dans le sanitizer forum → sommaires à ancres dans les posts longs (articles, docs)
- `scroll-margin-top` sur les titres ancrés pour compenser le header sticky

Micro-finition compatible ère de stabilisation : 2 fichiers, pas de nouvelle surface.

## Test plan
- [x] tsc clean, 364/364 tests verts
- [x] Utilisé immédiatement par l'article Type or Die (sommaire à ancres)
- [ ] CI verte