### PR TITLE
fix(e2e): restauration possible même quand l'appareil a déjà une clé

### DIFF
--- a/nodyx-frontend/src/lib/components/E2EKeyBackup.svelte
+++ b/nodyx-frontend/src/lib/components/E2EKeyBackup.svelte
@@ -25,6 +25,25 @@
 	let confirmRegen = $state(false)
 	let showPhrase   = $state(false)
 	let copied       = $state(false)
+	// Restauration depuis les réglages (device qui a déjà une clé différente)
+	let restoreMode  = $state(false)
+	let rPhrase      = $state('')
+	let rMsg         = $state('')
+
+	async function restoreHere() {
+		rMsg = ''
+		if (!rPhrase) { rMsg = 'Entre ta phrase de récupération.'; return }
+		busy = true
+		try {
+			const ok = await restoreKeyBackup(token, rPhrase)
+			if (ok) {
+				rMsg = '✓ Clé restaurée. Recharge ta conversation : tes messages chiffrés avec cette clé vont réapparaître.'
+				restoreMode = false; rPhrase = ''
+			} else {
+				rMsg = 'Phrase incorrecte, ou sauvegarde introuvable.'
+			}
+		} finally { busy = false }
+	}
 
 	// Générateur : mots simples et concrets, faciles à mémoriser une fois assemblés.
 	const WORDS = [
@@ -152,6 +171,28 @@
 		</div>
 		{/if}
 
+		{#if ready && backupExists}
+			<div class="kb-restore-box">
+				<div class="kb-restore-head">
+					<span>♻️</span>
+					<span>Tu as une sauvegarde. Sur un autre appareil, ou si tes messages chiffrés ne s'affichent pas ici, restaure ta clé.</span>
+				</div>
+				{#if !restoreMode}
+					<div class="kb-actions">
+						<button class="kb-btn-soft" type="button" onclick={() => { restoreMode = true; rMsg = '' }}>Restaurer ma clé sur cet appareil</button>
+					</div>
+				{:else}
+					<input class="kb-input" type="password" placeholder="Ta phrase de récupération"
+						bind:value={rPhrase} onkeydown={(e) => e.key === 'Enter' && restoreHere()} autocomplete="off" />
+					<div class="kb-actions">
+						<button class="kb-btn-primary" type="button" onclick={restoreHere} disabled={busy}>{busy ? '…' : 'Restaurer'}</button>
+						<button class="kb-btn-ghost" type="button" onclick={() => { restoreMode = false; rPhrase = '' }} disabled={busy}>Annuler</button>
+					</div>
+				{/if}
+				{#if rMsg}<div class={rMsg.startsWith('✓') ? 'kb-success' : 'kb-error'}>{rMsg}</div>{/if}
+			</div>
+		{/if}
+
 		{#if ready && !canBackup}
 			<div class="kb-note">
 				Ta clé a été créée avant cette fonctionnalité : elle n'est pas encore sauvegardable.
@@ -271,4 +312,9 @@
 	.kb-eye { flex-shrink: 0; padding: 0 12px; border-radius: 10px; cursor: pointer;
 		font-size: 13px; font-weight: 600; color: #94a3b8;
 		background: transparent; border: 1px solid rgba(148,163,184,.2); }
+	.kb-restore-box { display: flex; flex-direction: column; gap: 10px;
+		background: rgba(34,197,94,.06); border: 1px solid rgba(34,197,94,.2);
+		border-radius: 12px; padding: 12px 14px; }
+	.kb-restore-head { display: flex; gap: 10px; font-size: 13px; color: #bbf7d0; line-height: 1.45; }
+	.kb-restore-head span:first-child { flex-shrink: 0; }
 </style>

--- a/nodyx-frontend/src/routes/dm/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/dm/[id]/+page.svelte
@@ -104,6 +104,8 @@
 	// Garde-fou avant envoi : alerte si pas de sauvegarde de clé
 	let showSendGuard = $state(false)
 	let sendGuardAck  = $state(false)
+	// Des messages n'ont pas pu être déchiffrés (clé locale ne correspond pas)
+	let decryptFailed = $derived(messages.some((m) => m._decryptFailed))
 
 	function dismissE2eBanner() {
 		showE2eBanner = false
@@ -1420,7 +1422,21 @@
 			</div>
 		{/if}
 
-		{#if showE2eBanner}
+		{#if hasBackup && decryptFailed}
+		<div class="e2e-banner">
+			<div class="e2e-banner-icon">🔑</div>
+			<div class="e2e-banner-body">
+				<div class="e2e-banner-title">Certains messages ne s'affichent pas ici</div>
+				<div class="e2e-banner-text">
+					Cet appareil n'a pas la bonne clé. Tu as une sauvegarde : restaure-la avec ta phrase
+					de récupération pour déchiffrer tes conversations.
+				</div>
+			</div>
+			<div class="e2e-banner-actions">
+				<button class="e2e-banner-cta" type="button" onclick={() => showRestore = true}>Restaurer ma clé</button>
+			</div>
+		</div>
+		{:else if showE2eBanner}
 		<div class="e2e-banner">
 			<div class="e2e-banner-icon">🛡️</div>
 			<div class="e2e-banner-body">


### PR DESCRIPTION
## Le bug

La restauration n'était proposée que si **aucune** clé locale n'existait (`shouldOfferRestore` → `if hasKeyPair() return false`). Un appareil qui avait déjà généré une clé (ex : test antérieur, ou Chrome utilisé avant le backup) gardait sa clé, ne correspondait pas au backup, échouait à déchiffrer, et **aucun moyen de forcer la restauration** n'existait.

Cas réel : Firefox (clé sauvegardée) → Chrome (clé préexistante différente) = « Impossible de déchiffrer », sans issue.

## Le fix

- **Settings → Messages chiffrés** : bouton **« Restaurer ma clé sur cet appareil »** dès qu'un backup existe, quelle que soit la clé locale.
- **DM** : si des messages échouent au déchiffrement ET qu'un backup existe → bandeau **« Restaurer ma clé »** qui ouvre directement le flux de restauration.

## Note

Les messages chiffrés **avant** la création du backup (clés jamais sauvegardées) restent définitivement illisibles : c'est inhérent au E2E. Le backup protège tout ce qui suit sa création.

svelte-check 0 erreur, tests crypto 5/5, build OK, déployé.