### PR TITLE
fix(authenticator): ajout de @types/node manquant

### DIFF
--- a/nodyx-authenticator/package-lock.json
+++ b/nodyx-authenticator/package-lock.json
@@ -13,6 +13,7 @@
         "@sveltejs/kit": "^2.63.0",
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
         "@tailwindcss/vite": "^4.2.1",
+        "@types/node": "^25.9.2",
         "svelte": "^5.56.1",
         "svelte-check": "^4.4.2",
         "tailwindcss": "^4.2.1",
@@ -1273,6 +1274,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -2121,6 +2132,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.5",

--- a/nodyx-authenticator/package.json
+++ b/nodyx-authenticator/package.json
@@ -17,6 +17,7 @@
     "@sveltejs/kit": "^2.63.0",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "@tailwindcss/vite": "^4.2.1",
+    "@types/node": "^25.9.2",
     "svelte": "^5.56.1",
     "svelte-check": "^4.4.2",
     "tailwindcss": "^4.2.1",


### PR DESCRIPTION
Le tsconfig généré par SvelteKit déclare `"types": ["node"]` mais `@types/node` n'était pas dans les dépendances de nodyx-authenticator → l'IDE affichait `Cannot find type definition file for 'node'` (svelte-check le tolérait, pas le langage server). Ajouté en devDependency (25.9.2, aligné sur le frontend). `tsc --noEmit` et `svelte-check` passent à 0 erreur.