### PR TITLE
fix(feed): interactions du repartage → l'original (retweet)

### DIFF
--- a/nodyx-core/src/routes/social.ts
+++ b/nodyx-core/src/routes/social.ts
@@ -32,20 +32,23 @@ const AUDIO_MIME_PREFIX = 'audio/'
 
 function postSelect(viewerParam: string | null) {
   return `
-    sp.id, sp.content, sp.media_url, sp.link_preview, sp.reply_to_id,
-    sp.likes_count, sp.replies_count, sp.created_at,
+    sp.id, sp.content, sp.media_url, sp.link_preview, sp.reply_to_id, sp.created_at,
+    -- Interactions calculées sur l'ORIGINAL effectif : un repartage partage les
+    -- réactions/réponses de l'original (façon retweet), pas les siennes propres.
+    (SELECT likes_count   FROM status_posts WHERE id = COALESCE(sp.reshare_of, sp.id)) AS likes_count,
+    (SELECT replies_count FROM status_posts WHERE id = COALESCE(sp.reshare_of, sp.id)) AS replies_count,
     u.id AS author_id, u.username, p.display_name, p.avatar_url,
     ${viewerParam
-      ? `EXISTS(SELECT 1 FROM status_likes sl WHERE sl.user_id = ${viewerParam} AND sl.post_id = sp.id)`
+      ? `EXISTS(SELECT 1 FROM status_likes sl WHERE sl.user_id = ${viewerParam} AND sl.post_id = COALESCE(sp.reshare_of, sp.id))`
       : 'false'} AS liked_by_me,
     ${viewerParam
-      ? `(SELECT emoji FROM status_likes WHERE user_id = ${viewerParam} AND post_id = sp.id)`
+      ? `(SELECT emoji FROM status_likes WHERE user_id = ${viewerParam} AND post_id = COALESCE(sp.reshare_of, sp.id))`
       : 'NULL'} AS my_reaction,
     (SELECT json_object_agg(emoji, jc) FROM (
        SELECT sl2.emoji,
               json_build_object('count', COUNT(*), 'users', json_agg(u2.username ORDER BY u2.username)) AS jc
        FROM status_likes sl2 JOIN users u2 ON u2.id = sl2.user_id
-       WHERE sl2.post_id = sp.id GROUP BY sl2.emoji
+       WHERE sl2.post_id = COALESCE(sp.reshare_of, sp.id) GROUP BY sl2.emoji
      ) t) AS reactions,
     sp.reshare_of,
     (SELECT COUNT(*) FROM status_posts r WHERE r.reshare_of = COALESCE(sp.reshare_of, sp.id))::int AS reshares_count,

--- a/nodyx-frontend/src/routes/feed/+page.svelte
+++ b/nodyx-frontend/src/routes/feed/+page.svelte
@@ -106,7 +106,7 @@
 					posts = [post, ...posts]
 				} else {
 					const parentId = replyTo.id
-					posts = posts.map(p => p.id === parentId
+					posts = posts.map(p => (p.reshare_of || p.id) === parentId
 						? { ...p, replies_count: (p.replies_count ?? 0) + 1 }
 						: p
 					)
@@ -161,12 +161,16 @@
 		return { ...p, my_reaction: next, liked_by_me: !!next, likes_count: Math.max(0, (p.likes_count || 0) + delta), reactions }
 	}
 
+	// Cible effective : sur un repartage, on agit sur l'ORIGINAL (façon retweet).
+	const effId = (p: any) => p.reshare_of || p.id
+
 	async function react(post: any, emoji: string) {
 		pickerFor = null
 		const prev = post.my_reaction || null
 		if (prev === emoji) return removeReaction(post)   // re-cliquer son emoji = retirer
-		posts = posts.map(p => p.id === post.id ? applyReaction(p, prev, emoji) : p)
-		await apiFetch(fetch, `/social/status/${post.id}/react`, {
+		const target = effId(post)
+		posts = posts.map(p => effId(p) === target ? applyReaction(p, prev, emoji) : p)
+		await apiFetch(fetch, `/social/status/${target}/react`, {
 			method: 'POST',
 			headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
 			body: JSON.stringify({ emoji }),
@@ -177,8 +181,9 @@
 		pickerFor = null
 		const prev = post.my_reaction || null
 		if (!prev) return
-		posts = posts.map(p => p.id === post.id ? applyReaction(p, prev, null) : p)
-		await apiFetch(fetch, `/social/status/${post.id}/like`, {
+		const target = effId(post)
+		posts = posts.map(p => effId(p) === target ? applyReaction(p, prev, null) : p)
+		await apiFetch(fetch, `/social/status/${target}/like`, {
 			method: 'DELETE', headers: { Authorization: `Bearer ${token}` },
 		}).catch(() => {})
 	}
@@ -214,6 +219,7 @@
 
 	async function toggleReplies(post: any) {
 		const id = post.id
+		const src = post.reshare_of || post.id   // les réponses viennent de l'original
 		if (repliesOpen[id]) {
 			repliesOpen = { ...repliesOpen, [id]: false }
 			return
@@ -225,7 +231,7 @@
 		}
 		repliesLoading = { ...repliesLoading, [id]: true }
 		try {
-			const res = await apiFetch(fetch, `/social/status/${id}`)
+			const res = await apiFetch(fetch, `/social/status/${src}`)
 			if (res.ok) {
 				const data = await res.json()
 				repliesMap  = { ...repliesMap,  [id]: data.replies ?? [] }
@@ -519,7 +525,7 @@
 										<!-- Reply -->
 										<button
 											onclick={() => {
-												replyTo = post
+												replyTo = post.reshared || post   // répondre cible l'original (repartage)
 												composing = true
 												window.scrollTo({ top: 0, behavior: 'smooth' })
 											}}


### PR DESCRIPTION
Sur un repartage, répondre/réagir visent désormais l'ORIGINAL (façon retweet), et le repartage partage l'état d'interaction de l'original. postSelect calcule les interactions sur COALESCE(reshare_of, id) ; le front cible l'original. Vérifié end-to-end. Plus de réponses/réactions orphelines sur les repartages.