### PR TITLE
feat(feed): points réputation pour statuts + '+2 ✨' animé (lot 2.1)

### DIFF
--- a/nodyx-core/src/models/reputation.ts
+++ b/nodyx-core/src/models/reputation.ts
@@ -5,9 +5,10 @@ import { db } from '../config/database'
 //   +10 créer un thread/article · +2 répondre · +5 recevoir un Merci
 // On déduit à la suppression (anti-farming create/delete). points >= 0 garanti.
 export const REPUTATION = {
-  THREAD: 10,
-  REPLY:  2,
-  THANKS: 5,
+  THREAD:      10,
+  REPLY:       2,
+  THANKS:      5,
+  SOCIAL_POST: 2,   // un statut sur le fil d'actu (participation courte)
 } as const
 
 export async function awardPoints(userId: string, delta: number): Promise<void> {

--- a/nodyx-core/src/routes/social.ts
+++ b/nodyx-core/src/routes/social.ts
@@ -9,6 +9,7 @@ import { rateLimit } from '../middleware/rateLimit'
 import { requireAuth } from '../middleware/auth'
 import { validate } from '../middleware/validate'
 import { sanitize } from '../utils/sanitize'
+import { awardPoints, REPUTATION } from '../models/reputation'
 import { db } from '../config/database'
 import { io } from '../socket/io'
 
@@ -162,6 +163,9 @@ export default async function socialRoutes(app: FastifyInstance) {
       )
     }
 
+    // Réputation : poster un statut = +2 (participation au fil d'actu)
+    await awardPoints(userId, REPUTATION.SOCIAL_POST)
+
     const post = await db.query(`
       SELECT ${postSelect('$2')}
       FROM status_posts sp
@@ -193,6 +197,9 @@ export default async function socialRoutes(app: FastifyInstance) {
         [del.rows[0].reply_to_id]
       )
     }
+
+    // Réputation : suppression d'un statut = -2 (anti-farming)
+    await awardPoints(userId, -REPUTATION.SOCIAL_POST)
 
     return reply.send({ ok: true })
   })

--- a/nodyx-frontend/src/routes/feed/+page.svelte
+++ b/nodyx-frontend/src/routes/feed/+page.svelte
@@ -48,6 +48,15 @@
 	let mediaUrl    = $state<string | null>(null)
 	let mediaUploading = $state(false)
 
+	// "+2 ✨" qui s'envole quand on poste (récompense réputation visible)
+	let burstOn  = $state(false)
+	let burstKey = $state(0)
+	function triggerPointsBurst() {
+		burstKey++
+		burstOn = true
+		setTimeout(() => (burstOn = false), 1300)
+	}
+
 	// Text length for wave bar (strip HTML tags)
 	const textLen   = $derived(content.replace(/<[^>]*>/g, '').length)
 	const waveWidth = $derived(Math.min(100, (textLen / 500) * 100))
@@ -92,6 +101,7 @@
 			})
 			if (res.ok) {
 				const post = await res.json()
+				triggerPointsBurst()   // +2 réputation, petit feedback qui s'envole
 				if (!replyTo) {
 					posts = [post, ...posts]
 				} else {
@@ -331,6 +341,11 @@
 								>
 									{sending ? '…' : replyTo ? tFn('feed.reply') : tFn('feed.publish')}
 								</button>
+								{#if burstOn}
+									{#key burstKey}
+										<span class="points-burst">+2&nbsp;✨</span>
+									{/key}
+								{/if}
 							</div>
 						</div>
 					</div>
@@ -842,7 +857,27 @@
 	min-width: 2.5rem;
 	text-align: right;
 }
-.composer-actions { display: flex; gap: 0.5rem; }
+.composer-actions { display: flex; gap: 0.5rem; position: relative; }
+
+/* "+2 ✨" qui s'envole quand on poste */
+.points-burst {
+	position: absolute;
+	right: 0.5rem;
+	top: -0.25rem;
+	pointer-events: none;
+	font-size: 0.95rem;
+	font-weight: 800;
+	color: #fde68a;
+	text-shadow: 0 0 10px rgba(251, 191, 36, 0.6);
+	white-space: nowrap;
+	animation: points-burst-rise 1.2s ease-out forwards;
+}
+@keyframes points-burst-rise {
+	0%   { opacity: 0; transform: translateY(6px) scale(0.8); }
+	20%  { opacity: 1; transform: translateY(-2px) scale(1.1); }
+	60%  { opacity: 1; transform: translateY(-22px) scale(1); }
+	100% { opacity: 0; transform: translateY(-48px) scale(0.95); }
+}
 .composer-cancel {
 	font-size: 0.75rem;
 	font-weight: 600;


### PR DESCRIPTION
Poster un statut rapporte +2 de réputation (comme une réponse forum), avec un '+2 ✨' qui s'envole du bouton Publier pour rendre la participation gratifiante. Reverse à la suppression. Backfill prod appliqué. Vérifié live (+2/-2). Lot 2.2 = réactions emoji, 2.3 = repartage.