### PR TITLE
feat(e2e): backup de clé chiffré (récupération multi-appareil)

### DIFF
--- a/nodyx-core/src/migrations/109_e2e_key_backup.sql
+++ b/nodyx-core/src/migrations/109_e2e_key_backup.sql
@@ -1,0 +1,14 @@
+-- Migration 109 — Backup de clé E2E (récupération multi-appareil).
+-- Le serveur ne stocke qu'un BLOB OPAQUE : la clé privée chiffrée côté client
+-- avec une clé dérivée de la passphrase de l'utilisateur (PBKDF2 + AES-GCM).
+-- Le serveur reste AVEUGLE : il ne peut jamais lire la clé. Passphrase perdue =
+-- backup inutile (zéro-knowledge, assumé).
+CREATE TABLE IF NOT EXISTS e2e_key_backups (
+  user_id    UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  blob       TEXT        NOT NULL,   -- ciphertext base64 (IV + données chiffrées)
+  salt       TEXT        NOT NULL,   -- base64, sel du KDF
+  kdf        TEXT        NOT NULL DEFAULT 'PBKDF2-SHA256',
+  kdf_iters  INTEGER     NOT NULL DEFAULT 600000,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/nodyx-core/src/routes/users.ts
+++ b/nodyx-core/src/routes/users.ts
@@ -648,4 +648,54 @@ export default async function userRoutes(app: FastifyInstance) {
     }
     return reply.send({ public_key: rows[0].public_key ?? null })
   })
+
+  // ── Backup de clé E2E (récupération multi-appareil) ──────────────────────
+  // Le serveur ne stocke qu'un BLOB OPAQUE : la clé privée chiffrée côté client
+  // par la passphrase de l'user (AES-GCM). Le serveur reste AVEUGLE. Un user
+  // n'accède QU'À son propre backup (isolation par user_id).
+  app.put('/me/key-backup', {
+    preHandler: [rateLimit, requireAuth],
+  }, async (request, reply) => {
+    const me = request.user!.userId
+    const { blob, salt, kdf, kdf_iters } = (request.body ?? {}) as {
+      blob?: string; salt?: string; kdf?: string; kdf_iters?: number
+    }
+    if (!blob || !salt || typeof blob !== 'string' || typeof salt !== 'string') {
+      return reply.code(400).send({ error: 'blob and salt required', code: 'BAD_REQUEST' })
+    }
+    if (blob.length > 8192 || salt.length > 256) {
+      return reply.code(400).send({ error: 'backup too large', code: 'BAD_REQUEST' })
+    }
+    const kdfName = typeof kdf === 'string' ? kdf.slice(0, 50) : 'PBKDF2-SHA256'
+    const iters   = Number.isInteger(kdf_iters) && (kdf_iters as number) > 0
+      ? Math.min(kdf_iters as number, 5_000_000) : 600000
+
+    await db.query(
+      `INSERT INTO e2e_key_backups (user_id, blob, salt, kdf, kdf_iters, updated_at)
+       VALUES ($1, $2, $3, $4, $5, NOW())
+       ON CONFLICT (user_id) DO UPDATE
+         SET blob = EXCLUDED.blob, salt = EXCLUDED.salt, kdf = EXCLUDED.kdf,
+             kdf_iters = EXCLUDED.kdf_iters, updated_at = NOW()`,
+      [me, blob, salt, kdfName, iters]
+    )
+    return reply.send({ ok: true })
+  })
+
+  app.get('/me/key-backup', {
+    preHandler: [rateLimit, requireAuth],
+  }, async (request, reply) => {
+    const me = request.user!.userId
+    const { rows } = await db.query<{ blob: string; salt: string; kdf: string; kdf_iters: number }>(
+      `SELECT blob, salt, kdf, kdf_iters FROM e2e_key_backups WHERE user_id = $1`,
+      [me]
+    )
+    return reply.send({ backup: rows[0] ?? null })
+  })
+
+  app.delete('/me/key-backup', {
+    preHandler: [rateLimit, requireAuth],
+  }, async (request, reply) => {
+    await db.query(`DELETE FROM e2e_key_backups WHERE user_id = $1`, [request.user!.userId])
+    return reply.send({ ok: true })
+  })
 }

