### PR TITLE
feat(gossip): records signés Ed25519 (identité crypto, anti-spoofing)

### DIFF
--- a/nodyx-p2p/Cargo.lock
+++ b/nodyx-p2p/Cargo.lock
@@ -1736,6 +1736,10 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 [[package]]
 name = "nodyx-gossip"
 version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "nodyx-relay"

--- a/nodyx-p2p/crates/nodyx-gossip/Cargo.toml
+++ b/nodyx-p2p/crates/nodyx-gossip/Cargo.toml
@@ -9,5 +9,8 @@ name = "nodyx-gossip"
 path = "src/main.rs"
 
 [dependencies]
-# Zero dependance. std uniquement. C'est l'ADN Nodyx : pas de boite noire, pas de silo.
-# (Le profil release optimise est defini au niveau du workspace.)
+# Une seule entorse au zero-dependance, justifiee : la crypto a courbe elliptique
+# ne se code PAS a la main (constant-time, side-channels). ed25519-dalek est l'une
+# des implementations Rust les plus auditees. Tout le reste reste fait maison.
+ed25519-dalek = "2"
+getrandom = "0.2"   # seed CSPRNG (32 octets) pour la cle d'identite

--- a/nodyx-p2p/crates/nodyx-gossip/src/main.rs
+++ b/nodyx-p2p/crates/nodyx-gossip/src/main.rs
@@ -1,33 +1,63 @@
-//! nodyx-gossip : decouverte de pairs Nodyx par gossip. Zero dependance.
+//! nodyx-gossip : decouverte de pairs Nodyx par gossip.
+//! std + ed25519-dalek (signatures uniquement). Tout le reste est fait maison.
 //!
 //! Usage :
-//!   nodyx-gossip --slug <slug> --port <port> [--bootstrap addr1,addr2,...]
+//!   nodyx-gossip --slug <slug> --port <port> [--bootstrap a,b] [--key-file path]
 //!
-//! Demo : lancer 3 noeuds ; B et C ne connaissent que A au demarrage, puis se
-//! decouvrent mutuellement par gossip. On coupe A : B et C continuent a se voir.
+//! Sans --key-file, une identite ephemere est generee a chaque lancement.
+//! Avec, la cle est persistee (creee au premier lancement) : identite stable.
 
 mod node;
 mod protocol;
 
+use ed25519_dalek::SigningKey;
 use node::Node;
