### PR TITLE
refonte(admin): design sobre sidebar + dashboard (Linear/Vercel-like)

### DIFF
--- a/nodyx-frontend/src/routes/admin/+layout.svelte
+++ b/nodyx-frontend/src/routes/admin/+layout.svelte
@@ -5,61 +5,64 @@
 
 	let { children, data }: { children: any; data: LayoutData } = $props()
 
-	type NavItem = { href: string; label: string; icon: string; exact?: boolean; soon?: boolean }
+	// iconPath : SVG outline 24x24 (heroicons/lucide), rendu monochrome via
+	// stroke currentColor. Pas d'emoji dans les labels système (référence
+	// design admin : Linear / Vercel / Stripe, un seul accent).
+	type NavItem = { href: string; label: string; iconPath: string; exact?: boolean; soon?: boolean }
 	type NavGroup = { section: string; items: NavItem[] }
 
 	const nav: NavGroup[] = [
 		{
 			section: 'Communauté',
 			items: [
-				{ href: '/admin',             label: 'Dashboard',    icon: '📊', exact: true },
-				{ href: '/admin/members',     label: 'Membres',      icon: '👥' },
-				{ href: '/admin/grades',      label: 'Grades',       icon: '🏅' },
-				{ href: '/admin/categories',  label: 'Catégories',   icon: '📁' },
-				{ href: '/admin/moderation',  label: 'Modération',   icon: '🛡️' },
-				{ href: '/admin/octoguard',   label: 'OctoGuard',    icon: '🐙' },
-				{ href: '/admin/tags',        label: 'Tags',         icon: '🏷️' },
-				{ href: '/admin/audit-log',   label: 'Journal',      icon: '📋' },
+				{ href: '/admin',             label: 'Dashboard',    exact: true, iconPath: 'M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z' },
+				{ href: '/admin/members',     label: 'Membres',      iconPath: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z' },
+				{ href: '/admin/grades',      label: 'Grades',       iconPath: 'M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z' },
+				{ href: '/admin/categories',  label: 'Catégories',   iconPath: 'M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z' },
+				{ href: '/admin/moderation',  label: 'Modération',   iconPath: 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z' },
+				{ href: '/admin/octoguard',   label: 'OctoGuard',    iconPath: 'M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z' },
+				{ href: '/admin/tags',        label: 'Tags',         iconPath: 'M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z' },
+				{ href: '/admin/audit-log',   label: 'Journal',      iconPath: 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z' },
 			],
 		},
 		{
 			section: 'Communication',
 			items: [
-				{ href: '/admin/channels/text',  label: 'Canaux texte',  icon: '💬' },
-				{ href: '/admin/channels/voice', label: 'Canaux vocaux', icon: '🔊' },
+				{ href: '/admin/channels/text',  label: 'Canaux texte',  iconPath: 'M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z' },
+				{ href: '/admin/channels/voice', label: 'Canaux vocaux', iconPath: 'M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z' },
 			],
 		},
 		{
 			section: 'Contenu',
 			items: [
-				{ href: '/admin/homepage',         label: 'Homepage',     icon: '🏠' },
-				{ href: '/admin/homepage/builder', label: 'Grid Builder', icon: '⬛' },
-				{ href: '/admin/widgets',          label: 'Widgets',      icon: '🧩' },
-				{ href: '/admin/media',    label: 'Médiathèque', icon: '📷' },
-				{ href: '/admin/assets',   label: 'Assets',      icon: '🖼️' },
-				{ href: '/admin/garden',   label: 'Jardin',    icon: '🌱' },
+				{ href: '/admin/homepage',         label: 'Homepage',     iconPath: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6' },
+				{ href: '/admin/homepage/builder', label: 'Grid Builder', iconPath: 'M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z' },
+				{ href: '/admin/widgets',          label: 'Widgets',      iconPath: 'M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z' },
+				{ href: '/admin/media',            label: 'Médiathèque',  iconPath: 'M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z' },
+				{ href: '/admin/assets',           label: 'Assets',       iconPath: 'M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4' },
+				{ href: '/admin/garden',           label: 'Jardin',       iconPath: 'M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z' },
 			],
 		},
 		{
 			section: 'Plateforme',
 			items: [
-				{ href: '/admin/modules', label: 'Modules', icon: '🧩' },
+				{ href: '/admin/modules', label: 'Modules', iconPath: 'M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4' },
 			],
 		},
 		{
 			section: 'Intégrations',
 			items: [
-				{ href: '/admin/streamer-hub', label: 'Streamer Hub', icon: '🎬' },
+				{ href: '/admin/streamer-hub', label: 'Streamer Hub', iconPath: 'M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z' },
 			],
 		},
 		{
 			section: 'Instance',
 			items: [
-				{ href: '/admin/announcements', label: 'Annonces',      icon: '📢' },
-				{ href: '/admin/settings',      label: 'Paramètres',    icon: '⚙️' },
-				{ href: '/admin/status',        label: 'Statut réseau', icon: '🌐' },
-				{ href: '/admin/backups',       label: 'Sauvegardes',   icon: '💾' },
-				{ href: '/admin/ai',            label: 'Neural Engine', icon: '🧠' },
+				{ href: '/admin/announcements', label: 'Annonces',      iconPath: 'M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z' },
+				{ href: '/admin/settings',      label: 'Paramètres',    iconPath: 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z' },
+				{ href: '/admin/status',        label: 'Statut réseau', iconPath: 'M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9' },
+				{ href: '/admin/backups',       label: 'Sauvegardes',   iconPath: 'M4 7v10c0 2 3.582 3 8 3s8-1 8-3V7M4 7c0 2 3.582 3 8 3s8-1 8-3M4 7c0-2 3.582-3 8-3s8 1 8 3' },
+				{ href: '/admin/ai',            label: 'Neural Engine', iconPath: 'M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z' },
 			],
 		},
 	]
@@ -73,39 +76,47 @@
 <div class="flex flex-1 min-h-0">
 
 	<!-- ── Sidebar ──────────────────────────────────────────────────────────── -->
-	<aside class="w-56 shrink-0 border-r border-gray-800 bg-gray-900 flex flex-col">
+	<aside class="w-56 shrink-0 border-r border-zinc-800/80 bg-zinc-950 flex flex-col">
 
 		<!-- Header -->
-		<div class="h-14 flex items-center gap-2.5 px-4 border-b border-gray-800">
-			<div class="w-7 h-7 rounded-md bg-indigo-700 flex items-center justify-center text-xs font-bold text-white">
-				A
+		<div class="h-14 flex items-center gap-2.5 px-4 border-b border-zinc-800/80">
+			<div class="w-6 h-6 rounded-md bg-indigo-600 flex items-center justify-center shrink-0">
+				<svg class="w-3.5 h-3.5 text-white" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+					<path d="M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3z"/>
+				</svg>
 			</div>
 			<div class="min-w-0">
-				<div class="text-xs font-semibold text-white truncate">Administration</div>
-				<div class="text-xs text-gray-500 truncate">{data.communityName ?? 'Nodyx'}</div>
+				<div class="text-[13px] font-semibold text-zinc-100 truncate leading-tight">Administration</div>
+				<div class="text-[11px] text-zinc-500 truncate leading-tight">{data.communityName ?? 'Nodyx'}</div>
 			</div>
 		</div>
 
 		<!-- Nav -->
 		<nav class="flex-1 overflow-y-auto py-3 px-2">
 			{#each nav as group}
-				<div class="mb-4">
-					<p class="px-2 mb-1 text-xs font-semibold text-gray-600 uppercase tracking-wider">
+				<div class="mb-3.5">
+					<p class="px-2.5 mb-1 text-[10px] font-semibold text-zinc-600 uppercase tracking-[0.08em]">
 						{group.section}
 					</p>
 					{#each group.items as item}
+						{@const active = isActive(item.href, item.exact)}
 						<a
 							href={item.href}
-							class="flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-sm transition-colors mb-0.5
-							       {isActive(item.href, item.exact)
-							         ? 'bg-indigo-900/60 text-indigo-200'
-							         : 'text-gray-400 hover:text-white hover:bg-gray-800/60'}
+							class="relative flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] transition-colors mb-px
+							       {active
+							         ? 'bg-zinc-800/80 text-zinc-100'
+							         : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-900'}
 							       {item.soon ? 'opacity-60 pointer-events-none' : ''}"
 						>
-							<span class="text-base leading-none w-5 text-center">{item.icon}</span>
-							<span class="flex-1">{item.label}</span>
+							{#if active}
+								<span class="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-4 rounded-full bg-indigo-400"></span>
+							{/if}
+							<svg class="w-4 h-4 shrink-0 {active ? 'text-indigo-300' : 'text-zinc-500'}" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+								<path d={item.iconPath}/>
+							</svg>
+							<span class="flex-1 truncate">{item.label}</span>
 							{#if item.soon}
-								<span class="text-xs text-gray-600 font-medium shrink-0">bientôt</span>
+								<span class="text-[10px] text-zinc-600 font-medium shrink-0">bientôt</span>
 							{/if}
 						</a>
 					{/each}
@@ -114,16 +125,18 @@
 		</nav>
 
 		<!-- Footer -->
-		<div class="border-t border-gray-800 p-3 space-y-2">
+		<div class="border-t border-zinc-800/80 p-2 space-y-1">
 			<a
 				href="/"
-				class="flex items-center gap-2 px-2.5 py-2 rounded-lg text-sm text-gray-500
-				       hover:text-white hover:bg-gray-800/60 transition-colors"
+				class="flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] text-zinc-500
+				       hover:text-zinc-100 hover:bg-zinc-900 transition-colors"
 			>
-				<span>←</span>
+				<svg class="w-4 h-4 text-zinc-600" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+					<path d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
+				</svg>
 				<span>Retour au forum</span>
 			</a>
-			<div class="px-2.5 pt-1.5 border-t border-gray-800/60">
+			<div class="px-2.5 pt-1.5 border-t border-zinc-800/60">
 				<NodyxVersionBadge
 					version={data.updateCheck?.current_version ?? (data as any).nodyxVersion ?? 'unknown'}
 					variant="admin"
@@ -137,34 +150,35 @@
 
 		<!-- Update banner -->
 		{#if data.updateCheck?.has_update}
-			<div class="bg-indigo-900/70 border-b border-indigo-700/50 px-6 py-2.5 flex items-center justify-between gap-4 shrink-0">
-				<div class="flex items-center gap-2.5 text-sm">
-					<span class="text-indigo-300 font-semibold">Mise à jour disponible</span>
-					<span class="text-indigo-400">v{data.updateCheck.current_version} → v{data.updateCheck.latest_version}</span>
+			<div class="bg-zinc-900 border-b border-zinc-800 px-6 py-2 flex items-center justify-between gap-4 shrink-0">
+				<div class="flex items-center gap-2.5 text-[13px]">
+					<span class="w-1.5 h-1.5 rounded-full bg-indigo-400 shrink-0"></span>
+					<span class="text-zinc-200 font-medium">Mise à jour disponible</span>
+					<span class="text-zinc-500 tabular-nums">v{data.updateCheck.current_version} → v{data.updateCheck.latest_version}</span>
 				</div>
 				{#if data.updateCheck.release_url}
 					<a
 						href={data.updateCheck.release_url}
 						target="_blank"
 						rel="noopener noreferrer"
-						class="text-xs font-medium text-indigo-200 hover:text-white bg-indigo-700/60 hover:bg-indigo-600 px-3 py-1.5 rounded-lg transition-colors shrink-0"
+						class="text-xs font-medium text-zinc-200 hover:text-white border border-zinc-700 hover:border-zinc-500 px-2.5 py-1 rounded-md transition-colors shrink-0"
 					>
-						Voir les notes de version
+						Notes de version
 					</a>
 				{/if}
 			</div>
 		{/if}
 
 		<!-- Top bar -->
-		<header class="h-14 border-b border-gray-800 bg-gray-900/50 flex items-center justify-between px-6 shrink-0">
-			<nav class="text-sm text-gray-500 flex items-center gap-1.5">
-				<a href="/" class="hover:text-gray-300">Forum</a>
-				<span>/</span>
-				<span class="text-gray-300">Administration</span>
+		<header class="h-14 border-b border-zinc-800/80 bg-zinc-950/60 flex items-center justify-between px-6 shrink-0">
+			<nav class="text-[13px] text-zinc-500 flex items-center gap-1.5">
+				<a href="/" class="hover:text-zinc-300 transition-colors">Forum</a>
+				<svg class="w-3 h-3 text-zinc-700" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"/></svg>
+				<span class="text-zinc-300">Administration</span>
 			</nav>
-			<div class="flex items-center gap-2 text-xs text-gray-500">
-				<span class="w-1.5 h-1.5 rounded-full bg-green-400"></span>
-				<span class="text-green-500 font-medium">{data.stats?.online ?? 0}</span> en ligne
+			<div class="flex items-center gap-2 text-xs">
+				<span class="w-1.5 h-1.5 rounded-full bg-emerald-400"></span>
+				<span class="text-zinc-400"><span class="text-zinc-200 font-medium tabular-nums">{data.stats?.online ?? 0}</span> en ligne</span>
 			</div>
 		</header>
 

--- a/nodyx-frontend/src/routes/admin/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/+page.svelte
@@ -3,30 +3,27 @@
 	let { data }: { data: PageData } = $props()
 	const s = $derived(data.stats)
 
+	// Cartes stats : style UNIFORME (fond zinc, bordure discrète), un seul
+	// accent. L'émeraude est réservée aux deltas positifs (sémantique), pas
+	// de couleur par carte. Icônes SVG monochromes (iconPath outline 24x24).
 	const statCards = $derived([
-		{ label: 'Membres',    value: s.users.total,    delta: s.users.new_this_week,    icon: '👥', color: 'indigo', sub: `+${s.users.new_this_week} cette semaine` },
-		{ label: 'Fils',       value: s.threads.total,  delta: s.threads.new_this_week,  icon: '💬', color: 'violet', sub: `+${s.threads.new_this_week} cette semaine` },
-		{ label: 'Messages',   value: s.posts.total,    delta: s.posts.new_this_week,    icon: '✉️', color: 'blue',   sub: `+${s.posts.new_this_week} cette semaine` },
-		{ label: 'En ligne',   value: s.online,         delta: null,                     icon: '🟢', color: 'green',  sub: 'utilisateurs actifs' },
+		{ label: 'Membres',    value: s.users.total,   delta: s.users.new_this_week,   sub: 'cette semaine',
+		  iconPath: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z' },
+		{ label: 'Fils',       value: s.threads.total, delta: s.threads.new_this_week, sub: 'cette semaine',
+		  iconPath: 'M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a1.994 1.994 0 01-1.414-.586m0 0L11 13h4a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2v4l4.586-4.586z' },
+		{ label: 'Messages',   value: s.posts.total,   delta: s.posts.new_this_week,   sub: 'cette semaine',
+		  iconPath: 'M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z' },
+		{ label: 'En ligne',   value: s.online,        delta: null,                    sub: 'utilisateurs actifs', live: true,
+		  iconPath: 'M5.636 18.364a9 9 0 010-12.728m12.728 0a9 9 0 010 12.728m-9.9-2.829a5 5 0 010-7.07m7.072 0a5 5 0 010 7.07M13 12a1 1 0 11-2 0 1 1 0 012 0z' },
+		{ label: 'Événements', value: s.events?.total ?? 0, delta: null, sub: `${s.events?.upcoming ?? 0} à venir`,
+		  iconPath: 'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z' },
+		{ label: 'Sondages',   value: s.polls?.total ?? 0,  delta: null, sub: `${s.polls?.open ?? 0} ouverts`,
+		  iconPath: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z' },
+		{ label: 'Assets',     value: s.assets?.total ?? 0, delta: null, sub: 'dans la bibliothèque',
+		  iconPath: 'M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z' },
+		{ label: 'Chat',       value: s.chat?.total ?? 0,   delta: s.chat?.new_this_week ?? null, sub: 'cette semaine',
+		  iconPath: 'M13 10V3L4 14h7v7l9-11h-7z' },
 	])
-
-	const statCards2 = $derived([
-		{ label: 'Événements',  value: s.events?.total ?? 0,   sub: `${s.events?.upcoming ?? 0} à venir`,   icon: '📅', color: 'amber' },
-		{ label: 'Sondages',    value: s.polls?.total  ?? 0,   sub: `${s.polls?.open ?? 0} ouverts`,        icon: '📊', color: 'sky' },
-		{ label: 'Assets',      value: s.assets?.total ?? 0,   sub: 'dans la bibliothèque',                 icon: '🖼️', color: 'rose' },
-		{ label: 'Chat msgs',   value: s.chat?.total   ?? 0,   sub: `+${s.chat?.new_this_week ?? 0} cette semaine`, icon: '⚡', color: 'teal' },
-	])
-
-	const COLOR: Record<string, string> = {
-		indigo: 'bg-indigo-900/40 border-indigo-800/60 text-indigo-400',
-		violet: 'bg-violet-900/40 border-violet-800/60 text-violet-400',
-		blue:   'bg-blue-900/40   border-blue-800/60   text-blue-400',
-		green:  'bg-green-900/40  border-green-800/60  text-green-400',
-		amber:  'bg-amber-900/40  border-amber-800/60  text-amber-400',
-		sky:    'bg-sky-900/40    border-sky-800/60    text-sky-400',
-		rose:   'bg-rose-900/40   border-rose-800/60   text-rose-400',
-		teal:   'bg-teal-900/40   border-teal-800/60   text-teal-400',
-	}
 
 	function buildChartDays(rows: any[]) {
 		const axis: string[] = []
@@ -64,107 +61,119 @@
 		if (day < 30) return `${day}j`
 		return new Date(d).toLocaleDateString('fr-FR', { day: '2-digit', month: 'short' })
 	}
+
+	const quickActions = [
+		{ href: '/admin/members',    label: 'Membres',    iconPath: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z' },
+		{ href: '/admin/grades',     label: 'Grades',     iconPath: 'M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z' },
+		{ href: '/admin/categories', label: 'Catégories', iconPath: 'M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z' },
+		{ href: '/admin/moderation', label: 'Modération', iconPath: 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z' },
+		{ href: '/admin/channels',   label: 'Salons',     iconPath: 'M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z' },
+		{ href: '/admin/settings',   label: 'Paramètres', iconPath: 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z' },
+	]
 </script>
 
 <svelte:head><title>Dashboard — Admin Nodyx</title></svelte:head>
 
-<div class="space-y-6">
-	<h1 class="text-2xl font-bold text-white">Dashboard</h1>
-
-	<!-- ── Ligne 1 : stats principales ──────────────────────────────────────── -->
-	<div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
-		{#each statCards as card}
-			<div class="rounded-xl border p-5 {COLOR[card.color]}">
-				<div class="flex items-start justify-between mb-3">
-					<span class="text-xl">{card.icon}</span>
-					<span class="text-xs text-gray-600">{card.sub}</span>
-				</div>
-				<div class="text-3xl font-bold text-white">{card.value.toLocaleString('fr-FR')}</div>
-				<div class="text-sm text-gray-400 mt-1">{card.label}</div>
-			</div>
-		{/each}
+<div class="space-y-5 max-w-6xl">
+	<div>
+		<h1 class="text-xl font-semibold text-zinc-100">Dashboard</h1>
+		<p class="text-[13px] text-zinc-500 mt-0.5">Vue d'ensemble de l'instance</p>
 	</div>
 
-	<!-- ── Ligne 2 : stats secondaires ──────────────────────────────────────── -->
-	<div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
-		{#each statCards2 as card}
-			<div class="rounded-xl border p-4 {COLOR[card.color]} flex items-center gap-4">
-				<span class="text-2xl shrink-0">{card.icon}</span>
-				<div class="min-w-0">
-					<div class="text-2xl font-bold text-white">{card.value.toLocaleString('fr-FR')}</div>
-					<div class="text-xs font-medium text-gray-300 leading-tight">{card.label}</div>
-					<div class="text-xs text-gray-600 mt-0.5 truncate">{card.sub}</div>
+	<!-- ── Stats : 8 cartes uniformes ───────────────────────────────────────── -->
+	<div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
+		{#each statCards as card}
+			<div class="rounded-lg border border-zinc-800 bg-zinc-900/60 p-4">
+				<div class="flex items-center justify-between mb-3">
+					<span class="text-[11px] font-medium text-zinc-500 uppercase tracking-wide">{card.label}</span>
+					<svg class="w-4 h-4 text-zinc-600" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+						<path d={card.iconPath}/>
+					</svg>
+				</div>
+				<div class="flex items-baseline gap-2">
+					<span class="text-2xl font-semibold text-zinc-100 tabular-nums leading-none">{card.value.toLocaleString('fr-FR')}</span>
+					{#if card.live}
+						<span class="w-1.5 h-1.5 rounded-full bg-emerald-400 mb-0.5"></span>
+					{/if}
+				</div>
+				<div class="text-xs text-zinc-600 mt-1.5">
+					{#if card.delta !== null && card.delta !== undefined && card.delta > 0}
+						<span class="text-emerald-400 font-medium tabular-nums">+{card.delta}</span>
+						<span> {card.sub}</span>
+					{:else}
+						{card.sub}
+					{/if}
 				</div>
 			</div>
 		{/each}
 	</div>
 
 	<!-- ── Grille principale ────────────────────────────────────────────────── -->
-	<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+	<div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
 
 		<!-- Activité 7j — posts + nouveaux membres -->
-		<div class="rounded-xl border border-gray-800 bg-gray-900/40 p-5">
+		<div class="rounded-lg border border-zinc-800 bg-zinc-900/60 p-5">
 			<div class="flex items-center justify-between mb-4">
-				<h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider">
-					Activité — 7 derniers jours
+				<h2 class="text-[11px] font-semibold text-zinc-500 uppercase tracking-wide">
+					Activité · 7 derniers jours
 				</h2>
-				<div class="flex items-center gap-3 text-xs text-gray-600">
+				<div class="flex items-center gap-3 text-[11px] text-zinc-500">
 					<span class="flex items-center gap-1.5">
-						<span class="w-2.5 h-2.5 rounded-sm bg-indigo-600/80 inline-block"></span>
+						<span class="w-2 h-2 rounded-sm bg-indigo-500 inline-block"></span>
 						Messages
 					</span>
 					<span class="flex items-center gap-1.5">
-						<span class="w-2.5 h-2.5 rounded-sm bg-emerald-600/80 inline-block"></span>
+						<span class="w-2 h-2 rounded-sm bg-zinc-600 inline-block"></span>
 						Inscriptions
 					</span>
 				</div>
 			</div>
 			<div class="flex items-end gap-1.5 h-28">
 				{#each chartDays as day}
-					<div class="flex-1 flex flex-col items-center gap-0.5">
+					<div class="flex-1 flex flex-col items-center gap-1">
 						<div class="w-full flex items-end gap-0.5 h-20">
 							<!-- Posts bar -->
 							<div
-								class="flex-1 rounded-t bg-indigo-600/70 hover:bg-indigo-500 transition-colors min-h-[2px]"
+								class="flex-1 rounded-t-sm bg-indigo-500/80 hover:bg-indigo-400 transition-colors min-h-[2px]"
 								style="height: {Math.max((day.posts / chartMax) * 76, day.posts > 0 ? 3 : 0)}px"
 								title="{day.posts} message{day.posts !== 1 ? 's' : ''}"
 							></div>
 							<!-- New members bar -->
 							<div
-								class="flex-1 rounded-t bg-emerald-600/70 hover:bg-emerald-500 transition-colors min-h-[2px]"
+								class="flex-1 rounded-t-sm bg-zinc-600/80 hover:bg-zinc-500 transition-colors min-h-[2px]"
 								style="height: {Math.max((day.new_members / chartMax) * 76, day.new_members > 0 ? 3 : 0)}px"
 								title="{day.new_members} inscription{day.new_members !== 1 ? 's' : ''}"
 							></div>
 						</div>
-						<span class="text-[10px] text-gray-600 tabular-nums">{day.label}</span>
+						<span class="text-[10px] text-zinc-600 tabular-nums">{day.label}</span>
 					</div>
 				{/each}
 			</div>
 		</div>
 
 		<!-- Top contributeurs -->
-		<div class="rounded-xl border border-gray-800 bg-gray-900/40 p-5">
-			<h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">
-				Top contributeurs — 30 jours
+		<div class="rounded-lg border border-zinc-800 bg-zinc-900/60 p-5">
+			<h2 class="text-[11px] font-semibold text-zinc-500 uppercase tracking-wide mb-4">
+				Top contributeurs · 30 jours
 			</h2>
 			{#if s.top_contributors.length === 0}
-				<p class="text-sm text-gray-600">Aucun message ce mois-ci.</p>
+				<p class="text-sm text-zinc-600">Aucun message ce mois-ci.</p>
 			{:else}
 				<ol class="space-y-2.5">
 					{#each s.top_contributors as c, i}
 						<li class="flex items-center gap-3">
-							<span class="text-sm font-bold text-gray-600 w-4 tabular-nums">{i + 1}</span>
-							<div class="w-7 h-7 rounded-full bg-indigo-800 flex items-center justify-center text-xs font-bold text-indigo-200 shrink-0 overflow-hidden">
+							<span class="text-xs font-medium text-zinc-600 w-4 tabular-nums">{i + 1}</span>
+							<div class="w-6 h-6 rounded-full bg-zinc-800 flex items-center justify-center text-[10px] font-semibold text-zinc-300 shrink-0 overflow-hidden">
 								{#if c.avatar}
 									<img src={c.avatar} alt={c.username} class="w-full h-full object-cover" />
 								{:else}
 									{c.username.charAt(0).toUpperCase()}
 								{/if}
 							</div>
-							<a href="/users/{c.username}" class="text-sm text-gray-200 hover:text-white flex-1 font-medium">
+							<a href="/users/{c.username}" class="text-[13px] text-zinc-300 hover:text-white flex-1 font-medium transition-colors">
 								{c.username}
 							</a>
-							<span class="text-sm text-gray-500 tabular-nums">{c.post_count} msg</span>
+							<span class="text-xs text-zinc-500 tabular-nums">{c.post_count} msg</span>
 						</li>
 					{/each}
 				</ol>
@@ -172,17 +181,17 @@
 		</div>
 
 		<!-- Derniers inscrits -->
-		<div class="rounded-xl border border-gray-800 bg-gray-900/40 p-5">
-			<h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">
+		<div class="rounded-lg border border-zinc-800 bg-zinc-900/60 p-5">
+			<h2 class="text-[11px] font-semibold text-zinc-500 uppercase tracking-wide mb-4">
 				Derniers inscrits
 			</h2>
 			{#if !s.recent_members || s.recent_members.length === 0}
-				<p class="text-sm text-gray-600">Aucun membre récent.</p>
+				<p class="text-sm text-zinc-600">Aucun membre récent.</p>
 			{:else}
 				<ul class="space-y-2.5">
 					{#each s.recent_members as m}
 						<li class="flex items-center gap-3">
-							<div class="w-7 h-7 rounded-full bg-gray-700 flex items-center justify-center text-xs font-bold text-gray-300 shrink-0 overflow-hidden">
+							<div class="w-6 h-6 rounded-full bg-zinc-800 flex items-center justify-center text-[10px] font-semibold text-zinc-300 shrink-0 overflow-hidden">
 								{#if m.avatar}
 									<img src={m.avatar} alt={m.username} class="w-full h-full object-cover" />
 								{:else}
@@ -190,13 +199,13 @@
 								{/if}
 							</div>
 							<div class="flex-1 min-w-0">
-								<a href="/users/{m.username}" class="text-sm text-gray-200 hover:text-white font-medium block truncate">
+								<a href="/users/{m.username}" class="text-[13px] text-zinc-300 hover:text-white font-medium block truncate transition-colors">
 									{m.username}
 								</a>
-								<span class="text-xs text-gray-600 truncate block">{m.email}</span>
+								<span class="text-xs text-zinc-600 truncate block">{m.email}</span>
 							</div>
 							<div class="text-right shrink-0">
-								<span class="text-xs text-gray-500">{timeAgo(m.joined_at)}</span>
+								<span class="text-xs text-zinc-500 tabular-nums">{timeAgo(m.joined_at)}</span>
 								{#if m.role !== 'member'}
 									<span class="block text-[10px] text-indigo-400 font-medium capitalize">{m.role}</span>
 								{/if}
@@ -204,62 +213,58 @@
 						</li>
 					{/each}
 				</ul>
-				<a href="/admin/members" class="mt-4 text-xs text-indigo-400 hover:text-indigo-300 flex items-center gap-1">
-					Voir tous les membres →
+				<a href="/admin/members" class="mt-4 text-xs text-zinc-400 hover:text-zinc-200 inline-flex items-center gap-1 transition-colors">
+					Voir tous les membres
+					<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"/></svg>
 				</a>
 			{/if}
 		</div>
 
 		<!-- Forum + Actions rapides -->
 		<div class="space-y-4">
-			<div class="rounded-xl border border-gray-800 bg-gray-900/40 p-5">
-				<h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">État du forum</h2>
-				<dl class="space-y-2.5 text-sm">
+			<div class="rounded-lg border border-zinc-800 bg-zinc-900/60 p-5">
+				<h2 class="text-[11px] font-semibold text-zinc-500 uppercase tracking-wide mb-4">État du forum</h2>
+				<dl class="space-y-2 text-[13px]">
 					<div class="flex justify-between">
-						<dt class="text-gray-500">Catégories</dt>
-						<dd class="text-white font-medium">{s.categories.total}</dd>
+						<dt class="text-zinc-500">Catégories</dt>
+						<dd class="text-zinc-200 font-medium tabular-nums">{s.categories.total}</dd>
 					</div>
 					<div class="flex justify-between">
-						<dt class="text-gray-500">Fils épinglés</dt>
-						<dd class="text-white font-medium">{s.threads.pinned}</dd>
+						<dt class="text-zinc-500">Fils épinglés</dt>
+						<dd class="text-zinc-200 font-medium tabular-nums">{s.threads.pinned}</dd>
 					</div>
 					<div class="flex justify-between">
-						<dt class="text-gray-500">Fils verrouillés</dt>
-						<dd class="text-white font-medium">{s.threads.locked}</dd>
+						<dt class="text-zinc-500">Fils verrouillés</dt>
+						<dd class="text-zinc-200 font-medium tabular-nums">{s.threads.locked}</dd>
 					</div>
 					<div class="flex justify-between">
-						<dt class="text-gray-500">Moy. msgs / fil</dt>
-						<dd class="text-white font-medium">
+						<dt class="text-zinc-500">Moy. msgs / fil</dt>
+						<dd class="text-zinc-200 font-medium tabular-nums">
 							{s.threads.total > 0 ? (s.posts.total / s.threads.total).toFixed(1) : '—'}
 						</dd>
 					</div>
 					{#if s.dms}
 					<div class="flex justify-between">
-						<dt class="text-gray-500">Conversations DM</dt>
-						<dd class="text-white font-medium">{s.dms.total}</dd>
+						<dt class="text-zinc-500">Conversations DM</dt>
+						<dd class="text-zinc-200 font-medium tabular-nums">{s.dms.total}</dd>
 					</div>
 					{/if}
 				</dl>
 			</div>
 
-			<div class="rounded-xl border border-gray-800 bg-gray-900/40 p-5">
-				<h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">Actions rapides</h2>
+			<div class="rounded-lg border border-zinc-800 bg-zinc-900/60 p-5">
+				<h2 class="text-[11px] font-semibold text-zinc-500 uppercase tracking-wide mb-3">Actions rapides</h2>
 				<div class="grid grid-cols-2 gap-2">
-					{#each [
-						{ href: '/admin/members',    label: 'Membres',     icon: '👥' },
-						{ href: '/admin/grades',     label: 'Grades',      icon: '🏅' },
-						{ href: '/admin/categories', label: 'Catégories',  icon: '📁' },
-						{ href: '/admin/moderation', label: 'Modération',  icon: '🛡️' },
-						{ href: '/admin/channels',   label: 'Salons',      icon: '💬' },
-						{ href: '/admin/settings',   label: 'Paramètres',  icon: '⚙️' },
-					] as link}
+					{#each quickActions as link}
 						<a
 							href={link.href}
-							class="flex items-center gap-2 px-3 py-2.5 rounded-lg bg-gray-800 hover:bg-gray-700
-							       border border-gray-700 text-sm text-gray-300 hover:text-white transition-colors"
+							class="flex items-center gap-2.5 px-3 py-2 rounded-md bg-zinc-900 hover:bg-zinc-800/70
+							       border border-zinc-800 hover:border-zinc-700 text-zinc-400 hover:text-zinc-100 transition-colors"
 						>
-							<span>{link.icon}</span>
-							<span class="text-xs">{link.label}</span>
+							<svg class="w-4 h-4 text-zinc-500 shrink-0" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+								<path d={link.iconPath}/>
+							</svg>
+							<span class="text-xs font-medium">{link.label}</span>
 						</a>
 					{/each}
 				</div>


### PR DESCRIPTION
## Summary
Première passe de la refonte admin (ère stabilisation, chantier UX/UI) : la sidebar et le dashboard passent du look "jouet" (emojis multicolores, cartes arc-en-ciel, gros radius) à un design sobre type Linear/Vercel/Stripe.

- Icônes SVG outline monochromes partout (sidebar, cartes, actions rapides)
- Style de carte unique : zinc-900/60 + bordure zinc-800, radius lg max
- Un seul accent (indigo) + émeraude strictement sémantique (deltas positifs, online)
- Item de nav actif : barrette latérale fine au lieu d'un pill coloré
- Typo : 13px, micro-uppercase pour les sections, tabular-nums pour les chiffres

Présentation uniquement, zéro changement de logique. Les pages internes seront harmonisées progressivement.

## Test plan
- [x] svelte-check 0 erreur
- [ ] CI verte
- [ ] Validation visuelle Jonathan