### PR TITLE
fix(i18n): page Membres (#143)

### DIFF
--- a/nodyx-frontend/src/lib/locales/de.json
+++ b/nodyx-frontend/src/lib/locales/de.json
@@ -910,5 +910,20 @@
   "settings.connected.link_twitch": "Mein Twitch-Konto verknüpfen",
   "settings.connected.confirm_unlink": "{{login}} von deinem Nodyx-Profil trennen?",
   "settings.connected.unlinked_toast": "Twitch-Konto getrennt",
-  "settings.connected.unlink_failed": "Trennen fehlgeschlagen"
+  "settings.connected.unlink_failed": "Trennen fehlgeschlagen",
+  "members.page_title": "Mitglieder · Nodyx",
+  "members.total": "gesamt",
+  "members.filter_ph": "Nach Name oder Benutzername filtern…",
+  "members.sort_oldest": "Älteste zuerst",
+  "members.sort_newest": "Neueste zuerst",
+  "members.sort_points": "Punkte (absteigend)",
+  "members.sort_alpha": "Alphabetisch",
+  "members.none_match": "Kein Mitglied gefunden.",
+  "members.team": "Team",
+  "members.members_section": "Mitglieder",
+  "members.since": "Mitglied seit",
+  "members.pts": "Pkt",
+  "members.role_owner": "Gründer",
+  "members.role_admin": "Admin",
+  "members.role_moderator": "Mod"
 }

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -911,5 +911,20 @@
   "settings.connected.link_twitch": "Link my Twitch account",
   "settings.connected.confirm_unlink": "Unlink {{login}} from your Nodyx profile?",
   "settings.connected.unlinked_toast": "Twitch account unlinked",
-  "settings.connected.unlink_failed": "Unlink failed"
+  "settings.connected.unlink_failed": "Unlink failed",
+  "members.page_title": "Members · Nodyx",
+  "members.total": "total",
+  "members.filter_ph": "Filter by name or username…",
+  "members.sort_oldest": "Oldest first",
+  "members.sort_newest": "Newest first",
+  "members.sort_points": "Points (desc)",
+  "members.sort_alpha": "Alphabetical",
+  "members.none_match": "No member matches.",
+  "members.team": "Team",
+  "members.members_section": "Members",
+  "members.since": "since",
+  "members.pts": "pts",
+  "members.role_owner": "Founder",
+  "members.role_admin": "Admin",
+  "members.role_moderator": "Mod"
 }

--- a/nodyx-frontend/src/lib/locales/es.json
+++ b/nodyx-frontend/src/lib/locales/es.json
@@ -910,5 +910,20 @@
   "settings.connected.link_twitch": "Vincular mi cuenta de Twitch",
   "settings.connected.confirm_unlink": "¿Desvincular {{login}} de tu perfil Nodyx?",
   "settings.connected.unlinked_toast": "Cuenta de Twitch desvinculada",
-  "settings.connected.unlink_failed": "La desvinculación falló"
+  "settings.connected.unlink_failed": "La desvinculación falló",
+  "members.page_title": "Miembros · Nodyx",
+  "members.total": "total",
+  "members.filter_ph": "Filtrar por nombre o usuario…",
+  "members.sort_oldest": "Más antiguos primero",
+  "members.sort_newest": "Más nuevos primero",
+  "members.sort_points": "Puntos (desc)",
+  "members.sort_alpha": "Alfabético",
+  "members.none_match": "Ningún miembro coincide.",
+  "members.team": "Equipo",
+  "members.members_section": "Miembros",
+  "members.since": "desde el",
+  "members.pts": "pts",
+  "members.role_owner": "Fundador",
+  "members.role_admin": "Admin",
+  "members.role_moderator": "Mod"
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -911,5 +911,20 @@
   "settings.connected.link_twitch": "Lier mon compte Twitch",
   "settings.connected.confirm_unlink": "Délier {{login}} de votre profil Nodyx ?",
   "settings.connected.unlinked_toast": "Compte Twitch délié",
