### PR TITLE
fix(seo): sitemap sans threads, og:image relatives, llms.txt Nexus

### DIFF
--- a/nodyx-frontend/src/app.html
+++ b/nodyx-frontend/src/app.html
@@ -22,9 +22,6 @@
 		<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
 
 		<!-- Open Graph default image (overridable per page) -->
-		<meta property="og:image" content="/og-image.jpg" />
-		<meta property="og:image:width"  content="1200" />
-		<meta property="og:image:height" content="630" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:image" content="/og-image.jpg" />
 

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -450,6 +450,14 @@
 	     (community identity) prevents an uploaded square logo from being
 	     stretched into a 16×16 tab icon. -->
 	<meta property="og:site_name" content={communityName} />
+	<!-- og:image en URL ABSOLUE : Discord/Twitter/Facebook ne résolvent pas
+	     les chemins relatifs (l'ancien /og-image.jpg de app.html ne
+	     s'affichait jamais dans les partages). Les pages qui définissent
+	     leur propre og:image (threads) ajoutent la leur en plus. -->
+	<meta property="og:image" content="{$page.url.origin}/og-image.jpg" />
+	<meta property="og:image:width"  content="1200" />
+	<meta property="og:image:height" content="630" />
+	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="theme-color" content="#6366f1" />
 	<!-- Preload all Google Font presets (avatar/username effects) -->
 	<link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/nodyx-frontend/src/routes/forum/[category]/[thread]/+page.svelte
+++ b/nodyx-frontend/src/routes/forum/[category]/[thread]/+page.svelte
@@ -1,4 +1,13 @@
 <script lang="ts">
+	// Les scrapers OG (Discord, Twitter, Facebook) exigent des URLs absolues
+	// et lisent le HTML SSR : l'origin vient de $page.url, jamais de window.
+	// Les bannières/logos sont stockés en chemins relatifs (/uploads/...).
+	function absolutize(url: string | null | undefined, origin: string): string | null {
+		if (!url) return null
+		if (/^https?:\/\//.test(url)) return url
+		return origin + url
+	}
+
 	import { enhance } from '$app/forms';
 	import { untrack } from 'svelte';
 	import { invalidateAll } from '$app/navigation';
@@ -66,7 +75,7 @@
 	<meta property="og:description" content="Discussion par {thread.author_username} · {thread.post_count} {tFn('forum.replies_label')} · {thread.views} {tFn('forum.views')}" />
 	<meta property="og:type"        content="article" />
 	<meta property="og:url"         content={$page.url.href} />
-	<meta property="og:image"       content={$page.data.communityBannerUrl ?? $page.data.communityLogoUrl ?? `${$page.url.origin}/default-og-image.png`} />
+	<meta property="og:image"       content={absolutize($page.data.communityBannerUrl ?? $page.data.communityLogoUrl, $page.url.origin) ?? `${$page.url.origin}/og-image.jpg`} />
 	<meta property="og:site_name"   content={$page.data.communityName ?? 'Nodyx'} />
 	{@html `<script type="application/ld+json">${JSON.stringify({
 		"@context": "https://schema.org",

--- a/nodyx-frontend/src/routes/sitemap.xml/+server.ts
+++ b/nodyx-frontend/src/routes/sitemap.xml/+server.ts
@@ -33,13 +33,13 @@ export const GET: RequestHandler = async ({ fetch, url }) => {
 
 			// Page de chaque catégorie
 			for (const cat of flat) {
-				entries.push(urlEntry(`${origin}/forum/${cat.id}`, undefined, '0.8', 'daily'));
+				entries.push(urlEntry(`${origin}/forum/${cat.slug ?? cat.id}`, undefined, '0.8', 'daily'));
 			}
 
 			// Threads — fetch toutes les catégories en parallèle
 			const threadBatches = await Promise.all(
 				flat.map((cat: any) =>
-					apiFetch(fetch, `/forums/threads?category_id=${cat.id}&limit=500`)
+					apiFetch(fetch, `/forums/threads?category_id=${cat.id}&limit=100`)
 						.then(r => r.ok ? r.json() : { threads: [] })
 						.then(j => (j.threads ?? []) as any[])
 						.catch(() => [] as any[])

--- a/nodyx-frontend/static/llms.txt
+++ b/nodyx-frontend/static/llms.txt
@@ -1,42 +1,55 @@
-# Nexus
+# Nodyx
 
-> Nexus est une plateforme de forum communautaire libre, open source et décentralisée.
+> Nodyx est une plateforme communautaire libre, open source (AGPL-3.0),
+> auto-hébergée et décentralisée : forum, chat temps réel et salons vocaux.
 > Le contenu de ce forum est public, indexable et appartient à ses auteurs.
 > "Le réseau, ce sont les gens."
 
 ## À propos
 
-Nexus est un forum communautaire conçu pour que le savoir reste accessible et indexable.
-Contrairement à Discord ou Slack, chaque discussion est une page web permanente, lisible sans compte, indexée par les moteurs de recherche et les IA.
+Nodyx est conçu pour que le savoir des communautés reste accessible et
+indexable. Contrairement aux plateformes fermées (où les discussions
+disparaissent dans un flux), chaque discussion Nodyx est une page web
+permanente, lisible sans compte, indexée par les moteurs de recherche et
+les assistants IA. Une instance = une communauté ; le réseau est fédéré
+via un annuaire d'instances.
+
+Site officiel du projet : https://nodyx.org
+Documentation : https://nodyx.dev
+Code source : https://github.com/Pokled/nodyx
 
 ## Structure du contenu
 
-- [Accueil](/): Liste des communautés et catégories de discussion
-- [Forum](/forum/): Catégories de discussion avec leurs threads
-- [Sitemap](/sitemap.xml): Index complet de tout le contenu public
-- [RSS](/rss.xml): Flux des derniers sujets publiés
+- [Accueil](/): page d'accueil de la communauté (widgets, articles mis en avant)
+- [Forum](/forum): catégories de discussion avec leurs fils
+- [Sitemap](/sitemap.xml): index complet du contenu public (catégories + fils)
+- [RSS](/rss.xml): flux des derniers sujets publiés
 
 ## Contenu disponible
 
-Les discussions du forum couvrent des sujets communautaires librement choisis par les membres.
-Chaque thread est une page HTML complète avec : titre, auteur, date, contenu, réponses.
-Tout le contenu est rendu côté serveur (SSR) — aucun JavaScript requis pour lire le contenu.
+Les discussions du forum couvrent des sujets librement choisis par les membres.
+Chaque fil est une page HTML complète : titre, auteur, date, contenu, réponses,
+avec données structurées schema.org (DiscussionForumPosting) et URL canonique.
+Tout est rendu côté serveur (SSR) : aucun JavaScript requis pour lire le contenu.
+URLs canoniques : /forum/{slug-de-categorie}/{slug-du-fil}
 
 ## Ce qui n'est PAS indexable
 
-- /auth/ — pages d'authentification (login, inscription)
-- Contenus privés des communautés non-publiques
+- /auth/ — pages d'authentification (connexion, inscription)
+- /admin/ — administration de l'instance
+- /api/ — API (JSON, pas du contenu de page)
+- Messages privés et salons de chat (réservés aux membres)
 
 ## API publique
 
-Une API JSON est disponible pour accéder au contenu de façon structurée :
-- GET /api/v1/communities — liste des communautés publiques
-- GET /api/v1/forums/:slug — catégories d'une communauté
-- GET /api/v1/forums/threads?category_id=X — threads d'une catégorie
-- GET /api/v1/forums/threads/:id — thread complet avec posts
+Une API JSON est disponible pour accéder au contenu public de façon structurée :
+- GET /api/v1/instance/info — identité de l'instance
+- GET /api/v1/instance/categories — catégories du forum
+- GET /api/v1/forums/threads?category_id={slug} — fils d'une catégorie
+- GET /api/v1/forums/threads/{slug} — fil complet avec réponses
 - GET /api/v1/search?q=... — recherche full-text
 
 ## Licence
 
-Le code source de Nexus est sous licence AGPL-3.0.
+Le code source de Nodyx est sous licence AGPL-3.0.
 Le contenu des discussions appartient à leurs auteurs respectifs.


### PR DESCRIPTION
## Summary
4 fuites SEO/GEO trouvées à l'audit :
- **Sitemap sans aucun thread** (limit=500 > max API 100 → 400 silencieux) + catégories en UUID au lieu de slugs
- **og:image relatives** → aucun partage social avec image ; déplacées vers le layout en absolu + twitter:card, bannière thread absolutisée SSR-safe
- **llms.txt** : rebrand Nexus→Nodyx, endpoints corrigés, liens projet ajoutés

## Test plan
- [x] svelte-check 0 erreur
- [ ] CI verte
- [ ] Post-deploy : sitemap contient les threads en slugs, og:image absolues dans le HTML SSR