### PR TITLE
chore(seo): robots.txt Nodyx + gitignore vérifications moteurs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,11 @@ nodyx-core/uploads/**
 # Backups locaux (archives tar.gz du Backup System)
 nodyx-core/backups/
 
+# Fichiers de vérification moteurs de recherche (propres à CHAQUE instance :
+# un self-hoster met les siens, ils ne doivent pas venir du repo)
+nodyx-frontend/static/BingSiteAuth.xml
+nodyx-frontend/static/google*.html
+
 # Hub runtime files
 nodyx-hub/.env
 nodyx-hub/hub.db

--- a/nodyx-frontend/static/robots.txt
+++ b/nodyx-frontend/static/robots.txt
@@ -1,4 +1,4 @@
-# Nexus — Forum communautaire libre
+# Nodyx — Forum communautaire libre
 # Tous les crawlers sont les bienvenus. Le savoir appartient à internet.
 
 User-agent: *


### PR DESCRIPTION
En-tête robots.txt rebrandé (dernier 'Nexus' public) + .gitignore pour BingSiteAuth.xml / google*.html (vérifications par instance, jamais dans le repo). Le fichier Bing de nodyx.org est posé localement dans static/.