### PR TITLE
fix(perf): SSR 27s (directory sans timeout) + cache showcase jamais invalidé

### DIFF
--- a/nodyx-core/src/routes/forums.ts
+++ b/nodyx-core/src/routes/forums.ts
@@ -13,7 +13,7 @@ import * as ThanksModel from '../models/thanks'
 import * as TagModel from '../models/tag'
 import * as NotificationModel from '../models/notification'
 import { resolveMentions } from '../utils/mentions'
-import { db } from '../config/database'
+import { db, redis } from '../config/database'
 import { checkHtmlContent } from '../services/contentFilter'
 import { io } from '../socket/io'
 
@@ -161,6 +161,14 @@ function sanitize(raw: string): string {
       return false
     },
   })
+}
+
+// Invalide les caches de listes de threads (showcase homepage, etc.) en
+// incrémentant la version incluse dans leurs clés. Fire-and-forget : un
+// échec Redis ne doit jamais bloquer la mutation (le TTL 30s rattrape).
+// Consommé par instance.ts (threads/showcase).
+function bumpThreadsCache(): void {
+  redis.incr('threads:cache:ver').catch(() => {})
 }
 
 const CreateCategoryBody = z.object({
@@ -346,6 +354,7 @@ app.get('/threads', {
       author_id: request.user!.userId,
       content: sanitizedContent,
     })
+    bumpThreadsCache()
 
     // Attach tags if provided
     if (tag_ids && tag_ids.length > 0) {
@@ -432,6 +441,7 @@ app.get('/threads', {
       author_id: userId,
       content:   sanitized,
     })
+    bumpThreadsCache()
 
     // Notifications (fire-and-forget)
     ;(async () => {
@@ -510,6 +520,7 @@ app.get('/threads', {
     }
 
     const post = await PostModel.updateContent(id, editSanitized)
+    bumpThreadsCache()
     return reply.send({
       post,
       meta: { images_rehosted: rehostEdit.rehosted, images_failed: rehostEdit.failed.length },
@@ -575,6 +586,7 @@ app.get('/threads', {
         return reply.code(403).send({ error: 'Authors can only edit the title', code: 'FORBIDDEN' })
       }
       const updated = await ThreadModel.update(threadId, { title: body.title.trim() })
+      bumpThreadsCache()
       return reply.send({ thread: updated })
     }
 
@@ -589,6 +601,7 @@ app.get('/threads', {
     // Mod/owner actions
     if (body.delete) {
       await ThreadModel.remove(threadId)
+      bumpThreadsCache()
       return reply.code(204).send()
     }
 
@@ -602,6 +615,7 @@ app.get('/threads', {
       is_locked:   body.is_locked,
       is_featured: body.is_featured,
     })
+    bumpThreadsCache()
     return reply.send({ thread: updated })
   })
 

--- a/nodyx-core/src/routes/instance.ts
+++ b/nodyx-core/src/routes/instance.ts
@@ -275,8 +275,13 @@ export default async function instanceRoutes(app: FastifyInstance) {
       : 'recent'
     const categoryRaw = (query.category ?? '').trim()
 
-    // Cache 30s — les articles changent mais pas toutes les secondes
-    const cacheKey = `showcase:${communityId}:${categoryRaw}:${pinnedOnly}:${limit}:${orderKey}`
+    // Cache 30s, invalidé par version : forums.ts incrémente
+    // threads:cache:ver à chaque mutation de thread/post, ce qui orpheline
+    // instantanément toutes les entrées (elles expirent ensuite par TTL).
+    // Poster ou épingler un article apparaît donc immédiatement sur la
+    // homepage, sans rafraîchissement manuel.
+    const cacheVer = (await redis.get('threads:cache:ver').catch(() => null)) ?? '0'
+    const cacheKey = `showcase:v${cacheVer}:${communityId}:${categoryRaw}:${pinnedOnly}:${limit}:${orderKey}`
     const cached = await redis.get(cacheKey)
     if (cached) {
       reply.header('x-cache', 'HIT')

--- a/nodyx-frontend/src/routes/+layout.server.ts
+++ b/nodyx-frontend/src/routes/+layout.server.ts
@@ -5,6 +5,39 @@ import { env } from '$env/dynamic/public';
 
 const DIRECTORY_URL = (env.PUBLIC_DIRECTORY_URL ?? 'https://nodyx.org') + '/api/directory';
 
+// Cache mémoire du directory, partagé entre toutes les requêtes SSR du
+// process. Le directory est un appel réseau EXTERNE (autre instance, ou
+// notre propre URL publique via Cloudflare) : sans timeout ni cache, chaque
+// page SSR payait un aller-retour Internet, et un blackhole IPv6 pouvait
+// suspendre le rendu ~25 s (incident mesuré : homepage à 27 s). On sert la
+// version en cache pendant 5 min et on borne le fetch à 2,5 s ; en cas
+// d'échec, on resert la dernière version connue (stale acceptable pour une
+// liste d'instances qui bouge rarement).
+const DIRECTORY_TTL_MS = 5 * 60 * 1000;
+let directoryCache: { data: unknown; fetchedAt: number } = { data: null, fetchedAt: 0 };
+
+async function fetchDirectoryCached(): Promise<unknown> {
+	const now = Date.now();
+	if (directoryCache.data !== null && now - directoryCache.fetchedAt < DIRECTORY_TTL_MS) {
+		return directoryCache.data;
+	}
+	try {
+		const res = await globalThis.fetch(DIRECTORY_URL, { signal: AbortSignal.timeout(2500) });
+		if (res?.ok) {
+			const json = await res.json();
+			directoryCache = { data: json, fetchedAt: now };
+			return json;
+		}
+	} catch {
+		// timeout / réseau : on retombe sur le stale ci-dessous
+	}
+	if (directoryCache.data !== null) {
+		directoryCache.fetchedAt = now - DIRECTORY_TTL_MS + 30_000; // retente dans 30 s
+		return directoryCache.data;
+	}
+	return null;
+}
+
 // URLs stored in DB may include http://localhost:3000 prefix (legacy uploads)
 // Normalize to relative path so browser fetches via Vite proxy / reverse proxy
 function normalizeUrl(url: string | null): string | null {
@@ -18,12 +51,12 @@ function normalizeUrl(url: string | null): string | null {
 export const load: LayoutServerLoad = async ({ fetch, cookies, request, url }) => {
 	const token = cookies.get('token');
 
-	const [infoRes, userRes, directoryRes, announcementRes, modulesRes] = await Promise.all([
+	const [infoRes, userRes, directoryJson, announcementRes, modulesRes] = await Promise.all([
 		apiFetch(fetch, '/instance/info'),
 		token
 			? apiFetch(fetch, '/users/me', { headers: { Authorization: `Bearer ${token}` } })
 			: Promise.resolve(null),
-		globalThis.fetch(DIRECTORY_URL).catch(() => null),
+		fetchDirectoryCached(),
 		apiFetch(fetch, '/instance/announcement').catch(() => null),
 		apiFetch(fetch, '/admin/modules/public').catch(() => null),
 	]);
@@ -47,11 +80,10 @@ export const load: LayoutServerLoad = async ({ fetch, cookies, request, url }) =
 	const nodyxVersion: string       = infoJson?.version     ?? 'unknown';
 
 	// Toutes les instances du réseau (directory), filtre l'instance courante
-	const directoryJson = (directoryRes?.ok) ? await directoryRes.json().catch(() => null) : null;
 	const allInstances: Array<{
 		slug: string; name: string; url: string;
 		logo_url: string | null; members: number; online: number; last_seen: string | null;
-	}> = (directoryJson?.instances ?? []).filter((i: { slug: string }) => i.slug !== currentSlug);
+	}> = (((directoryJson as any)?.instances) ?? []).filter((i: { slug: string }) => i.slug !== currentSlug);
 
 	if (!token || !userRes?.ok) {
 		return { user: null, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount: 0, token: null, networkInstances: [], directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion };


### PR DESCRIPTION
## Summary
Deux bugs UX homepage :
- **27 s à froid** : fetch directory sans timeout dans le layout SSR, exécuté à chaque page (blackhole IPv6 → suspension). Fix : timeout 2,5 s + cache mémoire 5 min + fallback stale.
- **Article épinglé invisible sans F5** : cache `showcase:*` (30 s) sans invalidation à l'écriture. Fix : clé versionnée par `threads:cache:ver`, INCR fire-and-forget sur les 6 mutations forum.

## Test plan
- [x] tsc + 364/364 tests
- [x] Endpoints homepage mesurés < 16 ms à froid (le problème était bien le SSR)
- [ ] CI verte
- [ ] Mesure post-deploy : homepage à froid < 1 s, article épinglé visible immédiatement