### PR TITLE
fix(reputation): les points récompensent l'activité (pas que les Mercis)

### DIFF
--- a/nodyx-core/src/models/reputation.ts
+++ b/nodyx-core/src/models/reputation.ts
@@ -1,0 +1,19 @@
+import { db } from '../config/database'
+
+// Points de réputation (colonne users.points). Le niveau/badge est dérivé côté
+// front : level = floor(sqrt(points/10)) + 1.
+//   +10 créer un thread/article · +2 répondre · +5 recevoir un Merci
+// On déduit à la suppression (anti-farming create/delete). points >= 0 garanti.
+export const REPUTATION = {
+  THREAD: 10,
+  REPLY:  2,
+  THANKS: 5,
+} as const
+
+export async function awardPoints(userId: string, delta: number): Promise<void> {
+  if (!userId || !delta) return
+  await db.query(
+    `UPDATE users SET points = GREATEST(0, points + $1) WHERE id = $2`,
+    [delta, userId],
+  ).catch(() => {})   // jamais bloquer l'action principale sur l'attribution de points
+}

--- a/nodyx-core/src/routes/forums.ts
+++ b/nodyx-core/src/routes/forums.ts
@@ -12,6 +12,7 @@ import * as ReactionModel from '../models/reaction'
 import * as ThanksModel from '../models/thanks'
 import * as TagModel from '../models/tag'
 import * as NotificationModel from '../models/notification'
+import { awardPoints, REPUTATION } from '../models/reputation'
 import { resolveMentions } from '../utils/mentions'
 import { db, redis } from '../config/database'
 import { checkHtmlContent } from '../services/contentFilter'
@@ -355,6 +356,8 @@ app.get('/threads', {
       content: sanitizedContent,
     })
     bumpThreadsCache()
+    // Réputation : créer un thread/article = +10 (le premier post ne donne pas le +2 réponse)
+    await awardPoints(request.user!.userId, REPUTATION.THREAD)
 
     // Attach tags if provided
     if (tag_ids && tag_ids.length > 0) {
@@ -442,6 +445,8 @@ app.get('/threads', {
       content:   sanitized,
     })
     bumpThreadsCache()
+    // Réputation : répondre = +2
+    await awardPoints(userId, REPUTATION.REPLY)
 
     // Notifications (fire-and-forget)
     ;(async () => {
@@ -547,6 +552,8 @@ app.get('/threads', {
     }
 
     await PostModel.removeById(id)
+    // Réputation : suppression d'une réponse = -2 pour son auteur (anti-farming)
+    await awardPoints(existing.author_id, -REPUTATION.REPLY)
     return reply.code(204).send()
   })
 
@@ -602,6 +609,8 @@ app.get('/threads', {
     if (body.delete) {
       await ThreadModel.remove(threadId)
       bumpThreadsCache()
+      // Réputation : suppression d'un thread = -10 pour son créateur (anti-farming)
+      await awardPoints(thread.author_id, -REPUTATION.THREAD)
       return reply.code(204).send()
     }
 


### PR DESCRIPTION
**Bug** : users.points n'était incrémenté que par les Mercis reçus (thanks.ts +5). Créer des threads/articles ou répondre rapportait 0 point → 94/97 comptes à 0, Pokled bloqué à 15 (LVL 2) malgré 46 threads + 61 réponses.

**Fix** : helper awardPoints + barème +10 thread / +2 réponse / +5 Merci, avec déduction à la suppression (anti-farming). Pas de double comptage du premier post (le corps d'un thread EST son 1er post, +10 couvre tout).

**Backfill** rétroactif appliqué en prod : Pokled 15→505 (LVL 8), 11 comptes ont maintenant des points reflétant leur activité.

Vérifié live : create thread +10, admin delete -10 (net 0).