### PR TITLE
fix(editor): console SSH = nœud protégé (anti-perte de données)

### DIFF
--- a/nodyx-frontend/src/app.css
+++ b/nodyx-frontend/src/app.css
@@ -229,27 +229,56 @@ select option {
     .nodyx-prose .nodyx-term,
     .nodyx-content .tiptap .nodyx-term { font-size: 0.72rem; }
 }
-/* En édition : la console est un bloc protégé (non éditable). On le signale
-   clairement avec une étiquette et un contour à la sélection, pour que l'auteur
-   sache ce qu'est cette zone et qu'il peut la déplacer/supprimer mais pas la
-   taper au clavier. */
-.nodyx-content .tiptap .nodyx-term--edit { position: relative; cursor: default; }
-.nodyx-content .tiptap .nodyx-term--edit::before {
-    content: attr(data-label);
-    position: absolute;
-    top: -0.72rem; left: 0.7rem;
-    padding: 0.1rem 0.5rem;
-    font-size: 0.6rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em;
+/* En édition : la console est un bloc protégé. Le NodeView l'enveloppe d'une
+   barre d'outils (label + toggle Rendu/Code), façon CMS : on visualise le rendu,
+   et on modifie la source via le bouton Code, jamais au clavier directement. */
+.nodyx-content .tiptap .nodyx-term-wrap {
+    position: relative;
+    margin: 1.4rem 0;
+    border: 1px solid rgb(99 102 241 / 0.4);
+    border-radius: 0.6rem;
+    overflow: hidden;
+}
+.nodyx-content .tiptap .nodyx-term-wrap.ProseMirror-selectednode {
+    outline: 2px solid rgb(139 92 246 / 0.7);
+    outline-offset: 2px;
+}
+.nodyx-content .tiptap .nodyx-term-tools {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0.3rem 0.55rem;
+    background: rgb(30 27 75 / 0.6);
+    border-bottom: 1px solid rgb(99 102 241 / 0.3);
+}
+.nodyx-content .tiptap .ntt-label {
+    font-size: 0.62rem; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase;
     color: rgb(196 181 253);
-    background: rgb(30 27 75);
+}
+.nodyx-content .tiptap .ntt-btn {
+    font-family: ui-monospace, monospace;
+    font-size: 0.68rem; font-weight: 600;
+    color: rgb(199 210 254);
+    background: rgb(49 46 129 / 0.7);
     border: 1px solid rgb(99 102 241 / 0.5);
     border-radius: 0.3rem;
-    z-index: 3;
+    padding: 0.12rem 0.5rem;
+    cursor: pointer;
+    transition: background 120ms, color 120ms;
 }
-.nodyx-content .tiptap .nodyx-term--edit.ProseMirror-selectednode {
-    outline: 2px solid rgb(139 92 246 / 0.7);
-    outline-offset: 3px;
+.nodyx-content .tiptap .ntt-btn:hover  { background: rgb(76 29 149 / 0.7); color: white; }
+.nodyx-content .tiptap .ntt-btn.active { background: rgb(124 58 237 / 0.7); color: white; }
+.nodyx-content .tiptap .nodyx-term-wrap .nodyx-term { margin: 0; border: none; border-radius: 0; }
+.nodyx-content .tiptap .nodyx-term-code {
+    display: block; width: 100%;
+    min-height: 180px;
+    padding: 0.8rem 1rem;
+    background: #0a0e16;
+    color: rgb(203 213 225);
+    border: none;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.72rem; line-height: 1.6;
+    resize: vertical;
 }
+.nodyx-content .tiptap .nodyx-term-code:focus { outline: none; }
 
 .nodyx-prose h1,
 .nodyx-content .tiptap h1 {

--- a/nodyx-frontend/src/app.css
+++ b/nodyx-frontend/src/app.css
@@ -229,6 +229,27 @@ select option {
     .nodyx-prose .nodyx-term,
     .nodyx-content .tiptap .nodyx-term { font-size: 0.72rem; }
 }
+/* En édition : la console est un bloc protégé (non éditable). On le signale
+   clairement avec une étiquette et un contour à la sélection, pour que l'auteur
+   sache ce qu'est cette zone et qu'il peut la déplacer/supprimer mais pas la
+   taper au clavier. */
+.nodyx-content .tiptap .nodyx-term--edit { position: relative; cursor: default; }
+.nodyx-content .tiptap .nodyx-term--edit::before {
+    content: attr(data-label);
+    position: absolute;
+    top: -0.72rem; left: 0.7rem;
+    padding: 0.1rem 0.5rem;
+    font-size: 0.6rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em;
+    color: rgb(196 181 253);
+    background: rgb(30 27 75);
+    border: 1px solid rgb(99 102 241 / 0.5);
+    border-radius: 0.3rem;
+    z-index: 3;
+}
+.nodyx-content .tiptap .nodyx-term--edit.ProseMirror-selectednode {
+    outline: 2px solid rgb(139 92 246 / 0.7);
+    outline-offset: 3px;
+}
 
 .nodyx-prose h1,
 .nodyx-content .tiptap h1 {

--- a/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
+++ b/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
@@ -257,13 +257,73 @@
 				return dom
 			},
 			addNodeView() {
-				return ({ node }: any) => {
+				return ({ node, editor, getPos }: any) => {
+					// Wrapper non éditable : barre d'outils (label + toggle Rendu/Code)
+					// + zone d'affichage. Le code source du bloc se modifie via le
+					// bouton « Code » (façon CMS), jamais au clavier directement.
 					const dom = document.createElement('div')
-					dom.className = 'nodyx-term nodyx-term--edit'
+					dom.className = 'nodyx-term-wrap'
 					dom.setAttribute('contenteditable', 'false')
-					dom.setAttribute('data-label', 'Console — non éditable')
-					dom.innerHTML = node.attrs.html
-					return { dom }
+
+					const bar = document.createElement('div')
+					bar.className = 'nodyx-term-tools'
+					const label = document.createElement('span')
+					label.className = 'ntt-label'
+					label.textContent = 'Console SSH'
+					const btn = document.createElement('button')
+					btn.type = 'button'
+					btn.className = 'ntt-btn'
+					btn.textContent = '</> Code'
+					bar.appendChild(label)
+					bar.appendChild(btn)
+
+					const render = document.createElement('div')
+					render.className = 'nodyx-term'
+					render.innerHTML = node.attrs.html
+
+					dom.appendChild(bar)
+					dom.appendChild(render)
+
+					let editing = false
+					let textarea: HTMLTextAreaElement | null = null
+
+					btn.addEventListener('mousedown', (e) => e.preventDefault())
+					btn.addEventListener('click', () => {
+						if (!editing) {
+							editing = true
+							btn.textContent = '✓ Rendu'
+							btn.classList.add('active')
+							textarea = document.createElement('textarea')
+							textarea.className = 'nodyx-term-code'
+							textarea.value = render.innerHTML
+							render.style.display = 'none'
+							dom.appendChild(textarea)
+							textarea.focus()
+						} else {
+							editing = false
+							btn.textContent = '</> Code'
+							btn.classList.remove('active')
+							const newHtml = textarea ? textarea.value : render.innerHTML
+							render.innerHTML = newHtml
+							render.style.display = ''
+							if (textarea) { textarea.remove(); textarea = null }
+							if (typeof getPos === 'function') {
+								const pos = getPos()
+								editor.view.dispatch(editor.state.tr.setNodeMarkup(pos, undefined, { html: newHtml }))
+							}
+						}
+					})
+
+					return {
+						dom,
+						update(updated: any) {
+							if (updated.type.name !== 'nodyxTerm') return false
+							if (!editing) render.innerHTML = updated.attrs.html
+							return true
+						},
+						stopEvent: () => true,
+						ignoreMutation: () => true,
+					}
 				}
 			},
 		})

--- a/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
+++ b/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
@@ -287,6 +287,20 @@
 					let editing = false
 					let textarea: HTMLTextAreaElement | null = null
 
+					// Commit immédiat de la source vers l'attribut du nœud : la
+					// modification est prise en compte EN CONTINU pendant la frappe,
+					// sans dépendre du bouton « Rendu » (qui ne fait que rebasculer
+					// la vue). À l'enregistrement, getHTML a toujours la dernière
+					// version. addToHistory:false pour ne pas saturer le ctrl-z.
+					const commit = (val: string) => {
+						if (typeof getPos !== 'function') return
+						const pos = getPos()
+						if (pos == null) return
+						editor.view.dispatch(
+							editor.state.tr.setNodeMarkup(pos, undefined, { html: val }).setMeta('addToHistory', false),
+						)
+					}
+
 					btn.addEventListener('mousedown', (e) => e.preventDefault())
 					btn.addEventListener('click', () => {
 						if (!editing) {
@@ -296,6 +310,7 @@
 							textarea = document.createElement('textarea')
 							textarea.className = 'nodyx-term-code'
 							textarea.value = render.innerHTML
+							textarea.addEventListener('input', () => { if (textarea) commit(textarea.value) })
 							render.style.display = 'none'
 							dom.appendChild(textarea)
 							textarea.focus()
@@ -307,10 +322,7 @@
 							render.innerHTML = newHtml
 							render.style.display = ''
 							if (textarea) { textarea.remove(); textarea = null }
-							if (typeof getPos === 'function') {
-								const pos = getPos()
-								editor.view.dispatch(editor.state.tr.setNodeMarkup(pos, undefined, { html: newHtml }))
-							}
+							commit(newHtml)
 						}
 					})
 

--- a/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
+++ b/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
@@ -232,6 +232,42 @@
 			},
 		})
 
