### PR TITLE
feat(instance): thème d'instance via theme_css (couleurs personnalisées)

### DIFF
--- a/nodyx-core/src/routes/instance.ts
+++ b/nodyx-core/src/routes/instance.ts
@@ -92,7 +92,7 @@ export default async function instanceRoutes(app: FastifyInstance) {
   app.get('/info', { preHandler: [rateLimit] }, async (_request, reply) => {
     const communityId = await getCommunityId()
 
-    const [memberRes, threadRes, postRes, presenceSockets, brandingRes] = await Promise.all([
+    const [memberRes, threadRes, postRes, presenceSockets, brandingRes, themeRes] = await Promise.all([
       db.query(`SELECT COUNT(*)::int AS count FROM users`),
       db.query(`SELECT COUNT(*)::int AS count FROM threads`),
       db.query(`SELECT COUNT(*)::int AS count FROM posts`),
@@ -102,6 +102,10 @@ export default async function instanceRoutes(app: FastifyInstance) {
             `SELECT logo_url, banner_url FROM communities WHERE id = $1`, [communityId]
           )
         : Promise.resolve({ rows: [{ logo_url: null, banner_url: null }] }),
+      // Thème d'instance (CSS de surcharge de variables Tailwind) — optionnel, posé par l'owner
+      db.query<{ value: string | null }>(
+        `SELECT value FROM instance_settings WHERE key = 'theme_css' LIMIT 1`
+      ).catch(() => ({ rows: [] as { value: string | null }[] })),
     ])
 
     const seen = new Set<string>()
@@ -123,6 +127,7 @@ export default async function instanceRoutes(app: FastifyInstance) {
       post_count:   postRes.rows[0].count,
       logo_url:     branding.logo_url,
       banner_url:   branding.banner_url,
+      theme_css:    themeRes.rows[0]?.value ?? null,
       demo_mode:    process.env.NODYX_DEMO_MODE === 'true',
     })
   })

--- a/nodyx-frontend/src/routes/+layout.server.ts
+++ b/nodyx-frontend/src/routes/+layout.server.ts
@@ -78,6 +78,7 @@ export const load: LayoutServerLoad = async ({ fetch, cookies, request, url }) =
 	const currentSlug: string        = infoJson?.slug ?? '';
 	const demoMode: boolean          = infoJson?.demo_mode   ?? false;
 	const nodyxVersion: string       = infoJson?.version     ?? 'unknown';
+	const themeCss: string | null    = infoJson?.theme_css   ?? null;
 
 	// Toutes les instances du réseau (directory), filtre l'instance courante
 	const allInstances: Array<{
@@ -86,7 +87,7 @@ export const load: LayoutServerLoad = async ({ fetch, cookies, request, url }) =
 	}> = (((directoryJson as any)?.instances) ?? []).filter((i: { slug: string }) => i.slug !== currentSlug);
 
 	if (!token || !userRes?.ok) {
-		return { user: null, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount: 0, token: null, networkInstances: [], directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion };
+		return { user: null, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount: 0, token: null, networkInstances: [], directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion, themeCss };
 	}
 
 	const { user } = await userRes.json();
@@ -116,5 +117,5 @@ export const load: LayoutServerLoad = async ({ fetch, cookies, request, url }) =
 	const linkedSlugs: string[] = user.linked_instances ?? [];
 	const networkInstances = allInstances.filter(i => linkedSlugs.includes(i.slug));
 
-	return { user, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount, token: token || null, appTheme, networkInstances, directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion };
+	return { user, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount, token: token || null, appTheme, networkInstances, directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion, themeCss };
 };

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -478,6 +478,11 @@
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
 	<link rel="stylesheet" href={GOOGLE_FONTS_URL} />
+	<!-- Thème d'instance : surcharge des variables CSS, posé par l'owner (instance_settings.theme_css).
+	     On retire tout '<' pour empêcher un breakout </style>. -->
+	{#if data.themeCss}
+		{@html `<style id="instance-theme">${data.themeCss.replace(/</g, '')}</style>`}
+	{/if}
 </svelte:head>
 
 {#if isOverlayRoute}


### PR DESCRIPTION
Chaque instance peut avoir ses propres couleurs sans toucher au code (ADN Nodyx : chaque instance unique).

- Clé `instance_settings.theme_css` (posée par l'owner) qui surcharge les variables CSS de Tailwind v4 (`--color-indigo-*`, fond...).
- `/instance/info` expose `theme_css` ; le `+layout` injecte un `<style id="instance-theme">`, en retirant tout `<` (anti-breakout `</style>`).
- Aucun thème posé → comportement par défaut strictement inchangé (nodyx.org ne bouge pas).

Premier usage : thème Matrix (vert/noir/blanc) sur sleemstudio.nodyx.org.