### PR TITLE
fix(i18n): chaînes restantes du chat (#143)

### DIFF
--- a/nodyx-frontend/src/lib/locales/de.json
+++ b/nodyx-frontend/src/lib/locales/de.json
@@ -796,5 +796,15 @@
   "feed.tab_following": "Abonniert",
   "feed.reshared_by": "hat geteilt",
   "feed.reshare": "Teilen",
-  "feed.react": "Reagieren"
+  "feed.react": "Reagieren",
+  "chat.pinned": "Angeheftet",
+  "chat.hide": "Ausblenden",
+  "chat.edited": "(bearbeitet)",
+  "chat.floating_reaction": "Schwebende Reaktion",
+  "chat.gif_add_key_pre": "Füge einen kostenlosen Key in",
+  "chat.gif_add_key_post": "dann neu bauen:",
+  "chat.your_key": "dein_key",
+  "chat.gif_both_free": "Beide sind kostenlos mit großzügigem Kontingent.",
+  "chat.no_channel": "Noch kein Kanal verfügbar.",
+  "chat.no_channel_hint": "Ein Admin kann einen über das Panel Administration → Textkanäle erstellen."
 }

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -797,5 +797,15 @@
   "feed.tab_following": "Following",
   "feed.reshared_by": "reshared",
   "feed.reshare": "Reshare",
-  "feed.react": "React"
+  "feed.react": "React",
+  "chat.pinned": "Pinned",
+  "chat.hide": "Hide",
+  "chat.edited": "(edited)",
+  "chat.floating_reaction": "Floating reaction",
+  "chat.gif_add_key_pre": "Add a free key in",
+  "chat.gif_add_key_post": "then rebuild:",
+  "chat.your_key": "your_key",
+  "chat.gif_both_free": "Both are free with a generous quota.",
+  "chat.no_channel": "No channel available yet.",
+  "chat.no_channel_hint": "An admin can create one from the Administration → Text channels panel."
 }

--- a/nodyx-frontend/src/lib/locales/es.json
+++ b/nodyx-frontend/src/lib/locales/es.json
@@ -796,5 +796,15 @@
   "feed.tab_following": "Siguiendo",
   "feed.reshared_by": "compartió",
   "feed.reshare": "Compartir",
-  "feed.react": "Reaccionar"
+  "feed.react": "Reaccionar",
+  "chat.pinned": "Fijado",
+  "chat.hide": "Ocultar",
+  "chat.edited": "(editado)",
+  "chat.floating_reaction": "Reacción flotante",
+  "chat.gif_add_key_pre": "Añade una clave gratuita en",
+  "chat.gif_add_key_post": "luego reconstruye:",
+  "chat.your_key": "tu_clave",
+  "chat.gif_both_free": "Ambos son gratuitos con una cuota generosa.",
+  "chat.no_channel": "No hay ningún canal disponible todavía.",
+  "chat.no_channel_hint": "Un administrador puede crear uno desde el panel Administración → Canales de texto."
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -797,5 +797,15 @@
   "feed.tab_following": "Abonnements",
   "feed.reshared_by": "a repartagé",
   "feed.reshare": "Repartager",
-  "feed.react": "Réagir"
+  "feed.react": "Réagir",
+  "chat.pinned": "Épinglé",
+  "chat.hide": "Masquer",
+  "chat.edited": "(modifié)",
+  "chat.floating_reaction": "Réaction flottante",
+  "chat.gif_add_key_pre": "Ajoutez une clé gratuite dans",
+  "chat.gif_add_key_post": "puis rebuild :",
+  "chat.your_key": "votre_clé",
+  "chat.gif_both_free": "Les deux sont gratuits avec un quota généreux.",
+  "chat.no_channel": "Aucun canal disponible pour le moment.",
+  "chat.no_channel_hint": "Un admin peut en créer depuis le panneau Administration → Canaux texte."
 }

