### PR TITLE
chore(docs): tri du working tree (gitignore assets lourds)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,10 @@ nodyx-hub/hub.db
 nodyx-hub/build/
 instance.esy
 nodyx-docs/static/demo-honeypot.html
+
+# Assets lourds / locaux — pas dans le repo public (trailer 113 Mo, icônes dupliquées de static/)
+docs/img/Type_Or_Die/
+docs/img/icon-set/
+docs/img/Logo_icon_Nodyx_a.PNG
+# Stratégie SEO — locale (dossiers de soumission awesome-selfhosted / AlternativeTo)
+docs/seo/

--- a/docs/articles/streamer-hub.md
+++ b/docs/articles/streamer-hub.md
@@ -1,0 +1,170 @@
+# Streamer Hub : un QG de stream complet, auto-hébergé, et vraiment possédé par le streamer
+
+## En une phrase
+
+Le Streamer Hub transforme une instance Nodyx en QG complet pour un streamer : alertes, chat unifié, overlays OBS, stream deck mobile, stats et bot, le tout libre, auto-hébergé, et possédé par le streamer.
+
+## Le problème qu'on a voulu résoudre
+
+Un streamer un minimum équipé, c'est une pile d'outils :
+
+- Streamlabs ou StreamElements pour les alertes et overlays
+- Un bot dédié (Nightbot, StreamElements bot)
+- Un Stream Deck Elgato à 200-400 euros (ou l'app mobile payante)
+- Parfois un service de stats
+- Et tout ça éparpillé, avec des abonnements mensuels et des données captives
+
+Et au milieu de tout ça, la communauté vit sur Twitch. Pas chez le streamer.
+
+Si le streamer change de plateforme un jour, il repart de zéro. Ses viewers, son chat, son historique, ses commandes : tout reste derrière lui.
+
+On trouvait ça absurde.
+
+## Ce qu'on a fait
+
+On a intégré dans Nodyx un Streamer Hub qui remplace une bonne partie de cette pile. Tout tourne sur le VPS du streamer. Pas de SaaS, pas d'abonnement, pas d'analytics envoyés à un tiers.
+
+Et parce que Nodyx a déjà un forum, un chat, un vocal et un canvas, le Streamer Hub ne fait pas que des alertes : il transforme l'instance en espace de communauté où les viewers peuvent vivre même quand le stream est éteint.
+
+## Ce qu'il sait faire concrètement
+
+### Connexion Twitch
+
+OAuth Twitch, tokens chiffrés au repos (AES-256-GCM + HKDF), configuration depuis l'admin sans toucher au serveur. EventSub temps réel : follows, subs, subs offerts, raids, bits, sondages, début et fin de stream.
+
+### Chat unifié Twitch et Nodyx
+
+Le chat Twitch arrive dans un canal Nodyx. Les messages Nodyx peuvent repartir vers Twitch. Émotes natives Twitch plus BTTV, FFZ et 7TV, badges Twitch, le tout rendu fidèlement. La communauté peut discuter que le streamer soit en live ou non.
+
+### Overlays OBS (sources navigateur)
+
+Six types d'overlay, chacun déclinable en plusieurs thèmes visuels :
+
+- Alert box (follow, sub, raid, bits)
+- Event ticker défilant
+- Barre d'objectif
+- Leaderboard et podium
+- Minuteur de stream
+- Lecteur de clips avec autoplay
+
+Chaque overlay a une URL tokenisée à coller dans OBS. Zéro exposition inutile.
+
+### Studio Live (le cockpit admin)
+
+Une vue unique pendant le stream :
+
+- Hero Twitch plus courbe de stats sur 7 jours
+- Changement de titre et de catégorie en direct
+- Pose de marqueur VOD
+- Sondages et prédictions Twitch
+- Clips récents de la chaîne
+
+### Bot de chat
+
+Timers récurrents (trois modes : répétitif, une fois par live, one-shot). Variables dynamiques : `{nodyx_url}`, `{streamer}`, `{uptime}`, avec des alias tolérants comme `{url}`, `{lien}`, `{chaine}`, `{duree}`.
+
+Commandes natives : `!nodyx`, `!uptime`, `!commands`, `!so`, `!highlight`, `!topclips`. Commandes custom éditables avec cooldown.
+
+### Stream Deck tactile (Nodyx Deck)
+
+Une grille de boutons sur le téléphone, via une URL tokenisée. Plein écran, retour haptique, écran maintenu allumé.
+
+Actions disponibles : lancer les top clips dans un overlay, poser un marqueur VOD, envoyer un message dans le chat, déclencher une commande.
+
+Détail qui compte : le QR code d'accès est flouté par défaut, révélé au clic, refloué à la fermeture. Pour éviter qu'un viewer ne le prenne en photo à la caméra. Ça paraît anodin, mais c'est le genre de chose qu'on oublie jusqu'à ce que ça arrive.
+
+Éditeur WYSIWYG côté admin : presets, gradients, emojis. Partage par QR code.
+
+### Sons d'alerte
+
+Pas de bibliothèque MP3 sous licence douteuse. Un générateur WebAudio qui synthétise des sons à la volée (par exemple une rampe de 700 Hz vers 320 Hz). Tout est dans le navigateur, zéro fichier.
+
+### Récompenses Channel Points
+
+Gestion CRUD des récompenses via l'API Twitch (scope `channel:manage:redemptions`, pour les streamers Affiliate ou Partner). Le déclenchement d'actions en réaction à un échange est prévu mais pas encore livré. On assume.
+
+### Liaison comptes viewers
+
+Un viewer peut lier son compte Twitch à son profil Nodyx existant. Son identifiant Twitch persiste même si la connexion Twitch est rompue.
+
+### Sécurité
+
+Tokens chiffrés (AES-256-GCM + HKDF), webhooks EventSub signés HMAC avec URL à nonce, audit log des actions sensibles.
+
+## Ce qui nous différencie
+
+Un seul outil libre remplace ce qui demandait plusieurs services payants empilés.
+
+Le streamer possède ses données et son audience. La communauté vit dans son instance Nodyx (forum, chat, vocal), pas dans un silo tiers.
+
+Architecture multi-provider, avec une nuance importante : le code est organisé autour d'une interface `StreamerProvider`. Aujourd'hui seul Twitch est implémenté, parce que c'est notre cas d'usage principal. L'ajout d'un second provider (Owncast, PeerTube, YouTube, Kick) est identifié et spécifié, mais pas encore livré. On ne va pas dire "c'est trivial", on dit "c'est l'architecture, et le travail est cadré".
+
+Du soin produit : le QR flouté, le générateur audio, la config sans SSH, les overlays thémés. Ce n'est pas juste des fonctions brutes.
+
+## Ce qu'on assume honnêtement
+
+Le Streamer Hub n'est pas parfait, et il ne prétend pas l'être.
+
+- Dépendance à Twitch OAuth et EventSub aujourd'hui : c'est notre provider unique pour l'instant.
+- Pas d'app mobile native : le deck est une web-app, et ça suffit pour notre usage.
+- Channel Points : CRUD des récompenses présent, mais pas de déclenchement d'actions en live.
+- Pont chat Twitch et Nodyx : si EventSub tombe, le chat Nodyx continue mais le pont est rompu. On a des métriques de santé et un diagnostic de configuration, mais pas encore d'alerte automatique "aucun event depuis 1h".
+- Notifications live hors Twitch : webpush, RSS, ActivityPub ne sont pas encore là. C'est une roadmap identifiée.
+- Découverte : on ne remplace pas la page "live" de Twitch. La souveraineté a un prix : pour l'instant, les viewers viennent via Twitch ou via l'URL de l'instance.
+
+Sur la souveraineté, on ne va pas vendre du rêve impossible. La communauté et son historique vivent chez le streamer. La découverte et la monétisation restent côté Twitch tant que le streamer streame sur Twitch. Ce n'est pas "anti-Twitch", c'est "la communauté ne part pas si tu changes de plateforme".
+
+## La vision
+
+Aujourd'hui, c'est Twitch.
+
+Demain, l'architecture en providers permettra d'ajouter Owncast (libre, auto-hébergé, le plus aligné), PeerTube, YouTube Live, Kick, sans réécrire le moteur.
+
+Le combat n'est pas Nodyx contre une plateforme. C'est les silos contre la liberté du créateur.
+
+Ce qu'on veut, c'est qu'un streamer puisse changer de plateforme sans refaire son overlay, son bot, ses commandes, son chat, et sans perdre sa communauté.
+
+On n'y est pas encore à 100%. Mais l'architecture est posée, le chemin est tracé, et ce qui est livré aujourd'hui tient déjà la route pour des centaines d'heures de stream.
+
+## Pour qui c'est fait
+
+Pour les streamers qui :
+
+- En ont marre des abonnements SaaS qui s'additionnent
+- Veulent que leur communauté leur appartienne, pas à une plateforme
+- Ont un VPS ou sont prêts à en prendre un (l'instance Nodyx tourne sur un simple 4 à 8 Go)
+- Ne veulent pas dépendre d'un service tiers pour leurs alertes, leur bot, ou leur stream deck
+- Et qui aiment l'idée que leur chat, forum et vocal partagent la même brique
+
+## Et concrètement, comment on commence
+
+1. On déploie Nodyx via `install.sh` (one-click VPS) ou Docker Compose
+2. On va dans l'admin, on connecte Twitch (OAuth, tokens chiffrés)
+3. On configure ses overlays, on copie les URLs dans OBS
+4. On ouvre le Nodyx Deck sur son téléphone via le QR
+5. On streame
+
+Le reste (commandes, timers, chat bridge) se fait depuis l'interface.
+
+Le Streamer Hub est libre, auto-hébergé, et ne vous quittera pas si vous quittez Twitch un jour.
+
+Parce que votre communauté vous appartient.
+
+## Comparatif
+
+Ces outils ne sont pas mauvais, au contraire. Le problème n'est pas leur qualité, c'est l'empilement, l'abonnement, et la captivité des données.
+
+| Fonction | Streamlabs (pro) | StreamElements | Elgato Stream Deck | Nodyx Streamer Hub |
+|---|---|---|---|---|
+| Alertes OBS | ✅ | ✅ | ❌ | ✅ |
+| Overlays | ✅ | ✅ | ❌ | ✅ |
+| Bot chat | ✅ (freemium) | ✅ | ❌ | ✅ |
+| Stream deck | ❌ | ❌ | ✅ (physique, 200-400 euros) | ✅ (tactile, téléphone/tablette, inclus) |
+| Retour tactile physique | ❌ | ❌ | ✅ | ❌ |
+| Stats | ✅ (cloud) | ✅ (cloud) | ❌ | ✅ (locales) |
+| Banque de templates et maturité | ✅ | ✅ | ✅ | en construction |
+| Auto-hébergé | ❌ | ❌ | ❌ | ✅ |
+| Abonnement | optionnel | optionnel | non | non |
+| Chat unifié avec forum | ❌ | ❌ | ❌ | ✅ |
+
+Sur le stream deck, soyons précis : Elgato a l'avantage des boutons physiques avec un vrai retour tactile. Nodyx Deck, lui, fonctionne sur n'importe quel téléphone ou tablette que vous possédez déjà (coût zéro, accès par QR code). Et rien ne vous empêche de dédier une vieille tablette posée sur le bureau pour en faire un stream deck tactile permanent.

--- a/docs/articles/type-or-die.md
+++ b/docs/articles/type-or-die.md
@@ -1,0 +1,72 @@
+# Type or Die : tapez pour survivre, le roguelite d'un indé qu'on adore
+
+> Article forum Nodyx, à publier dans la catégorie Jeux/Découvertes.
+> Images : dossier /tmp/tod-showcase/publish/ (numérotées dans l'ordre d'insertion).
+> [IMAGE 01-hero.webp : bannière pleine largeur]
+
+Il y a des projets qu'on a envie de soutenir avant même d'y avoir joué. Et puis il y a ceux qu'on soutient parce qu'on a vu, pendant des mois, la passion et l'acharnement derrière chaque pixel. Type or Die, c'est les deux à la fois.
+
+Le 25 juin, un ami développeur indépendant sort son jeu sur Steam. Il s'appelle Hunt Games, il bosse en solo, et son jeu est déjà sur la wishlist de près de 10 000 joueurs. Aujourd'hui, on lui ouvre le forum : découvrez son jeu, posez-lui vos questions, il viendra y répondre en personne.
+
+## L'histoire : un cheval, une épée, un clavier
+
+Votre maître est tombé au combat. Vous êtes son destrier. Et vous allez le venger.
+
+Type or Die vous plonge dans un manuscrit gothique vivant, façon enluminure médiévale, où vous avancez case par case sur un plateau qui se déploie sous vos sabots. Face à vous : dragons, créatures médiévales et boss tout droit sortis des marges d'un grimoire.
+
+[IMAGE 02-miniature.webp : visuel principal du jeu]
+
+Votre arme ? Votre clavier. Littéralement.
+
+## Le gameplay : chaque mot est une arme
+
+Le concept est aussi simple que diabolique : pour attaquer, taper les mots qui s'affichent. Pour briser une défense, taper. Pour esquiver un coup, taper plus vite. Votre précision et votre vitesse de frappe SONT vos statistiques de combat.
+
+[IMAGE 05-keyboard.webp : le clavier, centré, petit]
+
+Et comme tout bon roguelite :
+
+- **Des cartes à collecter** au fil des victoires et des coffres, avec des bonus permanents et des capacités uniques
+- **Des combos à construire** : chaque run est l'occasion d'un deck différent
+- **Un plateau vivant** inspiré des jeux de société, où chaque case peut cacher un combat, un trésor ou pire
+- **Des boss** qui ne vous laisseront pas le temps de chercher la touche ù
+
+[IMAGE 06-separateur.webp]
+
+## Pourquoi on en parle ici
+
+Parce que c'est exactement pour ça que ce forum existe. Pas d'algorithme qui décide de ce que vous voyez, pas de pub achetée : une communauté qui met en avant ce qu'elle trouve beau, point.
+
+Et Type or Die coche toutes les cases : un dev solo, un concept original (un typing game roguelite, cherchez, il n'y en a pas des masses), une direction artistique enluminure superbe et cohérente de la première à la dernière case, et 28 langues supportées dès la sortie, dont le français évidemment.
+
+[IMAGE 03-dragon.webp : le dragon]
+
+## Posez vos questions, le dev vous répond ici
+
+C'est le cœur de ce thread : **Hunt Games passera répondre à vos questions directement dans les commentaires**. Comment on équilibre un jeu où le skill du joueur, c'est sa vitesse de frappe ? Combien de temps pour dessiner un dragon de manuscrit ? Pourquoi un cheval ?
+
+Tout ce que vous avez toujours voulu demander à un dev indé en pleine semaine de lancement, c'est maintenant.
+
+[IMAGE 04-chevalier.webp : le chevalier]
+
+## Les infos qui comptent
+
+- **Sortie : le 25 juin 2026 sur Steam** (Windows)
+- **Genre : roguelite / typing / stratégie**, solo
+- **Configuration modeste** : ça tourne sur un grille-pain honorable (i3, GTX 1050)
+- **Wishlist dès maintenant** : pour un indé, chaque wishlist avant la sortie compte vraiment, c'est ce qui décide de la visibilité du jeu sur Steam au lancement
+
+👉 **[Ajouter Type or Die à votre wishlist Steam](https://store.steampowered.com/app/4252830/Type_or_Die/)**
+
+[EMBED : trailer YouTube, lien à demander à Hunt Games]
+
+Bonne chance pour le lancement. On tape avec toi. ⌨️🐴
+
+---
+
+### Notes de publication (à supprimer avant de poster)
+1. Uploader les 6 images de /tmp/tod-showcase/publish/ via l'éditeur (dans l'ordre des placeholders)
+2. Demander à Hunt Games le lien YouTube du trailer (le mp4 de 112 MB dépasse la limite d'upload de 50 MB) et l'embarquer à la place du placeholder EMBED
+3. Confirmer avec lui la date/heure de l'AMA et qu'il a un compte sur nodyx.org
+4. Créer l'événement calendrier "Sortie Type or Die" le 25 juin avec le lien du thread
+5. Optionnel : épingler le thread + le mettre en avant via le Homepage Builder la semaine du lancement

--- a/docs/specs/015-streamer-hub/sessions/finition-hub-cdc.md
+++ b/docs/specs/015-streamer-hub/sessions/finition-hub-cdc.md
@@ -1,0 +1,118 @@
+# CDC — Finition du Streamer Hub (clôture du chantier)
+
+> Statut : EN ATTENTE DE VALIDATION JONATHAN
+> Date : 2026-06-10
+> Contexte : ère de stabilisation (voir décision du 2026-06-10). Ce CDC liste
+> TOUT ce qui manque pour déclarer le Streamer Hub "fini", après quoi le
+> chantier est clos et on passe à la stabilisation transversale (sécu, réseau,
+> perfs, UX). Aucune feature nouvelle : uniquement tenir les promesses déjà
+> faites dans l'UI et nettoyer.
+
+## 1. Inventaire des promesses non tenues (relevé du 2026-06-10)
+
+| # | Où | Promesse | Verdict proposé |
+|---|----|----------|-----------------|
+| P1 | Tab Scènes (header + canvas) | "Phase B (à venir) : aperçu réel via OBS WebSocket" | **Implémenter** (Session A) |
+| P2 | Tab Scènes, Audio Mixer | Badge "Phase B" : sliders volume une fois connecté à OBS | **Implémenter** (Session A) |
+| P3 | Tab Scènes, Contrôles | Badge "Phase C" : Start Streaming / Recording / Studio Mode "via OBS" | **Implémenter** (Session A, devient trivial une fois le bridge en place) |
+| P4 | Tab Scènes, source vidéo | "La vraie source OBS sera liée ici (Phase B)" | **Implémenter** (Session A, via import des scènes) |
+| P5 | Page publique /soundboard | "Bientôt : demande des sons via `!next sound <nom>` dans le chat Twitch" | **Implémenter** (Session B, l'infra queue existe déjà avec `source: 'chat'`) |
+| P6 | SoundLibraryPanel, tooltip visibilité | "Public (V2) : partagé avec tes modérateurs et utilisable via channel points" | **Reformuler** (Session B) : la moitié est déjà vraie (public = page viewers), la partie modérateurs/channel points est de l'idéation → retirer du tooltip |
+| P7 | Console admin | `GET /api/v1/forums/categories` → 404 (CommandPalette appelle une route inexistante, "categories" interprété comme slug de communauté) | **Fixer** (Session C, hors hub mais observé et trivial) |
+| P8 | Docs | Seul `docs/fr/streamer-hub/scenes-obs.md` existe. Pas de doc EN, pas de vue d'ensemble du hub (9 tabs) | **Écrire** (Session C) |
+
+## 2. Session A — OBS Bridge (le gros morceau, ~3-4 sessions de travail)
+
+### Principe d'architecture (à valider)
+- **Tout côté navigateur.** `obs-websocket-js` (lib officielle) en dépendance
+  frontend. Le navigateur de l'admin se connecte directement au WebSocket
+  d'OBS (port 4455, plugin natif depuis OBS 28).
+- **Le password OBS ne quitte JAMAIS la machine du streamer** : stocké en
+  localStorage, aucun transit par nodyx-core, aucun stockage serveur.
+  Cohérent avec la philosophie zéro-données du projet.
+- Aucune migration, aucune route backend nouvelle. Le bridge est purement
+  client. (Si un jour on veut du contrôle à distance hors du navigateur
+  admin, ce sera un autre chantier, pas celui-ci.)
+
+### Découpage
+**A1 — Connexion + statut**
+- Panneau "Connexion OBS" dans le tab Scènes : URL (défaut `ws://localhost:4455`),
+  password, bouton Connecter/Déconnecter, indicateur d'état (vert/rouge),
+  reconnexion auto avec backoff.
+- États gérés : OBS fermé, WebSocket désactivé, mauvais password, version < 5.
+
+**A2 — Aperçu réel**
+- Quand connecté : le canvas Scènes affiche le screenshot de la scène
+  programme (`GetSourceScreenshot`, polling 2-5 fps, fps réglable) à la place
+  des iframes Phase A. Toggle "Aperçu OBS / Aperçu Nodyx" (les iframes
+  restent le fallback hors connexion).
+- C'est LA réponse définitive au problème de scaling qu'on a accepté en
+  Phase A.
+
+**A3 — Import des scènes OBS**
+- Bouton "Importer depuis OBS" : `GetSceneList` + `GetSceneItemList` →
+  crée/met à jour les scènes Nodyx correspondantes (sources en
+  placeholders nommés, transforms récupérés).
+- One-shot, pas de sync continue (à valider, voir Q4).
+
+**A4 — Mixer + Contrôles (ex-Phase C, devient petit une fois A1 fait)**
+- Audio Mixer : `GetInputList` + sliders `SetInputVolume` + mute.
+- Contrôles : Start/Stop Stream, Start/Stop Record, toggle Studio Mode,
+  switch de scène programme depuis la liste Scènes Nodyx.
+- Garde-fous : confirmation avant Start/Stop Stream (action irréversible
+  en live).
+
+### Hors scope assumé (à rappeler si tentation)
+- Plugin OBS natif (Rust) : 2-4 mois, surdimensionné. Parké.
+- Push des layouts Nodyx vers OBS (`SetSceneItemTransform`) : utile mais
+  c'est de l'ajout, pas de la finition. Parké, listé dans ideas.
+- Contrôle OBS depuis le Deck mobile : idem, parké.
+
+## 3. Session B — Soundboard, tenir les promesses (~1 session)
+
+**B1 — Commande chat `!sound <nom>`**
+- Commande hardcodée dans le chat bridge Twitch : recherche fuzzy dans les
+  tracks publics, ajoute à la queue viewers (`source: 'chat'`, déjà typé
+  dans soundboardQueueService).
+- Mêmes garde-fous que le web : queue activée, rate-limit, cap par
+  utilisateur, dédup. Réponse chat : confirmation ou raison du refus.
+- Q3 à trancher : nom de la commande (`!sound` proposé, plus court que
+  `!next sound` annoncé) + cooldown.
+
+**B2 — Nettoyage des textes**
+- Tooltip P6 reformulé (retirer modérateurs/channel points).
+- Page publique : mettre à jour la mention de la commande avec le nom réel.
+
+## 4. Session C — Polish + documentation (~1 session)
+
+- Fix P7 (CommandPalette → bon endpoint).
+- `docs/en/streamer-hub/scenes-obs.md` (traduction).
+- Vue d'ensemble du hub : `docs/fr/streamer-hub/README.md` + EN (les 9 tabs,
+  quickstart streamer : connecter Twitch → overlays → deck → soundboard →
+  scènes, 1 page max chacun).
+- Passe "track l'useless" sur les 9 tabs : chaque élément d'UI doit servir,
+  sinon il saute (liste à constituer pendant la passe, validation Jonathan
+  avant suppression).
+
+## 5. Définition de "FINI"
+
+Le Streamer Hub est déclaré fini quand :
+1. Plus aucun badge "Phase X" / "à venir" / "bientôt" dans l'UI du hub.
+2. Un streamer peut faire le parcours complet (Twitch → overlays → scènes
+   avec aperçu OBS réel → deck → soundboard + playlists → commande chat)
+   en suivant uniquement la doc, sans aide.
+3. Tests verts, svelte-check 0 erreur, doc FR + EN.
+Ensuite : chantier CLOS, on n'y revient que pour des bugs.
+
+## 6. Questions ouvertes pour Jonathan
+
+- **Q1** : Session A4 (mixer + contrôles) incluse dans la finition, ou on
+  retire les placeholders de l'UI et on parke ? (Reco : inclure, c'est
+  petit une fois A1 fait, et ça tient les promesses affichées.)
+- **Q2** : aperçu OBS en remplacement du canvas quand connecté, ou en
+  vignette à côté ? (Reco : remplacement avec toggle.)
+- **Q3** : nom de la commande chat : `!sound <nom>` ? Cooldown 30s/user
+  comme le web ?
+- **Q4** : import scènes OBS one-shot (reco) ou sync continue (parké) ?
+- **Q5** : ordre des sessions : A puis B puis C (reco), ou B d'abord
+  (victoire rapide) ?


### PR DESCRIPTION
Nettoyage des 36 fichiers en attente :
- Supprime 2 fichiers vides accidentels (`docs/ref`, `docs/img/ref`).
- Gitignore les assets lourds/locaux : `docs/img/Type_Or_Die/` (130 Mo dont un trailer .mp4 de 113 Mo > limite GitHub), `icon-set/` + Logo (dupliqués de static/), `docs/seo/` (stratégie SEO gardée locale, décision du PO).
- Versionne les docs texte : articles + CDC finition Streamer Hub.