### PR TITLE
fix(security): XSS stocké réseau social + rendu profil

### DIFF
--- a/nodyx-core/src/routes/forums.ts
+++ b/nodyx-core/src/routes/forums.ts
@@ -1,6 +1,5 @@
 import { FastifyInstance } from 'fastify'
 import { z } from 'zod'
-import sanitizeHtml from 'sanitize-html'
 import { rehostExternalImages } from '../services/inlineImageRehost'
 import { validate } from '../middleware/validate'
 import { rateLimit } from '../middleware/rateLimit'
@@ -13,6 +12,7 @@ import * as ThanksModel from '../models/thanks'
 import * as TagModel from '../models/tag'
 import * as NotificationModel from '../models/notification'
 import { awardPoints, REPUTATION } from '../models/reputation'
+import { sanitize } from '../utils/sanitize'
 import { resolveMentions } from '../utils/mentions'
 import { db, redis } from '../config/database'
 import { checkHtmlContent } from '../services/contentFilter'
@@ -52,116 +52,6 @@ async function isAdmin(userId: string, threadId: string): Promise<boolean> {
 // Get author_id of a post (used for thanks)
 async function getPostAuthor(postId: string): Promise<{ author_id: string; thread_id: string } | null> {
   return PostModel.getAuthorAndThread(postId)
-}
-
-const ALLOWED_TAGS = [
-  'p', 'br', 'strong', 'em', 'u', 's', 'code', 'pre',
-  'h1', 'h2', 'h3', 'h4',
-  'ul', 'ol', 'li',
-  'blockquote', 'hr',
-  'a', 'img',
-  'table', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td',
-  'div', 'span',
-  'iframe',
-  'audio',
-  'nodyx-audio-player',
-  'nodyx-track',
-]
-
-const ALLOWED_ATTRS: sanitizeHtml.IOptions['allowedAttributes'] = {
-  '*':      ['class', 'data-align', 'data-type'],
-  'span':   ['class', 'style', 'data-align', 'data-type'],
-  'p':      ['class', 'style', 'data-align', 'data-type'],
-  // id sur les titres : permet les sommaires à ancres (#section) dans les
-  // posts longs façon documentation. Pas d'id ailleurs pour limiter le
-  // risque de collision avec les éléments de l'app (DOM clobbering).
-  'h2':     ['class', 'id', 'style', 'data-align', 'data-type'],
-  'h3':     ['class', 'id', 'data-align', 'data-type'],
-  'h4':     ['class', 'id', 'data-align', 'data-type'],
-  'a':      ['href', 'target', 'rel'],
-  'img':    ['src', 'alt', 'width', 'height'],
-  'iframe': ['src', 'width', 'height', 'frameborder', 'allowfullscreen', 'allow'],
-  'audio':              ['src', 'controls', 'preload'],
-  'nodyx-audio-player': ['src', 'track-title', 'artist', 'cover', 'download'],
-  'nodyx-track':        ['src', 'track-title', 'artist', 'cover'],
-  'th':     ['rowspan', 'colspan'],
-  'td':     ['rowspan', 'colspan'],
-}
-
-// Images autorisées : serveur propre + CDN GIF uniquement
-const ALLOWED_IMG_HOSTS_FORUM = new Set([
-  'media.tenor.com', 'c.tenor.com', 'media1.tenor.com', 'tenor.com',
-  'media.giphy.com', 'media0.giphy.com', 'media1.giphy.com',
-  'media2.giphy.com', 'media3.giphy.com', 'i.giphy.com',
-])
-
-function isAllowedImgSrcForum(src: string): boolean {
-  if (!src) return false
-  if (src.startsWith('/uploads/')) return true
-  if (src.startsWith('data:image/')) return true
-  try {
-    return ALLOWED_IMG_HOSTS_FORUM.has(new URL(src).hostname)
-  } catch {
-    return false
-  }
-}
-
-// Audio: only files served by our own /uploads/ (mp3, m4a, ogg, wav, webm).
-// No external host, no data: URLs.
-function isAllowedAudioSrcForum(src: string): boolean {
-  if (!src) return false
-  return src.startsWith('/uploads/')
-}
-
-const _envBlockedForum = (process.env.BLOCKED_LINK_DOMAINS ?? '')
-  .split(',').map(d => d.trim().toLowerCase()).filter(Boolean)
-
-const BLOCKED_LINK_DOMAINS_FORUM = new Set([
-  'pornhub.com', 'xvideos.com', 'xhamster.com', 'xnxx.com',
-  'redtube.com', 'youporn.com', 'tube8.com', 'spankbang.com',
-  'tnaflix.com', 'drtuber.com', 'beeg.com', 'txxx.com',
-  ..._envBlockedForum,
-])
-
-function sanitize(raw: string): string {
-  return sanitizeHtml(raw, {
-    allowedTags: ALLOWED_TAGS,
-    allowedAttributes: ALLOWED_ATTRS,
-    allowedIframeHostnames: ['www.youtube.com', 'youtube.com', 'www.youtube-nocookie.com', 'player.vimeo.com', 'vimeo.com'],
-    transformTags: {
-      'nodyx-audio-player': (tagName, attribs) => {
-        if (attribs.cover && !isAllowedImgSrcForum(attribs.cover)) {
-          const cleaned: Record<string, string> = { ...attribs }
-          delete cleaned.cover
-          return { tagName, attribs: cleaned }
-        }
-        return { tagName, attribs }
-      },
-      'nodyx-track': (tagName, attribs) => {
-        if (attribs.cover && !isAllowedImgSrcForum(attribs.cover)) {
-          const cleaned: Record<string, string> = { ...attribs }
-          delete cleaned.cover
-          return { tagName, attribs: cleaned }
-        }
-        return { tagName, attribs }
-      },
-    },
-    exclusiveFilter: (frame) => {
-      if (frame.tag === 'img')                 return !isAllowedImgSrcForum(frame.attribs?.src ?? '')
-      if (frame.tag === 'audio')               return !isAllowedAudioSrcForum(frame.attribs?.src ?? '')
-      // <nodyx-audio-player> may be empty (parent of <nodyx-track>) so src is optional
-      if (frame.tag === 'nodyx-audio-player')  return !!frame.attribs?.src && !isAllowedAudioSrcForum(frame.attribs.src)
-      if (frame.tag === 'nodyx-track')         return !isAllowedAudioSrcForum(frame.attribs?.src ?? '')
-      if (frame.tag === 'a') {
-        const href = frame.attribs?.href ?? ''
-        try {
-          const hostname = new URL(href).hostname.toLowerCase().replace(/^www\./, '')
-          return BLOCKED_LINK_DOMAINS_FORUM.has(hostname)
-        } catch { return false }
-      }
-      return false
-    },
-  })
 }
 
 // Invalide les caches de listes de threads (showcase homepage, etc.) en

--- a/nodyx-core/src/routes/social.ts
+++ b/nodyx-core/src/routes/social.ts
@@ -8,6 +8,7 @@ import sharp from 'sharp'
 import { rateLimit } from '../middleware/rateLimit'
 import { requireAuth } from '../middleware/auth'
 import { validate } from '../middleware/validate'
+import { sanitize } from '../utils/sanitize'
 import { db } from '../config/database'
 import { io } from '../socket/io'
 
@@ -134,6 +135,14 @@ export default async function socialRoutes(app: FastifyInstance) {
     const { userId } = request.user!
     const { content, reply_to_id, media_url } = request.body as z.infer<typeof statusSchema>
 
+    // SÉCURITÉ : le contenu est rendu en {@html} (feed + profil). On le passe par
+    // le sanitizer partagé (même allowlist que le forum) pour bloquer tout XSS
+    // stocké (script, on*, src externes…).
+    const safeContent = sanitize(content)
+    if (!safeContent.trim()) {
+      return reply.code(400).send({ error: 'Contenu vide après nettoyage.' })
+    }
+
     // Verify parent exists if replying
     if (reply_to_id) {
       const parent = await db.query('SELECT id FROM status_posts WHERE id = $1', [reply_to_id])
@@ -144,7 +153,7 @@ export default async function socialRoutes(app: FastifyInstance) {
       INSERT INTO status_posts (author_id, content, reply_to_id, media_url)
       VALUES ($1, $2, $3, $4)
       RETURNING id
-    `, [userId, content, reply_to_id ?? null, media_url ?? null])
+    `, [userId, safeContent, reply_to_id ?? null, media_url ?? null])
 
     if (reply_to_id) {
       await db.query(

--- a/nodyx-core/src/utils/sanitize.ts
+++ b/nodyx-core/src/utils/sanitize.ts
@@ -1,0 +1,115 @@
+import sanitizeHtml from 'sanitize-html'
+
+// ── Sanitizer HTML partagé (forum + réseau social) ──────────────────────────
+// Allowlist éprouvée : on autorise le rendu riche de l'éditeur Nodyx (titres,
+// listes, tables, images de notre serveur ou CDN GIF, audio interne, iframes
+// YouTube/Vimeo) et on retire tout le reste (script, on*, src d'images/audio
+// externes, domaines bloqués). Utilisé partout où du contenu utilisateur est
+// rendu en {@html}. NE JAMAIS rendre du contenu utilisateur sans passer par ici.
+
+const ALLOWED_TAGS = [
+  'p', 'br', 'strong', 'em', 'u', 's', 'code', 'pre',
+  'h1', 'h2', 'h3', 'h4',
+  'ul', 'ol', 'li',
+  'blockquote', 'hr',
+  'a', 'img',
+  'table', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td',
+  'div', 'span',
+  'iframe',
+  'audio',
+  'nodyx-audio-player',
+  'nodyx-track',
+]
+
+const ALLOWED_ATTRS: sanitizeHtml.IOptions['allowedAttributes'] = {
+  '*':      ['class', 'data-align', 'data-type'],
+  'span':   ['class', 'style', 'data-align', 'data-type'],
+  'p':      ['class', 'style', 'data-align', 'data-type'],
+  // id sur les titres : permet les sommaires à ancres (#section). Pas d'id
+  // ailleurs pour limiter le risque de DOM clobbering.
+  'h2':     ['class', 'id', 'style', 'data-align', 'data-type'],
+  'h3':     ['class', 'id', 'data-align', 'data-type'],
+  'h4':     ['class', 'id', 'data-align', 'data-type'],
+  'a':      ['href', 'target', 'rel'],
+  'img':    ['src', 'alt', 'width', 'height'],
+  'iframe': ['src', 'width', 'height', 'frameborder', 'allowfullscreen', 'allow'],
+  'audio':              ['src', 'controls', 'preload'],
+  'nodyx-audio-player': ['src', 'track-title', 'artist', 'cover', 'download'],
+  'nodyx-track':        ['src', 'track-title', 'artist', 'cover'],
+  'th':     ['rowspan', 'colspan'],
+  'td':     ['rowspan', 'colspan'],
+}
+
+// Images autorisées : serveur propre + CDN GIF uniquement
+const ALLOWED_IMG_HOSTS = new Set([
+  'media.tenor.com', 'c.tenor.com', 'media1.tenor.com', 'tenor.com',
+  'media.giphy.com', 'media0.giphy.com', 'media1.giphy.com',
+  'media2.giphy.com', 'media3.giphy.com', 'i.giphy.com',
+])
+
+function isAllowedImgSrc(src: string): boolean {
+  if (!src) return false
+  if (src.startsWith('/uploads/')) return true
+  if (src.startsWith('data:image/')) return true
+  try {
+    return ALLOWED_IMG_HOSTS.has(new URL(src).hostname)
+  } catch {
+    return false
+  }
+}
+
+// Audio : uniquement les fichiers servis par notre /uploads/.
+function isAllowedAudioSrc(src: string): boolean {
+  if (!src) return false
+  return src.startsWith('/uploads/')
+}
+
+const _envBlocked = (process.env.BLOCKED_LINK_DOMAINS ?? '')
+  .split(',').map(d => d.trim().toLowerCase()).filter(Boolean)
+
+const BLOCKED_LINK_DOMAINS = new Set([
+  'pornhub.com', 'xvideos.com', 'xhamster.com', 'xnxx.com',
+  'redtube.com', 'youporn.com', 'tube8.com', 'spankbang.com',
+  'tnaflix.com', 'drtuber.com', 'beeg.com', 'txxx.com',
+  ..._envBlocked,
+])
+
+export function sanitize(raw: string): string {
+  return sanitizeHtml(raw, {
+    allowedTags: ALLOWED_TAGS,
+    allowedAttributes: ALLOWED_ATTRS,
+    allowedIframeHostnames: ['www.youtube.com', 'youtube.com', 'www.youtube-nocookie.com', 'player.vimeo.com', 'vimeo.com'],
+    transformTags: {
+      'nodyx-audio-player': (tagName, attribs) => {
+        if (attribs.cover && !isAllowedImgSrc(attribs.cover)) {
+          const cleaned: Record<string, string> = { ...attribs }
+          delete cleaned.cover
+          return { tagName, attribs: cleaned }
+        }
+        return { tagName, attribs }
+      },
+      'nodyx-track': (tagName, attribs) => {
+        if (attribs.cover && !isAllowedImgSrc(attribs.cover)) {
+          const cleaned: Record<string, string> = { ...attribs }
+          delete cleaned.cover
+          return { tagName, attribs: cleaned }
+        }
+        return { tagName, attribs }
+      },
+    },
+    exclusiveFilter: (frame) => {
+      if (frame.tag === 'img')                 return !isAllowedImgSrc(frame.attribs?.src ?? '')
+      if (frame.tag === 'audio')               return !isAllowedAudioSrc(frame.attribs?.src ?? '')
+      if (frame.tag === 'nodyx-audio-player')  return !!frame.attribs?.src && !isAllowedAudioSrc(frame.attribs.src)
+      if (frame.tag === 'nodyx-track')         return !isAllowedAudioSrc(frame.attribs?.src ?? '')
+      if (frame.tag === 'a') {
+        const href = frame.attribs?.href ?? ''
+        try {
+          const hostname = new URL(href).hostname.toLowerCase().replace(/^www\./, '')
+          return BLOCKED_LINK_DOMAINS.has(hostname)
+        } catch { return false }
+      }
+      return false
+    },
+  })
+}

--- a/nodyx-frontend/src/routes/users/[username]/+page.svelte
+++ b/nodyx-frontend/src/routes/users/[username]/+page.svelte
@@ -818,7 +818,7 @@
 				{:else}
 					{#each userPosts as post (post.id)}
 						<article class="profile-post-card">
-							<p class="profile-post-text">{post.content}</p>
+							<div class="profile-post-text nodyx-prose">{@html post.content}</div>
 							<div class="profile-post-meta">
 								<time>{timeAgo(post.created_at)}</time>
 								<button


### PR DESCRIPTION
**Sécurité** : les status_posts étaient insérés sans sanitization et rendus en `{@html}` (feed) → XSS stocké. Fix : sanitizer forum extrait dans `utils/sanitize.ts`, appliqué à la création des status + backfill des existants. Vérifié : `<script>`/`onerror`/`javascript:` neutralisés, YouTube préservé.

**Affichage** : le profil affichait le HTML brut (`{post.content}`) au lieu de le rendre → `{@html}` + `nodyx-prose` (comme le feed).

Backfill prod déjà appliqué (14 status, 6 normalisés, 0 XSS actif).