### PR TITLE
feat(forum): console SSH dans les articles + fix og:image unique

### DIFF
--- a/nodyx-frontend/src/app.css
+++ b/nodyx-frontend/src/app.css
@@ -117,6 +117,80 @@ select option {
     }
 }
 
+/* ── Console SSH simulée ──────────────────────────────────────────────────── */
+/* <div class="nodyx-term"> : reproduit une fenêtre de terminal pour les tutos
+   d'installation. Barre de titre + corps monospace. Les couleurs passent par
+   des classes (le sanitizer n'autorise style que sur p/span, pas sur div) :
+     .t-prompt  invite shell        .t-cmd   commande tapée par l'utilisateur
+     .t-q       question du script  .t-a     réponse à donner (surlignée)
+     .t-ok      ligne ✔ verte       .t-info  ligne → cyan
+     .t-warn    ligne ⚠ jaune       .t-muted commentaire discret             */
+.nodyx-prose .nodyx-term,
+.nodyx-content .tiptap .nodyx-term {
+    margin: 1rem 0;
+    border: 1px solid rgb(31 41 55);
+    border-radius: 0.75rem;
+    overflow: hidden;
+    background: #0a0e16;
+    box-shadow: 0 12px 32px -12px rgb(0 0 0 / 0.65);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.8125rem;
+    line-height: 1.7;
+}
+.nodyx-prose .nodyx-term .term-bar,
+.nodyx-content .tiptap .nodyx-term .term-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.55rem 0.85rem;
+    background: rgb(17 24 39);
+    border-bottom: 1px solid rgb(31 41 55);
+}
+.nodyx-prose .nodyx-term .term-dot,
+.nodyx-content .tiptap .nodyx-term .term-dot {
+    width: 11px; height: 11px; border-radius: 50%;
+    display: inline-block; flex: none;
+}
+.nodyx-term .term-dot--r { background: #ff5f56; }
+.nodyx-term .term-dot--y { background: #ffbd2e; }
+.nodyx-term .term-dot--g { background: #27c93f; }
+.nodyx-prose .nodyx-term .term-title,
+.nodyx-content .tiptap .nodyx-term .term-title {
+    margin-left: 0.5rem;
+    color: rgb(148 163 184);
+    font-size: 0.72rem;
+    letter-spacing: 0.02em;
+}
+.nodyx-prose .nodyx-term .term-body,
+.nodyx-content .tiptap .nodyx-term .term-body {
+    margin: 0;
+    padding: 0.9rem 1rem;
+    overflow-x: auto;
+    color: rgb(203 213 225);
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+/* couleurs sémantiques */
+.nodyx-term .t-prompt { color: rgb(129 140 248); font-weight: 600; }
+.nodyx-term .t-cmd    { color: #ffffff; font-weight: 600; }
+.nodyx-term .t-q      { color: rgb(125 211 252); }
+.nodyx-term .t-a      {
+    color: #fde68a;
+    background: rgb(180 130 20 / 0.18);
+    border: 1px solid rgb(217 169 60 / 0.45);
+    border-radius: 0.3rem;
+    padding: 0.02rem 0.4rem;
+    font-weight: 600;
+}
+.nodyx-term .t-ok     { color: #34d399; }
+.nodyx-term .t-info   { color: rgb(125 211 252); }
+.nodyx-term .t-warn   { color: #fbbf24; }
+.nodyx-term .t-muted  { color: rgb(100 116 139); }
+@media (max-width: 640px) {
+    .nodyx-prose .nodyx-term,
+    .nodyx-content .tiptap .nodyx-term { font-size: 0.72rem; }
+}
+
 .nodyx-prose h1,
 .nodyx-content .tiptap h1 {
     font-size: 1.5rem; font-weight: 700; color: white;

--- a/nodyx-frontend/src/app.html
+++ b/nodyx-frontend/src/app.html
@@ -21,9 +21,9 @@
 		<link rel="icon"          type="image/png"   sizes="512x512" href="/icons/icon-512.png" />
 		<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
 
-		<!-- Open Graph default image (overridable per page) -->
-		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:image" content="/og-image.jpg" />
+		<!-- og:image / twitter:image / twitter:card sont gérés dynamiquement par
+		     +layout.svelte (défaut absolu) et surchargés par page (article, profil,
+		     événement...). Rien de statique ici pour éviter les doublons. -->
 
 		%sveltekit.head%
 	</head>

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -29,6 +29,18 @@
 
 	let { children, data }: { children: any; data: LayoutData } = $props();
 
+	// Pages qui définissent leur PROPRE og:image dans leur <svelte:head>. Sur
+	// celles-ci, le layout n'émet pas son og:image par défaut, sinon les scrapers
+	// (Discord, Twitter...) reçoivent deux images et en affichent une galerie.
+	const PAGES_WITH_OWN_OG = new Set([
+		'/forum/[category]/[thread]',
+		'/forum/[category]',
+		'/users/[username]',
+		'/users/[username]/card',
+		'/calendar/[id]',
+	]);
+	const ownsOgImage = $derived(PAGES_WITH_OWN_OG.has($page.route.id ?? ''));
+
 	const user            = $derived(data.user);
 	const isBanned        = $derived(data.user?.is_banned === true);
 	const announcement    = $derived((data as any).activeAnnouncement as { id: string; message: string; color: string } | null);
@@ -454,9 +466,12 @@
 	     les chemins relatifs (l'ancien /og-image.jpg de app.html ne
 	     s'affichait jamais dans les partages). Les pages qui définissent
 	     leur propre og:image (threads) ajoutent la leur en plus. -->
-	<meta property="og:image" content="{$page.url.origin}/og-image.jpg" />
-	<meta property="og:image:width"  content="1200" />
-	<meta property="og:image:height" content="630" />
+	{#if !ownsOgImage}
+		<meta property="og:image" content="{$page.url.origin}/og-image.jpg" />
+		<meta property="og:image:width"  content="1200" />
+		<meta property="og:image:height" content="630" />
+		<meta name="twitter:image" content="{$page.url.origin}/og-image.jpg" />
+	{/if}
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="theme-color" content="#6366f1" />
 	<!-- Preload all Google Font presets (avatar/username effects) -->

--- a/nodyx-frontend/src/routes/forum/[category]/[thread]/+page.server.ts
+++ b/nodyx-frontend/src/routes/forum/[category]/[thread]/+page.server.ts
@@ -21,6 +21,13 @@ export const load: PageServerLoad = async ({ fetch, params, cookies }) => {
 		redirect(301, canonical);
 	}
 
+	// Image de partage (og:image) : la première image du premier post, donc la
+	// bannière de l'article. Lue côté serveur pour que Discord/Twitter/Facebook
+	// (qui n'exécutent pas de JS) la voient dans le HTML SSR. Chemin relatif :
+	// le composant l'absolutise via $page.url.origin.
+	const ogImagePath: string | null =
+		(json.posts?.[0]?.content ?? '').match(/<img\b[^>]*\bsrc=["']([^"']+)["']/i)?.[1] ?? null;
+
 	// Charger le sondage lié à ce thread (s'il existe)
 	let poll: any = null;
 	if (token) {
@@ -33,7 +40,7 @@ export const load: PageServerLoad = async ({ fetch, params, cookies }) => {
 		}
 	}
 
-	return { thread: json.thread, posts: json.posts, poll, token };
+	return { thread: json.thread, posts: json.posts, poll, token, ogImagePath };
 };
 
 export const actions: Actions = {

--- a/nodyx-frontend/src/routes/forum/[category]/[thread]/+page.svelte
+++ b/nodyx-frontend/src/routes/forum/[category]/[thread]/+page.svelte
@@ -27,6 +27,14 @@
 	// ── Réactivité ────────────────────────────────────────────────────────
 	const thread = $derived(data.thread);
 	const posts  = $derived(data.posts);
+	// Image de partage : bannière de l'article (1re image du post) → bannière de
+	// communauté → logo → og-image par défaut. Toujours une seule og:image.
+	const shareImage = $derived(
+		absolutize(
+			data.ogImagePath ?? $page.data.communityBannerUrl ?? $page.data.communityLogoUrl,
+			$page.url.origin,
+		) ?? `${$page.url.origin}/og-image.jpg`,
+	);
 	const user   = $derived(data.user);
 	const isMod  = $derived(user?.role === 'owner' || user?.role === 'admin' || user?.role === 'moderator');
 
@@ -75,7 +83,12 @@
 	<meta property="og:description" content="Discussion par {thread.author_username} · {thread.post_count} {tFn('forum.replies_label')} · {thread.views} {tFn('forum.views')}" />
 	<meta property="og:type"        content="article" />
 	<meta property="og:url"         content={$page.url.href} />
-	<meta property="og:image"       content={absolutize($page.data.communityBannerUrl ?? $page.data.communityLogoUrl, $page.url.origin) ?? `${$page.url.origin}/og-image.jpg`} />
+	<!-- Pas de og:image:width/height ici : l'image de tête d'un article a des
+	     dimensions variables (le pipeline d'upload re-encode/redimensionne).
+	     Déclarer une taille fixe fausserait l'aperçu. Les scrapers lisent la
+	     vraie taille de l'image. -->
+	<meta property="og:image"        content={shareImage} />
+	<meta name="twitter:image"       content={shareImage} />
 	<meta property="og:site_name"   content={$page.data.communityName ?? 'Nodyx'} />
 	{@html `<script type="application/ld+json">${JSON.stringify({
 		"@context": "https://schema.org",


### PR DESCRIPTION
## Contexte
Pendant la rédaction des guides d'installation (FR/EN), deux besoins :

### 1. Composant console SSH (`feat`)
Un bloc terminal stylé réutilisable (`.nodyx-term`) pour simuler une installation pas à pas dans les articles : barre de titre macOS, monospace, couleurs sémantiques (invite, commande, question, réponse surlignée, lignes ✔/→/⚠). Survit au sanitizer du forum, rendu identique côté article et éditeur.

### 2. Fix og:image unique (`fix`)
Au partage d'un article (Discord, Twitter...), l'aperçu montrait deux images en galerie (logo par défaut + bannière de communauté), jamais celle de l'article.

- Le thread extrait en SSR la première image de son premier post (la bannière de l'article) et la passe en `og:image` / `twitter:image`.
- Garde-fou dans le layout : plus d'og:image par défaut quand la page a la sienne (thread, catégorie, profil, carte, événement).
- Nettoyage du `twitter:image` relatif cassé dans `app.html`.
- Correction rétroactive : tous les articles existants pointent maintenant sur leur propre image.

## Tests
- `npm run check` : 0 erreur
- Déployé et vérifié en prod : 1 seule og:image par page, image = hero de l'article, homepage garde son défaut.