--- a/nodyx-frontend/package-lock.json
+++ b/nodyx-frontend/package-lock.json
@@ -46,7 +46,8 @@
         "svelte-check": "4.6.0",
         "tailwindcss": "4.3.1",
         "typescript": "6.0.3",
-        "vite": "^7.3.5"
+        "vite": "^7.3.5",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2262,10 +2263,28 @@
         "@tiptap/extension-list": "3.27.1"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2336,6 +2355,129 @@
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2381,6 +2523,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2415,6 +2567,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -2475,6 +2637,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2660,6 +2829,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
@@ -2737,6 +2913,16 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3370,6 +3556,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3739,6 +3932,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -3791,6 +3991,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -3916,6 +4130,23 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3931,6 +4162,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/totalist": {
@@ -4069,6 +4310,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -4080,6 +4411,23 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "license": "ISC"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",

--- a/nodyx-frontend/package.json
+++ b/nodyx-frontend/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "prepare": "svelte-kit sync || echo ''",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "7.0.1",
@@ -23,7 +24,8 @@
     "svelte-check": "4.6.0",
     "tailwindcss": "4.3.1",
     "typescript": "6.0.3",
-    "vite": "^7.3.5"
+    "vite": "^7.3.5",
+    "vitest": "^4.1.9"
   },
   "dependencies": {
     "@iconify/svelte": "^5.2.2",

--- a/nodyx-frontend/src/lib/components/E2EKeyBackup.svelte
+++ b/nodyx-frontend/src/lib/components/E2EKeyBackup.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+	import { onMount } from 'svelte'
+	import {
+		hasServerBackup, canBackupLocalKey, uploadKeyBackup,
+		restoreKeyBackup, deleteKeyBackup,
+	} from '$lib/e2eBackupClient'
+
+	let { token, mode = 'manage', onDone, onSkip }: {
+		token: string
+		mode?: 'manage' | 'restore'
+		onDone?: () => void
+		onSkip?: () => void
+	} = $props()
+
+	let phrase  = $state('')
+	let phrase2 = $state('')
+	let busy    = $state(false)
+	let error   = $state('')
+	let success = $state('')
+
+	// Manage
+	let backupExists = $state(false)
+	let canBackup    = $state(true)
+	let ready        = $state(false)
+
+	onMount(async () => {
+		if (mode === 'manage') {
+			backupExists = await hasServerBackup(token)
+			canBackup    = await canBackupLocalKey()
+		}
+		ready = true
+	})
+
+	async function setupBackup() {
+		error = ''; success = ''
+		if (phrase.length < 8) { error = 'La phrase doit faire au moins 8 caractères.'; return }
+		if (phrase !== phrase2) { error = 'Les deux phrases ne correspondent pas.'; return }
+		busy = true
+		try {
+			const ok = await uploadKeyBackup(token, phrase)
+			if (ok) {
+				success = 'Sauvegarde activée. Garde précieusement ta phrase : sans elle, aucune récupération possible.'
+				backupExists = true
+				phrase = ''; phrase2 = ''
+			} else {
+				error = 'Échec de la sauvegarde. Réessaie.'
+			}
+		} catch {
+			error = 'Ta clé actuelle ne peut pas être sauvegardée (générée avant cette fonctionnalité).'
+		} finally { busy = false }
+	}
+
+	async function doRestore() {
+		error = ''; success = ''
+		if (!phrase) { error = 'Entre ta phrase de récupération.'; return }
+		busy = true
+		try {
+			const ok = await restoreKeyBackup(token, phrase)
+			if (ok) { success = 'Clé restaurée. Tes messages chiffrés vont réapparaître.'; onDone?.() }
+			else    { error = 'Phrase incorrecte, ou aucune sauvegarde trouvée.' }
+		} catch {
+			error = 'Échec de la restauration.'
+		} finally { busy = false }
+	}
+
+	async function removeBackup() {
+		busy = true; error = ''; success = ''
+		try {
+			if (await deleteKeyBackup(token)) { backupExists = false; success = 'Sauvegarde supprimée.' }
+		} finally { busy = false }
+	}
+</script>
+
+<div class="kb">
+	{#if mode === 'restore'}
+		<div class="kb-head">
+			<span class="kb-icon">🔑</span>
+			<div>
+				<div class="kb-title">Retrouve tes messages chiffrés</div>
+				<div class="kb-sub">Nouvel appareil détecté. Entre ta phrase de récupération pour restaurer ta clé et relire ton historique.</div>
+			</div>
+		</div>
+		<input class="kb-input" type="password" placeholder="Phrase de récupération"
+			bind:value={phrase} onkeydown={(e) => e.key === 'Enter' && doRestore()} autocomplete="off" />
+		{#if error}<div class="kb-error">{error}</div>{/if}
+		{#if success}<div class="kb-success">{success}</div>{/if}
+		<div class="kb-actions">
+			<button class="kb-btn-primary" onclick={doRestore} disabled={busy}>{busy ? '…' : 'Restaurer'}</button>
+			<button class="kb-btn-ghost" onclick={() => onSkip?.()} disabled={busy}>Créer une nouvelle identité</button>
+		</div>
+		<div class="kb-hint">Sans la phrase, l'historique précédent reste illisible (chiffrement de bout en bout).</div>
+
+	{:else}
+		<!-- mode manage -->
+		<div class="kb-head">
+			<span class="kb-icon">🔐</span>
+			<div>
+				<div class="kb-title">Sauvegarde des messages chiffrés</div>
+				<div class="kb-sub">Sauvegarde ta clé E2E, chiffrée par une phrase secrète, pour retrouver tes DMs sur un autre navigateur ou appareil. Le serveur ne voit jamais ta clé.</div>
+			</div>
+			{#if ready}
+				<span class="kb-pill {backupExists ? 'on' : 'off'}">
+					<span class="kb-dot"></span>{backupExists ? 'Active' : 'Inactive'}
+				</span>
+			{/if}
+		</div>
+
+		{#if ready && !canBackup}
+			<div class="kb-warn">
+				Ta clé actuelle a été générée avant cette fonctionnalité et ne peut pas être sauvegardée.
+				Elle deviendra sauvegardable à sa prochaine régénération (nouveau navigateur).
+			</div>
+		{:else if ready}
+			<input class="kb-input" type="password" placeholder="Phrase de récupération (8 caractères min.)"
+				bind:value={phrase} autocomplete="new-password" />
+			<input class="kb-input" type="password" placeholder="Confirme la phrase"
+				bind:value={phrase2} autocomplete="new-password" />
+			{#if error}<div class="kb-error">{error}</div>{/if}
+			{#if success}<div class="kb-success">{success}</div>{/if}
+			<div class="kb-actions">
+				<button class="kb-btn-primary" onclick={setupBackup} disabled={busy}>
+					{busy ? '…' : backupExists ? 'Mettre à jour la phrase' : 'Activer la sauvegarde'}
+				</button>
+				{#if backupExists}
+					<button class="kb-btn-danger" onclick={removeBackup} disabled={busy}>Supprimer</button>
+				{/if}
+			</div>
+			<div class="kb-hint">Choisis une phrase longue et mémorable. Perdue, elle est irrécupérable (zéro-knowledge).</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.kb { display: flex; flex-direction: column; gap: 12px; }
+	.kb-head { display: flex; align-items: flex-start; gap: 12px; }
+	.kb-icon { font-size: 22px; line-height: 1; }
+	.kb-title { font-size: 15px; font-weight: 600; color: #fff; }
+	.kb-sub { font-size: 13px; color: #94a3b8; margin-top: 2px; line-height: 1.45; }
+	.kb-pill { margin-left: auto; display: inline-flex; align-items: center; gap: 6px;
+		padding: 4px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; white-space: nowrap; }
+	.kb-pill.on  { background: rgba(34,197,94,.12);  color: #4ade80; }
+	.kb-pill.off { background: rgba(148,163,184,.12); color: #94a3b8; }
+	.kb-dot { width: 7px; height: 7px; border-radius: 50%; background: currentColor; }
+	.kb-input { width: 100%; padding: 10px 12px; border-radius: 10px;
+		background: rgba(15,23,42,.6); border: 1px solid rgba(148,163,184,.2);
+		color: #f1f5f9; font-size: 14px; outline: none; transition: border-color .15s; }
+	.kb-input:focus { border-color: #6366f1; }
+	.kb-actions { display: flex; gap: 10px; flex-wrap: wrap; }
+	.kb-btn-primary { padding: 9px 16px; border-radius: 10px; border: none; cursor: pointer;
+		font-weight: 600; font-size: 14px; color: #fff;
+		background: linear-gradient(135deg, #6366f1, #a855f7); transition: transform .12s, opacity .12s; }
+	.kb-btn-primary:hover:not(:disabled) { transform: translateY(-1px); }
+	.kb-btn-ghost, .kb-btn-danger { padding: 9px 16px; border-radius: 10px; cursor: pointer;
+		font-weight: 600; font-size: 14px; background: transparent; }
+	.kb-btn-ghost  { border: 1px solid rgba(148,163,184,.3); color: #cbd5e1; }
+	.kb-btn-danger { border: 1px solid rgba(239,68,68,.35); color: #f87171; }
+	.kb-btn-primary:disabled, .kb-btn-ghost:disabled, .kb-btn-danger:disabled { opacity: .5; cursor: default; }
+	.kb-error   { font-size: 13px; color: #f87171; }
+	.kb-success { font-size: 13px; color: #4ade80; }
+	.kb-warn { font-size: 13px; color: #fbbf24; background: rgba(251,191,36,.08);
+		border: 1px solid rgba(251,191,36,.2); border-radius: 10px; padding: 10px 12px; line-height: 1.45; }
+	.kb-hint { font-size: 12px; color: #64748b; line-height: 1.4; }
+</style>

--- a/nodyx-frontend/src/lib/e2e.ts
+++ b/nodyx-frontend/src/lib/e2e.ts
@@ -104,11 +104,13 @@ export async function initKeyPair(): Promise<string> {
     }
   } catch { /* IndexedDB indisponible (navigation privée, etc.) — génère en mémoire */ }
 
-  // Générer une paire ECDH P-256 fraîche
-  // private key non-extractable : le navigateur garantit qu'elle ne sort pas
+  // Générer une paire ECDH P-256 fraîche.
+  // Clé privée EXTRACTABLE : nécessaire pour le backup chiffré par passphrase
+  // (récupération multi-appareil). Elle ne sort jamais en clair — seulement
+  // chiffrée par la passphrase de l'user, le serveur reste aveugle.
   const pair = await crypto.subtle.generateKey(
     { name: 'ECDH', namedCurve: 'P-256' },
-    false,                          // private key non-extractable
+    true,                           // extractable (pour export/backup)
     ['deriveKey', 'deriveBits']
   )
 
@@ -120,6 +122,39 @@ export async function initKeyPair(): Promise<string> {
 
   _keys = keys
   return _jwkToB64(publicKeyJwk)
+}
+
+/**
+ * Exporte la clé privée d'identité en JWK (pour le backup chiffré par passphrase).
+ * Échoue si la clé est non-extractable (anciennes clés générées avant le backup).
+ */
+export async function exportIdentityKeyJwk(): Promise<string> {
+  await initKeyPair()
+  if (!_keys) throw new Error('no key pair')
+  const jwk = await crypto.subtle.exportKey('jwk', _keys.privateKey)
+  return JSON.stringify(jwk)
+}
+
+/** La clé locale peut-elle être sauvegardée (extractable) ? */
+export async function isKeyBackupable(): Promise<boolean> {
+  try { await exportIdentityKeyJwk(); return true } catch { return false }
+}
+
+/**
+ * Restaure une clé d'identité depuis un JWK (backup déchiffré) : importe la clé
+ * privée, dérive la publique, persiste en IndexedDB. Retourne la clé publique b64.
+ */
+export async function restoreIdentityKeyJwk(privateJwkStr: string): Promise<string> {
+  const jwk = JSON.parse(privateJwkStr) as JsonWebKey
+  const privateKey = await crypto.subtle.importKey(
+    'jwk', jwk, { name: 'ECDH', namedCurve: 'P-256' }, true, ['deriveKey', 'deriveBits'],
+  )
+  // Clé publique = même JWK sans la composante privée 'd'.
+  const pubJwk: JsonWebKey = { kty: jwk.kty, crv: jwk.crv, x: jwk.x, y: jwk.y, ext: true, key_ops: [] }
+  const keys: StoredKeys = { id: KEY_ID, privateKey, publicKeyJwk: pubJwk }
+  try { await _saveKeys(keys) } catch { /* IndexedDB indisponible */ }
+  _keys = keys
+  return _jwkToB64(pubJwk)
 }
 
 /** Vérifie si une paire de clés existe localement. */

--- a/nodyx-frontend/src/lib/e2eBackup.test.ts
+++ b/nodyx-frontend/src/lib/e2eBackup.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { encryptKeyBackup, decryptKeyBackup } from './e2eBackup'
+
+// Charge utile représentative : un JWK de clé privée ECDH P-256 (stringifié).
+const SAMPLE_JWK = JSON.stringify({
+	kty: 'EC', crv: 'P-256',
+	d: 'r4Nt7Q_privatecomponent_base64url',
+	x: 'AbCdEf_xcoord', y: 'GhIjKl_ycoord',
+	key_ops: ['deriveKey', 'deriveBits'], ext: true,
+})
+
+describe('e2eBackup — chiffrement de clé par passphrase', () => {
+	it('round-trip : la bonne passphrase restaure la clé à l\'identique', async () => {
+		const backup = await encryptKeyBackup(SAMPLE_JWK, 'ma-phrase-de-recuperation-42')
+		expect(backup.blob).toBeTruthy()
+		expect(backup.salt).toBeTruthy()
+		expect(backup.kdf).toBe('PBKDF2-SHA256')
+		expect(backup.kdf_iters).toBeGreaterThan(100_000)
+
+		const restored = await decryptKeyBackup(backup, 'ma-phrase-de-recuperation-42')
+		expect(restored).toBe(SAMPLE_JWK)
+	})
+
+	it('mauvaise passphrase → null (échec propre, pas de crash)', async () => {
+		const backup = await encryptKeyBackup(SAMPLE_JWK, 'bonne-phrase')
+		const restored = await decryptKeyBackup(backup, 'mauvaise-phrase')
+		expect(restored).toBeNull()
+	})
+
+	it('sel + blob uniques à chaque chiffrement (pas de réutilisation d\'IV/sel)', async () => {
+		const b1 = await encryptKeyBackup(SAMPLE_JWK, 'p')
+		const b2 = await encryptKeyBackup(SAMPLE_JWK, 'p')
+		expect(b1.salt).not.toBe(b2.salt)
+		expect(b1.blob).not.toBe(b2.blob)
+	})
+
+	it('blob altéré → null (AES-GCM authentifié)', async () => {
+		const backup = await encryptKeyBackup(SAMPLE_JWK, 'p')
+		const tampered = { ...backup, blob: backup.blob.slice(0, -4) + 'AAAA' }
+		const restored = await decryptKeyBackup(tampered, 'p')
+		expect(restored).toBeNull()
+	})
+
+	it('passphrase vide → rejet', async () => {
+		await expect(encryptKeyBackup(SAMPLE_JWK, '')).rejects.toThrow()
+	})
+})

--- a/nodyx-frontend/src/lib/e2eBackup.ts
+++ b/nodyx-frontend/src/lib/e2eBackup.ts
@@ -1,0 +1,70 @@
+// ── Backup de clé E2E chiffré par passphrase ────────────────────────────────
+// Sauvegarde la clé privée ECDH (exportée en JWK) chiffrée avec une clé dérivée
+// de la passphrase de l'utilisateur (PBKDF2-SHA256 → AES-256-GCM). Le serveur ne
+// stocke qu'un blob opaque (cf. /api/v1/users/me/key-backup). Serveur AVEUGLE.
+// Module pur (WebCrypto) → fonctionne navigateur ET Node (testable).
+
+const KDF = 'PBKDF2-SHA256'
+const DEFAULT_ITERS = 600_000
+
+export interface KeyBackup {
+  blob:      string   // base64 : IV(12) + ciphertext AES-GCM
+  salt:      string   // base64 : sel PBKDF2 (16 octets)
+  kdf:       string
+  kdf_iters: number
+}
+
+function toB64(bytes: Uint8Array): string {
+  let s = ''
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i])
+  return btoa(s)
+}
+
+function fromB64(str: string): Uint8Array {
+  const bin = atob(str)
+  const arr = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i)
+  return arr
+}
+
+async function deriveBackupKey(passphrase: string, salt: Uint8Array, iters: number): Promise<CryptoKey> {
+  const baseKey = await crypto.subtle.importKey(
+    'raw', new TextEncoder().encode(passphrase) as BufferSource, 'PBKDF2', false, ['deriveKey'],
+  )
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt: salt as BufferSource, iterations: iters, hash: 'SHA-256' },
+    baseKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  )
+}
+
+/** Chiffre une clé privée (JWK stringifié) avec la passphrase → blob de backup. */
+export async function encryptKeyBackup(privateKeyJwk: string, passphrase: string): Promise<KeyBackup> {
+  if (!passphrase) throw new Error('passphrase required')
+  const salt = crypto.getRandomValues(new Uint8Array(16))
+  const iv   = crypto.getRandomValues(new Uint8Array(12))
+  const key  = await deriveBackupKey(passphrase, salt, DEFAULT_ITERS)
+  const ct   = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv }, key, new TextEncoder().encode(privateKeyJwk),
+  )
+  const combined = new Uint8Array(iv.length + ct.byteLength)
+  combined.set(iv, 0)
+  combined.set(new Uint8Array(ct), iv.length)
+  return { blob: toB64(combined), salt: toB64(salt), kdf: KDF, kdf_iters: DEFAULT_ITERS }
+}
+
+/** Déchiffre un blob de backup. Retourne le JWK, ou null si mauvaise passphrase. */
+export async function decryptKeyBackup(backup: KeyBackup, passphrase: string): Promise<string | null> {
+  try {
+    const combined = fromB64(backup.blob)
+    const iv  = combined.slice(0, 12)
+    const ct  = combined.slice(12)
+    const key = await deriveBackupKey(passphrase, fromB64(backup.salt), backup.kdf_iters || DEFAULT_ITERS)
+    const pt  = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ct)
+    return new TextDecoder().decode(pt)
+  } catch {
+    return null   // mauvaise passphrase ou blob corrompu : échec propre
+  }
+}

--- a/nodyx-frontend/src/lib/e2eBackupClient.ts
+++ b/nodyx-frontend/src/lib/e2eBackupClient.ts
@@ -1,0 +1,74 @@
+// ── Liaison backup de clé E2E : crypto (e2eBackup) + API (/users/me/key-backup) ──
+// Orchestration côté client. Le serveur ne reçoit qu'un blob opaque.
+import {
+	exportIdentityKeyJwk, restoreIdentityKeyJwk, registerPublicKey, hasKeyPair,
+} from './e2e'
+import { encryptKeyBackup, decryptKeyBackup, type KeyBackup } from './e2eBackup'
+
+function authHeaders(token: string, json = false): Record<string, string> {
+	const h: Record<string, string> = { Authorization: `Bearer ${token}` }
+	if (json) h['Content-Type'] = 'application/json'
+	return h
+}
+
+/** Récupère le blob de backup du user, ou null s'il n'en a pas. */
+export async function getServerBackup(token: string): Promise<KeyBackup | null> {
+	try {
+		const res = await fetch('/api/v1/users/me/key-backup', { headers: authHeaders(token) })
+		if (!res.ok) return null
+		const j = await res.json()
+		return (j.backup as KeyBackup) ?? null
+	} catch {
+		return null
+	}
+}
+
+/** Un backup existe-t-il côté serveur ? (détection nouvel appareil) */
+export async function hasServerBackup(token: string): Promise<boolean> {
+	return !!(await getServerBackup(token))
+}
+
+/** La clé locale est-elle sauvegardable (extractable) ? */
+export async function canBackupLocalKey(): Promise<boolean> {
+	try { await exportIdentityKeyJwk(); return true } catch { return false }
+}
+
+/**
+ * Sauvegarde la clé locale, chiffrée par la passphrase, sur le serveur.
+ * Échoue si la clé locale est non-extractable (ancienne clé pré-backup).
+ */
+export async function uploadKeyBackup(token: string, passphrase: string): Promise<boolean> {
+	const jwk = await exportIdentityKeyJwk()
+	const backup = await encryptKeyBackup(jwk, passphrase)
+	const res = await fetch('/api/v1/users/me/key-backup', {
+		method: 'PUT', headers: authHeaders(token, true), body: JSON.stringify(backup),
+	})
+	return res.ok
+}
+
+/**
+ * Restaure la clé depuis le backup serveur avec la passphrase.
+ * Retourne false si pas de backup ou mauvaise passphrase (échec propre).
+ */
+export async function restoreKeyBackup(token: string, passphrase: string): Promise<boolean> {
+	const backup = await getServerBackup(token)
+	if (!backup) return false
+	const jwk = await decryptKeyBackup(backup, passphrase)
+	if (!jwk) return false   // mauvaise passphrase
+	await restoreIdentityKeyJwk(jwk)
+	// Ré-enregistre la clé publique restaurée pour que les pairs l'utilisent.
+	await registerPublicKey(token)
+	return true
+}
+
+/** Supprime le backup serveur (réinitialisation). */
+export async function deleteKeyBackup(token: string): Promise<boolean> {
+	const res = await fetch('/api/v1/users/me/key-backup', { method: 'DELETE', headers: authHeaders(token) })
+	return res.ok
+}
+
+/** Faut-il proposer une restauration ? (pas de clé locale mais un backup existe) */
+export async function shouldOfferRestore(token: string): Promise<boolean> {
+	if (await hasKeyPair()) return false
+	return hasServerBackup(token)
+}

--- a/nodyx-frontend/src/routes/dm/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/dm/[id]/+page.svelte
@@ -8,6 +8,8 @@
 		encryptDM, decryptDM, loadEsyKey, barbarizeVisual,
 		type E2EStatus, type EsyKey
 	} from '$lib/e2e'
+	import { shouldOfferRestore } from '$lib/e2eBackupClient'
+	import E2EKeyBackup from '$lib/components/E2EKeyBackup.svelte'
 	import ReactionTooltip from '$lib/components/ReactionTooltip.svelte'
 	import EmojiPicker from '$lib/components/EmojiPicker.svelte'
 	import MessageBody from '$lib/components/MessageBody.svelte'
@@ -93,10 +95,21 @@
 	let esyFingerprint: string | null = $state(null)
 	// Animation d'envoi — texte "barbarisé" affiché brièvement avant envoi
 	let sendingVisual: string | null = $state(null)
+	// Restauration de clé sur nouvel appareil (backup serveur présent, pas de clé locale)
+	let showRestore = $state(false)
+	let restoreDismissed = $state(false)
 
 	async function initE2E() {
 		if (!conversation) return
 		try {
+			// 0. Nouvel appareil ? backup serveur présent mais pas de clé locale →
+			//    proposer la restauration AVANT de générer une clé neuve (sinon on
+			//    perdrait l'accès à l'historique chiffré).
+			if (!restoreDismissed && await shouldOfferRestore(data.token)) {
+				showRestore = true
+				return
+			}
+
 			// 1. Init keypair local + enregistrer sur le serveur
 			const registered = await registerPublicKey(data.token)
 			if (!registered) {
@@ -1005,6 +1018,19 @@
      ondragleave={onDragLeave}
      ondrop={onDrop}>
 
+	{#if showRestore}
+		<div class="kb-overlay">
+			<div class="kb-modal">
+				<E2EKeyBackup
+					token={data.token}
+					mode="restore"
+					onDone={() => { showRestore = false; initE2E() }}
+					onSkip={() => { restoreDismissed = true; showRestore = false; initE2E() }}
+				/>
+			</div>
+		</div>
+	{/if}
+
 	{#if isDraggingFile}
 		<div class="dm-drop-overlay">
 			<div class="dm-drop-card">
@@ -1661,6 +1687,28 @@
 </div>
 
 <style>
+/* ── Overlay de restauration de clé E2E (nouvel appareil) ─────────────────── */
+.kb-overlay {
+	position: absolute;
+	inset: 0;
+	z-index: 40;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: rgba(2, 6, 23, .72);
+	backdrop-filter: blur(4px);
+	padding: 20px;
+}
+.kb-modal {
+	width: 100%;
+	max-width: 460px;
+	background: #0f172a;
+	border: 1px solid rgba(148, 163, 184, .18);
+	border-radius: 16px;
+	padding: 22px;
+	box-shadow: 0 24px 60px rgba(0, 0, 0, .5);
+}
+
 /* ── Drag & drop image overlay ────────────────────────────────────────────── */
 .dm-drop-overlay {
 	position: absolute;

--- a/nodyx-frontend/src/routes/settings/+page.svelte
+++ b/nodyx-frontend/src/routes/settings/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import NetworkDoctor from '$lib/components/NetworkDoctor.svelte';
+    import E2EKeyBackup from '$lib/components/E2EKeyBackup.svelte';
     import { page } from '$app/stores';
 
     import { PUBLIC_API_URL, PUBLIC_SIGNET_URL } from '$env/static/public';
@@ -901,6 +902,13 @@
                     {tFn('settings.security.2fa.privacy')}
                 </p>
             </div>
+
+            <!-- Sauvegarde de clé E2E (récupération multi-appareil) -->
+            {#if ($page.data as any).token}
+            <div class="s-card">
+                <E2EKeyBackup token={($page.data as any).token} mode="manage" />
+            </div>
+            {/if}
         </div>
         {/if}
 

--- a/nodyx-frontend/vitest.config.ts
+++ b/nodyx-frontend/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+// Config Vitest dédiée (séparée de vite.config.ts pour ne pas toucher au build
+// SvelteKit). Environnement node : suffisant pour les modules purs (WebCrypto).
+export default defineConfig({
+	test: {
+		environment: 'node',
+		include: ['src/**/*.test.ts'],
+	},
+})


### PR DESCRIPTION
## Pourquoi

Incident : les DMs E2E affichent \"Unable to decrypt\" dès qu'on change de navigateur. Cause : la clé privée ECDH vit dans un seul navigateur (IndexedDB), jamais sauvegardée. Nouveau navigateur = clé neuve = tout l'historique illisible (ECDH statique, pas de versioning).

## Quoi

Backup de clé chiffré par passphrase (modèle Signal PIN), serveur aveugle :
1. L'utilisateur définit une phrase de récupération (jamais envoyée).
2. La clé privée est chiffrée côté client (PBKDF2-SHA256 600k → AES-256-GCM).
3. Le blob opaque est stocké côté serveur (illisible pour lui).
4. Sur un nouvel appareil : entrer la phrase → restaurer la clé → relire l'historique.

## Détail

- **Migration 109** : table `e2e_key_backups` (blob, salt, kdf, iters), `ON DELETE CASCADE`.
- **Routes** `PUT/GET/DELETE /api/v1/users/me/key-backup`, isolées par `user_id` (un user ne lit que son propre backup, vérifié en live).
- **Crypto** `e2eBackup.ts` + **5 tests Vitest** : round-trip, mauvaise passphrase → null, sel unique, blob altéré → null, passphrase vide → rejet.
- **e2e.ts** : clé identité désormais extractable (nécessaire au backup) + `exportIdentityKeyJwk` / `restoreIdentityKeyJwk`.
- **UI** : section Sécurité (définir/mettre à jour/supprimer la phrase) + écran de restauration dans le flux DM, proposé AVANT toute génération de clé neuve sur un nouvel appareil.

## Compatibilité Double Ratchet

Le mécanisme passphrase → blob chiffré → table backup est réutilisable plus tard pour sauvegarder la clé d'identité long-terme et l'état des sessions ratchet. Serveur aveugle + ESY Barbare conservés.

## Limites assumées

- Zéro-knowledge : passphrase perdue = backup irrécupérable (indiqué à l'user).
- Les clés générées AVANT ce PR sont non-extractables : non-sauvegardables jusqu'à régénération.
- L'historique déjà perdu sur un nouveau navigateur ne revient que sur le navigateur d'origine.