### PR TITLE
fix(i18n): réglages restants (#143)

### DIFF
--- a/nodyx-frontend/src/lib/locales/de.json
+++ b/nodyx-frontend/src/lib/locales/de.json
@@ -882,5 +882,14 @@
   "dm.enter": "Enter",
   "dm.reply_to": "Antwort an",
   "dm.cancel_reply": "Antwort abbrechen",
-  "dm.insert_emoji": "Emoji einfügen"
+  "dm.insert_emoji": "Emoji einfügen",
+  "settings.encryption.label": "Verschlüsselte Nachrichten",
+  "settings.encryption.desc": "Backup und Wiederherstellung deines Ende-zu-Ende-Schlüssels.",
+  "settings.connected.label": "Verknüpfte Konten",
+  "settings.sounds.desc": "In Echtzeit synthetisierte Töne — keine Audiodateien.",
+  "settings.sounds.enabled": "Töne aktiviert",
+  "settings.sounds.enabled_desc": "Alle Benachrichtigungstöne aktivieren oder deaktivieren.",
+  "settings.sounds.hint": "Töne über die Web Audio API erzeugt — keine heruntergeladenen Dateien, keine Netzwerklatenz. Einstellungen werden lokal im Browser gespeichert.",
+  "settings.streamer.desc": "Erhalte auf Nodyx einen Ton für Follows, Subs, Raids, Cheers. Praktisch, wenn du den Audio-Rückkanal deines Streams stummschaltest.",
+  "settings.streamer.enabled": "Streamer-Benachrichtigungen aktiviert"
 }

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -883,5 +883,14 @@
   "dm.enter": "Enter",
   "dm.reply_to": "Reply to",
   "dm.cancel_reply": "Cancel reply",
-  "dm.insert_emoji": "Insert an emoji"
+  "dm.insert_emoji": "Insert an emoji",
+  "settings.encryption.label": "Encrypted messages",
+  "settings.encryption.desc": "Backup and recovery of your end-to-end encryption key.",
+  "settings.connected.label": "Connected accounts",
+  "settings.sounds.desc": "Sounds synthesized in real time — no audio files.",
+  "settings.sounds.enabled": "Sounds enabled",
+  "settings.sounds.enabled_desc": "Enable or disable all notification sounds.",
+  "settings.sounds.hint": "Sounds generated via the Web Audio API — no downloaded files, no network latency. Settings are saved locally in your browser.",
+  "settings.streamer.desc": "Get a sound on Nodyx for follows, subs, raids, cheers. Handy when you mute your stream's audio return.",
+  "settings.streamer.enabled": "Streamer notifications enabled"
 }

--- a/nodyx-frontend/src/lib/locales/es.json
+++ b/nodyx-frontend/src/lib/locales/es.json
@@ -882,5 +882,14 @@
   "dm.enter": "Intro",
   "dm.reply_to": "Respuesta a",
   "dm.cancel_reply": "Cancelar respuesta",
-  "dm.insert_emoji": "Insertar un emoji"
+  "dm.insert_emoji": "Insertar un emoji",
+  "settings.encryption.label": "Mensajes cifrados",
+  "settings.encryption.desc": "Copia y recuperación de tu clave de cifrado de extremo a extremo.",
+  "settings.connected.label": "Cuentas vinculadas",
+  "settings.sounds.desc": "Sonidos sintetizados en tiempo real — sin archivos de audio.",
+  "settings.sounds.enabled": "Sonidos activados",
+  "settings.sounds.enabled_desc": "Activa o desactiva todos los sonidos de notificación.",
+  "settings.sounds.hint": "Sonidos generados mediante la Web Audio API — sin archivos descargados, sin latencia de red. Los ajustes se guardan localmente en tu navegador.",
+  "settings.streamer.desc": "Recibe un sonido en Nodyx para follows, subs, raids, cheers. Útil cuando silencias el retorno de audio de tu directo.",
+  "settings.streamer.enabled": "Notificaciones de streamer activadas"
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -883,5 +883,14 @@
   "dm.enter": "Entrée",
   "dm.reply_to": "Réponse à",
   "dm.cancel_reply": "Annuler la réponse",
-  "dm.insert_emoji": "Insérer un emoji"
+  "dm.insert_emoji": "Insérer un emoji",
+  "settings.encryption.label": "Messages chiffrés",
+  "settings.encryption.desc": "Sauvegarde et récupération de ta clé de chiffrement de bout en bout.",
+  "settings.connected.label": "Comptes liés",
+  "settings.sounds.desc": "Sons synthétisés en temps réel — aucun fichier audio.",
+  "settings.sounds.enabled": "Sons activés",
+  "settings.sounds.enabled_desc": "Active ou désactive tous les sons de notification.",
+  "settings.sounds.hint": "Sons générés via Web Audio API — aucun fichier téléchargé, aucune latence réseau. Les réglages sont sauvegardés localement dans votre navigateur.",
+  "settings.streamer.desc": "Reçois un son côté Nodyx pour follow, sub, raid, cheer. Utile quand tu coupes le retour audio de ton live.",
+  "settings.streamer.enabled": "Notifs Streamer activées"
 }

