### PR TITLE
feat(feed): repartage (lot 2.3)

### DIFF
--- a/nodyx-core/src/migrations/108_status_reshare.sql
+++ b/nodyx-core/src/migrations/108_status_reshare.sql
@@ -1,0 +1,10 @@
+-- Migration 108 — Repartage (reshare) des statuts.
+-- Un repartage est un status_post avec reshare_of → l'original. Contenu vide
+-- autorisé dans ce cas (repartage simple, sans commentaire).
+ALTER TABLE status_posts ADD COLUMN IF NOT EXISTS reshare_of UUID REFERENCES status_posts(id) ON DELETE CASCADE;
+
+ALTER TABLE status_posts DROP CONSTRAINT IF EXISTS status_posts_content_check;
+ALTER TABLE status_posts ADD CONSTRAINT status_posts_content_check
+  CHECK (char_length(content) >= 1 OR reshare_of IS NOT NULL);
+
+CREATE INDEX IF NOT EXISTS idx_status_posts_reshare_of ON status_posts(reshare_of);

--- a/nodyx-core/src/routes/social.ts
+++ b/nodyx-core/src/routes/social.ts
@@ -46,7 +46,23 @@ function postSelect(viewerParam: string | null) {
               json_build_object('count', COUNT(*), 'users', json_agg(u2.username ORDER BY u2.username)) AS jc
        FROM status_likes sl2 JOIN users u2 ON u2.id = sl2.user_id
        WHERE sl2.post_id = sp.id GROUP BY sl2.emoji
-     ) t) AS reactions
+     ) t) AS reactions,
+    sp.reshare_of,
+    (SELECT COUNT(*) FROM status_posts r WHERE r.reshare_of = COALESCE(sp.reshare_of, sp.id))::int AS reshares_count,
+    ${viewerParam
+      ? `EXISTS(SELECT 1 FROM status_posts r WHERE r.reshare_of = COALESCE(sp.reshare_of, sp.id) AND r.author_id = ${viewerParam})`
+      : 'false'} AS reshared_by_me,
+    CASE WHEN sp.reshare_of IS NOT NULL THEN (
+      SELECT json_build_object(
+        'id', o.id, 'content', o.content, 'media_url', o.media_url,
+        'link_preview', o.link_preview, 'created_at', o.created_at,
+        'author_id', o.author_id, 'username', ou.username,
+        'display_name', op.display_name, 'avatar_url', op.avatar_url
+      )
+      FROM status_posts o JOIN users ou ON ou.id = o.author_id
+      LEFT JOIN user_profiles op ON op.user_id = o.author_id
+      WHERE o.id = sp.reshare_of
+    ) ELSE NULL END AS reshared
   `
 }
 
@@ -295,6 +311,34 @@ export default async function socialRoutes(app: FastifyInstance) {
       likes_count = r.rows[0]?.likes_count
     }
     return reply.send({ ok: true, likes_count })
+  })
+
+  // ── Repartage ───────────────────────────────────────────────────────────────
+  app.post('/status/:id/reshare', { preHandler: [rateLimit, requireAuth] }, async (request, reply) => {
+    const { userId } = request.user!
+    const { id } = request.params as { id: string }
+
+    const orig = await db.query<{ id: string; reshare_of: string | null }>(
+      'SELECT id, reshare_of FROM status_posts WHERE id = $1', [id]
+    )
+    if (!orig.rows[0]) return reply.code(404).send({ error: 'Post introuvable' })
+    // Repartager un repartage cible l'original.
+    const targetId = orig.rows[0].reshare_of ?? id
+
+    // Toggle : si je l'ai déjà repartagé, on retire.
+    const existing = await db.query(
+      'SELECT id FROM status_posts WHERE author_id = $1 AND reshare_of = $2',
+      [userId, targetId]
+    )
+    if (existing.rows[0]) {
+      await db.query('DELETE FROM status_posts WHERE id = $1', [existing.rows[0].id])
+      return reply.send({ ok: true, reshared: false })
+    }
+    await db.query(
+      "INSERT INTO status_posts (author_id, content, reshare_of) VALUES ($1, '', $2)",
+      [userId, targetId]
+    )
+    return reply.send({ ok: true, reshared: true })
   })
 
   // ── Feed & user posts ─────────────────────────────────────────────────────

--- a/nodyx-frontend/src/routes/feed/+page.svelte
+++ b/nodyx-frontend/src/routes/feed/+page.svelte
@@ -183,6 +183,22 @@
 		}).catch(() => {})
 	}
 
+	// ── Repartage ───────────────────────────────────────────────────────────────
+	async function toggleReshare(post: any) {
+		const now = !post.reshared_by_me
+		const delta = now ? 1 : -1
+		// MAJ optimiste sur l'original effectif (toutes les lignes qui le ciblent)
+		const target = post.reshare_of || post.id
+		posts = posts.map(p =>
+			(p.id === target || p.reshare_of === target)
+				? { ...p, reshared_by_me: now, reshares_count: Math.max(0, (p.reshares_count ?? 0) + delta) }
+				: p
+		)
+		await apiFetch(fetch, `/social/status/${post.id}/reshare`, {
+			method: 'POST', headers: { Authorization: `Bearer ${token}` },
+		}).catch(() => {})
+	}
+
 	async function deletePost(id: string) {
 		const res = await apiFetch(fetch, `/social/status/${id}`, {
 			method: 'DELETE',
@@ -285,6 +301,18 @@
 			{#if lp.title}<span class="link-card-title">{lp.title}</span>{/if}
 			{#if lp.description}<span class="link-card-desc">{lp.description}</span>{/if}
 		</div>
+	</a>
+{/snippet}
+
+{#snippet quotedPost(o: any)}
+	<a href="/users/{o.username}" class="quoted-post">
+		<div class="quoted-head">
+			{#if o.avatar_url}<img src={o.avatar_url} alt="" class="quoted-avatar" />{:else}<span class="quoted-avatar quoted-avatar--i">{(o.display_name || o.username || '?').charAt(0).toUpperCase()}</span>{/if}
+			<span class="quoted-name">{o.display_name || o.username}</span>
+			<span class="quoted-handle">@{o.username}</span>
+		</div>
+		<div class="quoted-body prose-feed">{@html o.content}</div>
+		{#if o.media_url}<img src={o.media_url} alt="" class="quoted-media" loading="lazy" />{/if}
 	</a>
 {/snippet}
 
@@ -434,6 +462,13 @@
 								<div class="post-resonance-glow" style="opacity: {Math.min(0.6, (post.likes_count - 4) * 0.05)}"></div>
 							{/if}
 
+							{#if post.reshare_of}
+								<div class="reshare-label">
+									<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5"/></svg>
+									<a href="/users/{post.username}">{post.display_name || post.username}</a> a repartagé
+								</div>
+							{/if}
+
 							<div class="post-inner">
 								<!-- Avatar -->
 								<a href="/users/{post.username}" class="post-avatar-link">
@@ -465,7 +500,9 @@
 										{/if}
 									</div>
 
-									<div class="post-text prose-feed">{@html post.content}</div>
+									{#if post.content}
+										<div class="post-text prose-feed">{@html post.content}</div>
+									{/if}
 
 									{#if post.media_url}
 										<div class="post-media">
@@ -474,6 +511,8 @@
 									{/if}
 
 									{#if post.link_preview}{@render linkCard(post.link_preview)}{/if}
+
+									{#if post.reshared}{@render quotedPost(post.reshared)}{/if}
 
 									<!-- Actions -->
 									<div class="post-actions">
@@ -490,6 +529,16 @@
 											<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
 												<path stroke-linecap="round" stroke-linejoin="round" d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3"/>
 											</svg>
+										</button>
+										<!-- Repartage -->
+										<button
+											onclick={() => toggleReshare(post)}
+											class="post-action-btn post-reshare-btn"
+											class:post-reshare-btn--active={post.reshared_by_me}
+											title="Repartager"
+										>
+											<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5"/></svg>
+											{#if post.reshares_count > 0}<span class="resonance-count">{fmt(post.reshares_count)}</span>{/if}
 										</button>
 										{#if post.replies_count > 0}
 											<button
@@ -1159,6 +1208,29 @@
 .reaction-chip--mine { background: rgba(124,58,237,0.22); border-color: rgba(124,58,237,0.6); }
 .reaction-chip-e { font-size: 0.9rem; }
 .reaction-chip-n { font-weight: 700; color: rgba(255,255,255,0.7); }
+
+/* Repartage */
+.reshare-label {
+	display: flex; align-items: center; gap: 0.4rem;
+	padding: 0 0 0.4rem 0.25rem; font-size: 0.78rem; color: rgba(255,255,255,0.45); font-weight: 600;
+}
+.reshare-label a { color: rgba(255,255,255,0.6); text-decoration: none; }
+.reshare-label a:hover { text-decoration: underline; }
+.post-reshare-btn--active { color: #34d399; }
+.post-reshare-btn--active .resonance-count { color: #34d399; }
+.quoted-post {
+	display: block; margin-top: 0.625rem; padding: 0.7rem 0.85rem; text-decoration: none;
+	border: 1px solid rgba(255,255,255,0.1); border-radius: 14px; background: rgba(255,255,255,0.02);
+	transition: background 0.15s, border-color 0.15s;
+}
+.quoted-post:hover { background: rgba(255,255,255,0.04); border-color: rgba(255,255,255,0.18); }
+.quoted-head { display: flex; align-items: center; gap: 0.4rem; margin-bottom: 0.35rem; }
+.quoted-avatar { width: 20px; height: 20px; border-radius: 999px; object-fit: cover; }
+.quoted-avatar--i { display: inline-flex; align-items: center; justify-content: center; background: rgba(124,58,237,0.3); color: #fff; font-size: 0.65rem; font-weight: 700; }
+.quoted-name { font-weight: 700; color: rgba(255,255,255,0.9); font-size: 0.85rem; }
+.quoted-handle { color: rgba(255,255,255,0.4); font-size: 0.8rem; }
+.quoted-body { font-size: 0.875rem; color: rgba(255,255,255,0.8); }
+.quoted-media { width: 100%; max-height: 200px; object-fit: cover; border-radius: 10px; margin-top: 0.4rem; display: block; }
 .reaction-backdrop { position: fixed; inset: 0; z-index: 40; }
 .reaction-picker {
 	position: absolute;


### PR DESCRIPTION
Repartage des statuts façon retweet : bouton 🔁 (toggle), label 'X a repartagé', original cité. Migration 108 (reshare_of), endpoint toggle, postSelect enrichi (original + compteur + état via COALESCE). Vérifié end-to-end. **Lot 2 bouclé** (Découvrir + points + cartes lien + réactions + repartage).