+		// ── Console SSH (.nodyx-term) : bloc HTML protégé ────────────────────
+		// Les tutos d'installation contiennent des consoles stylées (div.nodyx-term
+		// avec barre/corps/spans colorés). Ce n'est PAS éditable inline : on en
+		// fait un nœud ATOMIQUE qui capture son HTML interne au chargement et le
+		// ré-émet tel quel à la sauvegarde. Sans ça, l'éditeur déstructurait la
+		// console à la réédition (perte de données).
+		const NodyxTerm = Node.create({
+			name: 'nodyxTerm',
+			group: 'block',
+			atom: true,
+			selectable: true,
+			draggable: true,
+			addAttributes() {
+				return {
+					html: { default: '', parseHTML: (el: HTMLElement) => el.innerHTML, renderHTML: () => ({}) },
+				}
+			},
+			parseHTML() { return [{ tag: 'div.nodyx-term' }] },
+			renderHTML({ node }: any) {
+				const dom = document.createElement('div')
+				dom.className = 'nodyx-term'
+				dom.innerHTML = node.attrs.html
+				return dom
+			},
+			addNodeView() {
+				return ({ node }: any) => {
+					const dom = document.createElement('div')
+					dom.className = 'nodyx-term nodyx-term--edit'
+					dom.setAttribute('contenteditable', 'false')
+					dom.setAttribute('data-label', 'Console — non éditable')
+					dom.innerHTML = node.attrs.html
+					return { dom }
+				}
+			},
+		})
+
 		// ── Two-Column layout extension ───────────────────────────────────────
 		// PRINCIPE round-trip : on parse sur la CLASSE (que le sanitizer conserve
 		// toujours), pas sur data-col/data-two-cols (que le sanitizer supprime des
@@ -383,6 +419,7 @@
 				HeadingIds, TocBox,
 				NodyxTwoCols, NodyxColumn,
 				NodyxAudio, NodyxTrack,
+				NodyxTerm,
 			],
 			content: initialContent,
 			onTransaction() { syncActive(); syncBubble() },


### PR DESCRIPTION
Les blocs console (.nodyx-term) des tutos n'étaient pas un nœud de l'éditeur : TipTap les déstructurait à la réédition (perte de données réelle, consoles disparues des tutos FR/EN).

- `nodyxTerm` : nœud atomique qui capture son HTML interne au chargement et le ré-émet tel quel à la sauvegarde. Survit à tout aller-retour.
- NodeView non éditable + étiquette « Console — non éditable » + contour à la sélection.

Données restaurées en prod (5 consoles par tuto). Déployé. **À vérifier sur l'article test jetable avant merge.**