--- a/nodyx-frontend/src/routes/settings/+page.svelte
+++ b/nodyx-frontend/src/routes/settings/+page.svelte
@@ -543,7 +543,7 @@
                         <rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
                     </svg>
                 </span>
-                <span class="sb-label">Messages chiffrés</span>
+                <span class="sb-label">{tFn('settings.encryption.label')}</span>
             </button>
 
             <button class="sb-item {activeSection === 'signet' ? 'active' : ''}"
@@ -566,7 +566,7 @@
                         <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
                     </svg>
                 </span>
-                <span class="sb-label">Comptes liés</span>
+                <span class="sb-label">{tFn('settings.connected.label')}</span>
                 {#if twitchLoaded && twitchLink}
                     <span class="sb-badge-dot" style="background:#10b981"></span>
                 {/if}
@@ -936,8 +936,8 @@
                     </svg>
                 </div>
                 <div>
-                    <h2 class="s-pane-title">Messages chiffrés</h2>
-                    <p class="s-pane-desc">Sauvegarde et récupération de ta clé de chiffrement de bout en bout.</p>
+                    <h2 class="s-pane-title">{tFn('settings.encryption.label')}</h2>
+                    <p class="s-pane-desc">{tFn('settings.encryption.desc')}</p>
                 </div>
             </div>
 
@@ -1054,7 +1054,7 @@
                     </svg>
                 </div>
                 <div>
-                    <h2 class="s-pane-title">Comptes liés</h2>
+                    <h2 class="s-pane-title">{tFn('settings.connected.label')}</h2>
                     <p class="s-pane-desc">
                         Lie tes comptes externes à ton profil Nodyx pour qu'ils soient reconnus
                         automatiquement dans les fonctionnalités correspondantes.
@@ -1147,7 +1147,7 @@
                 </div>
                 <div>
                     <h2 class="s-pane-title">Notifications sonores</h2>
-                    <p class="s-pane-desc">Sons synthétisés en temps réel — aucun fichier audio.</p>
+                    <p class="s-pane-desc">{tFn('settings.sounds.desc')}</p>
                 </div>
             </div>
 
@@ -1155,8 +1155,8 @@
             <div class="s-card">
                 <div class="s-row">
                     <div class="s-row-info">
-                        <div class="s-row-title">Sons activés</div>
-                        <div class="s-row-sub">Active ou désactive tous les sons de notification.</div>
+                        <div class="s-row-title">{tFn('settings.sounds.enabled')}</div>
+                        <div class="s-row-sub">{tFn('settings.sounds.enabled_desc')}</div>
                     </div>
                     <button
                         onclick={() => soundSettings.update(s => ({ ...s, enabled: !s.enabled }))}
@@ -1278,14 +1278,14 @@
                 </div>
                 <div>
                     <h2 class="s-pane-title">Notifications Streamer (Twitch)</h2>
-                    <p class="s-pane-desc">Reçois un son côté Nodyx pour follow, sub, raid, cheer. Utile quand tu coupes le retour audio de ton live.</p>
+                    <p class="s-pane-desc">{tFn('settings.streamer.desc')}</p>
                 </div>
             </div>
 
             <div class="s-card">
                 <div class="s-row">
                     <div class="s-row-info">
-                        <div class="s-row-title">Notifs Streamer activées</div>
+                        <div class="s-row-title">{tFn('settings.streamer.enabled')}</div>
                         <div class="s-row-sub">Écoute les events Twitch de ton instance en direct.</div>
                     </div>
                     <button
@@ -1362,7 +1362,7 @@
             {/if}
 
             <div class="s-card s-card-muted">
-                <p class="s-hint-text">Sons générés via Web Audio API — aucun fichier téléchargé, aucune latence réseau. Les réglages sont sauvegardés localement dans votre navigateur.</p>
+                <p class="s-hint-text">{tFn('settings.sounds.hint')}</p>
             </div>
         </div>
         {/if}


### PR DESCRIPTION
Suite #143. Résidus en dur de la page Réglages : nav + panneaux Messages chiffrés / Comptes liés, section Sons, section Notifs Streamer. +9 clés `settings.*` ×4 langues. (Les libellés d'events streamer dans le script restent pour la passe admin.)