### PR TITLE
docs: MAJ README + CHANGELOG + ROADMAP (à jour v2.7 / juin 2026)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versio
 
 ## [Unreleased]
 
+### Éditeur d'articles : refonte de robustesse et d'UX (sprint juin)
+
+Gros chantier sur l'éditeur riche (TipTap) après un audit complet. Cause racine identifiée et corrigée : certains blocs personnalisés se reconnaissaient via des attributs `data-*` que le sanitizer backend supprime, donc l'éditeur les déstructurait à la réédition (perte silencieuse de contenu). Principe établi : **un bloc se reconnaît sur sa classe CSS** (préservée), jamais sur un `data-*` volatil.
+
+**Robustesse round-trip (anti-perte de données)**
+- Colonnes et vidéos YouTube : ne disparaissent plus à la réédition (parse sur la classe + reparse des iframes nus)
+- Console SSH des tutos (`.nodyx-term`) : devient un **nœud atomique protégé** qui capture son HTML et le ré-émet tel quel, avec un toggle **Rendu / Code** façon CMS (la source est éditable, jamais corrompue au clavier)
+- Sommaire étanche : une image ne peut plus se faire aspirer dans la boîte sommaire
+- Remplacement d'image réel : capture de la sélection à l'ouverture du menu
+
+**Nouvelles fonctionnalités d'édition**
+- **Ancres à la sélection** : barre flottante sur le texte surligné avec un bouton « Ancre » qui transforme la ligne en titre de section et l'ajoute à un menu Sommaire dérivé (recalculé, avec flash de feedback)
+- **Redimensionnement d'image** : poignées de coin avec aimant aux largeurs clés (25 / 50 / 75 / 100 %), largeur stockée en attribut `width`
+- **Zone éditable à hauteur bornée** + ascenseur interne : la barre d'outils reste toujours accessible sur les longs articles
+- **Console SSH stylée** (`.nodyx-term`) pour les tutoriels d'installation : fenêtre terminal avec barre de titre et coloration sémantique
+
+**Doc** : audit complet de l'éditeur dans `docs/audits/2026-06-15-editeur-rich.md`
+
+### Streamer Hub : playlists audio et scènes OBS
+
+- Playlists nommées dans la bibliothèque audio (Dev, Discussion, etc.), URL d'overlay OBS dédiée par playlist, contrôle depuis le Stream Deck
+- Tab « Scènes OBS » : compositeur visuel inspiré d'OBS pour placer overlays et playlists, avec pickers et création inline
+- Migrations 100 à 102 (playlists, jonction, scènes OBS)
+
+### Référencement (SEO / GEO) : fondations
+
+- Correction du sitemap (les threads n'y apparaissaient jamais : passé de 14 à plus de 60 URLs)
+- **og:image unique** par page = image de l'article (fini les doublons et la mauvaise image dans les partages Discord / Twitter), résolution rétroactive sur tous les articles
+- `llms.txt` réécrit, `robots.txt` rebrandé Nodyx, fichiers de vérification moteurs gitignorés (propres à chaque instance)
+- Guides publiés : comparatif honnête des alternatives (FR + EN) et guide d'installation débutant pas à pas (FR + EN)
+
+### Admin et performance
+
+- Refonte sobre (style Linear / Vercel / Stripe) de la sidebar et du dashboard admin : palette zinc, un seul accent, emojis hors labels système
+- SSR sans suspension sur le fetch directory + invalidation du cache showcase par clé de version (un article épinglé apparaît immédiatement)
+- La home se rafraîchit après suppression d'un thread (invalidation des chargements, plus de refresh manuel)
+- Grid Builder : scroll automatique vers la nouvelle ligne ajoutée
+
+### Sécurité et dépendances
+
+- ws (high, DoS WebSocket) et tar (medium) corrigés sur core et frontend
+- esbuild porté à `>= 0.28.1` via override sur les 4 projets SvelteKit (sans montée vite 8 cassante)
+- nodemailer 8 → 9 (validé en production), `@types/node` ajouté à l'authenticator, groupes de dépendances minor/patch à jour, GitHub Actions checkout / setup-node à jour
+- js-yaml (turn-server legacy non déployé) : dismissée avec motif documenté
+
 ---
 
 ## [2.7.0] — 2026-06-02

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### *"The network is the people."*
 
 **The self-hosted community platform you actually own.**  
-Forum + Chat + Voice + P2P + Canvas + Homepage Builder + Widget SDK, one server, one community, forever.
+Forum + Chat + Voice + P2P + Canvas + Homepage Builder + Streamer Hub, one server, one community, forever.
 
 [![Version](https://img.shields.io/github/v/release/Pokled/nodyx?label=version&color=7c3aed)](https://github.com/Pokled/nodyx/releases/latest)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
@@ -145,6 +145,8 @@ The community-tools landscape isn't a battle. Each project optimizes for differe
 - **Widget Store**, install external widgets via .zip
 - **Widget SDK**, build custom widgets, no framework needed
 - **OctoGuard**, native auto-mod (regex/word/link/emoji-flood, ReDoS-safe via Google `re2`), welcome bot, custom commands, mutes, signed webhook, all admin-tunable, off by default
+- **Streamer Hub**, Twitch integration with a native Soundboard (ID3 tags, viewer queue, `!ns` chat command), a multi-page mobile Stream Deck, OBS browser-source overlays (alerts, goals, timers, tickers, leaderboards, clips, soundboard) and audio playlists with per-playlist OBS scenes
+- **Rich article editor**, anchor-on-selection table of contents, corner-handle image resize, protected code/render blocks, two-column layouts, embedded media, all round-trip safe through the sanitizer
 
 ---
 

--- a/docs/en/ROADMAP.md
+++ b/docs/en/ROADMAP.md
@@ -1,5 +1,5 @@
 # NODYX — Roadmap
-### Version 2.4 — Backup System + Live Maintenance Mode
+### Version 2.7 — Streamer Hub (Soundboard + Deck) · then Stabilization Era
 
 ---
 
@@ -9,7 +9,7 @@
 
 ---
 
-## CURRENT STATE — May 2026
+## CURRENT STATE — June 2026
 
 | Phase | Title | Status |
 |---|---|---|
@@ -30,7 +30,10 @@
 | **Phase 4.14** | Universal Media Player + Builder Catalog Fusion + Tunnel Hardening (v2.3) | ✅ Complete |
 | **Phase 4.15** | Backup System Phase 1 + Live Maintenance Mode (v2.4) | ✅ Complete |
 | **Phase 4.16** | OctoGuard Phase 1 — Native auto-moderation (v2.6) | ✅ Complete (rollout) |
-| Phase 5 | Mobile + Nodes + Reactions + Discord import | 🔨 In Progress |
+| **Phase 4.17** | Streamer Hub — Soundboard, multi-page Deck, Playlists & OBS Scenes (v2.7) | ✅ Complete |
+| **Phase 4.18** | Editor robustness + UX overhaul, SEO/GEO foundations, security sweep | ✅ Complete |
+| **Stabilization Era** | No new big features. Finish the Streamer Hub, then polish everything (security, network, perf, UX). Goal: a stable core that outlives its creator. | 🛠️ Active |
+| Phase 5 | Mobile + Nodes + Reactions + Discord import | ⏸️ Deferred (after stabilization) |
 | **Phase Horizon** | NODYX-ETHER — Physical layer sovereignty | 🌌 Vision |
 | **Phase Radio** | NODYX-RADIO — Internet radio + cooperative ad network | 📻 Vision |
 


### PR DESCRIPTION
Rattrapage du retard documentaire : README (Streamer Hub + éditeur), CHANGELOG [Unreleased] (sprint juin complet), ROADMAP (juin 2026, phases 4.17/4.18, Ère de Stabilisation).