### PR TITLE
feat(p2p): nodyx-gossip — découverte de pairs par gossip, zéro dépendance

### DIFF
--- a/nodyx-p2p/Cargo.lock
+++ b/nodyx-p2p/Cargo.lock
@@ -1734,6 +1734,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nodyx-gossip"
+version = "0.1.0"
+
+[[package]]
 name = "nodyx-relay"
 version = "0.1.4"
 dependencies = [

--- a/nodyx-p2p/Cargo.toml
+++ b/nodyx-p2p/Cargo.toml
@@ -3,5 +3,6 @@ members = [
     "crates/nexus-relay",
     "crates/nexus-turn",
     "crates/nodyx-server",
+    "crates/nodyx-gossip",
 ]
 resolver = "2"

--- a/nodyx-p2p/crates/nodyx-gossip/Cargo.toml
+++ b/nodyx-p2p/crates/nodyx-gossip/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "nodyx-gossip"
+version = "0.1.0"
+edition = "2021"
+description = "Decouverte de pairs Nodyx par gossip (anti-entropie epidemique). Zero dependance, std uniquement."
+
+[[bin]]
+name = "nodyx-gossip"
+path = "src/main.rs"
+
+[dependencies]
+# Zero dependance. std uniquement. C'est l'ADN Nodyx : pas de boite noire, pas de silo.
+# (Le profil release optimise est defini au niveau du workspace.)

--- a/nodyx-p2p/crates/nodyx-gossip/src/main.rs
+++ b/nodyx-p2p/crates/nodyx-gossip/src/main.rs
@@ -1,0 +1,47 @@
+//! nodyx-gossip : decouverte de pairs Nodyx par gossip. Zero dependance.
+//!
+//! Usage :
+//!   nodyx-gossip --slug <slug> --port <port> [--bootstrap addr1,addr2,...]
+//!
+//! Demo : lancer 3 noeuds ; B et C ne connaissent que A au demarrage, puis se
+//! decouvrent mutuellement par gossip. On coupe A : B et C continuent a se voir.
+
+mod node;
+mod protocol;
+
+use node::Node;
+
+fn main() -> std::io::Result<()> {
+    let mut slug: Option<String> = None;
+    let mut port: Option<u16> = None;
+    let mut bootstrap: Vec<String> = Vec::new();
+
+    let mut args = std::env::args().skip(1);
+    while let Some(a) = args.next() {
+        match a.as_str() {
+            "--slug" => slug = args.next(),
+            "--port" => port = args.next().and_then(|p| p.parse().ok()),
+            "--bootstrap" => {
+                if let Some(v) = args.next() {
+                    bootstrap = v.split(',').filter(|s| !s.is_empty()).map(String::from).collect();
+                }
+            }
+            "-h" | "--help" => {
+                println!("nodyx-gossip --slug <slug> --port <port> [--bootstrap addr1,addr2]");
+                return Ok(());
+            }
+            other => eprintln!("argument ignore: {other}"),
+        }
+    }
+
+    let slug = slug.unwrap_or_else(|| {
+        eprintln!("erreur: --slug est requis");
+        std::process::exit(2);
+    });
+    let port = port.unwrap_or_else(|| {
+        eprintln!("erreur: --port est requis");
+        std::process::exit(2);
+    });
+
+    Node::bind(slug, port, bootstrap)?.run()
+}

--- a/nodyx-p2p/crates/nodyx-gossip/src/node.rs
+++ b/nodyx-p2p/crates/nodyx-gossip/src/node.rs
@@ -1,0 +1,178 @@
+//! Noeud de decouverte par gossip. std uniquement : un socket UDP, deux fils.
+//!
+//! Anti-entropie epidemique : a chaque tour, le noeud envoie "voici qui je suis
+//! + tous ceux que je connais" a quelques pairs au hasard. L'info se propage
+//! sans aucun serveur central. Les noeuds qui ne se rafraichissent plus
+//! vieillissent et disparaissent (auto-guerison).
+
+use crate::protocol::{decode_gossip, encode_gossip, PeerInfo};
+use std::collections::HashMap;
+use std::net::UdpSocket;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const GOSSIP_INTERVAL: Duration = Duration::from_secs(2);
+const PEER_TTL_SECS: u64 = 15; // un noeud non rafraichi depuis 15s est considere mort
+const FANOUT: usize = 3; // nombre de pairs contactes a chaque tour
+
+pub fn now_secs() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()
+}
+
+/// PRNG minimal (xorshift64). Fait maison, pas de crate `rand`.
+fn xorshift(state: &mut u64) -> u64 {
+    let mut x = *state;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    *state = x;
+    x
+}
+
+fn gen_node_id() -> String {
+    let t = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64;
+    let pid = std::process::id() as u64;
+    let mut s = (t ^ pid.wrapping_mul(0x9E37_79B9_7F4A_7C15)) | 1;
+    s ^= s << 13;
+    s ^= s >> 7;
+    s ^= s << 17;
+    format!("{s:016x}")
+}
+
+fn shuffle(v: &mut [String], rng: &mut u64) {
+    for i in (1..v.len()).rev() {
+        let j = (xorshift(rng) as usize) % (i + 1);
+        v.swap(i, j);
+    }
+}
+
+/// Fusionne des pairs entrants dans la table locale.
+/// On ne s'ajoute jamais soi-meme ; on ne garde que l'info la plus fraiche.
+fn merge(table: &mut HashMap<String, PeerInfo>, me_id: &str, incoming: impl Iterator<Item = PeerInfo>) {
+    for p in incoming {
+        if p.node_id == me_id {
+            continue;
+        }
+        match table.get(&p.node_id) {
+            Some(existing) if existing.heartbeat >= p.heartbeat => {}
+            _ => {
+                table.insert(p.node_id.clone(), p);
+            }
+        }
+    }
+}
+
+pub struct Node {
+    me: PeerInfo,
+    peers: Arc<Mutex<HashMap<String, PeerInfo>>>,
+    socket: UdpSocket,
+    bootstrap: Vec<String>,
+}
+
+impl Node {
+    pub fn bind(slug: String, port: u16, bootstrap: Vec<String>) -> std::io::Result<Self> {
+        let socket = UdpSocket::bind(("0.0.0.0", port))?;
+        let slug: String = slug.chars().filter(|c| *c != '|' && *c != '\n' && *c != '\r').collect();
+        let me = PeerInfo {
+            node_id: gen_node_id(),
+            slug,
+            addr: format!("127.0.0.1:{port}"),
+            heartbeat: now_secs(),
+        };
+        Ok(Self {
+            me,
+            peers: Arc::new(Mutex::new(HashMap::new())),
+            socket,
+            bootstrap,
+        })
+    }
+
+    pub fn run(self) -> std::io::Result<()> {
+        println!(
+            "[{}] noeud {} demarre sur {} ({} bootstrap)",
+            self.me.slug,
+            &self.me.node_id[..8],
+            self.me.addr,
+            self.bootstrap.len()
+        );
+
+        // Fil de reception : fusionne tout ce qu'on recoit.
+        let rx_socket = self.socket.try_clone()?;
+        let rx_peers = self.peers.clone();
+        let rx_me = self.me.node_id.clone();
+        std::thread::spawn(move || {
+            let mut buf = vec![0u8; 64 * 1024];
+            loop {
+                let Ok((n, _from)) = rx_socket.recv_from(&mut buf) else {
+                    continue;
+                };
+                if let Some((from, incoming)) = decode_gossip(&buf[..n]) {
+                    if let Ok(mut table) = rx_peers.lock() {
+                        merge(&mut table, &rx_me, std::iter::once(from).chain(incoming));
+                    }
+                }
+            }
+        });
+
+        // Fil d'emission : prune les morts, rafraichit mon heartbeat, gossipe.
+        let mut rng = now_secs().wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+        loop {
+            std::thread::sleep(GOSSIP_INTERVAL);
+
+            let snapshot: Vec<PeerInfo> = {
+                let mut table = self.peers.lock().unwrap();
+                let cutoff = now_secs().saturating_sub(PEER_TTL_SECS);
+                table.retain(|_, p| p.heartbeat >= cutoff);
+                table.values().cloned().collect()
+            };
+
+            let mut me = self.me.clone();
+            me.heartbeat = now_secs();
+            let bytes = encode_gossip(&me, &snapshot);
+
+            // Cibles : bootstrap + pairs connus, tirage au hasard, FANOUT max.
+            let mut targets: Vec<String> = self.bootstrap.clone();
+            targets.extend(snapshot.iter().map(|p| p.addr.clone()));
+            shuffle(&mut targets, &mut rng);
+            for addr in targets.iter().take(FANOUT) {
+                let _ = self.socket.send_to(&bytes, addr.as_str());
+            }
+
+            let list: Vec<String> = snapshot.iter().map(|p| format!("{}@{}", p.slug, p.addr)).collect();
+            println!("[{}] connait {} pair(s): {}", self.me.slug, snapshot.len(), list.join(", "));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn peer(id: &str, hb: u64) -> PeerInfo {
+        PeerInfo { node_id: id.into(), slug: id.into(), addr: "127.0.0.1:1".into(), heartbeat: hb }
+    }
+
+    #[test]
+    fn merge_ignore_self() {
+        let mut t = HashMap::new();
+        merge(&mut t, "me", std::iter::once(peer("me", 10)));
+        assert!(t.is_empty(), "un noeud ne doit jamais s'ajouter lui-meme");
+    }
+
+    #[test]
+    fn merge_keeps_freshest() {
+        let mut t = HashMap::new();
+        merge(&mut t, "me", std::iter::once(peer("a", 10)));
+        merge(&mut t, "me", std::iter::once(peer("a", 5))); // plus vieux -> ignore
+        assert_eq!(t.get("a").unwrap().heartbeat, 10);
+        merge(&mut t, "me", std::iter::once(peer("a", 20))); // plus frais -> remplace
+        assert_eq!(t.get("a").unwrap().heartbeat, 20);
+    }
+
+    #[test]
+    fn merge_adds_new_peers() {
+        let mut t = HashMap::new();
+        merge(&mut t, "me", vec![peer("a", 1), peer("b", 1)].into_iter());
+        assert_eq!(t.len(), 2);
+    }
+}

--- a/nodyx-p2p/crates/nodyx-gossip/src/protocol.rs
+++ b/nodyx-p2p/crates/nodyx-gossip/src/protocol.rs
@@ -1,0 +1,95 @@
+//! Format de fil gossip, fait maison, sans serde.
+//!
+//! Un datagramme est du texte UTF-8 :
+//! ```text
+//! NDX1
+//! <expediteur>
+//! <pair 1>
+//! <pair 2>
+//! ...
+//! ```
+//! Chaque ligne de pair : `node_id|slug|addr|heartbeat`. Lisible, debuggable,
+//! zero dependance.
+
+/// Ce qu'on sait d'un noeud du reseau Nodyx.
+/// `heartbeat` (epoch secondes) est rafraichi par le noeud lui-meme a chaque
+/// tour : c'est la mesure de fraicheur qui permet l'auto-guerison (un noeud qui
+/// ne se rafraichit plus vieillit puis disparait des tables, cf. PEER_TTL_SECS).
+#[derive(Clone, Debug, PartialEq)]
+pub struct PeerInfo {
+    pub node_id: String,
+    pub slug: String,
+    pub addr: String,
+    pub heartbeat: u64,
+}
+
+impl PeerInfo {
+    pub fn encode(&self) -> String {
+        format!("{}|{}|{}|{}", self.node_id, self.slug, self.addr, self.heartbeat)
+    }
+
+    pub fn decode(line: &str) -> Option<PeerInfo> {
+        // splitn(4) : node_id, slug, addr ne peuvent pas contenir '|' ; heartbeat
+        // est le reste mais doit parser en u64, donc pas de '|' non plus.
+        let mut it = line.splitn(4, '|');
+        let node_id = it.next()?.to_string();
+        let slug = it.next()?.to_string();
+        let addr = it.next()?.to_string();
+        let heartbeat = it.next()?.parse().ok()?;
+        if node_id.is_empty() || slug.is_empty() || addr.is_empty() {
+            return None;
+        }
+        Some(PeerInfo { node_id, slug, addr, heartbeat })
+    }
+}
+
+const MAGIC: &str = "NDX1";
+
+/// Serialise un message gossip : magic, expediteur, puis pairs connus.
+pub fn encode_gossip(from: &PeerInfo, peers: &[PeerInfo]) -> Vec<u8> {
+    let mut s = String::with_capacity(64 + peers.len() * 64);
+    s.push_str(MAGIC);
+    s.push('\n');
+    s.push_str(&from.encode());
+    for p in peers {
+        s.push('\n');
+        s.push_str(&p.encode());
+    }
+    s.into_bytes()
+}
+
+/// Parse un message gossip. Retourne (expediteur, pairs connus).
+pub fn decode_gossip(bytes: &[u8]) -> Option<(PeerInfo, Vec<PeerInfo>)> {
+    let text = std::str::from_utf8(bytes).ok()?;
+    let mut lines = text.lines();
+    if lines.next()? != MAGIC {
+        return None;
+    }
+    let from = PeerInfo::decode(lines.next()?)?;
+    let peers = lines.filter_map(PeerInfo::decode).collect();
+    Some((from, peers))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip() {
+        let from = PeerInfo { node_id: "abcd".into(), slug: "alice".into(), addr: "127.0.0.1:9001".into(), heartbeat: 42 };
+        let peers = vec![
+            PeerInfo { node_id: "ef01".into(), slug: "bob".into(), addr: "127.0.0.1:9002".into(), heartbeat: 41 },
+        ];
+        let bytes = encode_gossip(&from, &peers);
+        let (f, p) = decode_gossip(&bytes).expect("doit parser");
+        assert_eq!(f, from);
+        assert_eq!(p, peers);
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(decode_gossip(b"pas du nodyx").is_none());
+        assert!(PeerInfo::decode("trop|peu").is_none());
+        assert!(PeerInfo::decode("a|b|c|pasunnombre").is_none());
+    }
+}


### PR DESCRIPTION
## Premier jalon de la Phase 3.0-D (réseau immortel)

Un nœud de **découverte de pairs par gossip** (anti-entropie épidémique) : les instances Nodyx se trouvent entre elles **sans serveur central**. C'est le socle de la résilience ("if nodyx.org is unreachable, nodes find each other").

### Fidèle à l'ADN Nodyx
- **Zéro dépendance.** `std` uniquement, aucune crate externe (pas de libp2p, pas de serde, pas de tokio). Dans la lignée de nexus-turn fait maison.
- UDP + 2 fils (réception / émission), table de pairs `node_id → PeerInfo` avec heartbeat + TTL.
- Format de fil maison (texte `NDX1`, lisible/debuggable), args parsés à la main.
- Auto-guérison : un nœud qui ne se rafraîchit plus vieillit puis disparaît (TTL 15s).

### Démo validée (3 nœuds, local)
- carol bootstrap **seulement** sur alice → découvre bob transitivement par gossip.
- On **coupe alice** (le nœud central) → bob et carol **continuent de se voir**. Pas de point unique de défaillance.

### Tests
5 tests (`cargo test -p nodyx-gossip`) : merge (fraîcheur, exclusion de soi, ajout), round-trip + rejet du format de fil.

### Suite
Signature des records (anti-usurpation de slug) → tunnel WireGuard fait maison (jalon 2) → IPC vers nodyx-core (jalon 3).