### PR TITLE
feat(feed): cartes d'aperçu de lien (Open Graph, SSRF-safe)

### DIFF
--- a/nodyx-core/src/migrations/106_status_link_preview.sql
+++ b/nodyx-core/src/migrations/106_status_link_preview.sql
@@ -1,0 +1,4 @@
+-- Migration 106 — Aperçu de lien (Open Graph) pour les statuts du fil d'actu.
+-- JSONB : { url, title, description, image, site_name }. NULL si pas de lien
+-- ou métadonnées non récupérables.
+ALTER TABLE status_posts ADD COLUMN IF NOT EXISTS link_preview JSONB;

--- a/nodyx-core/src/routes/social.ts
+++ b/nodyx-core/src/routes/social.ts
@@ -10,6 +10,12 @@ import { requireAuth } from '../middleware/auth'
 import { validate } from '../middleware/validate'
 import { sanitize } from '../utils/sanitize'
 import { awardPoints, REPUTATION } from '../models/reputation'
+import { fetchLinkPreview } from '../services/linkPreview'
+
+// Premier lien http(s) dans le contenu HTML (pour l'aperçu de lien).
+function firstLink(html: string): string | null {
+  return html.match(/<a[^>]+href=["'](https?:\/\/[^"']+)["']/i)?.[1] ?? null
+}
 import { db } from '../config/database'
 import { io } from '../socket/io'
 