+
+fn gen_seed() -> [u8; 32] {
+    let mut seed = [0u8; 32];
+    getrandom::getrandom(&mut seed).expect("CSPRNG indisponible");
+    seed
+}
+
+/// Charge la cle depuis `path` (32 octets) ou la genere et la persiste.
+fn load_or_gen_key(path: Option<&str>) -> SigningKey {
+    match path {
+        Some(p) => {
+            if let Ok(bytes) = std::fs::read(p) {
+                if let Ok(seed) = <[u8; 32]>::try_from(bytes.as_slice()) {
+                    return SigningKey::from_bytes(&seed);
+                }
+                eprintln!("avertissement: {p} invalide (taille != 32), regeneration");
+            }
+            let seed = gen_seed();
+            if let Err(e) = std::fs::write(p, seed) {
+                eprintln!("avertissement: impossible d'ecrire {p}: {e}");
+            }
+            SigningKey::from_bytes(&seed)
+        }
+        None => SigningKey::from_bytes(&gen_seed()),
+    }
+}
 
 fn main() -> std::io::Result<()> {
     let mut slug: Option<String> = None;
     let mut port: Option<u16> = None;
     let mut bootstrap: Vec<String> = Vec::new();
+    let mut key_file: Option<String> = None;
 
     let mut args = std::env::args().skip(1);
     while let Some(a) = args.next() {
         match a.as_str() {
             "--slug" => slug = args.next(),
             "--port" => port = args.next().and_then(|p| p.parse().ok()),
+            "--key-file" => key_file = args.next(),
             "--bootstrap" => {
                 if let Some(v) = args.next() {
                     bootstrap = v.split(',').filter(|s| !s.is_empty()).map(String::from).collect();
                 }
             }
             "-h" | "--help" => {
-                println!("nodyx-gossip --slug <slug> --port <port> [--bootstrap addr1,addr2]");
+                println!("nodyx-gossip --slug <slug> --port <port> [--bootstrap a,b] [--key-file path]");
                 return Ok(());
             }
             other => eprintln!("argument ignore: {other}"),
@@ -43,5 +73,6 @@ fn main() -> std::io::Result<()> {
         std::process::exit(2);
     });
 
-    Node::bind(slug, port, bootstrap)?.run()
+    let key = load_or_gen_key(key_file.as_deref());
+    Node::bind(slug, port, bootstrap, key)?.run()
 }

--- a/nodyx-p2p/crates/nodyx-gossip/src/node.rs
+++ b/nodyx-p2p/crates/nodyx-gossip/src/node.rs
@@ -1,11 +1,15 @@
-//! Noeud de decouverte par gossip. std uniquement : un socket UDP, deux fils.
+//! Noeud de decouverte par gossip. std + ed25519-dalek (signatures).
 //!
 //! Anti-entropie epidemique : a chaque tour, le noeud envoie "voici qui je suis
 //! et tous ceux que je connais" a quelques pairs au hasard. L'info se propage
 //! sans aucun serveur central. Les noeuds qui ne se rafraichissent plus
 //! vieillissent et disparaissent (auto-guerison).
+//!
+//! Chaque record est SIGNE par la cle du noeud : on ne fusionne que ce qui est
+//! authentique. node_id = cle publique Ed25519.
 
-use crate::protocol::{decode_gossip, encode_gossip, PeerInfo};
+use crate::protocol::{decode_gossip, encode_gossip, to_hex, PeerInfo};
+use ed25519_dalek::SigningKey;
 use std::collections::HashMap;
 use std::net::UdpSocket;
 use std::sync::{Arc, Mutex};
@@ -19,7 +23,8 @@ pub fn now_secs() -> u64 {
     SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()
 }
 
-/// PRNG minimal (xorshift64). Fait maison, pas de crate `rand`.
+/// PRNG minimal (xorshift64). Fait maison, pas de crate `rand` (non crypto :
+/// sert uniquement a choisir des cibles de gossip au hasard).
 fn xorshift(state: &mut u64) -> u64 {
     let mut x = *state;
     x ^= x << 13;
@@ -29,16 +34,6 @@ fn xorshift(state: &mut u64) -> u64 {
     x
 }
 
-fn gen_node_id() -> String {
-    let t = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64;
-    let pid = std::process::id() as u64;
-    let mut s = (t ^ pid.wrapping_mul(0x9E37_79B9_7F4A_7C15)) | 1;
-    s ^= s << 13;
-    s ^= s >> 7;
-    s ^= s << 17;
-    format!("{s:016x}")
-}
-
 fn shuffle(v: &mut [String], rng: &mut u64) {
     for i in (1..v.len()).rev() {
         let j = (xorshift(rng) as usize) % (i + 1);
@@ -46,12 +41,16 @@ fn shuffle(v: &mut [String], rng: &mut u64) {
     }
 }
 
-/// Fusionne des pairs entrants dans la table locale.
-/// On ne s'ajoute jamais soi-meme ; on ne garde que l'info la plus fraiche.
+/// Fusionne des pairs entrants dans la table locale. On ignore soi-meme, on
+/// REJETTE tout record dont la signature est invalide, et on ne garde que
+/// l'info la plus fraiche pour chaque noeud.
 fn merge(table: &mut HashMap<String, PeerInfo>, me_id: &str, incoming: impl Iterator<Item = PeerInfo>) {
     for p in incoming {
         if p.node_id == me_id {
             continue;
+        }
+        if !p.verify() {
+            continue; // record falsifie ou non signe : on jette
         }
         match table.get(&p.node_id) {
             Some(existing) if existing.heartbeat >= p.heartbeat => {}
@@ -64,30 +63,35 @@ fn merge(table: &mut HashMap<String, PeerInfo>, me_id: &str, incoming: impl Iter
 
 pub struct Node {
     me: PeerInfo,
+    signing_key: SigningKey,
     peers: Arc<Mutex<HashMap<String, PeerInfo>>>,
     socket: UdpSocket,
     bootstrap: Vec<String>,
 }
 
 impl Node {
-    pub fn bind(slug: String, port: u16, bootstrap: Vec<String>) -> std::io::Result<Self> {
+    pub fn bind(slug: String, port: u16, bootstrap: Vec<String>, signing_key: SigningKey) -> std::io::Result<Self> {
         let socket = UdpSocket::bind(("0.0.0.0", port))?;
         let slug: String = slug.chars().filter(|c| *c != '|' && *c != '\n' && *c != '\r').collect();
-        let me = PeerInfo {
-            node_id: gen_node_id(),
+        let node_id = to_hex(&signing_key.verifying_key().to_bytes());
+        let mut me = PeerInfo {
+            node_id,
             slug,
             addr: format!("127.0.0.1:{port}"),
             heartbeat: now_secs(),
+            sig: String::new(),
         };
+        me.sign(&signing_key);
         Ok(Self {
             me,
+            signing_key,
             peers: Arc::new(Mutex::new(HashMap::new())),
             socket,
             bootstrap,
         })
     }
 
-    pub fn run(self) -> std::io::Result<()> {
+    pub fn run(mut self) -> std::io::Result<()> {
         println!(
             "[{}] noeud {} demarre sur {} ({} bootstrap)",
             self.me.slug,
@@ -96,7 +100,7 @@ impl Node {
             self.bootstrap.len()
         );
 
-        // Fil de reception : fusionne tout ce qu'on recoit.
+        // Fil de reception : fusionne (et verifie) tout ce qu'on recoit.
         let rx_socket = self.socket.try_clone()?;
         let rx_peers = self.peers.clone();
         let rx_me = self.me.node_id.clone();
@@ -114,7 +118,7 @@ impl Node {
             }
         });
 
-        // Fil d'emission : prune les morts, rafraichit mon heartbeat, gossipe.
+        // Fil d'emission : prune les morts, re-signe mon record frais, gossipe.
         let mut rng = now_secs().wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
         loop {
             std::thread::sleep(GOSSIP_INTERVAL);
@@ -126,9 +130,9 @@ impl Node {
                 table.values().cloned().collect()
             };
 
-            let mut me = self.me.clone();
-            me.heartbeat = now_secs();
-            let bytes = encode_gossip(&me, &snapshot);
+            self.me.heartbeat = now_secs();
+            self.me.sign(&self.signing_key);
+            let bytes = encode_gossip(&self.me, &snapshot);
 
             // Cibles : bootstrap + pairs connus, tirage au hasard, FANOUT max.
             let mut targets: Vec<String> = self.bootstrap.clone();
@@ -148,31 +152,51 @@ impl Node {
 mod tests {
     use super::*;
 
-    fn peer(id: &str, hb: u64) -> PeerInfo {
-        PeerInfo { node_id: id.into(), slug: id.into(), addr: "127.0.0.1:1".into(), heartbeat: hb }
+    fn signed(tag: u8, slug: &str, hb: u64) -> PeerInfo {
+        let key = SigningKey::from_bytes(&[tag; 32]);
+        let node_id = to_hex(&key.verifying_key().to_bytes());
+        let mut p = PeerInfo { node_id, slug: slug.into(), addr: "127.0.0.1:1".into(), heartbeat: hb, sig: String::new() };
+        p.sign(&key);
+        p
     }
 
     #[test]
     fn merge_ignore_self() {
+        let me = signed(1, "me", 10);
         let mut t = HashMap::new();
-        merge(&mut t, "me", std::iter::once(peer("me", 10)));
+        merge(&mut t, &me.node_id, std::iter::once(me.clone()));
         assert!(t.is_empty(), "un noeud ne doit jamais s'ajouter lui-meme");
+    }
+
+    #[test]
+    fn merge_rejects_unsigned_or_forged() {
+        let mut t = HashMap::new();
+        // record sans signature valide
+        let bad = PeerInfo { node_id: "deadbeef".into(), slug: "x".into(), addr: "1:1".into(), heartbeat: 1, sig: "00".into() };
+        merge(&mut t, "me", std::iter::once(bad));
+        assert!(t.is_empty(), "un record non signe doit etre rejete");
+        // record signe puis falsifie
+        let mut forged = signed(7, "evil", 5);
+        forged.addr = "6.6.6.6:1".into();
+        merge(&mut t, "me", std::iter::once(forged));
+        assert!(t.is_empty(), "un record falsifie doit etre rejete");
     }
 
     #[test]
     fn merge_keeps_freshest() {
         let mut t = HashMap::new();
-        merge(&mut t, "me", std::iter::once(peer("a", 10)));
-        merge(&mut t, "me", std::iter::once(peer("a", 5))); // plus vieux -> ignore
-        assert_eq!(t.get("a").unwrap().heartbeat, 10);
-        merge(&mut t, "me", std::iter::once(peer("a", 20))); // plus frais -> remplace
-        assert_eq!(t.get("a").unwrap().heartbeat, 20);
+        merge(&mut t, "me", std::iter::once(signed(9, "a", 10)));
+        merge(&mut t, "me", std::iter::once(signed(9, "a", 5))); // plus vieux -> ignore
+        let id = signed(9, "a", 0).node_id;
+        assert_eq!(t.get(&id).unwrap().heartbeat, 10);
+        merge(&mut t, "me", std::iter::once(signed(9, "a", 20))); // plus frais -> remplace
+        assert_eq!(t.get(&id).unwrap().heartbeat, 20);
     }
 
     #[test]
-    fn merge_adds_new_peers() {
+    fn merge_adds_distinct_peers() {
         let mut t = HashMap::new();
-        merge(&mut t, "me", vec![peer("a", 1), peer("b", 1)].into_iter());
+        merge(&mut t, "me", vec![signed(11, "a", 1), signed(12, "b", 1)].into_iter());
         assert_eq!(t.len(), 2);
     }
 }

--- a/nodyx-p2p/crates/nodyx-gossip/src/protocol.rs
+++ b/nodyx-p2p/crates/nodyx-gossip/src/protocol.rs
@@ -1,53 +1,113 @@
-//! Format de fil gossip, fait maison, sans serde.
+//! Format de fil gossip + signature des records, fait maison (sauf la courbe).
 //!
 //! Un datagramme est du texte UTF-8 :
 //! ```text
 //! NDX1
 //! <expediteur>
 //! <pair 1>
-//! <pair 2>
 //! ...
 //! ```
-//! Chaque ligne de pair : `node_id|slug|addr|heartbeat`. Lisible, debuggable,
-//! zero dependance.
+//! Chaque ligne de pair : `node_id|slug|addr|heartbeat|sig`.
+//! - `node_id` = cle publique Ed25519 (hex). C'est l'identite du noeud.
+//! - `sig`     = signature Ed25519 (hex) de `node_id|slug|addr|heartbeat`.
+//!
+//! Consequence : on ne peut pas falsifier le record d'un noeud (il faudrait sa
+//! cle privee), ni l'alterer en transit. Le heartbeat etant signe, on ne peut
+//! pas non plus rejouer un vieux record avec un horodatage gonfle.
+
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
 
 /// Ce qu'on sait d'un noeud du reseau Nodyx.
-/// `heartbeat` (epoch secondes) est rafraichi par le noeud lui-meme a chaque
-/// tour : c'est la mesure de fraicheur qui permet l'auto-guerison (un noeud qui
-/// ne se rafraichit plus vieillit puis disparait des tables, cf. PEER_TTL_SECS).
 #[derive(Clone, Debug, PartialEq)]
 pub struct PeerInfo {
-    pub node_id: String,
+    pub node_id: String, // hex de la cle publique Ed25519
     pub slug: String,
     pub addr: String,
     pub heartbeat: u64,
+    pub sig: String, // hex de la signature Ed25519
 }
 
 impl PeerInfo {
+    /// Message canonique signe : tout sauf la signature.
+    fn signed_bytes(&self) -> Vec<u8> {
+        format!("{}|{}|{}|{}", self.node_id, self.slug, self.addr, self.heartbeat).into_bytes()
+    }
+
+    /// Signe ce record avec la cle privee du noeud (met a jour `sig`).
+    pub fn sign(&mut self, key: &SigningKey) {
+        let sig = key.sign(&self.signed_bytes());
+        self.sig = to_hex(&sig.to_bytes());
+    }
+
+    /// Verifie que la signature correspond bien a la cle publique (node_id) et
+    /// aux champs. `verify_strict` rejette les formes non canoniques / d'ordre
+    /// faible. Retourne false a la moindre anomalie (parse, cle, signature).
+    pub fn verify(&self) -> bool {
+        let Some(pk) = from_hex(&self.node_id).and_then(|v| <[u8; 32]>::try_from(v).ok()) else {
+            return false;
+        };
+        let Ok(vk) = VerifyingKey::from_bytes(&pk) else {
+            return false;
+        };
+        let Some(sigb) = from_hex(&self.sig).and_then(|v| <[u8; 64]>::try_from(v).ok()) else {
+            return false;
+        };
+        let sig = Signature::from_bytes(&sigb);
+        vk.verify_strict(&self.signed_bytes(), &sig).is_ok()
+    }
+
     pub fn encode(&self) -> String {
-        format!("{}|{}|{}|{}", self.node_id, self.slug, self.addr, self.heartbeat)
+        format!("{}|{}|{}|{}|{}", self.node_id, self.slug, self.addr, self.heartbeat, self.sig)
     }
 
     pub fn decode(line: &str) -> Option<PeerInfo> {
-        // splitn(4) : node_id, slug, addr ne peuvent pas contenir '|' ; heartbeat
-        // est le reste mais doit parser en u64, donc pas de '|' non plus.
-        let mut it = line.splitn(4, '|');
+        // splitn(5) : seul `sig` (dernier) pourrait contenir '|', mais c'est de
+        // l'hex donc non. Les autres champs ne contiennent jamais '|'.
+        let mut it = line.splitn(5, '|');
         let node_id = it.next()?.to_string();
         let slug = it.next()?.to_string();
         let addr = it.next()?.to_string();
         let heartbeat = it.next()?.parse().ok()?;
-        if node_id.is_empty() || slug.is_empty() || addr.is_empty() {
+        let sig = it.next()?.to_string();
+        if node_id.is_empty() || slug.is_empty() || addr.is_empty() || sig.is_empty() {
             return None;
         }
-        Some(PeerInfo { node_id, slug, addr, heartbeat })
+        Some(PeerInfo { node_id, slug, addr, heartbeat, sig })
     }
+}
+
+// --- hex fait maison (zero dependance) ---
+
+pub fn to_hex(bytes: &[u8]) -> String {
+    const H: &[u8; 16] = b"0123456789abcdef";
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        s.push(H[(b >> 4) as usize] as char);
+        s.push(H[(b & 0x0f) as usize] as char);
+    }
+    s
+}
+
+pub fn from_hex(s: &str) -> Option<Vec<u8>> {
+    if !s.len().is_multiple_of(2) {
+        return None;
+    }
+    let b = s.as_bytes();
+    (0..b.len())
+        .step_by(2)
+        .map(|i| {
+            let hi = (b[i] as char).to_digit(16)?;
+            let lo = (b[i + 1] as char).to_digit(16)?;
+            Some((hi * 16 + lo) as u8)
+        })
+        .collect()
 }
 
 const MAGIC: &str = "NDX1";
 
 /// Serialise un message gossip : magic, expediteur, puis pairs connus.
 pub fn encode_gossip(from: &PeerInfo, peers: &[PeerInfo]) -> Vec<u8> {
-    let mut s = String::with_capacity(64 + peers.len() * 64);
+    let mut s = String::with_capacity(256 + peers.len() * 256);
     s.push_str(MAGIC);
     s.push('\n');
     s.push_str(&from.encode());
@@ -59,6 +119,7 @@ pub fn encode_gossip(from: &PeerInfo, peers: &[PeerInfo]) -> Vec<u8> {
 }
 
 /// Parse un message gossip. Retourne (expediteur, pairs connus).
+/// La VERIFICATION des signatures se fait a la fusion (cf. node::merge).
 pub fn decode_gossip(bytes: &[u8]) -> Option<(PeerInfo, Vec<PeerInfo>)> {
     let text = std::str::from_utf8(bytes).ok()?;
     let mut lines = text.lines();
@@ -74,22 +135,58 @@ pub fn decode_gossip(bytes: &[u8]) -> Option<(PeerInfo, Vec<PeerInfo>)> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn round_trip() {
-        let from = PeerInfo { node_id: "abcd".into(), slug: "alice".into(), addr: "127.0.0.1:9001".into(), heartbeat: 42 };
-        let peers = vec![
-            PeerInfo { node_id: "ef01".into(), slug: "bob".into(), addr: "127.0.0.1:9002".into(), heartbeat: 41 },
-        ];
-        let bytes = encode_gossip(&from, &peers);
-        let (f, p) = decode_gossip(&bytes).expect("doit parser");
-        assert_eq!(f, from);
-        assert_eq!(p, peers);
+    fn key_for(tag: u8) -> SigningKey {
+        let mut seed = [tag; 32];
+        seed[1] = 0xA5;
+        SigningKey::from_bytes(&seed)
+    }
+
+    fn signed_peer(key: &SigningKey, slug: &str, hb: u64) -> PeerInfo {
+        let node_id = to_hex(&key.verifying_key().to_bytes());
+        let mut p = PeerInfo { node_id, slug: slug.into(), addr: "127.0.0.1:1".into(), heartbeat: hb, sig: String::new() };
+        p.sign(key);
+        p
     }
 
     #[test]
-    fn rejects_garbage() {
-        assert!(decode_gossip(b"pas du nodyx").is_none());
-        assert!(PeerInfo::decode("trop|peu").is_none());
-        assert!(PeerInfo::decode("a|b|c|pasunnombre").is_none());
+    fn hex_round_trip() {
+        let b = [0u8, 1, 15, 16, 255, 128];
+        assert_eq!(from_hex(&to_hex(&b)).unwrap(), b);
+        assert!(from_hex("zz").is_none());
+        assert!(from_hex("abc").is_none()); // longueur impaire
+    }
+
+    #[test]
+    fn signature_valid() {
+        let p = signed_peer(&key_for(1), "alice", 10);
+        assert!(p.verify());
+    }
+
+    #[test]
+    fn signature_rejects_tampering() {
+        let mut p = signed_peer(&key_for(2), "bob", 10);
+        p.addr = "6.6.6.6:1".into(); // alteration apres signature
+        assert!(!p.verify(), "un record altere doit etre rejete");
+        let mut p2 = signed_peer(&key_for(2), "bob", 10);
+        p2.heartbeat = 9999; // rejeu/gonflage d'horodatage
+        assert!(!p2.verify());
+    }
+
+    #[test]
+    fn signature_rejects_wrong_key() {
+        // node_id d'une cle, signature d'une autre → invalide
+        let mut p = signed_peer(&key_for(3), "carol", 5);
+        p.node_id = to_hex(&key_for(4).verifying_key().to_bytes());
+        assert!(!p.verify());
+    }
+
+    #[test]
+    fn gossip_round_trip() {
+        let from = signed_peer(&key_for(5), "alice", 42);
+        let peers = vec![signed_peer(&key_for(6), "bob", 41)];
+        let (f, p) = decode_gossip(&encode_gossip(&from, &peers)).expect("doit parser");
+        assert_eq!(f, from);
+        assert_eq!(p, peers);
+        assert!(f.verify() && p[0].verify());
     }
 }


### PR DESCRIPTION
## Signature des records (jalon 1bis de la 3.0-D)

Suite de #148. Chaque nœud a maintenant une **vraie identité cryptographique** : `node_id` = sa clé publique Ed25519. Chaque record gossip est **signé** ; un nœud ne fusionne que ce qui est authentique.

### Ce que ça verrouille
- **Anti-spoofing** : impossible de forger le record d'un nœud sans sa clé privée.
- **Intégrité en transit** : un relais ne peut pas altérer l'`addr` ou le `slug` d'autrui.
- **Anti-rejeu** : le `heartbeat` est signé, donc pas de rejeu avec horodatage gonflé. `verify_strict` rejette les formes non canoniques / d'ordre faible.

### Le choix crypto (validé avec le mainteneur)
La courbe elliptique ne se code pas à la main (constant-time, side-channels). Seule entorse au zéro-dépendance : `ed25519-dalek` (parmi les crates Rust les plus auditées) + `getrandom`. Tout le reste reste fait maison, **y compris l'hex**.

### Validé (campagne de tests)
- **9 tests** : signature valide, rejet de falsification, rejet mauvaise clé, hex round-trip, gossip round-trip, merge (rejet non signé/forgé, fraîcheur).
- Démo 3 nœuds avec records signés : découverte transitive OK.
- Convergence N=50 → 10,8s · N=100 → 11,1s (vérification incluse).
- **Faux paquet forgé envoyé sur le fil → rejeté** (0 adoption par la victime).
- clippy clean, binaire 699K.

### Note d'échelle (honnête)
La signature porte la taille par pair à ~224 o → datagramme O(N), plafond UDP ~280 nœuds en l'état. Pour une fédération réaliste c'est large ; à très grande échelle, ce sera le rôle du DHT Kademlia (gossip de deltas / chunking).