### PR TITLE
fix(i18n): panneau Comptes liés / Twitch (#143)

### DIFF
--- a/nodyx-frontend/src/lib/locales/de.json
+++ b/nodyx-frontend/src/lib/locales/de.json
@@ -898,5 +898,17 @@
   "members.offline": "Offline",
   "members.none_online": "Keine Mitglieder online",
   "members.see_all": "Alle anzeigen",
-  "settings.sounds.nav": "Töne"
+  "settings.sounds.nav": "Töne",
+  "settings.connected.desc": "Verknüpfe deine externen Konten mit deinem Nodyx-Profil, damit sie in den entsprechenden Funktionen automatisch erkannt werden.",
+  "settings.connected.linked": "verknüpft",
+  "settings.connected.twitch_connected_pre": "Verbunden mit",
+  "settings.connected.twitch_connected_post": ". Wenn du dem Haupt-Twitch-Kanal dieser Instanz folgst, abonnierst oder ihn raidest, wird das Ereignis mit deinem Nodyx-Profil verknüpft.",
+  "settings.connected.twitch_unlinked_desc": "Verknüpfe dein Twitch-Konto, damit deine Follows / Subs / Cheers / Raids in Nodyx automatisch als deine erkannt werden. Es wird kein Token gespeichert: wir speichern nur deine Twitch-ID und deinen Login.",
+  "settings.connected.unlinking": "Wird getrennt…",
+  "settings.connected.unlink_twitch": "Mein Twitch-Konto trennen",
+  "settings.connected.redirecting": "Weiterleitung…",
+  "settings.connected.link_twitch": "Mein Twitch-Konto verknüpfen",
+  "settings.connected.confirm_unlink": "{{login}} von deinem Nodyx-Profil trennen?",
+  "settings.connected.unlinked_toast": "Twitch-Konto getrennt",
+  "settings.connected.unlink_failed": "Trennen fehlgeschlagen"
 }

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -899,5 +899,17 @@
   "members.offline": "Offline",
   "members.none_online": "No members online",
   "members.see_all": "See all",
-  "settings.sounds.nav": "Sounds"
+  "settings.sounds.nav": "Sounds",
+  "settings.connected.desc": "Link your external accounts to your Nodyx profile so they are recognized automatically in the matching features.",
+  "settings.connected.linked": "linked",
+  "settings.connected.twitch_connected_pre": "Connected to",
+  "settings.connected.twitch_connected_post": ". When you follow, sub or raid on this instance's main Twitch channel, the event will be linked to your Nodyx profile.",
+  "settings.connected.twitch_unlinked_desc": "Link your Twitch account so your follows / subs / cheers / raids are automatically recognized as yours in Nodyx. No token is stored: we only save your Twitch ID and login.",
+  "settings.connected.unlinking": "Unlinking…",
+  "settings.connected.unlink_twitch": "Unlink my Twitch account",
+  "settings.connected.redirecting": "Redirecting…",
+  "settings.connected.link_twitch": "Link my Twitch account",
+  "settings.connected.confirm_unlink": "Unlink {{login}} from your Nodyx profile?",
+  "settings.connected.unlinked_toast": "Twitch account unlinked",
+  "settings.connected.unlink_failed": "Unlink failed"
 }

--- a/nodyx-frontend/src/lib/locales/es.json
+++ b/nodyx-frontend/src/lib/locales/es.json
@@ -898,5 +898,17 @@
   "members.offline": "Desconectado",
   "members.none_online": "Ningún miembro en línea",
   "members.see_all": "Ver todos",
-  "settings.sounds.nav": "Sonidos"
+  "settings.sounds.nav": "Sonidos",
+  "settings.connected.desc": "Vincula tus cuentas externas a tu perfil Nodyx para que se reconozcan automáticamente en las funciones correspondientes.",
+  "settings.connected.linked": "vinculado",
+  "settings.connected.twitch_connected_pre": "Conectado a",
+  "settings.connected.twitch_connected_post": ". Cuando sigues, te suscribes o haces raid en el canal de Twitch principal de esta instancia, el evento se vinculará a tu perfil Nodyx.",
+  "settings.connected.twitch_unlinked_desc": "Vincula tu cuenta de Twitch para que tus follows / subs / cheers / raids se reconozcan automáticamente como tuyos en Nodyx. No se guarda ningún token: solo guardamos tu ID de Twitch y tu login.",
+  "settings.connected.unlinking": "Desvinculando…",
+  "settings.connected.unlink_twitch": "Desvincular mi cuenta de Twitch",
+  "settings.connected.redirecting": "Redirigiendo…",
+  "settings.connected.link_twitch": "Vincular mi cuenta de Twitch",
+  "settings.connected.confirm_unlink": "¿Desvincular {{login}} de tu perfil Nodyx?",
+  "settings.connected.unlinked_toast": "Cuenta de Twitch desvinculada",
+  "settings.connected.unlink_failed": "La desvinculación falló"
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -899,5 +899,17 @@
   "members.offline": "Hors ligne",
   "members.none_online": "Aucun membre en ligne",
   "members.see_all": "Voir tous",
