### PR TITLE
fix(i18n): traduire le fil d'actu + label nav (#143)

### DIFF
--- a/nodyx-frontend/src/lib/locales/de.json
+++ b/nodyx-frontend/src/lib/locales/de.json
@@ -791,5 +791,10 @@
   "tasks.columns_plural": "Spalten",
   "tasks.cards_one": "Karte",
   "tasks.cards_plural": "Karten",
-  "tasks.confirm_delete": "Dieses Board löschen?"
+  "tasks.confirm_delete": "Dieses Board löschen?",
+  "feed.tab_discover": "Entdecken",
+  "feed.tab_following": "Abonniert",
+  "feed.reshared_by": "hat geteilt",
+  "feed.reshare": "Teilen",
+  "feed.react": "Reagieren"
 }

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -792,5 +792,10 @@
   "tasks.columns_plural": "columns",
   "tasks.cards_one": "card",
   "tasks.cards_plural": "cards",
-  "tasks.confirm_delete": "Delete this board?"
+  "tasks.confirm_delete": "Delete this board?",
+  "feed.tab_discover": "Discover",
+  "feed.tab_following": "Following",
+  "feed.reshared_by": "reshared",
+  "feed.reshare": "Reshare",
+  "feed.react": "React"
 }

--- a/nodyx-frontend/src/lib/locales/es.json
+++ b/nodyx-frontend/src/lib/locales/es.json
@@ -791,5 +791,10 @@
   "tasks.columns_plural": "columnas",
   "tasks.cards_one": "tarjeta",
   "tasks.cards_plural": "tarjetas",
-  "tasks.confirm_delete": "¿Eliminar este tablero?"
+  "tasks.confirm_delete": "¿Eliminar este tablero?",
+  "feed.tab_discover": "Descubrir",
+  "feed.tab_following": "Siguiendo",
+  "feed.reshared_by": "compartió",
+  "feed.reshare": "Compartir",
+  "feed.react": "Reaccionar"
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -792,5 +792,10 @@
   "tasks.columns_plural": "colonnes",
   "tasks.cards_one": "carte",
   "tasks.cards_plural": "cartes",
-  "tasks.confirm_delete": "Supprimer ce tableau ?"
+  "tasks.confirm_delete": "Supprimer ce tableau ?",
+  "feed.tab_discover": "Découvrir",
+  "feed.tab_following": "Abonnements",
+  "feed.reshared_by": "a repartagé",
+  "feed.reshare": "Repartager",
+  "feed.react": "Réagir"
 }

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -842,7 +842,7 @@
 					<div class="space-y-px">
 						{#each [
 							{ href: '/',         label: tFn('nav.home'),    icon: 'M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z',                                                                                                                                                 show: true },
-							{ href: '/feed',     label: 'Fil d\'actu', icon: 'M3 12h18M3 6h18M3 18h18',                                                                                                                                                               show: !!user },
+							{ href: '/feed',     label: tFn('nav.feed'),    icon: 'M3 12h18M3 6h18M3 18h18',                                                                                                                                                               show: !!user },
 							{ href: '/forum',    label: tFn('nav.forum'),   icon: 'M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z',                          show: true },
 							{ href: '/chat',     label: tFn('nav.chat'),    icon: 'M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z',                                                                                                                                    show: mods.chat !== false },
 							{ href: '/dm',       label: tFn('nav.dm'),      icon: 'M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z',                                                                                    show: mods.dm !== false },

--- a/nodyx-frontend/src/routes/feed/+page.svelte
+++ b/nodyx-frontend/src/routes/feed/+page.svelte
@@ -350,10 +350,10 @@
 			<!-- Onglets : Découvrir / Abonnements ──────────────────────────── -->
 			<div class="feed-tabs">
 				<button class="feed-tab" class:feed-tab--active={scope === 'discover'} onclick={() => switchScope('discover')}>
-					Découvrir
+					{tFn('feed.tab_discover')}
 				</button>
 				<button class="feed-tab" class:feed-tab--active={scope === 'following'} onclick={() => switchScope('following')}>
-					Abonnements
+					{tFn('feed.tab_following')}
 				</button>
 			</div>
 
@@ -471,7 +471,7 @@
 							{#if post.reshare_of}
 								<div class="reshare-label">
 									<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5"/></svg>
-									<a href="/users/{post.username}">{post.display_name || post.username}</a> a repartagé
+									<a href="/users/{post.username}">{post.display_name || post.username}</a> {tFn('feed.reshared_by')}
 								</div>
 							{/if}
 
@@ -530,7 +530,7 @@
 												window.scrollTo({ top: 0, behavior: 'smooth' })
 											}}
 											class="post-action-btn"
-											title="Répondre"
+											title={tFn('feed.reply')}
 										>
 											<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
 												<path stroke-linecap="round" stroke-linejoin="round" d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3"/>
@@ -541,7 +541,7 @@
 											onclick={() => toggleReshare(post)}
 											class="post-action-btn post-reshare-btn"
 											class:post-reshare-btn--active={post.reshared_by_me}
-											title="Repartager"
+											title={tFn('feed.reshare')}
 										>
 											<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5"/></svg>
 											{#if post.reshares_count > 0}<span class="resonance-count">{fmt(post.reshares_count)}</span>{/if}
@@ -582,7 +582,7 @@
 												onclick={() => pickerFor = pickerFor === post.id ? null : post.id}
 												class="post-action-btn post-resonance-btn"
 												class:post-resonance-btn--active={post.my_reaction}
-												aria-label="Réagir"
+												aria-label={tFn('feed.react')}
 											>
 												<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
 													<path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z"/>
@@ -642,7 +642,7 @@
 											<div class="post-actions" style="margin-top: 0.5rem;">
 												<button
 													onclick={() => { replyTo = reply; composing = true; window.scrollTo({ top: 0, behavior: 'smooth' }) }}
-													class="post-action-btn" title="Répondre"
+													class="post-action-btn" title={tFn('feed.reply')}
 												>
 													<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
 														<path stroke-linecap="round" stroke-linejoin="round" d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3"/>


### PR DESCRIPTION
Suite #143. Le switch de langue ne touchait pas le fil d'actu.

- `+layout.svelte` : le label de nav du fil d'actu était codé en dur (`'Fil d\'actu'`) au milieu de `tFn(...)` partout ailleurs → utilise `tFn('nav.feed')` (clé déjà présente).
- `feed` : onglets **Découvrir/Abonnements**, mention de repartage, et titres Répondre/Repartager/Réagir passent par `t()`.
- +5 clés `feed.*` dans les 4 dictionnaires.