### PR TITLE
docs(readme): 'What's built' réordonné/complété + sync FR

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,23 +618,61 @@ Each Nodyx instance runs a **Gossip Protocol** scheduler that periodically pings
 
 </details>
 
-<details open>
-<summary><b>v2.6, OctoGuard Phase 1: native auto-moderation 🐙</b></summary>
+<details>
+<summary><b>v2.1, Homepage Builder + Widget SDK 🧩</b></summary>
 
 | Feature | Version |
 |---|---|
-| **OctoGuard auto-mod pipeline**, 50 ms fail-open, 5 matcher types: substring, word-boundary, regex, link allow/blocklist, emoji-flood. ReDoS-safe via Google `re2` linear-time engine (84 s native vs 0 ms `re2` confirmed in bench) plus `safe-regex` heuristic on pattern admission | v2.6 |
-| **6 actions**, `delete`, `warn`, `mute_timed`, `kick`, `ban` (with optional `community_bans.expires_at` for temporary bans), `report_only` dry-run | v2.6 |
-| **Welcome flow**, ghost `OctoGuard` bot user (`users.is_system=true`, login refused), public message with `{user}` / `{userMention}` / `{communityName}` variables, optional auto-grade on join. DM system message reserved for spec 019 | v2.6 |
-| **Custom commands**, `!règles`, `!discord`, ... in markdown, Redis-backed per-channel cooldown (SET NX EX), allowed channels and roles configurable per command | v2.6 |
-| **Chat mutes**, new `chat_mutes` table, global or per-channel scope, free-form duration (`15m`, `2h`, `1w`, permanent), Redis-cached 60 s, background purge worker | v2.6 |
-| **Reports queue**, member-driven, anti-abuse rate limit per reporter + cooldown per target via Redis, admin inbox with mute/delete/dismiss actions | v2.6 |
-| **HMAC-SHA256 webhook**, outbound POST signed with `X-Octoguard-Signature: sha256=hex`, queued in Redis, worker fires async with 10 s timeout. The chat pipeline never pays the webhook latency | v2.6 |
-| **Audit log**, every action persisted to `admin_audit_log` with `event_id`, action type, target, metadata. Logger is fire-and-forget IIFE (caught by pre-emptive bench: p95 dropped from 13 ms to 0.2 ms after switching from `await` to fire-and-forget) | v2.6 |
-| **Admin UI**, `/admin/octoguard` with 8 tabs: overview, automod, welcome, commands, mutes, reports, logs, webhook. All CRUD with optimistic `enhance` forms | v2.6 |
-| **Kill-switch**, `OCTOGUARD_ENABLED=false` bypasses the entire pipeline. Rules table empty equals zero impact even when enabled, progressive rollout pattern | v2.6 |
-| **69 vitest tests**, `octoguard-matchers`, `octoguard-commands`, `octoguard-session-c` covering matchers, `assessPatternSafety`, `durationToExpiresAt`, `substituteVariables`, mutes, env migration | v2.6 |
-| **`bench.ts`**, dedicated performance benchmark proves p95 < 1 ms under load, caught the logger bottleneck before activation | v2.6 |
+| **Homepage Builder**, drag-and-drop admin, 11 layout zones (banner, hero, stats-bar, main, sidebar, half ×2, trio ×3, footer ×4) | v2.1 |
+| **Plugin registry**, each native widget is a self-contained file, zero core changes to add new ones | v2.1 |
+| **4 native widgets Phase 1**, Hero Banner (live/event/night variants), Stats Bar (animated counters), Join Card, Announcement Banner | v2.1 |
+| **Visibility rules**, per-widget audience (all / guests / members) + scheduled start/end dates | v2.1 |
+| **Widget Store**, install external widgets via `.zip` upload (XHR progress bar, 4-step validation, extraction whitelist) | v2.1 |
+| **Dynamic Widget Loader**, Web Components loaded at runtime, no rebuild, no deploy | v2.1 |
+| **Widget SDK**, plain JS Custom Elements (Shadow DOM), `manifest.json` schema → auto-generated config fields in builder | v2.1 |
+| **Demo widget: Video Player**, YouTube / Vimeo / MP4 with live preview, source viewer, one-click install | v2.1 |
+| **nodyx.dev/create-widget**, step-by-step guide for non-developers (7 steps, EN) | v2.1 |
+
+</details>
+
+<details>
+<summary><b>v2.2, NodyxCanvas major upgrade 🎨</b></summary>
+
+| Feature | Version |
+|---|---|
+| **Canvas UI refactor**, 4 dedicated components: CanvasLeftToolbar, CanvasTopBar (contextual per tool), CanvasBottomBar, CanvasRightPanel | v2.2 |
+| **Undo / Redo**, 50-op stack, Ctrl+Z/Y/Shift+Z, buttons with active/disabled state. Fixed CRDT LWW timestamp so undo always applies | v2.2 |
+| **Snap to grid**, 28px world grid, toggle (G key), visual grid overlay | v2.2 |
+| **Rich text**, bold, italic, underline, strikethrough, alignment (left/center/right), 3 font families (sans/serif/mono), 12 font sizes | v2.2 |
+| **Advanced shapes**, triangle, diamond (losange), star, hexagon, cloud, rendered via Path2D, fill + stroke + label | v2.2 |
+| **Connectors**, straight / bezier / elbow lines, independent start & end caps (arrow/dot/none), solid/dashed/dotted style, 2-click creation | v2.2 |
+| **Frames / Sections**, named rectangular regions with dashed border, label rendered above, inline name input on creation | v2.2 |
+| **Image insertion**, drag & drop from desktop or file picker, uploaded to `/api/v1/assets`, cached and rendered on canvas, proportional sizing | v2.2 |
+| **Resize handles**, 8 handles (corners + midpoints) on selected rect/circle/shape/frame/image/sticky elements, live preview, snap-aware | v2.2 |
+| **Real user avatars**, participant panel shows real user avatars (with initials fallback) and their active tool | v2.2 |
+| **Board chat**, real-time chat scoped to the canvas board, independent from the voice channel chat | v2.2 |
+| **Full keyboard shortcuts**, V P T N R C S A X I F E (tools) + G (grid) + Ctrl+Z/Y/Shift+Z (undo/redo) + Delete + Escape | v2.2 |
+| **Portal rendering**, canvas mounted on `document.body` via portal action, bypasses CSS `transform` ancestors that break `position:fixed` | v2.2 |
+
+</details>
+
+<details>
+<summary><b>v2.3, Universal Media Player + Builder Catalog Fusion 🎬</b></summary>
+
+| Feature | Version |
+|---|---|
+| **Universal Media Player**, auto-detects YouTube, Vimeo, Dailymotion, Twitch (live / VOD / clip), SoundCloud, Spotify, plus direct `.mp4` / `.webm` / `.mp3` hosted files. Single URL field, platform inferred at render time | v2.3 |
+| **Builder catalog fusion**, installed widgets now appear in the Grid Builder picker next to native plugins. New `CatalogEntry` aggregation layer with `checkbox → boolean` field type canonicalization | v2.3 |
+| **Tunnel installer hardening (#23)**, 12 fixes for Pangolin mode: Caddy site-address `:80 { bind ... }` rewrite (Host filter root cause), atomic Caddyfile regen on `--repair`, UFW RFC1918 rules, doctor false-positive gate | v2.3 |
+| **nodyx-doctor**, Method A (`--network host`) no longer triggers a misleading "LAN IP not bound" warning | v2.3 |
+| **nodyx-relay v0.1.4**, TCP keepalive + read deadline to detect dead sessions | v2.3 |
+| **Doc search rewrite**, heading-aware index with deep-link anchors, scrollspy TOC sidebar, slug correctness pass (108 broken TOC links + 60 leading-dash ids cleaned) | v2.3 |
+| **Why-Nodyx posture**, new positioning page listing alternative platforms (Matrix, Stoat, Fluxer, Haven, ...), README aligned, "silos vs liberty, not Nodyx vs X" framing | v2.3 |
+| **i18n**, German (`de.json`) + Spanish (`es.json`) translations, native review for both | v2.3 |
+| **Homepage Builder polish**, Twitch stream + Articles showcase widgets, clickable `(?)` info panel on field labels | v2.3 |
+| **Voice kick**, owners, admins and moderators can remove a user from a voice channel | v2.3 |
+| **Community Pulse**, co-presence trail and wave visualization page | v2.3 |
+| **Nodyx Stars**, proper recognition system for external contributors with public CONTRIBUTORS.md, avatar block in README, polish-trail transparency | v2.3 |
 
 </details>
 
@@ -661,80 +699,73 @@ Each Nodyx instance runs a **Gossip Protocol** scheduler that periodically pings
 </details>
 
 <details>
-<summary><b>v2.3, Universal Media Player + Builder Catalog Fusion 🎬</b></summary>
+<summary><b>v2.5, Streamer Hub Phase 2: unified Twitch ↔ Nodyx chat 💬</b></summary>
 
 | Feature | Version |
 |---|---|
-| **Universal Media Player**, auto-detects YouTube, Vimeo, Dailymotion, Twitch (live / VOD / clip), SoundCloud, Spotify, plus direct `.mp4` / `.webm` / `.mp3` hosted files. Single URL field, platform inferred at render time | v2.3 |
-| **Builder catalog fusion**, installed widgets now appear in the Grid Builder picker next to native plugins. New `CatalogEntry` aggregation layer with `checkbox → boolean` field type canonicalization | v2.3 |
-| **Tunnel installer hardening (#23)**, 12 fixes for Pangolin mode: Caddy site-address `:80 { bind ... }` rewrite (Host filter root cause), atomic Caddyfile regen on `--repair`, UFW RFC1918 rules, doctor false-positive gate | v2.3 |
-| **nodyx-doctor**, Method A (`--network host`) no longer triggers a misleading "LAN IP not bound" warning | v2.3 |
-| **nodyx-relay v0.1.4**, TCP keepalive + read deadline to detect dead sessions | v2.3 |
-| **Doc search rewrite**, heading-aware index with deep-link anchors, scrollspy TOC sidebar, slug correctness pass (108 broken TOC links + 60 leading-dash ids cleaned) | v2.3 |
-| **Why-Nodyx posture**, new positioning page listing alternative platforms (Matrix, Stoat, Fluxer, Haven, ...), README aligned, "silos vs liberty, not Nodyx vs X" framing | v2.3 |
-| **i18n**, German (`de.json`) + Spanish (`es.json`) translations, native review for both | v2.3 |
-| **Homepage Builder polish**, Twitch stream + Articles showcase widgets, clickable `(?)` info panel on field labels | v2.3 |
-| **Voice kick**, owners, admins and moderators can remove a user from a voice channel | v2.3 |
-| **Community Pulse**, co-presence trail and wave visualization page | v2.3 |
-| **Nodyx Stars**, proper recognition system for external contributors with public CONTRIBUTORS.md, avatar block in README, polish-trail transparency | v2.3 |
+| **Two-way live chat**, real-time bridge between a Nodyx instance and the streamer's Twitch chat, 100% EventSub + Helix, zero IRC. Verified in prod (277 messages during the test session) | v2.5 |
+| **Inbound (Twitch → Nodyx)**, `channel.chat.message` EventSub, auto-created `#twitch-chat` channel, each Twitch message mapped to a Nodyx author (resolved via `twitch_id` or placeholder) | v2.5 |
+| **Outbound (Nodyx → Twitch)**, members writing in `#twitch-chat` are relayed via Helix `POST /chat/messages`, `[username]` prefix for viewer transparency, only while a live session is open | v2.5 |
+| **Rate-limit queue**, on Twitch 429 the message is enqueued in a Redis sorted set, a worker dequeues by batch with exponential backoff, audit alert on overflow | v2.5 |
+| **Session lifecycle**, `stream.online` / `stream.offline` tracked in `streamer_sessions` (idempotent), gating the outbound bridge | v2.5 |
+| **Emotes & badges**, native Twitch emotes from payload fragments, BTTV / FFZ / 7TV fetched and cached (24h), global + channel badges via Helix, graceful degradation if a provider fails | v2.5 |
+| **65 new tests**, bridge, emotes, lifecycle, outbound queue, badges. Full suite 269/269 green | v2.5 |
 
 </details>
 
 <details>
-<summary><b>v2.2, NodyxCanvas major upgrade 🎨</b></summary>
+<summary><b>v2.6, OctoGuard Phase 1: native auto-moderation 🐙</b></summary>
 
 | Feature | Version |
 |---|---|
-| **Canvas UI refactor**, 4 dedicated components: CanvasLeftToolbar, CanvasTopBar (contextual per tool), CanvasBottomBar, CanvasRightPanel | v2.2 |
-| **Undo / Redo**, 50-op stack, Ctrl+Z/Y/Shift+Z, buttons with active/disabled state. Fixed CRDT LWW timestamp so undo always applies | v2.2 |
-| **Snap to grid**, 28px world grid, toggle (G key), visual grid overlay | v2.2 |
-| **Rich text**, bold, italic, underline, strikethrough, alignment (left/center/right), 3 font families (sans/serif/mono), 12 font sizes | v2.2 |
-| **Advanced shapes**, triangle, diamond (losange), star, hexagon, cloud, rendered via Path2D, fill + stroke + label | v2.2 |
-| **Connectors**, straight / bezier / elbow lines, independent start & end caps (arrow/dot/none), solid/dashed/dotted style, 2-click creation | v2.2 |
-| **Frames / Sections**, named rectangular regions with dashed border, label rendered above, inline name input on creation | v2.2 |
-| **Image insertion**, drag & drop from desktop or file picker, uploaded to `/api/v1/assets`, cached and rendered on canvas, proportional sizing | v2.2 |
-| **Resize handles**, 8 handles (corners + midpoints) on selected rect/circle/shape/frame/image/sticky elements, live preview, snap-aware | v2.2 |
-| **Real user avatars**, participant panel shows real user avatars (with initials fallback) and their active tool | v2.2 |
-| **Board chat**, real-time chat scoped to the canvas board, independent from the voice channel chat | v2.2 |
-| **Full keyboard shortcuts**, V P T N R C S A X I F E (tools) + G (grid) + Ctrl+Z/Y/Shift+Z (undo/redo) + Delete + Escape | v2.2 |
-| **Portal rendering**, canvas mounted on `document.body` via portal action, bypasses CSS `transform` ancestors that break `position:fixed` | v2.2 |
+| **OctoGuard auto-mod pipeline**, 50 ms fail-open, 5 matcher types: substring, word-boundary, regex, link allow/blocklist, emoji-flood. ReDoS-safe via Google `re2` linear-time engine (84 s native vs 0 ms `re2` confirmed in bench) plus `safe-regex` heuristic on pattern admission | v2.6 |
+| **6 actions**, `delete`, `warn`, `mute_timed`, `kick`, `ban` (with optional `community_bans.expires_at` for temporary bans), `report_only` dry-run | v2.6 |
+| **Welcome flow**, ghost `OctoGuard` bot user (`users.is_system=true`, login refused), public message with `{user}` / `{userMention}` / `{communityName}` variables, optional auto-grade on join. DM system message reserved for spec 019 | v2.6 |
+| **Custom commands**, `!règles`, `!discord`, ... in markdown, Redis-backed per-channel cooldown (SET NX EX), allowed channels and roles configurable per command | v2.6 |
+| **Chat mutes**, new `chat_mutes` table, global or per-channel scope, free-form duration (`15m`, `2h`, `1w`, permanent), Redis-cached 60 s, background purge worker | v2.6 |
+| **Reports queue**, member-driven, anti-abuse rate limit per reporter + cooldown per target via Redis, admin inbox with mute/delete/dismiss actions | v2.6 |
+| **HMAC-SHA256 webhook**, outbound POST signed with `X-Octoguard-Signature: sha256=hex`, queued in Redis, worker fires async with 10 s timeout. The chat pipeline never pays the webhook latency | v2.6 |
+| **Audit log**, every action persisted to `admin_audit_log` with `event_id`, action type, target, metadata. Logger is fire-and-forget IIFE (caught by pre-emptive bench: p95 dropped from 13 ms to 0.2 ms after switching from `await` to fire-and-forget) | v2.6 |
+| **Admin UI**, `/admin/octoguard` with 8 tabs: overview, automod, welcome, commands, mutes, reports, logs, webhook. All CRUD with optimistic `enhance` forms | v2.6 |
+| **Kill-switch**, `OCTOGUARD_ENABLED=false` bypasses the entire pipeline. Rules table empty equals zero impact even when enabled, progressive rollout pattern | v2.6 |
+| **69 vitest tests**, `octoguard-matchers`, `octoguard-commands`, `octoguard-session-c` covering matchers, `assessPatternSafety`, `durationToExpiresAt`, `substituteVariables`, mutes, env migration | v2.6 |
+| **`bench.ts`**, dedicated performance benchmark proves p95 < 1 ms under load, caught the logger bottleneck before activation | v2.6 |
 
 </details>
 
 <details>
-<summary><b>v2.1, Homepage Builder + Widget SDK 🧩</b></summary>
+<summary><b>v2.7, Streamer Hub: Soundboard + multi-page Stream Deck 🔊</b></summary>
 
 | Feature | Version |
 |---|---|
-| **Homepage Builder**, drag-and-drop admin, 11 layout zones (banner, hero, stats-bar, main, sidebar, half ×2, trio ×3, footer ×4) | v2.1 |
-| **Plugin registry**, each native widget is a self-contained file, zero core changes to add new ones | v2.1 |
-| **4 native widgets Phase 1**, Hero Banner (live/event/night variants), Stats Bar (animated counters), Join Card, Announcement Banner | v2.1 |
-| **Visibility rules**, per-widget audience (all / guests / members) + scheduled start/end dates | v2.1 |
-| **Widget Store**, install external widgets via `.zip` upload (XHR progress bar, 4-step validation, extraction whitelist) | v2.1 |
-| **Dynamic Widget Loader**, Web Components loaded at runtime, no rebuild, no deploy | v2.1 |
-| **Widget SDK**, plain JS Custom Elements (Shadow DOM), `manifest.json` schema → auto-generated config fields in builder | v2.1 |
-| **Demo widget: Video Player**, YouTube / Vimeo / MP4 with live preview, source viewer, one-click install | v2.1 |
-| **nodyx.dev/create-widget**, step-by-step guide for non-developers (7 steps, EN) | v2.1 |
+| **Soundboard**, upload sounds (mp3/ogg/wav/flac), automatic ID3 tags (title, artist, cover), per-track volume / fade / loop / visibility, batch upload with live progress | v2.7 |
+| **OBS Soundboard overlay**, transparent browser source, Web Audio fade and cross-fade, discreet OSD (4 corners or hidden), multiple overlays per owner | v2.7 |
+| **Public viewer page** (`/soundboard`, no login), browse the library, hover preview, live "now playing" and "up next" queue | v2.7 |
+| **Viewer queue**, Redis FIFO (max 50, per-IP rate limit and cap, global dedup), admin toggle + skip + clear, auto-consume on `audio:ended`, anti-raid by design | v2.7 |
+| **`!ns` chat command** (alias `!nextsound`), fuzzy matcher with normalization, cascade scoring and Levenshtein, ambiguity detection that asks the viewer instead of guessing wrong | v2.7 |
+| **Multi-page Stream Deck**, up to 8 logical pages with accent colors, inline rename, drag-to-reorder, backwards-compatible V1 decks (no migration) | v2.7 |
+| **New Deck actions**, `play_audio`, `stop_audio`, `pause_audio`, `navigate_page` (intercepted client-side for zero latency) | v2.7 |
+| **Mobile deck**, floating page dock with haptics and iOS safe-area, "Send to Deck" modal with mini-grid and auto-placement | v2.7 |
 
 </details>
 
-### Coming
+<details open>
+<summary><b>v2.8, Article Editor Overhaul · Playlists & OBS Scenes · Security ✍️</b></summary>
 
-| Feature | Notes |
+| Feature | Version |
 |---|---|
-| **Canvas, Ghost Mode**, anonymous brainstorming: contributions appear under random pseudonyms, author revealed at end | Sprint D |
-| **Canvas, Audio Stickies**, voice note recorded directly on the canvas, waveform rendered as post-it | Sprint D |
-| **Canvas, Contextual Chat**, threaded discussion anchored to a canvas zone, spatially indexed | Sprint D |
-| **More native widgets**, Countdown, Leaderboard, Latest Threads, Featured Events, Jukebox Player | Phase 2 |
-| **Widget marketplace**, community-published widgets, ratings, one-click install from directory |, |
-| **Nodes**, durable structured knowledge, community-validated via Garden | [SPEC 013](docs/en/specs/013-node/SPEC.md) |
-| **Module system**, 26 activatable modules from admin panel (Joomla-style CMS) | [Spec](.claude/ideas/MODULE_SYSTEM.md) |
-| **DM reactions**, emoji reactions on private messages |, |
-| **Discord import**, bulk import channels, threads, reactions, avatars |, |
-| Mobile (Capacitor) / Desktop (Tauri) |, |
-| Rust migration, nodyx-server (Axum) replacing nodyx-core progressively |, |
+| **Editor round-trip robustness**, columns and YouTube videos no longer vanish on re-edit (parse on class, not on stripped `data-*`). Full audit in `docs/audits/2026-06-15-editeur-rich.md` | v2.8 |
+| **Protected SSH console block**, atomic node that preserves its HTML, with a CMS-style Render / Code toggle, source editable but never corrupted by the keyboard | v2.8 |
+| **Anchor-on-selection table of contents**, floating bar with an "Anchor" button that turns the line into a section and adds it to a derived menu (with feedback flash) | v2.8 |
+| **Image resize**, corner handles with snap to key widths (25 / 50 / 75 / 100 %), width stored as a `width` attribute, round-trip safe | v2.8 |
+| **Bounded editable area + sticky toolbar**, always reachable on long articles | v2.8 |
+| **Streamer Hub playlists + OBS Scenes**, named audio playlists with per-playlist OBS overlay URLs, plus an OBS-style visual Scenes composer | v2.8 |
+| **SEO / GEO foundations**, sitemap fix (14 → 60+ URLs), single correct `og:image` per page (Discord / Twitter shares), rewritten `llms.txt`, honest comparison + beginner install guides (FR + EN) | v2.8 |
+| **Admin redesign**, sober Linear / Vercel / Stripe style for the sidebar and dashboard | v2.8 |
+| **Performance**, non-blocking SSR directory fetch + version-keyed showcase cache, home refresh after thread deletion | v2.8 |
+| **Security sweep**, ws (high) and tar (medium) patched, esbuild >= 0.28.1 via override across the 4 SvelteKit projects, nodemailer 8 → 9 validated in prod | v2.8 |
 
----
+</details>
 
 ## The Vision
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -7,7 +7,7 @@
 ### *"Le réseau, c'est les gens."*
 
 **La plateforme communautaire auto-hébergée qui vous appartient vraiment.**  
-Forum + Chat + Voix + P2P + Canvas + Constructeur de page d'accueil + SDK Widget, un seul serveur, une communauté, pour toujours.
+Forum + Chat + Voix + P2P + Canvas + Constructeur de page d'accueil + Streamer Hub, un seul serveur, une communauté, pour toujours.
 
 [![Version](https://img.shields.io/github/v/release/Pokled/nodyx?label=version&color=7c3aed)](https://github.com/Pokled/nodyx/releases/latest)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
@@ -129,6 +129,8 @@ Le paysage des outils communautaires n'est pas un combat. Chaque projet optimise
 - **Boutique de widgets**, installer des widgets externes via .zip
 - **SDK Widget**, créer des widgets custom, sans framework
 - **OctoGuard**, auto-modération native (regex/word/link/emoji-flood, anti-ReDoS via `re2` Google), bot de bienvenue, commandes custom, mutes, webhook signé, entièrement paramétrable par l'admin, désactivé par défaut
+- **Streamer Hub**, intégration Twitch avec un Soundboard natif (tags ID3, queue viewers, commande chat `!ns`), un Stream Deck mobile multi-pages, des overlays OBS en browser source (alertes, objectifs, timers, tickers, classements, clips, soundboard) et des playlists audio avec scènes OBS dédiées
+- **Éditeur d'articles riche**, sommaire par ancre à la sélection, redimensionnement d'image aux poignées, blocs code/rendu protégés, colonnes, médias embarqués, le tout robuste au round-trip via le sanitizer
 
 ---
 
@@ -191,6 +193,42 @@ customElements.define('nodyx-widget-my-widget', MyWidget)
 ```
 
 → **[Guide complet pas à pas pour non-développeurs → nodyx.dev/create-widget](https://nodyx.dev/create-widget)**
+
+---
+
+## Streamer Hub, tout ton live depuis Nodyx
+
+Nodyx embarque un **Streamer Hub** complet (v2.5 à v2.7) : un Soundboard natif, un Stream Deck mobile, des overlays OBS en browser source et l'intégration Twitch. Tu démarres OBS, puis tu n'y touches presque plus. Pas trois SaaS à câbler ensemble, pas de bots mensuels, ta communauté possède tout le setup.
+
+### Soundboard
+
+Le streamer upload ses sons, les viewers aident à remplir la queue, OBS les joue.
+
+- Upload drag-and-drop (mp3, ogg, wav, flac), **tags ID3** automatiques (titre, artiste, durée, cover embarquée)
+- Réglages par piste : visibilité (privé / public), volume par défaut (0 à 2x), fade in/out, loop, indicateur royalty-free
+- Déclenché depuis le **Stream Deck mobile**, le **chat Twitch**, ou l'overlay OBS lui-même
+- **Page viewers publique** (`/soundboard`, sans login) : parcourir la bibliothèque, preview au survol, ajouter un son à la queue
+- **Queue viewers** Redis FIFO (max 50, rate-limit et cap par IP, déduplication globale), toggle admin + skip + tout vider, anti-raid par conception
+- Commande chat **`!ns <nom>`** (alias `!nextsound`) avec fuzzy matcher et détection d'ambiguïté : si deux sons sont trop proches, le bot demande au viewer de préciser au lieu de deviner mal
+
+### Stream Deck, mobile et multi-pages
+
+- Jusqu'à **8 pages logiques** (sons, commandes, modération...) avec couleurs d'accent, rename inline, drag-to-reorder
+- Actions : `play_audio`, `stop_audio`, `pause_audio`, `navigate_page`, plus alertes, changements de scène et commandes chat
+- Dock de pages flottant sur mobile (haptique, safe-area iOS), rétrocompatible avec les decks V1 mono-page (sans migration)
+- Modal « Envoyer au Deck » : rattacher un son à un bouton depuis le tab Soundboard, mini-grille pour choisir une case libre, auto-placement
+
+### Overlays OBS, browser sources
+
+Sept types d'overlay, chacun une URL browser source transparente à déposer dans OBS :
+
+```
+alert · goal · timer · ticker · leaderboard · clips · soundboard
+```
+
+- Fade et cross-fade Web Audio, OSD configurable (4 coins ou caché)
+- **Playlists audio** : listes nommées (Dev, Discussion...), chacune avec son URL d'overlay OBS dédiée, pilotable depuis le Deck
+- **Compositeur de scènes OBS** : un éditeur visuel façon OBS pour placer overlays et playlists par scène, avec création inline
 
 ---
 
@@ -564,22 +602,20 @@ Chaque instance Nodyx fait tourner un scheduler **Protocole Gossip** qui pinge p
 
 </details>
 
-<details open>
-<summary><b>v2.6, OctoGuard Phase 1 : auto-modération native 🐙</b></summary>
+<details>
+<summary><b>v2.1, Constructeur de page d'accueil + SDK Widget 🧩</b></summary>
 
 | Fonctionnalité | Version |
 |---|---|
-| **Pipeline auto-mod OctoGuard**, fail-open 50 ms, 5 types de matchers : substring, word-boundary, regex, link allow/blocklist, emoji-flood. Anti-ReDoS via moteur linéaire `re2` Google (84 s natif vs 0 ms `re2` mesuré en bench) + `safe-regex` heuristique à l'admission | v2.6 |
-| **6 actions**, `delete`, `warn`, `mute_timed`, `kick`, `ban` (avec `community_bans.expires_at` optionnel pour bans temporaires), `report_only` dry-run | v2.6 |
-| **Flux de bienvenue**, ghost bot `OctoGuard` (`users.is_system=true`, login refusé), message public avec variables `{user}` / `{userMention}` / `{communityName}`, auto-grade optionnel à l'inscription. Message DM système reporté à la spec 019 | v2.6 |
-| **Commandes personnalisées**, `!règles`, `!discord`, ... en markdown, cooldown Redis par canal (`SET NX EX`), canaux et rôles autorisés configurables par commande | v2.6 |
-| **Mutes chat**, nouvelle table `chat_mutes`, portée globale ou par canal, durée libre (`15m`, `2h`, `1w`, permanent), cache Redis 60 s, worker de purge en arrière-plan | v2.6 |
-| **File de signalements**, driven par les membres, anti-abus rate limit par signaleur + cooldown par cible via Redis, inbox admin avec actions mute/delete/dismiss | v2.6 |
-| **Webhook HMAC-SHA256**, POST sortant signé `X-Octoguard-Signature: sha256=hex`, queue Redis, worker async timeout 10 s. Le pipeline chat ne paye jamais la latence webhook | v2.6 |
-| **Journal d'audit**, chaque action persistée dans `admin_audit_log` avec `event_id`. Logger fire-and-forget IIFE (capté par le bench pré-emptif : p95 passé de 13 ms à 0,2 ms) | v2.6 |
-| **UI admin**, `/admin/octoguard` avec 8 onglets : vue d'ensemble, automod, bienvenue, commandes, mutes, signalements, journal, webhook. CRUD complet avec formulaires `enhance` optimistes | v2.6 |
-| **Kill-switch**, `OCTOGUARD_ENABLED=false` court-circuite tout le pipeline. Table de règles vide = impact zéro même activé. Pattern de rollout dégressif | v2.6 |
-| **69 tests Vitest** + script `bench.ts` dédié, prouve p95 < 1 ms en charge, a permis d'attraper le goulot du logger avant activation prod | v2.6 |
+| **Constructeur de page d'accueil**, admin drag-and-drop, 11 zones de mise en page (banner, hero, stats-bar, main, sidebar, half ×2, trio ×3, footer ×4) | v2.1 |
+| **Registre de plugins**, chaque widget natif est un fichier autonome, zéro changement core pour en ajouter de nouveaux | v2.1 |
+| **4 widgets natifs Phase 1**, Bannière Héro (variantes live/événement/nuit), Barre de stats (compteurs animés), Carte d'adhésion, Bannière d'annonce | v2.1 |
+| **Règles de visibilité**, audience par widget (tous / visiteurs / membres) + dates de début/fin planifiées | v2.1 |
+| **Boutique de widgets**, installation de widgets externes via upload `.zip` (barre de progression XHR, validation en 4 étapes, liste blanche d'extraction) | v2.1 |
+| **Chargeur de widgets dynamique**, Web Components chargés à l'exécution, sans recompilation, sans déploiement | v2.1 |
+| **SDK Widget**, Custom Elements JS pur (Shadow DOM), schéma `manifest.json` → champs de config auto-générés dans le constructeur | v2.1 |
+| **Widget démo : Lecteur Vidéo**, YouTube / Vimeo / MP4 avec aperçu en direct, visualiseur de source, installation en un clic | v2.1 |
+| **nodyx.dev/create-widget**, guide pas à pas pour non-développeurs (7 étapes, EN) | v2.1 |
 
 </details>
 
@@ -605,42 +641,103 @@ Chaque instance Nodyx fait tourner un scheduler **Protocole Gossip** qui pinge p
 </details>
 
 <details>
-<summary><b>v2.1, Constructeur de page d'accueil + SDK Widget 🧩</b></summary>
+<summary><b>v2.3, Lecteur Média Universel + Fusion du Catalogue Builder 🎬</b></summary>
 
 | Fonctionnalité | Version |
 |---|---|
-| **Constructeur de page d'accueil**, admin drag-and-drop, 11 zones de mise en page (banner, hero, stats-bar, main, sidebar, half ×2, trio ×3, footer ×4) | v2.1 |
-| **Registre de plugins**, chaque widget natif est un fichier autonome, zéro changement core pour en ajouter de nouveaux | v2.1 |
-| **4 widgets natifs Phase 1**, Bannière Héro (variantes live/événement/nuit), Barre de stats (compteurs animés), Carte d'adhésion, Bannière d'annonce | v2.1 |
-| **Règles de visibilité**, audience par widget (tous / visiteurs / membres) + dates de début/fin planifiées | v2.1 |
-| **Boutique de widgets**, installation de widgets externes via upload `.zip` (barre de progression XHR, validation en 4 étapes, liste blanche d'extraction) | v2.1 |
-| **Chargeur de widgets dynamique**, Web Components chargés à l'exécution, sans recompilation, sans déploiement | v2.1 |
-| **SDK Widget**, Custom Elements JS pur (Shadow DOM), schéma `manifest.json` → champs de config auto-générés dans le constructeur | v2.1 |
-| **Widget démo : Lecteur Vidéo**, YouTube / Vimeo / MP4 avec aperçu en direct, visualiseur de source, installation en un clic | v2.1 |
-| **nodyx.dev/create-widget**, guide pas à pas pour non-développeurs (7 étapes, EN) | v2.1 |
+| **Lecteur Média Universel**, auto-détection YouTube, Vimeo, Dailymotion, Twitch (live / VOD / clip), SoundCloud, Spotify, plus les fichiers `.mp4` / `.webm` / `.mp3` hébergés. Un seul champ URL, plateforme inférée au rendu | v2.3 |
+| **Fusion du catalogue Builder**, les widgets installés apparaissent dans le picker du Grid Builder à côté des plugins natifs | v2.3 |
+| **Durcissement de l'installeur tunnel (#23)**, 12 correctifs mode Pangolin : réécriture de l'adresse Caddy, regen atomique du Caddyfile au `--repair`, règles UFW RFC1918, garde-fou faux-positif du doctor | v2.3 |
+| **Réécriture de la recherche docs**, index par titres avec ancres deep-link, sommaire scrollspy, passe de correction des slugs | v2.3 |
+| **Posture Why-Nodyx**, page de positionnement listant les alternatives (Matrix, Stoat, Fluxer, Haven...), cadre « silos vs liberté, pas Nodyx vs X » | v2.3 |
+| **i18n**, traductions allemand (`de.json`) + espagnol (`es.json`), relecture native | v2.3 |
+| **Nodyx Stars**, système de reconnaissance des contributeurs externes (CONTRIBUTORS.md public, bloc avatars dans le README) | v2.3 |
 
 </details>
 
-### À venir
+<details>
+<summary><b>v2.4, Système de Sauvegarde + Mode Maintenance Live 💾</b></summary>
 
-| Fonctionnalité | Notes |
+| Fonctionnalité | Version |
 |---|---|
-| **Canvas, Synchronisation Brainwave**, l'hôte diffuse le pan+zoom à tous les participants en temps réel, les abonnés restent synchronisés | Sprint C |
-| **Canvas, Mode Fantôme**, brainstorming anonyme : les contributions apparaissent sous des pseudonymes aléatoires, l'auteur révélé à la fin | Sprint C |
-| **Canvas, Minimap**, vignette 160×120 en bas à droite, cliquer pour naviguer | Sprint C |
-| **Canvas, Sélection multiple**, Shift+clic ou lasso pour sélectionner + déplacer + supprimer plusieurs éléments | Sprint C |
-| **Canvas, Post-its audio**, note vocale enregistrée directement sur le canvas, forme d'onde rendue en post-it | Sprint D |
-| **Canvas, Chat contextuel**, discussion en fil ancrée à une zone du canvas, indexée spatialement | Sprint D |
-| **Plus de widgets natifs**, Compte à rebours, Classement, Derniers fils, Événements mis en avant, Lecteur Jukebox | Phase 2 |
-| **Marketplace de widgets**, widgets publiés par la communauté, notes, installation en un clic depuis l'annuaire |, |
-| **Nœuds**, connaissance structurée durable, validée par la communauté via Garden | [SPEC 013](docs/en/specs/013-node/SPEC.md) |
-| **Système de modules**, 26 modules activables depuis le panneau admin (CMS style Joomla) | [Spec](.claude/ideas/MODULE_SYSTEM.md) |
-| **Réactions DM**, réactions emoji sur les messages privés |, |
-| **Import Discord**, import en masse de canaux, fils, réactions, avatars |, |
-| Mobile (Capacitor) / Bureau (Tauri) |, |
-| Migration Rust, nodyx-server (Axum) remplaçant nodyx-core progressivement |, |
+| **UI de sauvegarde admin**, page `/admin/backups` avec indicateur de stockage, table d'archives, actions par ligne Télécharger / Vérifier / Restaurer / Supprimer | v2.4 |
+| **Créer une sauvegarde**, `pg_dump --format=custom --compress=9` + `tar`, checksum SHA-256, manifest. Inclusion optionnelle des fichiers uploadés | v2.4 |
+| **Restaurer avec filet**, `pg_restore --single-transaction` atomique, snapshot pré-restauration protégé 24h (rollback en un clic), confirmation par slug + compte à rebours | v2.4 |
+| **Dry-run**, vérifier checksum + compat de version + structure tar sans toucher à la DB ni au filesystem | v2.4 |
+| **Journal d'audit**, chaque action sensible loggée avec utilisateur + IP + user-agent, page dédiée `/admin/backups/audit` | v2.4 |
+| **Mode Maintenance Live**, flag Redis pendant create/restore, hook global qui renvoie 503 sur les écritures (les lectures et l'admin restent ouverts), bannière sticky, auto-clear avec ceinture de sécurité | v2.4 |
+| **Tables système exclues du dump**, une restauration ne peut pas effacer son propre filet (découvert en prod, voir « The Yannick Story » dans le CHANGELOG) | v2.4 |
+| **13 tests vitest**, invariants du service (path traversal, refus de version, bypass protégé), 194 au total, 0 régression | v2.4 |
 
----
+</details>
+
+<details>
+<summary><b>v2.5, Streamer Hub Phase 2 : chat Twitch ↔ Nodyx unifié 💬</b></summary>
+
+| Fonctionnalité | Version |
+|---|---|
+| **Chat bidirectionnel temps réel**, pont entre une instance Nodyx et le chat Twitch du streamer, 100% EventSub + Helix, zéro IRC. Vérifié en prod (277 messages pendant la session test) | v2.5 |
+| **Entrant (Twitch → Nodyx)**, EventSub `channel.chat.message`, channel `#twitch-chat` auto-créé, chaque message mappé à un author Nodyx (résolu via `twitch_id` ou placeholder) | v2.5 |
+| **Sortant (Nodyx → Twitch)**, les membres qui écrivent dans `#twitch-chat` sont relayés via Helix, préfixe `[username]` pour la transparence, uniquement pendant une session live | v2.5 |
+| **Queue anti rate-limit**, sur 429 Twitch le message est enqueué dans un sorted set Redis, worker qui dépile par batch avec backoff exponentiel, alerte audit en cas d'overflow | v2.5 |
+| **Cycle de vie des sessions**, `stream.online` / `stream.offline` suivis dans `streamer_sessions` (idempotent), gating du pont sortant | v2.5 |
+| **Emotes & badges**, emotes Twitch natives, BTTV / FFZ / 7TV fetchées et cachées (24h), badges globaux + channel via Helix, dégradation gracieuse | v2.5 |
+| **65 nouveaux tests**, pont, emotes, lifecycle, queue sortante, badges. Suite complète 269/269 verts | v2.5 |
+
+</details>
+
+<details>
+<summary><b>v2.6, OctoGuard Phase 1 : auto-modération native 🐙</b></summary>
+
+| Fonctionnalité | Version |
+|---|---|
+| **Pipeline auto-mod OctoGuard**, fail-open 50 ms, 5 types de matchers : substring, word-boundary, regex, link allow/blocklist, emoji-flood. Anti-ReDoS via moteur linéaire `re2` Google (84 s natif vs 0 ms `re2` mesuré en bench) + `safe-regex` heuristique à l'admission | v2.6 |
+| **6 actions**, `delete`, `warn`, `mute_timed`, `kick`, `ban` (avec `community_bans.expires_at` optionnel pour bans temporaires), `report_only` dry-run | v2.6 |
+| **Flux de bienvenue**, ghost bot `OctoGuard` (`users.is_system=true`, login refusé), message public avec variables `{user}` / `{userMention}` / `{communityName}`, auto-grade optionnel à l'inscription. Message DM système reporté à la spec 019 | v2.6 |
+| **Commandes personnalisées**, `!règles`, `!discord`, ... en markdown, cooldown Redis par canal (`SET NX EX`), canaux et rôles autorisés configurables par commande | v2.6 |
+| **Mutes chat**, nouvelle table `chat_mutes`, portée globale ou par canal, durée libre (`15m`, `2h`, `1w`, permanent), cache Redis 60 s, worker de purge en arrière-plan | v2.6 |
+| **File de signalements**, driven par les membres, anti-abus rate limit par signaleur + cooldown par cible via Redis, inbox admin avec actions mute/delete/dismiss | v2.6 |
+| **Webhook HMAC-SHA256**, POST sortant signé `X-Octoguard-Signature: sha256=hex`, queue Redis, worker async timeout 10 s. Le pipeline chat ne paye jamais la latence webhook | v2.6 |
+| **Journal d'audit**, chaque action persistée dans `admin_audit_log` avec `event_id`. Logger fire-and-forget IIFE (capté par le bench pré-emptif : p95 passé de 13 ms à 0,2 ms) | v2.6 |
+| **UI admin**, `/admin/octoguard` avec 8 onglets : vue d'ensemble, automod, bienvenue, commandes, mutes, signalements, journal, webhook. CRUD complet avec formulaires `enhance` optimistes | v2.6 |
+| **Kill-switch**, `OCTOGUARD_ENABLED=false` court-circuite tout le pipeline. Table de règles vide = impact zéro même activé. Pattern de rollout dégressif | v2.6 |
+| **69 tests Vitest** + script `bench.ts` dédié, prouve p95 < 1 ms en charge, a permis d'attraper le goulot du logger avant activation prod | v2.6 |
+
+</details>
+
+<details>
+<summary><b>v2.7, Streamer Hub : Soundboard + Stream Deck multi-pages 🔊</b></summary>
+
+| Fonctionnalité | Version |
+|---|---|
+| **Soundboard**, upload de sons (mp3/ogg/wav/flac), tags ID3 automatiques (titre, artiste, cover), volume / fade / loop / visibilité par piste, upload batch avec progression live | v2.7 |
+| **Overlay OBS Soundboard**, browser source transparente, fade et cross-fade Web Audio, OSD discret (4 coins ou caché), plusieurs overlays par owner | v2.7 |
+| **Page viewers publique** (`/soundboard`, sans login), parcours de la bibliothèque, preview au survol, « en cours » et « à suivre » en temps réel | v2.7 |
+| **Queue viewers**, FIFO Redis (max 50, rate-limit et cap par IP, dédup globale), toggle admin + skip + tout vider, auto-consume sur `audio:ended`, anti-raid | v2.7 |
+| **Commande chat `!ns`** (alias `!nextsound`), fuzzy matcher avec normalisation, scoring en cascade et Levenshtein, détection d'ambiguïté qui demande au viewer au lieu de deviner mal | v2.7 |
+| **Stream Deck multi-pages**, jusqu'à 8 pages logiques avec couleurs d'accent, rename inline, drag-to-reorder, rétrocompatible decks V1 (sans migration) | v2.7 |
+| **Nouvelles actions Deck**, `play_audio`, `stop_audio`, `pause_audio`, `navigate_page` (intercepté client-side pour zéro latence) | v2.7 |
+| **Deck mobile**, dock de pages flottant avec haptique et safe-area iOS, modal « Envoyer au Deck » avec mini-grille et auto-placement | v2.7 |
+
+</details>
+
+<details open>
+<summary><b>v2.8, Refonte de l'Éditeur d'Articles · Playlists & Scènes OBS · Sécurité ✍️</b></summary>
+
+| Fonctionnalité | Version |
+|---|---|
+| **Robustesse round-trip de l'éditeur**, les colonnes et vidéos YouTube ne disparaissent plus à la réédition (parse sur la classe, pas sur les `data-*` retirés). Audit complet dans `docs/audits/2026-06-15-editeur-rich.md` | v2.8 |
+| **Bloc console SSH protégé**, nœud atomique qui préserve son HTML, avec un toggle Rendu / Code façon CMS, source éditable mais jamais corrompue au clavier | v2.8 |
+| **Sommaire par ancre à la sélection**, barre flottante avec un bouton « Ancre » qui transforme la ligne en section et l'ajoute à un menu dérivé (avec flash de feedback) | v2.8 |
+| **Redimensionnement d'image**, poignées de coin avec aimant aux largeurs clés (25 / 50 / 75 / 100 %), largeur stockée en attribut `width`, robuste au round-trip | v2.8 |
+| **Zone éditable bornée + barre d'outils collante**, toujours accessible sur les longs articles | v2.8 |
+| **Playlists Streamer Hub + Scènes OBS**, playlists audio nommées avec URL d'overlay OBS dédiée, plus un compositeur de scènes visuel façon OBS | v2.8 |
+| **Fondations SEO / GEO**, correction du sitemap (14 → 60+ URLs), `og:image` unique et correct par page (partages Discord / Twitter), `llms.txt` réécrit, guides comparatif + installation débutant (FR + EN) | v2.8 |
+| **Refonte admin**, design sobre Linear / Vercel / Stripe pour la sidebar et le dashboard | v2.8 |
+| **Performance**, fetch directory SSR non bloquant + cache showcase par clé de version, rafraîchissement de la home après suppression de thread | v2.8 |
+| **Balayage sécurité**, ws (high) et tar (medium) patchés, esbuild >= 0.28.1 via override sur les 4 projets SvelteKit, nodemailer 8 → 9 validé en prod | v2.8 |
+
+</details>
 
 ## La Vision
 


### PR DESCRIPTION
Le README était à la masse sur l'historique : section 'What's built' dans le désordre (v2.6 après v2.0, puis à rebours) et incomplète (v2.5/2.7/2.8 manquantes). Réordonnée v0.1 → v2.8, complétée, `<details open>` sur la dernière. README FR synchronisé (Streamer Hub + section 'Ce qui est fait' qui sautait 5 versions).