-  "settings.sounds.nav": "Sons"
+  "settings.sounds.nav": "Sons",
+  "settings.connected.desc": "Lie tes comptes externes à ton profil Nodyx pour qu'ils soient reconnus automatiquement dans les fonctionnalités correspondantes.",
+  "settings.connected.linked": "lié",
+  "settings.connected.twitch_connected_pre": "Connecté à",
+  "settings.connected.twitch_connected_post": ". Quand tu follow, sub ou raid sur la chaîne Twitch principale de cette instance, l'événement sera relié à ton profil Nodyx.",
+  "settings.connected.twitch_unlinked_desc": "Lie ton compte Twitch pour que tes follows / subs / cheers / raids soient automatiquement reconnus comme étant les tiens dans Nodyx. Aucun token n'est conservé : on enregistre juste l'identifiant Twitch et ton login.",
+  "settings.connected.unlinking": "Délier…",
+  "settings.connected.unlink_twitch": "Délier mon compte Twitch",
+  "settings.connected.redirecting": "Redirection…",
+  "settings.connected.link_twitch": "Lier mon compte Twitch",
+  "settings.connected.confirm_unlink": "Délier {{login}} de votre profil Nodyx ?",
+  "settings.connected.unlinked_toast": "Compte Twitch délié",
+  "settings.connected.unlink_failed": "Délier a échoué"
 }

--- a/nodyx-frontend/src/lib/locales/pt-PT.json
+++ b/nodyx-frontend/src/lib/locales/pt-PT.json
@@ -899,5 +899,17 @@
   "members.offline": "Offline",
   "members.none_online": "Nenhum membro online",
   "members.see_all": "Ver todos",
-  "settings.sounds.nav": "Sons"
+  "settings.sounds.nav": "Sons",
+  "settings.connected.desc": "Liga as tuas contas externas ao teu perfil Nodyx para que sejam reconhecidas automaticamente nas funcionalidades correspondentes.",
+  "settings.connected.linked": "ligado",
+  "settings.connected.twitch_connected_pre": "Ligado a",
+  "settings.connected.twitch_connected_post": ". Quando segues, fazes sub ou raid no canal Twitch principal desta instância, o evento será associado ao teu perfil Nodyx.",
+  "settings.connected.twitch_unlinked_desc": "Liga a tua conta Twitch para que os teus follows / subs / cheers / raids sejam automaticamente reconhecidos como teus no Nodyx. Nenhum token é guardado: apenas guardamos o teu ID Twitch e o teu login.",
+  "settings.connected.unlinking": "A desligar…",
+  "settings.connected.unlink_twitch": "Desligar a minha conta Twitch",
+  "settings.connected.redirecting": "A redirecionar…",
+  "settings.connected.link_twitch": "Ligar a minha conta Twitch",
+  "settings.connected.confirm_unlink": "Desligar {{login}} do teu perfil Nodyx?",
+  "settings.connected.unlinked_toast": "Conta Twitch desligada",
+  "settings.connected.unlink_failed": "Falha ao desligar"
 }

--- a/nodyx-frontend/src/lib/locales/ru.json
+++ b/nodyx-frontend/src/lib/locales/ru.json
@@ -899,5 +899,17 @@
   "members.offline": "Не в сети",
   "members.none_online": "Нет участников в сети",
   "members.see_all": "Показать всех",
-  "settings.sounds.nav": "Звуки"
+  "settings.sounds.nav": "Звуки",
+  "settings.connected.desc": "Привяжи свои внешние аккаунты к профилю Nodyx, чтобы они автоматически распознавались в соответствующих функциях.",
+  "settings.connected.linked": "привязан",
+  "settings.connected.twitch_connected_pre": "Подключено к",
+  "settings.connected.twitch_connected_post": ". Когда ты подписываешься, оформляешь sub или делаешь raid на основном Twitch-канале этого сервера, событие будет привязано к твоему профилю Nodyx.",
+  "settings.connected.twitch_unlinked_desc": "Привяжи свой аккаунт Twitch, чтобы твои фолловы / сабы / cheers / рейды автоматически распознавались как твои в Nodyx. Токен не сохраняется: мы храним только твой Twitch-ID и логин.",
+  "settings.connected.unlinking": "Отвязка…",
+  "settings.connected.unlink_twitch": "Отвязать мой аккаунт Twitch",
+  "settings.connected.redirecting": "Перенаправление…",
+  "settings.connected.link_twitch": "Привязать мой аккаунт Twitch",
+  "settings.connected.confirm_unlink": "Отвязать {{login}} от вашего профиля Nodyx?",
+  "settings.connected.unlinked_toast": "Аккаунт Twitch отвязан",
+  "settings.connected.unlink_failed": "Не удалось отвязать"
 }

