### PR TITLE
feat(theme): thème d'instance imposé par l'owner (base de la cascade)

### DIFF
--- a/nodyx-core/src/routes/instance.ts
+++ b/nodyx-core/src/routes/instance.ts
@@ -102,10 +102,12 @@ export default async function instanceRoutes(app: FastifyInstance) {
             `SELECT logo_url, banner_url FROM communities WHERE id = $1`, [communityId]
           )
         : Promise.resolve({ rows: [{ logo_url: null, banner_url: null }] }),
-      // Thème d'instance (CSS de surcharge de variables Tailwind) — optionnel, posé par l'owner
-      db.query<{ value: string | null }>(
-        `SELECT value FROM instance_settings WHERE key = 'theme_css' LIMIT 1`
-      ).catch(() => ({ rows: [] as { value: string | null }[] })),
+      // Thème d'instance posé par l'owner (son univers, base pour tous) :
+      //  - theme_vars : thème structuré (--p-bg/--p-accent…), base de la cascade
+      //  - theme_css  : surcharge CSS libre (variables Tailwind) en complément
+      db.query<{ key: string; value: string | null }>(
+        `SELECT key, value FROM instance_settings WHERE key IN ('theme_css','theme_vars')`
+      ).catch(() => ({ rows: [] as { key: string; value: string | null }[] })),
     ])
 
     const seen = new Set<string>()
@@ -127,7 +129,12 @@ export default async function instanceRoutes(app: FastifyInstance) {
       post_count:   postRes.rows[0].count,
       logo_url:     branding.logo_url,
       banner_url:   branding.banner_url,
-      theme_css:    themeRes.rows[0]?.value ?? null,
+      theme_css:    themeRes.rows.find(r => r.key === 'theme_css')?.value ?? null,
+      theme_vars:   (() => {
+        const raw = themeRes.rows.find(r => r.key === 'theme_vars')?.value
+        if (!raw) return null
+        try { return JSON.parse(raw) } catch { return null }
+      })(),
       demo_mode:    process.env.NODYX_DEMO_MODE === 'true',
     })
   })

--- a/nodyx-frontend/src/lib/profileThemes.ts
+++ b/nodyx-frontend/src/lib/profileThemes.ts
@@ -105,8 +105,12 @@ export const PROFILE_PRESETS: ProfilePreset[] = [
 ]
 
 /** Merge saved partial theme with defaults */
-export function resolveTheme(saved: Partial<ProfileThemeVars> | null | undefined): ProfileThemeVars {
-	return { ...DEFAULT_THEME, ...(saved ?? {}) }
+// Cascade : défaut → thème d'INSTANCE (owner, son univers) → thème du MEMBRE (override perso).
+export function resolveTheme(
+	saved: Partial<ProfileThemeVars> | null | undefined,
+	instanceBase?: Partial<ProfileThemeVars> | null | undefined,
+): ProfileThemeVars {
+	return { ...DEFAULT_THEME, ...(instanceBase ?? {}), ...(saved ?? {}) }
 }
 
 /** CSS variable declarations only — use on parent containers for app-wide theming */

--- a/nodyx-frontend/src/routes/+layout.server.ts
+++ b/nodyx-frontend/src/routes/+layout.server.ts
@@ -79,6 +79,8 @@ export const load: LayoutServerLoad = async ({ fetch, cookies, request, url }) =
 	const demoMode: boolean          = infoJson?.demo_mode   ?? false;
 	const nodyxVersion: string       = infoJson?.version     ?? 'unknown';
 	const themeCss: string | null    = infoJson?.theme_css   ?? null;
+	// Thème imposé par l'owner de l'instance (base de la cascade ; un membre peut le surcharger via son profil)
+	const instanceTheme: Record<string, unknown> | null = infoJson?.theme_vars ?? null;
 
 	// Toutes les instances du réseau (directory), filtre l'instance courante
 	const allInstances: Array<{
@@ -87,7 +89,7 @@ export const load: LayoutServerLoad = async ({ fetch, cookies, request, url }) =
 	}> = (((directoryJson as any)?.instances) ?? []).filter((i: { slug: string }) => i.slug !== currentSlug);
 
 	if (!token || !userRes?.ok) {
-		return { user: null, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount: 0, token: null, networkInstances: [], directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion, themeCss };
+		return { user: null, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount: 0, token: null, networkInstances: [], directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion, themeCss, instanceTheme };
 	}
 
 	const { user } = await userRes.json();
@@ -117,5 +119,5 @@ export const load: LayoutServerLoad = async ({ fetch, cookies, request, url }) =
 	const linkedSlugs: string[] = user.linked_instances ?? [];
 	const networkInstances = allInstances.filter(i => linkedSlugs.includes(i.slug));
 
-	return { user, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount, token: token || null, appTheme, networkInstances, directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion, themeCss };
+	return { user, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount, token: token || null, appTheme, networkInstances, directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion, themeCss, instanceTheme };
 };

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -117,8 +117,8 @@
 			? $page.url.pathname === '/'
 			: $page.url.pathname.startsWith(href)
 
-	// App-wide theme — uses the logged-in user's theme, falls back to default
-	const appVars = $derived(themeToVars(resolveTheme((data as any).appTheme)))
+	// App-wide theme — cascade : défaut → thème d'INSTANCE (owner, son univers) → thème du MEMBRE (override perso)
+	const appVars = $derived(themeToVars(resolveTheme((data as any).appTheme, (data as any).instanceTheme)))
 
 	// All community members (for offline section in presence sidebar)
 	let allMembers = $state<{ user_id: string; username: string; avatar: string | null }[]>([])


### PR DESCRIPTION
L'owner d'une instance impose son thème (son univers). Un membre peut le surcharger pour lui via son profil. Cascade : **défaut -> thème d'instance -> thème du membre**.

- `/instance/info` renvoie `theme_vars` (thème structuré `--p-*`, base) + `theme_css` (surcharge libre complémentaire)
- `resolveTheme(saved, instanceBase)` insère la base d'instance dans la cascade
- `+layout.svelte` passe `instanceTheme` à `resolveTheme`

nodyx.org n'a pas de `theme_vars` -> retombe sur `DEFAULT_THEME` -> rendu identique. Pose la fondation propre du theming multi-instance (l'accent sweep des 426 hex en dur viendra par lots).