-  "settings.connected.unlink_failed": "Délier a échoué"
+  "settings.connected.unlink_failed": "Délier a échoué",
+  "members.page_title": "Membres · Nodyx",
+  "members.total": "total",
+  "members.filter_ph": "Filtrer par nom ou pseudo…",
+  "members.sort_oldest": "Anciens d'abord",
+  "members.sort_newest": "Nouveaux d'abord",
+  "members.sort_points": "Points (desc)",
+  "members.sort_alpha": "Alphabétique",
+  "members.none_match": "Aucun membre ne correspond.",
+  "members.team": "Équipe",
+  "members.members_section": "Membres",
+  "members.since": "depuis le",
+  "members.pts": "pts",
+  "members.role_owner": "Fondateur",
+  "members.role_admin": "Admin",
+  "members.role_moderator": "Modo"
 }

--- a/nodyx-frontend/src/lib/locales/pt-PT.json
+++ b/nodyx-frontend/src/lib/locales/pt-PT.json
@@ -911,5 +911,20 @@
   "settings.connected.link_twitch": "Ligar a minha conta Twitch",
   "settings.connected.confirm_unlink": "Desligar {{login}} do teu perfil Nodyx?",
   "settings.connected.unlinked_toast": "Conta Twitch desligada",
-  "settings.connected.unlink_failed": "Falha ao desligar"
+  "settings.connected.unlink_failed": "Falha ao desligar",
+  "members.page_title": "Membros · Nodyx",
+  "members.total": "total",
+  "members.filter_ph": "Filtrar por nome ou utilizador…",
+  "members.sort_oldest": "Mais antigos primeiro",
+  "members.sort_newest": "Mais recentes primeiro",
+  "members.sort_points": "Pontos (desc)",
+  "members.sort_alpha": "Alfabético",
+  "members.none_match": "Nenhum membro corresponde.",
+  "members.team": "Equipa",
+  "members.members_section": "Membros",
+  "members.since": "desde",
+  "members.pts": "pts",
+  "members.role_owner": "Fundador",
+  "members.role_admin": "Admin",
+  "members.role_moderator": "Mod"
 }

--- a/nodyx-frontend/src/lib/locales/ru.json
+++ b/nodyx-frontend/src/lib/locales/ru.json
@@ -911,5 +911,20 @@
   "settings.connected.link_twitch": "Привязать мой аккаунт Twitch",
   "settings.connected.confirm_unlink": "Отвязать {{login}} от вашего профиля Nodyx?",
   "settings.connected.unlinked_toast": "Аккаунт Twitch отвязан",
-  "settings.connected.unlink_failed": "Не удалось отвязать"
+  "settings.connected.unlink_failed": "Не удалось отвязать",
+  "members.page_title": "Участники · Nodyx",
+  "members.total": "всего",
+  "members.filter_ph": "Фильтр по имени или нику…",
+  "members.sort_oldest": "Сначала старые",
+  "members.sort_newest": "Сначала новые",
+  "members.sort_points": "Очки (по убыв.)",
+  "members.sort_alpha": "По алфавиту",
+  "members.none_match": "Нет подходящих участников.",
+  "members.team": "Команда",
+  "members.members_section": "Участники",
+  "members.since": "с",
+  "members.pts": "очк.",
+  "members.role_owner": "Основатель",
+  "members.role_admin": "Админ",
+  "members.role_moderator": "Модер"
 }

--- a/nodyx-frontend/src/routes/members/+page.svelte
+++ b/nodyx-frontend/src/routes/members/+page.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import type { PageData } from './$types'
 	import type { FullMember } from './+page.server'
+	import { t } from '$lib/i18n'
+
+	const tFn = $derived($t)
 
 	let { data }: { data: PageData } = $props()
 
@@ -53,26 +56,26 @@
 	function fmtDate(iso: string): string {
 		try {
 			const d = new Date(iso)
-			return d.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric' })
+			return d.toLocaleDateString([], { day: '2-digit', month: '2-digit', year: 'numeric' })
 		} catch { return '' }
 	}
 </script>
 
-<svelte:head><title>Membres · Nodyx</title></svelte:head>
+<svelte:head><title>{tFn('members.page_title')}</title></svelte:head>
 
 <div class="mb-page">
 	<header class="mb-header">
 		<div class="mb-header-title">
-			<h1 class="mb-title">Membres</h1>
+			<h1 class="mb-title">{tFn('members.title')}</h1>
 			<div class="mb-counts">
 				<span class="mb-count">
 					<span class="mb-count-num">{data.members?.length ?? 0}</span>
-					<span class="mb-count-label">total</span>
+					<span class="mb-count-label">{tFn('members.total')}</span>
 				</span>
 				<span class="mb-count-sep">·</span>
 				<span class="mb-count">
 					<span class="mb-count-num">{(data.members ?? []).filter((m: FullMember) => m.is_online).length}</span>
