### PR TITLE
fix(e2e): section dédiée Messages chiffrés + cas non-extractable actionnable

### DIFF
--- a/nodyx-frontend/src/lib/components/E2EKeyBackup.svelte
+++ b/nodyx-frontend/src/lib/components/E2EKeyBackup.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte'
 	import {
 		hasServerBackup, canBackupLocalKey, uploadKeyBackup,
-		restoreKeyBackup, deleteKeyBackup,
+		restoreKeyBackup, deleteKeyBackup, regenerateKey,
 	} from '$lib/e2eBackupClient'
 
 	let { token, mode = 'manage', onDone, onSkip }: {
@@ -22,6 +22,7 @@
 	let backupExists = $state(false)
 	let canBackup    = $state(true)
 	let ready        = $state(false)
+	let confirmRegen = $state(false)
 
 	onMount(async () => {
 		if (mode === 'manage') {
@@ -69,6 +70,16 @@
 			if (await deleteKeyBackup(token)) { backupExists = false; success = 'Sauvegarde supprimée.' }
 		} finally { busy = false }
 	}
+
+	async function doRegenerate() {
+		busy = true; error = ''; success = ''
+		try {
+			if (await regenerateKey(token)) {
+				canBackup = true; confirmRegen = false
+				success = 'Nouvelle clé générée. Définis maintenant ta phrase de récupération.'
+			} else { error = 'Échec de la régénération.' }
+		} finally { busy = false }
+	}
 </script>
 
 <div class="kb">
@@ -108,8 +119,27 @@
 		{#if ready && !canBackup}
 			<div class="kb-warn">
 				Ta clé actuelle a été générée avant cette fonctionnalité et ne peut pas être sauvegardée.
-				Elle deviendra sauvegardable à sa prochaine régénération (nouveau navigateur).
+				Tu peux générer une nouvelle clé sauvegardable maintenant.
 			</div>
+			{#if error}<div class="kb-error">{error}</div>{/if}
+			{#if !confirmRegen}
+				<div class="kb-actions">
+					<button class="kb-btn-primary" onclick={() => confirmRegen = true} disabled={busy}>
+						Générer une clé sauvegardable
+					</button>
+				</div>
+			{:else}
+				<div class="kb-warn">
+					La nouvelle clé remplacera l'actuelle : les messages chiffrés <strong>sur cet appareil</strong>
+					avec l'ancienne clé deviendront illisibles. Tes futurs messages, eux, seront sauvegardables.
+				</div>
+				<div class="kb-actions">
+					<button class="kb-btn-danger" onclick={doRegenerate} disabled={busy}>
+						{busy ? '…' : 'Confirmer, générer la nouvelle clé'}
+					</button>
+					<button class="kb-btn-ghost" onclick={() => confirmRegen = false} disabled={busy}>Annuler</button>
+				</div>
+			{/if}
 		{:else if ready}
 			<input class="kb-input" type="password" placeholder="Phrase de récupération (8 caractères min.)"
 				bind:value={phrase} autocomplete="new-password" />

--- a/nodyx-frontend/src/lib/e2e.ts
+++ b/nodyx-frontend/src/lib/e2e.ts
@@ -157,6 +157,30 @@ export async function restoreIdentityKeyJwk(privateJwkStr: string): Promise<stri
   return _jwkToB64(pubJwk)
 }
 
+/**
+ * Régénère une paire de clés fraîche (extractable, donc sauvegardable).
+ * ATTENTION : remplace la clé locale → l'historique chiffré avec l'ancienne clé
+ * sur cet appareil devient illisible. À n'appeler qu'avec confirmation explicite.
+ */
+export async function regenerateKeyPair(token: string): Promise<string> {
+  _keys = null
+  if (browser) {
+    try {
+      const db = await _openDB()
+      await new Promise<void>((resolve, reject) => {
+        const tx  = db.transaction(STORE, 'readwrite')
+        const req = tx.objectStore(STORE).delete(KEY_ID)
+        req.onsuccess = () => { resolve(); db.close() }
+        req.onerror   = () => { reject(req.error); db.close() }
+      })
+    } catch { /* IndexedDB indisponible */ }
+    try { localStorage.removeItem('nodyx_e2e_registered_key') } catch { /* ignore */ }
+  }
+  const pub = await initKeyPair()   // nouvelle clé extractable
+  await registerPublicKey(token)    // ré-enregistre la nouvelle clé publique
+  return pub
+}
+
 /** Vérifie si une paire de clés existe localement. */
 export async function hasKeyPair(): Promise<boolean> {
   if (!browser) return false

--- a/nodyx-frontend/src/lib/e2eBackupClient.ts
+++ b/nodyx-frontend/src/lib/e2eBackupClient.ts
@@ -2,6 +2,7 @@
 // Orchestration côté client. Le serveur ne reçoit qu'un blob opaque.
 import {
 	exportIdentityKeyJwk, restoreIdentityKeyJwk, registerPublicKey, hasKeyPair,
+	regenerateKeyPair,
 } from './e2e'
 import { encryptKeyBackup, decryptKeyBackup, type KeyBackup } from './e2eBackup'
 
@@ -71,4 +72,12 @@ export async function deleteKeyBackup(token: string): Promise<boolean> {
 export async function shouldOfferRestore(token: string): Promise<boolean> {
 	if (await hasKeyPair()) return false
 	return hasServerBackup(token)
+}
+
+/**
+ * Régénère une clé extractable (sauvegardable). Remplace la clé locale →
+ * l'historique chiffré sur cet appareil devient illisible. Confirmation requise.
+ */
+export async function regenerateKey(token: string): Promise<boolean> {
+	try { await regenerateKeyPair(token); return true } catch { return false }
 }

--- a/nodyx-frontend/src/routes/dm/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/dm/[id]/+page.svelte
@@ -1262,6 +1262,15 @@
 						</div>
 					{/if}
 
+					<!-- Réglages du chiffrement (sauvegarde / récupération de clé) -->
+					<a href="/settings?section=encryption"
+						class="p-1.5 rounded-lg transition-colors hover:bg-white/5 text-gray-400 hover:text-gray-200 shrink-0"
+						title="Sauvegarde des messages chiffrés">
+						<svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+							<rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+						</svg>
+					</a>
+
 					<!-- Bouton inviter (1:1 → convertir en groupe) -->
 					<div class="relative shrink-0">
 						<button

--- a/nodyx-frontend/src/routes/settings/+page.svelte
+++ b/nodyx-frontend/src/routes/settings/+page.svelte
@@ -137,6 +137,17 @@
         }
     })
 
+    // Deep-link ?section=xxx (ex: bouton « Paramètres » depuis les DM)
+    $effect(() => {
+        const s = $page.url.searchParams.get('section')
+        if (s) {
+            activeSection = s
+            const url = new URL(window.location.href)
+            url.searchParams.delete('section')
+            window.history.replaceState({}, '', url)
+        }
+    })
+
     // Charge le link au premier passage sur la section
     $effect(() => {
         if (activeSection === 'connected-accounts' && !twitchLoaded) {
@@ -525,6 +536,16 @@
                 {/if}
             </button>
 
+            <button class="sb-item {activeSection === 'encryption' ? 'active' : ''}"
+                    onclick={() => activeSection = 'encryption'}>
+                <span class="sb-icon" style="background: rgba(99,102,241,0.12); color: #818cf8">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+                    </svg>
+                </span>
+                <span class="sb-label">Messages chiffrés</span>
+            </button>
+
             <button class="sb-item {activeSection === 'signet' ? 'active' : ''}"
                     onclick={() => activeSection = 'signet'}>
                 <span class="sb-icon" style="background: rgba(251,191,36,0.1); color: #fbbf24">
@@ -902,8 +923,24 @@
                     {tFn('settings.security.2fa.privacy')}
                 </p>
             </div>
+        </div>
+        {/if}
 
-            <!-- Sauvegarde de clé E2E (récupération multi-appareil) -->
+        <!-- ═══ MESSAGES CHIFFRÉS (sauvegarde de clé E2E) ════════════════════ -->
+        {#if activeSection === 'encryption' && $page.data.user}
+        <div class="s-pane" style="--accent: #818cf8; --accent-bg: rgba(99,102,241,0.08); --accent-border: rgba(99,102,241,0.2)">
+            <div class="s-pane-header">
+                <div class="s-pane-icon" style="background: var(--accent-bg); border-color: var(--accent-border); color: var(--accent)">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
+                        <rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+                    </svg>
+                </div>
+                <div>
+                    <h2 class="s-pane-title">Messages chiffrés</h2>
+                    <p class="s-pane-desc">Sauvegarde et récupération de ta clé de chiffrement de bout en bout.</p>
+                </div>
+            </div>
+
             {#if ($page.data as any).token}
             <div class="s-card">
                 <E2EKeyBackup token={($page.data as any).token} mode="manage" />


### PR DESCRIPTION
Suite de #141. Retours UX de test :

1. **Mauvais endroit** : le bloc sauvegarde apparaissait dans le panneau « Double auth (2FA) ». → Section nav dédiée **Messages chiffrés** sous Sécurité.
2. **Rien à faire** quand la clé locale est non-extractable (générée avant la feature) : seul un avertissement s'affichait. → Bouton **« Générer une clé sauvegardable »** avec confirmation explicite (l'historique chiffré sur cet appareil devient illisible, les futurs messages seront sauvegardables).
3. **Pas de raccourci depuis les DM** : ajout d'un bouton réglages-chiffrement dans le header DM → deep-link `/settings?section=encryption`.

Détail technique : `regenerateKeyPair()` (efface la clé locale + génère une clé extractable + ré-enregistre la clé publique), deep-link `?section=` dans settings.

svelte-check 0 erreur, build OK, déployé.