### PR TITLE
feat(editor): redimensionnement d'image aux poignées de coin

### DIFF
--- a/nodyx-frontend/src/app.css
+++ b/nodyx-frontend/src/app.css
@@ -396,14 +396,68 @@ select option {
     margin-top: 0.75rem;
     margin-bottom: 0.75rem;
 }
-.nodyx-prose img[data-align="left"],
-.nodyx-content .tiptap img[data-align="left"]   { float: left;  margin-right: 1rem; max-width: 45%; }
-.nodyx-prose img[data-align="right"],
-.nodyx-content .tiptap img[data-align="right"]  { float: right; margin-left: 1rem;  max-width: 45%; }
-.nodyx-prose img[data-align="center"],
-.nodyx-content .tiptap img[data-align="center"] { margin-left: auto; margin-right: auto; display: block; }
-.nodyx-prose img[data-align="full"],
-.nodyx-content .tiptap img[data-align="full"]   { width: 100%; display: block; float: none; }
+/* ── Rendu public (img nu) ─────────────────────────────────────────────────
+   La largeur vient de l'attribut width (posé par le resize). Les caps par défaut
+   (45% floté, 100% full) ne s'appliquent QUE sans largeur explicite, pour ne pas
+   écraser un redimensionnement et préserver le comportement des images legacy. */
+.nodyx-prose img[data-align="left"]   { float: left;  margin-right: 1rem; }
+.nodyx-prose img[data-align="right"]  { float: right; margin-left: 1rem;  }
+.nodyx-prose img[data-align="left"]:not([width]),
+.nodyx-prose img[data-align="right"]:not([width])  { max-width: 45%; }
+.nodyx-prose img[data-align="center"] { margin-left: auto; margin-right: auto; display: block; }
+.nodyx-prose img[data-align="full"]   { display: block; float: none; }
+.nodyx-prose img[data-align="full"]:not([width]) { width: 100%; }
+
+/* ── Éditeur : NodeView avec poignées de redimensionnement ─────────────────── */
+.nodyx-content .tiptap .nodyx-img-wrap {
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+    line-height: 0;
+    vertical-align: top;
+}
+.nodyx-content .tiptap .nodyx-img-wrap img {
+    display: block;
+    width: 100%;
+    height: auto;
+    border-radius: 0.5rem;
+}
+.nodyx-content .tiptap .nodyx-img-wrap[data-align="left"]   { float: left;  margin: 0.75rem 1rem 0.75rem 0; }
+.nodyx-content .tiptap .nodyx-img-wrap[data-align="right"]  { float: right; margin: 0.75rem 0 0.75rem 1rem; }
+.nodyx-content .tiptap .nodyx-img-wrap[data-align="center"] { display: block; margin: 0.75rem auto; }
+.nodyx-content .tiptap .nodyx-img-wrap[data-align="full"]   { display: block; margin: 0.75rem 0; }
+/* Contour + poignées seulement quand l'image est sélectionnée */
+.nodyx-content .tiptap .nodyx-img-wrap.ProseMirror-selectednode { outline: 2px solid rgb(139 92 246 / 0.8); outline-offset: 1px; }
+.nodyx-content .tiptap .nodyx-img-handle {
+    position: absolute;
+    width: 13px; height: 13px;
+    background: white;
+    border: 2px solid rgb(124 58 237);
+    border-radius: 3px;
+    display: none;
+    z-index: 4;
+}
+.nodyx-content .tiptap .nodyx-img-wrap.ProseMirror-selectednode .nodyx-img-handle,
+.nodyx-content .tiptap .nodyx-img-wrap.resizing .nodyx-img-handle { display: block; }
+.nodyx-content .tiptap .nodyx-img-handle.h-nw { top: -7px;  left: -7px;  cursor: nwse-resize; }
+.nodyx-content .tiptap .nodyx-img-handle.h-ne { top: -7px;  right: -7px; cursor: nesw-resize; }
+.nodyx-content .tiptap .nodyx-img-handle.h-sw { bottom: -7px; left: -7px; cursor: nesw-resize; }
+.nodyx-content .tiptap .nodyx-img-handle.h-se { bottom: -7px; right: -7px; cursor: nwse-resize; }
+.nodyx-content .tiptap .nodyx-img-badge {
+    position: absolute;
+    top: 6px; left: 6px;
+    padding: 0.05rem 0.4rem;
+    font-family: ui-monospace, monospace;
+    font-size: 0.62rem; font-weight: 700;
+    color: white;
+    background: rgb(76 29 149 / 0.85);
+    border-radius: 0.25rem;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 120ms;
+}
+.nodyx-content .tiptap .nodyx-img-wrap.resizing .nodyx-img-badge,
+.nodyx-content .tiptap .nodyx-img-wrap.ProseMirror-selectednode .nodyx-img-badge { opacity: 1; }
 
 /* ── Vidéo / iframe ───────────────────────────────────────────────────────── */
 .nodyx-prose iframe,