--- a/nodyx-frontend/src/routes/chat/+page.svelte
+++ b/nodyx-frontend/src/routes/chat/+page.svelte
@@ -1047,16 +1047,16 @@
 			{#if pinnedMessage && showPinned}
 				<div class="shrink-0 flex items-center gap-2.5 px-4 py-1.5 text-xs" style="background: rgba(124,58,237,.06); border-bottom: 1px solid rgba(124,58,237,.15)">
 					<svg class="w-3 h-3 shrink-0" viewBox="0 0 24 24" fill="#a78bfa"><path d="M16 12V4h1V2H7v2h1v8l-2 2v2h5v6h2v-6h5v-2l-2-2z"/></svg>
-					<span class="font-black uppercase tracking-wider shrink-0 text-[10px]" style="color: #a78bfa; font-family: 'Space Grotesk', sans-serif">Épinglé</span>
+					<span class="font-black uppercase tracking-wider shrink-0 text-[10px]" style="color: #a78bfa; font-family: 'Space Grotesk', sans-serif">{tFn('chat.pinned')}</span>
 					<span class="truncate flex-1" style="color: #6b7280">
 						<span class="font-semibold" style="color: #4b5563">{pinnedMessage.author_username} · </span>{pinnedMessage.content?.replace(/<[^>]*>/g, '').slice(0, 120) ?? ''}
 					</span>
 					{#if isAdmin}
 						<button onclick={() => s?.emit('chat:pin', { channelId: selectedChannel?.id, messageId: null })}
-						        class="ml-auto shrink-0 transition-colors w-4 h-4 flex items-center justify-center text-sm leading-none" style="color: #374151" title="Désépingler">×</button>
+						        class="ml-auto shrink-0 transition-colors w-4 h-4 flex items-center justify-center text-sm leading-none" style="color: #374151" title={tFn('chat.unpin')}>×</button>
 					{:else}
 						<button onclick={() => showPinned = false}
-						        class="ml-auto shrink-0 transition-colors w-4 h-4 flex items-center justify-center text-sm leading-none" style="color: #374151" title="Masquer">×</button>
+						        class="ml-auto shrink-0 transition-colors w-4 h-4 flex items-center justify-center text-sm leading-none" style="color: #374151" title={tFn('chat.hide')}>×</button>
 					{/if}
 				</div>
 			{/if}
@@ -1137,7 +1137,7 @@
 										{formatTime(msg.created_at)}
 									</span>
 									{#if msg.edited_at && !msg.is_deleted}
-										<span class="text-[10px] italic" style="color: #374151">(modifié)</span>
+										<span class="text-[10px] italic" style="color: #374151">{tFn('chat.edited')}</span>
 									{/if}
 								</div>
 							{/if}
@@ -1172,7 +1172,7 @@
 								<div class="nodyx-prose text-sm leading-relaxed break-words" style="color: #d1d5db">
 									{@html linkifyHtml(msg.content ?? '')}
 									{#if shouldGroup && msg.edited_at}
-										<span class="text-[9px] text-gray-700 italic ml-2">(modifié)</span>
+										<span class="text-[9px] text-gray-700 italic ml-2">{tFn('chat.edited')}</span>
 									{/if}
 								</div>
 								<!-- Link preview card -->
@@ -1257,7 +1257,7 @@
 								</div>
 								<span class="w-px h-4 mx-0.5" style="background: rgba(255,255,255,.07)"></span>
 								<!-- Répondre -->
-								<button onclick={() => startReply(msg)} title="Répondre"
+								<button onclick={() => startReply(msg)} title={tFn('chat.reply')}
 								        class="w-7 h-7 flex items-center justify-center transition-colors" style="color: #4b5563"
 								        onmouseenter={(e) => (e.currentTarget as HTMLElement).style.color = '#a78bfa'}
 								        onmouseleave={(e) => (e.currentTarget as HTMLElement).style.color = '#4b5563'}>
@@ -1362,7 +1362,7 @@
 						onclick={() => floatReact(emoji)}
 						disabled={floatCooldown || !selectedChannel}
 						class="fr-bar-btn"
-						title="Réaction flottante"
+						title={tFn('chat.floating_reaction')}
 					>{emoji}</button>
 				{/each}
 			</div>
@@ -1398,21 +1398,21 @@
 								<div class="p-4 space-y-3">
 									<p class="text-xs font-semibold text-white">{tFn('chat.gif_not_configured')}</p>
 									<p class="text-xs text-gray-400 leading-relaxed">
-										Ajoutez une clé gratuite dans <code class="bg-gray-800 px-1 rounded text-indigo-300">/var/www/nexus/nodyx-frontend/.env</code> puis rebuild :
+										{tFn('chat.gif_add_key_pre')} <code class="bg-gray-800 px-1 rounded text-indigo-300">/var/www/nexus/nodyx-frontend/.env</code> {tFn('chat.gif_add_key_post')}
 									</p>
 									<div class="space-y-1.5 text-xs text-gray-500">
 										<div class="bg-gray-800 rounded p-2 font-mono">
 											<span class="text-green-400"># Tenor (Google)</span><br>
-											<span class="text-amber-300">PUBLIC_TENOR_KEY</span>=votre_clé<br>
+											<span class="text-amber-300">PUBLIC_TENOR_KEY</span>={tFn('chat.your_key')}<br>
 											<span class="text-gray-600 text-[10px]">console.cloud.google.com → Tenor API v2</span>
 										</div>
 										<div class="bg-gray-800 rounded p-2 font-mono">
 											<span class="text-green-400"># Giphy (Meta)</span><br>
-											<span class="text-amber-300">PUBLIC_GIPHY_KEY</span>=votre_clé<br>
+											<span class="text-amber-300">PUBLIC_GIPHY_KEY</span>={tFn('chat.your_key')}<br>
 											<span class="text-gray-600 text-[10px]">developers.giphy.com → Create App</span>
 										</div>
 									</div>
-									<p class="text-[10px] text-gray-600">Les deux sont gratuits avec un quota généreux.</p>
+									<p class="text-[10px] text-gray-600">{tFn('chat.gif_both_free')}</p>
 								</div>
 							{:else}
 								<div class="p-2 border-b border-gray-800">
@@ -1537,8 +1537,8 @@
 			<!-- No channel -->
 			<div class="flex-1 flex items-center justify-center flex-col gap-3 text-gray-600">
 				<span class="text-5xl">💬</span>
-				<p class="text-sm">Aucun canal disponible pour le moment.</p>
-				<p class="text-xs">Un admin peut en créer depuis le panneau Administration → Canaux texte.</p>
+				<p class="text-sm">{tFn('chat.no_channel')}</p>
+				<p class="text-xs">{tFn('chat.no_channel_hint')}</p>
 			</div>
 			
 		{/if}


### PR DESCRIPTION
Suite #143, chasse aux chaînes en dur. Le chat était déjà à ~90% traduit ; cette passe finit le reste (épinglé/désépingler/masquer, (modifié), Répondre, réaction flottante, aide config GIF, état sans canal). +10 clés chat.* ×4 langues.