-					<span class="mb-count-label">en ligne</span>
+					<span class="mb-count-label">{tFn('members.online')}</span>
 				</span>
 			</div>
 		</div>
@@ -85,30 +88,30 @@
 				<input
 					type="text"
 					bind:value={query}
-					placeholder="Filtrer par nom ou pseudo…"
+					placeholder={tFn('members.filter_ph')}
 					class="mb-search-input"
 				/>
 			</div>
 			<select bind:value={sortBy} class="mb-sort">
-				<option value="joined_asc">Anciens d'abord</option>
-				<option value="joined_desc">Nouveaux d'abord</option>
-				<option value="points">Points (desc)</option>
-				<option value="username">Alphabétique</option>
+				<option value="joined_asc">{tFn('members.sort_oldest')}</option>
+				<option value="joined_desc">{tFn('members.sort_newest')}</option>
+				<option value="points">{tFn('members.sort_points')}</option>
+				<option value="username">{tFn('members.sort_alpha')}</option>
 			</select>
 			<label class="mb-toggle">
 				<input type="checkbox" bind:checked={onlyOnline} />
-				<span>En ligne</span>
+				<span>{tFn('members.online')}</span>
 			</label>
 		</div>
 	</header>
 
 	{#if data.error}
-		<div class="mb-empty mb-empty--error">Erreur : {data.error}</div>
+		<div class="mb-empty mb-empty--error">{tFn('common.error')} : {data.error}</div>
 	{:else if filtered.total === 0}
-		<div class="mb-empty">Aucun membre ne correspond.</div>
+		<div class="mb-empty">{tFn('members.none_match')}</div>
 	{:else}
 		{#if filtered.staff.length > 0}
-			<div class="mb-section-label">Équipe</div>
+			<div class="mb-section-label">{tFn('members.team')}</div>
 			<ul class="mb-list">
 				{#each filtered.staff as m (m.user_id)}
 					{@render row(m)}
@@ -117,7 +120,7 @@
 		{/if}
 		{#if filtered.members.length > 0}
 			{#if filtered.staff.length > 0}
-				<div class="mb-section-label">Membres</div>
+				<div class="mb-section-label">{tFn('members.members_section')}</div>
 			{/if}
 			<ul class="mb-list">
 				{#each filtered.members as m (m.user_id)}
@@ -138,7 +141,7 @@
 					<div class="mb-avatar mb-avatar--init">{m.username[0].toUpperCase()}</div>
 				{/if}
 				{#if m.is_online}
-					<span class="mb-online-dot" aria-label="En ligne"></span>
+					<span class="mb-online-dot" aria-label={tFn('members.online')}></span>
 				{/if}
 			</div>
 
@@ -154,19 +157,19 @@
 							style={m.grade_color ? `color: ${m.grade_color}; border-color: ${m.grade_color}55` : ''}
 						>{m.grade_name}</span>
 					{:else if roleLabels[m.role] && m.role !== 'member'}
-						<span class="mb-grade mb-grade--role">{roleLabels[m.role]}</span>
+						<span class="mb-grade mb-grade--role">{tFn('members.role_' + m.role)}</span>
 					{/if}
 				</div>
 				<div class="mb-row-line2">
 					<span class="mb-user">@{m.username}</span>
 					<span class="mb-sep">·</span>
-					<span class="mb-joined">depuis le {fmtDate(m.joined_at)}</span>
+					<span class="mb-joined">{tFn('members.since')} {fmtDate(m.joined_at)}</span>
 				</div>
 			</div>
 
 			<div class="mb-row-meta">
 				<span class="mb-points-num">{m.points}</span>
-				<span class="mb-points-label">pts</span>
+				<span class="mb-points-label">{tFn('members.pts')}</span>
 			</div>
 		</a>
 	</li>


### PR DESCRIPTION
Repérée sur une capture (@mrmeloman). Traduit le titre, les compteurs (total / en ligne), le filtre, le tri, les sections Équipe / Membres, le "depuis le", "pts", le message vide, et les libellés de rôle fallback (Fondateur / Admin / Modo). Date affichée au format de la langue active.

+15 clés (`members.*`, `common.error`) dans les 6 langues.

Important : les **grades personnalisés** (`grade_name`, ex "Testeur") restent intacts, ce sont des données de la communauté, pas de l'UI.