### PR TITLE
feat(library): lecteur audio Nodyx pour les assets son

### DIFF
--- a/nodyx-frontend/src/routes/library/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/library/[id]/+page.svelte
@@ -150,9 +150,12 @@
 					class="max-h-64 max-w-full rounded-lg shadow-xl" />
 			</div>
 		{:else if asset.mime_type?.startsWith('audio/')}
-			<div class="bg-gray-950 flex flex-col items-center justify-center gap-3 p-8">
-				<span class="text-5xl">🔊</span>
-				<audio controls src={fileUrl(asset.file_path)} class="w-full max-w-xs"></audio>
+			<div class="bg-gray-950 p-6">
+				<nodyx-audio-player
+					src={fileUrl(asset.file_path)}
+					track-title={asset.name}
+					download="1"
+				></nodyx-audio-player>
 			</div>
 		{:else}
 			<div class="bg-gray-950 flex items-center justify-center min-h-40 text-5xl">


### PR DESCRIPTION
Sur la page d'un asset de type son (ex /library/d1e34823…), on affichait un `<audio controls>` brut du navigateur. On le remplace par notre **Web Component `<nodyx-audio-player>`**, le même lecteur soigné que dans les articles. Plus pro, cohérent, et fidèle au principe "pas de rendu brut, composant themé Nodyx".

- `track-title` = nom de l'asset, téléchargement activé.
- Le custom element est déjà enregistré globalement (+layout), donc rien d'autre à brancher.

svelte-check 0 erreur, build OK, déployé (page 200, le tag remplace bien l'audio brut).