### PR TITLE
fix(i18n): widgets de la page d'accueil (#143)

### DIFF
--- a/nodyx-frontend/src/lib/components/homepage/widgets/ArticleSlideshow.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/ArticleSlideshow.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte'
+	import { t, locale } from '$lib/i18n'
+
+	const tFn = $derived($t)
+	const loc = $derived($locale)
 
 	// ── Types ────────────────────────────────────────────────────────────────
 	type SourceArticles = {
@@ -107,7 +111,7 @@
 					title:         src.title,
 					imageUrl:      src.thumbnail || (videoId ? youtubeThumbnail(videoId) : undefined),
 					excerpt:       src.excerpt,
-					categoryLabel: src.label ?? 'Vidéo',
+					categoryLabel: src.label ?? tFn('widgets.video'),
 					isVideo:       true,
 					videoId:       videoId ?? undefined,
 					href:          src.cta_url || src.url,
@@ -159,12 +163,12 @@
 
 	// ── Time helper ──────────────────────────────────────────────────────────
 	function timeAgo(dateStr: string): string {
-		const diff = Date.now() - new Date(dateStr).getTime()
-		const m = Math.floor(diff / 60000)
-		if (m < 60)  return `${m}min`
-		const h = Math.floor(m / 60)
-		if (h < 24)  return `${h}h`
-		return `${Math.floor(h / 24)}j`
+		const min = (new Date(dateStr).getTime() - Date.now()) / 60000 // négatif = passé
+		const rtf = new Intl.RelativeTimeFormat(loc, { numeric: 'auto', style: 'narrow' })
+		if (Math.abs(min) < 60) return rtf.format(Math.round(min), 'minute')
+		const h = min / 60
+		if (Math.abs(h) < 24)   return rtf.format(Math.round(h), 'hour')
+		return rtf.format(Math.round(h / 24), 'day')
 	}
 </script>
 
@@ -175,7 +179,7 @@
 		</div>
 
 	{:else if slides.length === 0}
-		<div class="as-empty">Aucun contenu à afficher</div>
+		<div class="as-empty">{tFn('widgets.no_content')}</div>
 
 	{:else}
 		{@const slide = slides[slideIndex]}
@@ -201,7 +205,7 @@
 				target="_blank"
 				rel="noopener noreferrer"
 				class="as-play"
-				aria-label="Regarder la vidéo"
+				aria-label={tFn('widgets.watch_video')}
 			>
 				<svg viewBox="0 0 24 24" fill="currentColor">
 					<path d="M8 5v14l11-7z"/>
@@ -216,7 +220,7 @@
 					<span class="as-cat-line"></span>
 					<span class="as-cat-text">{slide.categoryLabel}</span>
 					{#if slide.isVideo}
-						<span class="as-cat-badge">▶ Vidéo</span>
+						<span class="as-cat-badge">▶ {tFn('widgets.video')}</span>
 					{/if}
 				</div>
 			{/if}
@@ -258,7 +262,7 @@
 						rel={slide.isVideo ? 'noopener noreferrer' : undefined}
 						class="as-cta"
 					>
-						{slide.isVideo ? '▶ Regarder' : 'Lire'}
+						{slide.isVideo ? '▶ ' + tFn('widgets.watch') : tFn('widgets.read')}
 						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
 							<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
 						</svg>
@@ -284,12 +288,12 @@
 						{/each}
 					</div>
 					<div class="as-arrows">
-						<button class="as-arrow" onclick={() => { slidePrev(); startTimers() }} aria-label="Précédent">
+						<button class="as-arrow" onclick={() => { slidePrev(); startTimers() }} aria-label={tFn('common.previous')}>
 							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/>
 							</svg>
 						</button>
-						<button class="as-arrow" onclick={() => { slideNext(); startTimers() }} aria-label="Suivant">
+						<button class="as-arrow" onclick={() => { slideNext(); startTimers() }} aria-label={tFn('common.next')}>
 							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
 							</svg>

--- a/nodyx-frontend/src/lib/components/homepage/widgets/ArticlesShowcase.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/ArticlesShowcase.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte'
 	import { browser } from '$app/environment'
+	import { t, locale } from '$lib/i18n'
+
+	const tFn = $derived($t)
+	const loc = $derived($locale)
 
 	interface Article {
 		id:              string
@@ -43,7 +47,7 @@
 	const showDate      = $derived((config.show_date     as boolean) ?? true)
 	const showCategory  = $derived((config.show_category as boolean) ?? true)
 	const showViews     = $derived((config.show_views    as boolean) ?? false)
-	const ctaText       = $derived((config.cta_text      as string)  ?? 'Lire la suite')
+	const ctaText       = $derived((config.cta_text      as string)  ?? tFn('widgets.read_more'))
 	const accent        = $derived((config.accent_color  as string)  ?? '#a78bfa')
 	const aspectRatio   = $derived((config.aspect_ratio  as string)  ?? '16:9')
 	const sliderAuto    = $derived((config.slider_autoplay as boolean) ?? true)
@@ -74,16 +78,16 @@
 
 	// ── Helpers ──
 	function timeAgo(dateStr: string): string {
-		const diff = Date.now() - new Date(dateStr).getTime()
-		const m = Math.floor(diff / 60000)
-		if (m < 60)  return `il y a ${m} min`
-		const h = Math.floor(m / 60)
-		if (h < 24)  return `il y a ${h}h`
-		const d = Math.floor(h / 24)
-		if (d < 30)  return `il y a ${d}j`
-		const mo = Math.floor(d / 30)
-		if (mo < 12) return `il y a ${mo} mois`
-		return `il y a ${Math.floor(mo / 12)} an`
+		const min = (new Date(dateStr).getTime() - Date.now()) / 60000 // négatif = passé
+		const rtf = new Intl.RelativeTimeFormat(loc, { numeric: 'auto' })
+		if (Math.abs(min) < 60)      return rtf.format(Math.round(min), 'minute')
+		const h = min / 60
+		if (Math.abs(h) < 24)        return rtf.format(Math.round(h), 'hour')
+		const d = h / 24
+		if (Math.abs(d) < 30)        return rtf.format(Math.round(d), 'day')
+		const mo = d / 30
+		if (Math.abs(mo) < 12)       return rtf.format(Math.round(mo), 'month')
+		return rtf.format(Math.round(mo / 12), 'year')
 	}
 
 	function articleUrl(a: Article): string {
@@ -151,7 +155,7 @@
 		</div>
 
 	{:else if articles.length === 0}
-		<div class="as-empty">Aucun article à afficher pour le moment.</div>
+		<div class="as-empty">{tFn('widgets.no_articles')}</div>
 
 	{:else if layout === 'magazine'}
 		<!-- ─────────── MAGAZINE : 1 hero + 2x2 grid ─────────── -->
@@ -176,10 +180,10 @@
 						{/if}
 						<div class="as-meta">
 							{#if showAuthor}
-								<span class="as-meta-author">par <strong>{magazineHero.author_username}</strong></span>
+								<span class="as-meta-author">{tFn('widgets.by')} <strong>{magazineHero.author_username}</strong></span>
 							{/if}
 							{#if showDate}<span class="as-meta-dot">·</span><span>{timeAgo(magazineHero.created_at)}</span>{/if}
-							{#if showViews}<span class="as-meta-dot">·</span><span>{magazineHero.views} vues</span>{/if}
+							{#if showViews}<span class="as-meta-dot">·</span><span>{magazineHero.views} {tFn('widgets.views')}</span>{/if}
 						</div>
 						<span class="as-cta">{ctaText}<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M14 5l7 7m0 0l-7 7m7-7H3"/></svg></span>
 					</div>
@@ -245,7 +249,7 @@
 							{#if showAuthor}<span><strong>{a.author_username}</strong></span>{/if}
 							{#if showAuthor && showDate}<span class="as-meta-dot">·</span>{/if}
 							{#if showDate}<span>{timeAgo(a.created_at)}</span>{/if}
-							{#if showViews}<span class="as-meta-dot">·</span><span>{a.views} vues</span>{/if}
+							{#if showViews}<span class="as-meta-dot">·</span><span>{a.views} {tFn('widgets.views')}</span>{/if}
 						</div>
 					</div>
 					<span class="as-horiz-arrow" aria-hidden="true">→</span>
@@ -272,7 +276,7 @@
 							<h3 class="as-hero-title">{a.title}</h3>
 							{#if showExcerpt && a.excerpt}<p class="as-hero-excerpt">{a.excerpt}</p>{/if}
 							<div class="as-meta">
-								{#if showAuthor}<span>par <strong>{a.author_username}</strong></span>{/if}
+								{#if showAuthor}<span>{tFn('widgets.by')} <strong>{a.author_username}</strong></span>{/if}
 								{#if showDate}<span class="as-meta-dot">·</span><span>{timeAgo(a.created_at)}</span>{/if}
 							</div>
 							<span class="as-cta">{ctaText}<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M14 5l7 7m0 0l-7 7m7-7H3"/></svg></span>
@@ -282,10 +286,10 @@
 			{/each}
 
 			{#if articles.length > 1}
-				<button class="as-slide-btn as-slide-btn--prev" onclick={sliderPrev} aria-label="Précédent">
+				<button class="as-slide-btn as-slide-btn--prev" onclick={sliderPrev} aria-label={tFn('common.previous')}>
 					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/></svg>
 				</button>
-				<button class="as-slide-btn as-slide-btn--next" onclick={sliderNext} aria-label="Suivant">
+				<button class="as-slide-btn as-slide-btn--next" onclick={sliderNext} aria-label={tFn('common.next')}>
 					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
 				</button>
 
@@ -331,7 +335,7 @@
 							<div class="as-meta as-meta--sm">
 								{#if showAuthor}<span>{a.author_username}</span>{/if}
 								{#if showDate}<span class="as-meta-dot">·</span><span>{timeAgo(a.created_at)}</span>{/if}
-								{#if showViews}<span class="as-meta-dot">·</span><span>{a.views} vues</span>{/if}
+								{#if showViews}<span class="as-meta-dot">·</span><span>{a.views} {tFn('widgets.views')}</span>{/if}
 							</div>
 						</div>
 					</a>

--- a/nodyx-frontend/src/lib/components/homepage/widgets/RecentThreads.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/RecentThreads.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
 	import { onMount } from 'svelte'
+	import { t, locale } from '$lib/i18n'
+
+	const tFn = $derived($t)
+	const loc = $derived($locale)
 
 	interface Thread {
 		id:                   string
@@ -57,14 +61,14 @@
 	})
 
 	function timeAgo(dateStr: string): string {
-		const diff = Date.now() - new Date(dateStr).getTime()
-		const m = Math.floor(diff / 60000)
-		if (m < 60)  return `${m}min`
-		const h = Math.floor(m / 60)
-		if (h < 24)  return `${h}h`
-		const d = Math.floor(h / 24)
-		if (d < 30)  return `${d}j`
-		return `${Math.floor(d / 30)}mois`
+		const min = (new Date(dateStr).getTime() - Date.now()) / 60000 // négatif = passé
+		const rtf = new Intl.RelativeTimeFormat(loc, { numeric: 'auto', style: 'narrow' })
+		if (Math.abs(min) < 60) return rtf.format(Math.round(min), 'minute')
+		const h = min / 60
+		if (Math.abs(h) < 24)   return rtf.format(Math.round(h), 'hour')
+		const d = h / 24
+		if (Math.abs(d) < 30)   return rtf.format(Math.round(d), 'day')
+		return rtf.format(Math.round(d / 30), 'month')
 	}
 </script>
 
@@ -85,7 +89,7 @@
 		</div>
 
 	{:else if threads.length === 0}
-		<div class="rt-empty">Aucun sujet récent.</div>
+		<div class="rt-empty">{tFn('widgets.no_recent_threads')}</div>
 
 	{:else if style === 'cards'}
 		<div class="rt-cards">

--- a/nodyx-frontend/src/lib/components/homepage/widgets/TwitchStream.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/TwitchStream.svelte
@@ -2,6 +2,9 @@
 	import { onMount, onDestroy } from 'svelte'
 	import { browser } from '$app/environment'
 	import { apiFetch } from '$lib/api'
+	import { t } from '$lib/i18n'
+
+	const tFn = $derived($t)
 
 	interface Props {
 		config:   Record<string, unknown>
@@ -157,7 +160,7 @@
 			Twitch Stream
 		</p>
 		<p class="text-xs max-w-xs" style="color:#6b7280">
-			Configure une chaîne Twitch depuis le builder pour afficher le stream ici.
+			{tFn('widgets.twitch_configure')}
 		</p>
 	</div>
 
@@ -220,8 +223,8 @@
 				   rel="noopener noreferrer"
 				   class="shrink-0 flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-bold uppercase tracking-[.18em] transition-all twitch-cta"
 				   style="font-family:'Space Grotesk',sans-serif; color:#e2e8f0; background:{accent}1a; border:1px solid {accent}55"
-				   aria-label="Ouvrir la chaîne {activeChannel} sur Twitch">
-					<span class="hidden sm:inline">Ouvrir</span>
+				   aria-label={tFn('widgets.twitch_open_channel', { channel: activeChannel })}>
+					<span class="hidden sm:inline">{tFn('widgets.open')}</span>
 					<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
 						<path stroke-linecap="round" stroke-linejoin="round" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
 					</svg>
@@ -237,7 +240,7 @@
 					<path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"/>
 				</svg>
 				<span class="truncate">
-					<span style="color:#6b7280">{configuredChannel}</span> est offline — découvre <span class="font-bold">{activeChannel}</span> en attendant
+					<span style="color:#6b7280">{configuredChannel}</span> {tFn('widgets.twitch_offline_mid')} <span class="font-bold">{activeChannel}</span> {tFn('widgets.twitch_offline_end')}
 				</span>
 			</div>
 		{/if}

--- a/nodyx-frontend/src/lib/locales/de.json
+++ b/nodyx-frontend/src/lib/locales/de.json
@@ -925,5 +925,22 @@
   "members.pts": "Pkt",
   "members.role_owner": "Gründer",
   "members.role_admin": "Admin",
-  "members.role_moderator": "Mod"
+  "members.role_moderator": "Mod",
+  "common.previous": "Zurück",
+  "common.next": "Weiter",
+  "widgets.read_more": "Mehr lesen",
+  "widgets.no_articles": "Momentan keine Artikel.",
+  "widgets.by": "von",
+  "widgets.views": "Aufrufe",
+  "widgets.video": "Video",
+  "widgets.no_content": "Kein Inhalt vorhanden",
+  "widgets.watch_video": "Video ansehen",
+  "widgets.watch": "Ansehen",
+  "widgets.read": "Lesen",
+  "widgets.no_recent_threads": "Keine aktuellen Themen.",
+  "widgets.twitch_configure": "Richte im Builder einen Twitch-Kanal ein, um den Stream hier anzuzeigen.",
+  "widgets.twitch_open_channel": "Den Kanal {{channel}} auf Twitch öffnen",
+  "widgets.open": "Öffnen",
+  "widgets.twitch_offline_mid": "ist offline — entdecke",
+  "widgets.twitch_offline_end": "in der Zwischenzeit"
 }

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -926,5 +926,22 @@
   "members.pts": "pts",
   "members.role_owner": "Founder",
   "members.role_admin": "Admin",
-  "members.role_moderator": "Mod"
+  "members.role_moderator": "Mod",
+  "common.previous": "Previous",
+  "common.next": "Next",
+  "widgets.read_more": "Read more",
+  "widgets.no_articles": "No articles to show right now.",
+  "widgets.by": "by",
+  "widgets.views": "views",
+  "widgets.video": "Video",
+  "widgets.no_content": "No content to show",
+  "widgets.watch_video": "Watch the video",
+  "widgets.watch": "Watch",
+  "widgets.read": "Read",
+  "widgets.no_recent_threads": "No recent topics.",
+  "widgets.twitch_configure": "Set up a Twitch channel from the builder to show the stream here.",
+  "widgets.twitch_open_channel": "Open the {{channel}} channel on Twitch",
+  "widgets.open": "Open",
+  "widgets.twitch_offline_mid": "is offline — check out",
+  "widgets.twitch_offline_end": "in the meantime"
 }

--- a/nodyx-frontend/src/lib/locales/es.json
+++ b/nodyx-frontend/src/lib/locales/es.json
@@ -925,5 +925,22 @@
   "members.pts": "pts",
   "members.role_owner": "Fundador",
   "members.role_admin": "Admin",
-  "members.role_moderator": "Mod"
+  "members.role_moderator": "Mod",
+  "common.previous": "Anterior",
+  "common.next": "Siguiente",
+  "widgets.read_more": "Leer más",
+  "widgets.no_articles": "Ningún artículo para mostrar por ahora.",
+  "widgets.by": "por",
+  "widgets.views": "vistas",
+  "widgets.video": "Vídeo",
+  "widgets.no_content": "Ningún contenido para mostrar",
+  "widgets.watch_video": "Ver el vídeo",
+  "widgets.watch": "Ver",
+  "widgets.read": "Leer",
+  "widgets.no_recent_threads": "Ningún tema reciente.",
+  "widgets.twitch_configure": "Configura un canal de Twitch desde el builder para mostrar el directo aquí.",
+  "widgets.twitch_open_channel": "Abrir el canal {{channel}} en Twitch",
+  "widgets.open": "Abrir",
+  "widgets.twitch_offline_mid": "está desconectado — descubre",
+  "widgets.twitch_offline_end": "mientras tanto"
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -926,5 +926,22 @@
   "members.pts": "pts",
   "members.role_owner": "Fondateur",
   "members.role_admin": "Admin",
-  "members.role_moderator": "Modo"
+  "members.role_moderator": "Modo",
+  "common.previous": "Précédent",
+  "common.next": "Suivant",
+  "widgets.read_more": "Lire la suite",
+  "widgets.no_articles": "Aucun article à afficher pour le moment.",
+  "widgets.by": "par",
+  "widgets.views": "vues",
+  "widgets.video": "Vidéo",
+  "widgets.no_content": "Aucun contenu à afficher",
+  "widgets.watch_video": "Regarder la vidéo",
+  "widgets.watch": "Regarder",
+  "widgets.read": "Lire",
+  "widgets.no_recent_threads": "Aucun sujet récent.",
+  "widgets.twitch_configure": "Configure une chaîne Twitch depuis le builder pour afficher le stream ici.",
+  "widgets.twitch_open_channel": "Ouvrir la chaîne {{channel}} sur Twitch",
+  "widgets.open": "Ouvrir",
+  "widgets.twitch_offline_mid": "est offline — découvre",
+  "widgets.twitch_offline_end": "en attendant"
 }

--- a/nodyx-frontend/src/lib/locales/pt-PT.json
+++ b/nodyx-frontend/src/lib/locales/pt-PT.json
@@ -926,5 +926,22 @@
   "members.pts": "pts",
   "members.role_owner": "Fundador",
   "members.role_admin": "Admin",
-  "members.role_moderator": "Mod"
+  "members.role_moderator": "Mod",
+  "common.previous": "Anterior",
+  "common.next": "Seguinte",
+  "widgets.read_more": "Ler mais",
+  "widgets.no_articles": "Nenhum artigo para mostrar de momento.",
+  "widgets.by": "por",
+  "widgets.views": "visualizações",
+  "widgets.video": "Vídeo",
+  "widgets.no_content": "Nenhum conteúdo para mostrar",
+  "widgets.watch_video": "Ver o vídeo",
+  "widgets.watch": "Ver",
+  "widgets.read": "Ler",
+  "widgets.no_recent_threads": "Nenhum tópico recente.",
+  "widgets.twitch_configure": "Configura um canal Twitch a partir do builder para mostrar a stream aqui.",
+  "widgets.twitch_open_channel": "Abrir o canal {{channel}} no Twitch",
+  "widgets.open": "Abrir",
+  "widgets.twitch_offline_mid": "está offline — vê",
+  "widgets.twitch_offline_end": "entretanto"
 }

--- a/nodyx-frontend/src/lib/locales/ru.json
+++ b/nodyx-frontend/src/lib/locales/ru.json
@@ -926,5 +926,22 @@
   "members.pts": "очк.",
   "members.role_owner": "Основатель",
   "members.role_admin": "Админ",
-  "members.role_moderator": "Модер"
+  "members.role_moderator": "Модер",
+  "common.previous": "Назад",
+  "common.next": "Далее",
+  "widgets.read_more": "Читать далее",
+  "widgets.no_articles": "Пока нет статей для показа.",
+  "widgets.by": "от",
+  "widgets.views": "просм.",
+  "widgets.video": "Видео",
+  "widgets.no_content": "Нет контента для показа",
+  "widgets.watch_video": "Смотреть видео",
+  "widgets.watch": "Смотреть",
+  "widgets.read": "Читать",
+  "widgets.no_recent_threads": "Нет недавних тем.",
+  "widgets.twitch_configure": "Настройте Twitch-канал в билдере, чтобы показать стрим здесь.",
+  "widgets.twitch_open_channel": "Открыть канал {{channel}} на Twitch",
+  "widgets.open": "Открыть",
+  "widgets.twitch_offline_mid": "офлайн — посмотри",
+  "widgets.twitch_offline_end": "пока что"
 }


### PR DESCRIPTION
Le contenu des articles sur la home était en dur ("Lire la suite", "par {auteur}", "{n} vues", "Vidéo", états vides, "Regarder/Lire", textes Twitch).

- 4 widgets : ArticlesShowcase, ArticleSlideshow, RecentThreads, TwitchStream.
- Le temps relatif ("il y a 3j") passe par `Intl.RelativeTimeFormat` : pluriels et formats corrects par langue, automatiquement (y compris ru/pt-PT).
- +17 clés (`widgets.*`, `common.previous/next`) dans les 6 langues.

Note : les valeurs de config par défaut non textuelles (layout 'magazine', source 'recent'...) restent intactes, ce ne sont pas de l'UI.