--- a/nodyx-frontend/src/routes/settings/+page.svelte
+++ b/nodyx-frontend/src/routes/settings/+page.svelte
@@ -100,7 +100,7 @@
 
     async function unlinkTwitch() {
         if (twitchUnlinking || !twitchLink) return
-        if (!confirm(`Délier ${twitchLink.twitchLogin} de votre profil Nodyx ?`)) return
+        if (!confirm(tFn('settings.connected.confirm_unlink', { login: twitchLink.twitchLogin }))) return
         twitchUnlinking = true
         twitchError = null
         try {
@@ -111,10 +111,10 @@
             })
             if (res.ok) {
                 twitchLink = null
-                twitchToast = 'Compte Twitch délié'
+                twitchToast = tFn('settings.connected.unlinked_toast')
                 setTimeout(() => twitchToast = null, 3500)
             } else {
-                twitchError = 'Délier a échoué'
+                twitchError = tFn('settings.connected.unlink_failed')
             }
         } catch {
             twitchError = 'Erreur réseau'
@@ -1055,10 +1055,7 @@
                 </div>
                 <div>
                     <h2 class="s-pane-title">{tFn('settings.connected.label')}</h2>
-                    <p class="s-pane-desc">
-                        Lie tes comptes externes à ton profil Nodyx pour qu'ils soient reconnus
-                        automatiquement dans les fonctionnalités correspondantes.
-                    </p>
+                    <p class="s-pane-desc">{tFn('settings.connected.desc')}</p>
                 </div>
             </div>
 
@@ -1072,20 +1069,15 @@
                             <h3 style="margin: 0; font-size: 16px; font-weight: 600; color: #fff;">Twitch</h3>
                             {#if twitchLink}
                                 <span style="font-size: 11px; padding: 2px 8px; border-radius: 999px; background: rgba(16,185,129,0.15); color:#34d399; border: 1px solid rgba(16,185,129,0.3);">
-                                    lié
+                                    {tFn('settings.connected.linked')}
                                 </span>
                             {/if}
                         </div>
                         <p style="margin: 6px 0 0; font-size: 13px; color: #94a3b8; line-height: 1.5;">
                             {#if twitchLink}
-                                Connecté à <strong style="color:#a78bfa;">@{twitchLink.twitchLogin}</strong>.
-                                Quand tu follow, sub ou raid sur la chaîne Twitch principale de cette
-                                instance, l'événement sera relié à ton profil Nodyx.
+                                {tFn('settings.connected.twitch_connected_pre')} <strong style="color:#a78bfa;">@{twitchLink.twitchLogin}</strong>{tFn('settings.connected.twitch_connected_post')}
                             {:else}
-                                Lie ton compte Twitch pour que tes follows / subs / cheers / raids
-                                soient automatiquement reconnus comme étant les tiens dans Nodyx.
-                                Aucun token n'est conservé : on enregistre juste l'identifiant
-                                Twitch et ton login.
+                                {tFn('settings.connected.twitch_unlinked_desc')}
                             {/if}
                         </p>
 
@@ -1097,7 +1089,7 @@
 
                         <div style="margin-top: 14px; display: flex; gap: 10px; flex-wrap: wrap;">
                             {#if !twitchLoaded}
-                                <span style="font-size: 12px; color: #64748b;">Chargement…</span>
+                                <span style="font-size: 12px; color: #64748b;">{tFn('common.loading')}</span>
                             {:else if twitchLink}
                                 <button
                                     onclick={unlinkTwitch}
@@ -1106,7 +1098,7 @@
                                     onmouseenter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'rgba(239,68,68,0.2)' }}
                                     onmouseleave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'rgba(239,68,68,0.12)' }}
                                 >
-                                    {twitchUnlinking ? 'Délier…' : 'Délier mon compte Twitch'}
+                                    {twitchUnlinking ? tFn('settings.connected.unlinking') : tFn('settings.connected.unlink_twitch')}
                                 </button>
                             {:else}
                                 <button
@@ -1117,9 +1109,9 @@
                                     onmouseleave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = '#7c3aed' }}
                                 >
                                     {#if twitchConnecting}
-                                        <span style="display: inline-block; animation: spin 1s linear infinite;">◌</span> Redirection…
+                                        <span style="display: inline-block; animation: spin 1s linear infinite;">◌</span> {tFn('settings.connected.redirecting')}
                                     {:else}
-                                        Lier mon compte Twitch
+                                        {tFn('settings.connected.link_twitch')}
                                     {/if}
                                 </button>
                             {/if}


### PR DESCRIPTION
Repéré sur une capture en russe (@mrmeloman) : le panneau Comptes liés avait son titre traduit mais tout le corps en français (description, badge lié, textes Twitch, boutons lier/délier, et les chaînes JS confirm/toast/erreur). +12 clés `settings.connected.*` + `common.loading` dans les 6 langues, avec interpolation `{{login}}` pour le confirm de déliaison.
