### PR TITLE
fix(redis): honorer REDIS_KEY_PREFIX (isolation multi-instance)

### DIFF
--- a/nodyx-core/src/config/database.ts
+++ b/nodyx-core/src/config/database.ts
@@ -21,5 +21,7 @@ export const redis = new Redis({
   host: process.env.REDIS_HOST || 'localhost',
   port: Number(process.env.REDIS_PORT) || 6379,
   password: process.env.REDIS_PASSWORD || undefined,
-  keyPrefix: 'nodyx:',
+  // Isolation multi-instance : chaque instance a son préfixe (ex 'sleemstudio:').
+  // Sans ça, plusieurs instances sur le même Redis partagent sessions + cache.
+  keyPrefix: process.env.REDIS_KEY_PREFIX || 'nodyx:',
 })


### PR DESCRIPTION
Le `keyPrefix` Redis était codé en dur `'nodyx:'` dans `config/database.ts`. Conséquence : plusieurs instances sur le même Redis (ex sleemstudio.nodyx.org à côté de nodyx.org) **partageaient sessions et cache** → collision (la 2e instance servait le homepage/grid en cache de la 1re, contamination dans les deux sens).

Fix : `keyPrefix: process.env.REDIS_KEY_PREFIX || 'nodyx:'`. nodyx.org (sans la var) reste sur `nodyx:`, les autres instances posent leur propre préfixe.