### PR TITLE
feat(admin): toggle OctoGuard depuis /admin/settings

### DIFF
--- a/nodyx-core/src/config/settingsRegistry.ts
+++ b/nodyx-core/src/config/settingsRegistry.ts
@@ -197,6 +197,18 @@ export const SETTINGS_REGISTRY: SettingDescriptor[] = [
     helpEn: 'Must match EXACTLY the Twitch app OAuth Redirect URL.',
     validate: (v) => { try { new URL(v); return null } catch { return 'URL invalide' } },
   },
+
+  // ── Sécurité & modération ──────────────────────────────────────────────────
+  // tier 3 : relu via process.env à chaque appel (isOctoGuardEnabled lit déjà
+  // process.env.OCTOGUARD_ENABLED) → toggle admin à effet immédiat, zéro modif
+  // du code OctoGuard, zéro redémarrage.
+  {
+    key: 'OCTOGUARD_ENABLED', group: 'security', type: 'boolean', tier: 3, secret: false,
+    labelFr: 'Activer OctoGuard (auto-modération)', labelEn: 'Enable OctoGuard (auto-moderation)',
+    helpFr: "Active le moteur d'auto-modération du chat. Sans aucune règle configurée, il n'a aucun effet. Effet immédiat, pas de redémarrage. Règles dans /admin/octoguard.",
+    helpEn: 'Turns on the chat auto-moderation engine. With no rule configured it does nothing. Applies instantly, no restart. Configure rules in /admin/octoguard.',
+    optional: true,
+  },
 ]
 
 const BY_KEY = new Map(SETTINGS_REGISTRY.map(d => [d.key, d]))

--- a/nodyx-frontend/src/routes/admin/settings/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/settings/+page.svelte
@@ -47,8 +47,9 @@
 		email:        'Email (SMTP)',
 		integrations: 'Intégrations',
 		streamer:     'Streamer Hub (Twitch)',
+		security:     'Sécurité & modération',
 	}
-	const GROUP_ORDER = ['identity', 'federation', 'email', 'integrations', 'streamer']
+	const GROUP_ORDER = ['identity', 'federation', 'email', 'integrations', 'streamer', 'security']
 
 	// Génère une clé 64 hex côté navigateur pour STREAMER_OAUTH_KEY.
 	function generateHexKey(key: string) {


### PR DESCRIPTION
Active/désactive OctoGuard depuis l'admin (section Sécurité & modération) au lieu du .env, comme le reste des réglages. Setting tier-3 (effet immédiat, pas de redémarrage), zéro modif de la logique OctoGuard (isOctoGuardEnabled lit déjà process.env). Vérifié : exposé par l'API, value cohérente. Déployé.