@@ -26,7 +32,7 @@ const AUDIO_MIME_PREFIX = 'audio/'
 
 function postSelect(viewerParam: string | null) {
   return `
-    sp.id, sp.content, sp.media_url, sp.reply_to_id,
+    sp.id, sp.content, sp.media_url, sp.link_preview, sp.reply_to_id,
     sp.likes_count, sp.replies_count, sp.created_at,
     u.id AS author_id, u.username, p.display_name, p.avatar_url,
     ${viewerParam
@@ -150,11 +156,19 @@ export default async function socialRoutes(app: FastifyInstance) {
       if (!parent.rows[0]) return reply.code(404).send({ error: 'Post parent introuvable' })
     }
 
+    // Aperçu de lien : si le statut contient un lien et pas d'image attachée,
+    // on récupère ses métadonnées Open Graph (fetch SSRF-safe, borné).
+    let linkPreview = null
+    if (!media_url) {
+      const link = firstLink(safeContent)
+      if (link) linkPreview = await fetchLinkPreview(link).catch(() => null)
+    }
+
     const ins = await db.query(`
-      INSERT INTO status_posts (author_id, content, reply_to_id, media_url)
-      VALUES ($1, $2, $3, $4)
+      INSERT INTO status_posts (author_id, content, reply_to_id, media_url, link_preview)
+      VALUES ($1, $2, $3, $4, $5)
       RETURNING id
-    `, [userId, safeContent, reply_to_id ?? null, media_url ?? null])
+    `, [userId, safeContent, reply_to_id ?? null, media_url ?? null, linkPreview ? JSON.stringify(linkPreview) : null])
 
     if (reply_to_id) {
       await db.query(

--- a/nodyx-core/src/services/linkPreview.ts
+++ b/nodyx-core/src/services/linkPreview.ts
@@ -1,0 +1,135 @@
+import { lookup } from 'dns/promises'
+
+// ── Aperçu de lien (Open Graph) avec garde-fou SSRF ─────────────────────────
+// On récupère côté serveur les métadonnées d'une URL (titre/description/image)
+// pour afficher une carte d'aperçu dans le fil d'actu. Comme on fetch une URL
+// fournie par un utilisateur, on se protège du SSRF : protocole http(s) seul,
+// blocage des hôtes locaux et IP privées, redirections suivies MANUELLEMENT et
+// revalidées à chaque saut, timeout court, taille de réponse plafonnée.
+
+export interface LinkPreview {
+  url:         string
+  title?:      string
+  description?: string
+  image?:      string
+  site_name?:  string
+}
+
+const TIMEOUT_MS = 4000
+const MAX_BYTES  = 512 * 1024
+const MAX_HOPS   = 3
+
+function isPrivateIp(ip: string): boolean {
+  const v4 = ip.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/)
+  if (v4) {
+    const a = +v4[1], b = +v4[2]
+    if (a === 0 || a === 10 || a === 127) return true
+    if (a === 169 && b === 254) return true            // link-local
+    if (a === 172 && b >= 16 && b <= 31) return true   // private
+    if (a === 192 && b === 168) return true            // private
+    if (a === 100 && b >= 64 && b <= 127) return true  // CGNAT
+    if (a >= 224) return true                          // multicast/reserved
+    return false
+  }
+  const h = ip.toLowerCase()
+  if (h === '::1' || h === '::' || h === '0:0:0:0:0:0:0:1') return true
+  if (h.startsWith('fe80')) return true                // link-local
+  if (h.startsWith('fc') || h.startsWith('fd')) return true // ULA
+  if (h.startsWith('::ffff:')) return isPrivateIp(h.replace('::ffff:', '')) // IPv4-mapped
+  return false
+}
+
+async function isSafeHost(hostname: string): Promise<boolean> {
+  const h = hostname.toLowerCase().replace(/\.$/, '')
+  if (!h || h === 'localhost') return false
+  if (h.endsWith('.localhost') || h.endsWith('.local') || h.endsWith('.internal')) return false
+  if (/^[\d.]+$/.test(h) || h.includes(':')) return !isPrivateIp(h)  // IP littérale
+  try {
+    const addrs = await lookup(h, { all: true })
+    return addrs.length > 0 && addrs.every(a => !isPrivateIp(a.address))
+  } catch {
+    return false
+  }
+}
+
+function meta(html: string, prop: string): string | undefined {
+  const a = new RegExp(`<meta[^>]+(?:property|name)=["']${prop}["'][^>]*content=["']([^"']*)["']`, 'i')
+  const b = new RegExp(`<meta[^>]+content=["']([^"']*)["'][^>]*(?:property|name)=["']${prop}["']`, 'i')
+  return (html.match(a)?.[1] ?? html.match(b)?.[1])?.trim() || undefined
+}
+
+function decode(s?: string): string | undefined {
+  if (!s) return s
+  return s.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+          .replace(/&quot;/g, '"').replace(/&#0?39;/g, "'").replace(/&#x27;/gi, "'")
+          .replace(/&nbsp;/g, ' ').trim() || undefined
+}
+
+// Suit les redirections à la main en revalidant chaque hôte (anti-SSRF).
+async function safeFetchHtml(startUrl: string): Promise<{ html: string; finalUrl: string } | null> {
+  let current = startUrl
+  for (let hop = 0; hop < MAX_HOPS; hop++) {
+    let u: URL
+    try { u = new URL(current) } catch { return null }
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return null
+    if (!await isSafeHost(u.hostname)) return null
+
+    let res: Response
+    try {
+      res = await fetch(u.href, {
+        method: 'GET',
+        redirect: 'manual',
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+        headers: { 'User-Agent': 'NodyxBot/1.0 (+https://nodyx.org)', 'Accept': 'text/html' },
+      })
+    } catch { return null }
+
+    if (res.status >= 300 && res.status < 400) {
+      const loc = res.headers.get('location')
+      if (!loc) return null
+      current = new URL(loc, u.href).href
+      continue
+    }
+    if (!res.ok) return null
+    if (!(res.headers.get('content-type') ?? '').includes('text/html')) return null
+
+    const reader = res.body?.getReader()
+    if (!reader) return null
+    const dec = new TextDecoder()
+    let html = '', total = 0
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      total += value.length
+      html += dec.decode(value, { stream: true })
+      if (total > MAX_BYTES || /<\/head>/i.test(html)) { try { await reader.cancel() } catch { /* noop */ } break }
+    }
+    return { html, finalUrl: u.href }
+  }
+  return null
+}
+
+export async function fetchLinkPreview(rawUrl: string): Promise<LinkPreview | null> {
+  const fetched = await safeFetchHtml(rawUrl)
+  if (!fetched) return null
+  const { html, finalUrl } = fetched
+
+  const title       = decode(meta(html, 'og:title') ?? html.match(/<title[^>]*>([^<]*)<\/title>/i)?.[1])
+  const description = decode(meta(html, 'og:description') ?? meta(html, 'description'))
+  const site_name   = decode(meta(html, 'og:site_name')) ?? new URL(finalUrl).hostname.replace(/^www\./, '')
+  let   image       = meta(html, 'og:image') ?? meta(html, 'og:image:url')
+
+  if (image) {
+    try { image = new URL(image, finalUrl).href } catch { image = undefined }
+    if (image && !/^https?:\/\//i.test(image)) image = undefined
+  }
+
+  if (!title && !description && !image) return null
+  return {
+    url:         rawUrl,
+    title:       title?.slice(0, 300),
+    description: description?.slice(0, 500),
+    image,
+    site_name:   site_name?.slice(0, 100),
+  }
+}

--- a/nodyx-frontend/src/routes/feed/+page.svelte
+++ b/nodyx-frontend/src/routes/feed/+page.svelte
@@ -231,6 +231,19 @@
 	<title>{tFn('feed.title')} — Nodyx</title>
 </svelte:head>
 
+{#snippet linkCard(lp: any)}
+	<a href={lp.url} target="_blank" rel="noopener noreferrer nofollow" class="link-card">
+		{#if lp.image}
+			<div class="link-card-img"><img src={lp.image} alt="" loading="lazy" /></div>
+		{/if}
+		<div class="link-card-body">
+			{#if lp.site_name}<span class="link-card-site">{lp.site_name}</span>{/if}
+			{#if lp.title}<span class="link-card-title">{lp.title}</span>{/if}
+			{#if lp.description}<span class="link-card-desc">{lp.description}</span>{/if}
+		</div>
+	</a>
+{/snippet}
+
 <div class="feed-root">
 	<!-- ── Page header ──────────────────────────────────────────────────────── -->
 	<div class="feed-header">
@@ -412,6 +425,8 @@
 										</div>
 									{/if}
 
+									{#if post.link_preview}{@render linkCard(post.link_preview)}{/if}
+
 									<!-- Actions -->
 									<div class="post-actions">
 										<!-- Reply -->
@@ -515,6 +530,7 @@
 													<img src={reply.media_url} alt="" class="post-media-img" loading="lazy" />
 												</div>
 											{/if}
+											{#if reply.link_preview}{@render linkCard(reply.link_preview)}{/if}
 											<div class="post-actions" style="margin-top: 0.5rem;">
 												<button
 													onclick={() => { replyTo = reply; composing = true; window.scrollTo({ top: 0, behavior: 'smooth' }) }}
@@ -1019,6 +1035,28 @@
 .prose-feed :global(pre code) { background: none; padding: 0; }
 
 /* Post media */
+/* Carte d'aperçu de lien (Open Graph) */
+.link-card {
+	display: flex;
+	flex-direction: column;
+	margin-top: 0.625rem;
+	border: 1px solid rgba(255,255,255,0.1);
+	border-radius: 14px;
+	overflow: hidden;
+	text-decoration: none;
+	background: rgba(255,255,255,0.02);
+	transition: border-color 0.15s, background 0.15s;
+}
+.link-card:hover { border-color: rgba(124,58,237,0.5); background: rgba(255,255,255,0.04); }
+.link-card-img { width: 100%; max-height: 240px; overflow: hidden; background: rgba(0,0,0,0.2); }
+.link-card-img img { width: 100%; height: 100%; max-height: 240px; object-fit: cover; display: block; }
+.link-card-body { display: flex; flex-direction: column; gap: 0.2rem; padding: 0.7rem 0.85rem; }
+.link-card-site { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.04em; color: #818cf8; font-weight: 700; }
+.link-card-title { font-size: 0.9rem; font-weight: 700; color: rgba(255,255,255,0.92); line-height: 1.3;
+	display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.link-card-desc { font-size: 0.8rem; color: rgba(255,255,255,0.55); line-height: 1.4;
+	display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+
 .post-media { margin-top: 0.625rem; }
 .post-media-img {
 	width: 100%;


### PR DESCRIPTION
Coller un lien dans un statut génère une carte d'aperçu (image/titre/description/site), comme les autres réseaux. Service linkPreview SSRF-safe (IP privées bloquées, redirections revalidées, timeout, taille max, parse OG regex sans dep). Migration 106 (link_preview JSONB). Carte cliquable dans le feed. Backfill des liens existants. Vérifié : OG ok, SSRF bloqué (localhost/127.0.0.1/169.254.169.254).