--- a/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
+++ b/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
@@ -163,8 +163,91 @@
 			addAttributes() {
 				return {
 					...this.parent?.(),
-					align: { default: 'center', parseHTML: el => el.getAttribute('data-align'), renderHTML: attrs => ({ 'data-align': attrs.align }) },
-					width: { default: null, parseHTML: el => el.getAttribute('width'), renderHTML: attrs => attrs.width ? { width: attrs.width } : {} },
+					align: { default: 'center', parseHTML: (el: HTMLElement) => el.getAttribute('data-align'), renderHTML: (attrs: any) => ({ 'data-align': attrs.align }) },
+					width: { default: null, parseHTML: (el: HTMLElement) => el.getAttribute('width'), renderHTML: (attrs: any) => attrs.width ? { width: attrs.width } : {} },
+				}
+			},
+			// NodeView avec poignées de coin : on attrape un coin, on tire, et au
+			// relâchement la largeur s'aimante à 25/50/75/100 %. La largeur est
+			// stockée en attribut width (% — survit au sanitizer) ; le rendu public
+			// reste un simple <img data-align width>, sans wrapper.
+			addNodeView() {
+				return ({ node, editor, getPos }: any) => {
+					const applyWidth = (align: string, width: string | null) => {
+						wrap.style.width = align === 'full' ? (width || '100%') : (width || '')
+					}
+					const wrap = document.createElement('div')
+					wrap.className = 'nodyx-img-wrap'
+					wrap.setAttribute('data-align', node.attrs.align || 'center')
+					applyWidth(node.attrs.align || 'center', node.attrs.width)
+
+					const img = document.createElement('img')
+					img.src = node.attrs.src
+					if (node.attrs.alt) img.alt = node.attrs.alt
+					img.draggable = false
+					wrap.appendChild(img)
+
+					const badge = document.createElement('span')
+					badge.className = 'nodyx-img-badge'
+					badge.textContent = node.attrs.width || (node.attrs.align === 'full' ? '100%' : 'auto')
+					wrap.appendChild(badge)
+
+					const SNAPS = [25, 50, 75, 100]
+					let curPct = 100
+
+					const startResize = (e: MouseEvent, corner: string) => {
+						e.preventDefault(); e.stopPropagation()
+						const startX = e.clientX
+						const startW = img.getBoundingClientRect().width
+						const parent = wrap.parentElement
+						const containerW = parent ? parent.getBoundingClientRect().width : startW
+						const dir = (corner === 'ne' || corner === 'se') ? 1 : -1
+						wrap.classList.add('resizing')
+						const onMove = (ev: MouseEvent) => {
+							const dx = (ev.clientX - startX) * dir
+							const newW = Math.max(40, Math.min(containerW, startW + dx))
+							curPct = Math.round((newW / containerW) * 100)
+							wrap.style.width = curPct + '%'
+							badge.textContent = curPct + '%'
+						}
+						const onUp = () => {
+							document.removeEventListener('mousemove', onMove)
+							document.removeEventListener('mouseup', onUp)
+							wrap.classList.remove('resizing')
+							const snapped = SNAPS.reduce((a, b) => Math.abs(b - curPct) < Math.abs(a - curPct) ? b : a, SNAPS[0])
+							const widthVal = snapped + '%'
+							wrap.style.width = widthVal
+							badge.textContent = widthVal
+							if (typeof getPos === 'function') {
+								const pos = getPos()
+								const cur = editor.state.doc.nodeAt(pos)
+								if (cur) editor.view.dispatch(editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, width: widthVal }))
+							}
+						}
+						document.addEventListener('mousemove', onMove)
+						document.addEventListener('mouseup', onUp)
+					}
+
+					for (const c of ['nw', 'ne', 'sw', 'se']) {
+						const h = document.createElement('span')
+						h.className = 'nodyx-img-handle h-' + c
+						h.addEventListener('mousedown', (e) => startResize(e, c))
+						wrap.appendChild(h)
+					}
+
+					return {
+						dom: wrap,
+						update(updated: any) {
+							if (updated.type.name !== 'image') return false
+							if (updated.attrs.src !== img.getAttribute('src')) img.src = updated.attrs.src
+							img.alt = updated.attrs.alt || ''
+							wrap.setAttribute('data-align', updated.attrs.align || 'center')
+							applyWidth(updated.attrs.align || 'center', updated.attrs.width)
+							badge.textContent = updated.attrs.width || (updated.attrs.align === 'full' ? '100%' : 'auto')
+							return true
+						},
+						ignoreMutation: () => true,
+					}
 				}
 			},
 		})


### PR DESCRIPTION
Sélectionne une image → 4 poignées violettes aux coins. On tire un coin (badge de largeur en direct) et au relâchement ça s'aimante à 25/50/75/100 % de la colonne. Largeur stockée en attribut `width` (% — round-trip prouvé safe), rendu public = `<img data-align width>` nu.

- `AlignableImage` gagne un NodeView (wrapper + poignées + badge).
- CSS public : caps par défaut (45% floté, 100% full) seulement `:not([width])`, pour ne pas écraser un resize ni casser les images legacy.

`npm run check` : 0 erreur. Déployé. **À tester sur l'article jetable avant merge.**