### PR TITLE
feat(theme): tokeniser la palette d'accent (var(--nx-*))

### DIFF
--- a/nodyx-frontend/src/app.css
+++ b/nodyx-frontend/src/app.css
@@ -8,6 +8,23 @@ html, body {
   overscroll-behavior: none;
 }
 
+/* ── Palette de marque (design tokens) ───────────────────────────────────────
+   Source unique des accents indigo/violet de l'app. Les défauts ci-dessous =
+   les hex historiques -> nodyx.org rend à l'identique. Une instance surcharge
+   ces variables (via theme_css posé par l'owner) pour imposer son univers.
+   Les couleurs en dur des composants ont été remplacées par var(--nx-*).      */
+:root {
+  --nx-accent:          #6366f1;  /* indigo-500 : accent principal */
+  --nx-accent-strong:   #4f46e5;  /* indigo-600 */
+  --nx-accent-soft:     #818cf8;  /* indigo-400 */
+  --nx-accent-deep:     #6d28d9;  /* violet-700 */
+  --nx-accent-2:        #a855f7;  /* purple-500 : 2e couleur des dégradés */
+  --nx-accent-2-strong: #7c3aed;  /* violet-600 */
+  --nx-accent-2-mid:    #8b5cf6;  /* violet-500 */
+  --nx-accent-2-soft:   #a78bfa;  /* violet-400 */
+  --nx-accent-2-soft2:  #c4b5fd;  /* violet-300 */
+}
+
 /* ── Theme CSS vars (définis dynamiquement par +layout.svelte via appVars) ──
    Portée actuelle :
      · Layout chrome (nav, galaxy bar, members bar, bottom nav) ✓

--- a/nodyx-frontend/src/lib/components/AudioRecorder.svelte
+++ b/nodyx-frontend/src/lib/components/AudioRecorder.svelte
@@ -361,7 +361,7 @@
 	.ar-spin {
 		width: 10px;
 		height: 10px;
-		border: 2px solid #818cf8;
+		border: 2px solid var(--nx-accent-soft);
 		border-top-color: transparent;
 		border-radius: 50%;
 		animation: ar-spin 0.7s linear infinite;

--- a/nodyx-frontend/src/lib/components/CanvasBottomBar.svelte
+++ b/nodyx-frontend/src/lib/components/CanvasBottomBar.svelte
@@ -232,7 +232,7 @@
 	}
 	.bar-btn.toggle.on {
 		background: rgba(124,58,237,0.18);
-		color: #a78bfa;
+		color: var(--nx-accent-2-soft);
 	}
 	.bar-btn.toggle.on:hover { background: rgba(124,58,237,0.25); }
 
@@ -305,7 +305,7 @@
 		z-index: 1;
 	}
 	.bg-swatch.active {
-		border-color: #818cf8;
+		border-color: var(--nx-accent-soft);
 		box-shadow: 0 0 0 2px rgba(129,140,248,0.45);
 		transform: scale(1.2);
 		z-index: 1;
@@ -314,11 +314,11 @@
 	.bg-picker {
 		background: conic-gradient(
 			#f87171, #fb923c, #fbbf24, #4ade80,
-			#22d3ee, #818cf8, #e879f9, #f87171
+			#22d3ee, var(--nx-accent-soft), #e879f9, #f87171
 		);
 		border-color: rgba(255,255,255,0.2);
 		color: transparent;
 	}
 	.bg-picker:hover { border-color: rgba(255,255,255,0.5); }
-	.bg-picker.active { border-color: #818cf8; }
+	.bg-picker.active { border-color: var(--nx-accent-soft); }
 </style>

--- a/nodyx-frontend/src/lib/components/CanvasLeftToolbar.svelte
+++ b/nodyx-frontend/src/lib/components/CanvasLeftToolbar.svelte
@@ -175,7 +175,7 @@
 	}
 
 	.tool-btn.active {
-		background: linear-gradient(135deg, #6d28d9, #7c3aed);
+		background: linear-gradient(135deg, var(--nx-accent-deep), var(--nx-accent-2-strong));
 		color: white;
 		box-shadow: 0 0 0 1px rgba(124,58,237,0.4), 0 4px 12px rgba(124,58,237,0.35);
 	}

--- a/nodyx-frontend/src/lib/components/CanvasRightPanel.svelte
+++ b/nodyx-frontend/src/lib/components/CanvasRightPanel.svelte
@@ -227,7 +227,7 @@
 		width: 8px;
 		height: 8px;
 		border-radius: 50%;
-		background: #a855f7;
+		background: var(--nx-accent-2);
 		animation: pulse-dot 2s ease-in-out infinite;
 		flex-shrink: 0;
 	}
@@ -254,7 +254,7 @@
 		font-size: 9px;
 		font-weight: 700;
 		background: rgba(124,58,237,0.25);
-		color: #a78bfa;
+		color: var(--nx-accent-2-soft);
 		padding: 1px 5px;
 		border-radius: 20px;
 		letter-spacing: 0;
@@ -465,7 +465,7 @@
 		height: 32px;
 		border: none;
 		border-radius: 10px;
-		background: linear-gradient(135deg, #6d28d9, #7c3aed);
+		background: linear-gradient(135deg, var(--nx-accent-deep), var(--nx-accent-2-strong));
 		color: white;
 		cursor: pointer;
 		display: flex;

--- a/nodyx-frontend/src/lib/components/CanvasTopBar.svelte
+++ b/nodyx-frontend/src/lib/components/CanvasTopBar.svelte
@@ -497,7 +497,7 @@
 		transition: all 0.1s;
 	}
 	.fmt-btn:hover { background: rgba(255,255,255,0.06); color: white; }
-	.fmt-btn.on { background: rgba(124,58,237,0.25); color: #a78bfa; }
+	.fmt-btn.on { background: rgba(124,58,237,0.25); color: var(--nx-accent-2-soft); }
 	.italic-btn { font-style: italic; }
 	.underline-btn { text-decoration: underline; }
 	.strike-btn { text-decoration: line-through; }
@@ -516,7 +516,7 @@
 		transition: all 0.1s;
 	}
 	.icon-btn:hover { background: rgba(255,255,255,0.06); color: white; }
-	.icon-btn.on { background: rgba(124,58,237,0.25); color: #a78bfa; }
+	.icon-btn.on { background: rgba(124,58,237,0.25); color: var(--nx-accent-2-soft); }
 
 	.size-val {
 		font-size: 12px;
@@ -539,7 +539,7 @@
 		transition: all 0.1s;
 	}
 	.font-btn:hover { background: rgba(255,255,255,0.06); color: #d1d5db; }
-	.font-btn.on { background: rgba(124,58,237,0.2); color: #a78bfa; }
+	.font-btn.on { background: rgba(124,58,237,0.2); color: var(--nx-accent-2-soft); }
 
 	.fill-toggle {
 		width: 28px;
@@ -555,7 +555,7 @@
 		transition: all 0.1s;
 	}
 	.fill-toggle:hover { background: rgba(255,255,255,0.08); color: #d1d5db; }
-	.fill-toggle.on { background: rgba(124,58,237,0.2); color: #a78bfa; }
+	.fill-toggle.on { background: rgba(124,58,237,0.2); color: var(--nx-accent-2-soft); }
 
 	.width-btn {
 		width: 28px;
@@ -579,7 +579,7 @@
 		display: block;
 		flex-shrink: 0;
 	}
-	.width-btn.selected .width-dot { background: #a78bfa; }
+	.width-btn.selected .width-dot { background: var(--nx-accent-2-soft); }
 
 	.dash-btn {
 		padding: 2px 7px;
@@ -594,5 +594,5 @@
 		transition: all 0.1s;
 	}
 	.dash-btn:hover { background: rgba(255,255,255,0.06); color: #d1d5db; }
-	.dash-btn.on { background: rgba(124,58,237,0.2); color: #a78bfa; }
+	.dash-btn.on { background: rgba(124,58,237,0.2); color: var(--nx-accent-2-soft); }
 </style>

--- a/nodyx-frontend/src/lib/components/ChannelSidebar.svelte
+++ b/nodyx-frontend/src/lib/components/ChannelSidebar.svelte
@@ -319,7 +319,7 @@
 	.ch-active {
 		color: #e2e8f0;
 		background: rgba(124,58,237,.14);
-		box-shadow: inset 2px 0 0 #7c3aed;
+		box-shadow: inset 2px 0 0 var(--nx-accent-2-strong);
 	}
 
 	/* ── Unread state: bioluminescent breathing glow ───────────────────────── */
@@ -380,7 +380,7 @@
 
 	/* ── Hash symbol ───────────────────────────────────────────────────────── */
 	.ch-hash { color: #6b7280; transition: color .15s; min-width: 14px; display: inline-flex; justify-content: center; }
-	.ch-hash-unread { color: #a78bfa; }
+	.ch-hash-unread { color: var(--nx-accent-2-soft); }
 	.ch-idle:hover .ch-hash { color: #cbd5e1; }
 
 	/* ── Voice channel items ───────────────────────────────────────────────── */
@@ -445,7 +445,7 @@
 		height: 16px;
 		padding: 0 4px;
 		border-radius: 99px;
-		background: #7c3aed;
+		background: var(--nx-accent-2-strong);
 		color: white;
 		font-size: 9px;
 		font-weight: 800;

--- a/nodyx-frontend/src/lib/components/E2EKeyBackup.svelte
+++ b/nodyx-frontend/src/lib/components/E2EKeyBackup.svelte
@@ -273,11 +273,11 @@
 	.kb-input { width: 100%; padding: 10px 12px; border-radius: 10px;
 		background: rgba(15,23,42,.6); border: 1px solid rgba(148,163,184,.2);
 		color: #f1f5f9; font-size: 14px; outline: none; transition: border-color .15s; }
-	.kb-input:focus { border-color: #6366f1; }
+	.kb-input:focus { border-color: var(--nx-accent); }
 	.kb-actions { display: flex; gap: 10px; flex-wrap: wrap; }
 	.kb-btn-primary { padding: 9px 16px; border-radius: 10px; border: none; cursor: pointer;
 		font-weight: 600; font-size: 14px; color: #fff;
-		background: linear-gradient(135deg, #6366f1, #a855f7); transition: transform .12s, opacity .12s; }
+		background: linear-gradient(135deg, var(--nx-accent), var(--nx-accent-2)); transition: transform .12s, opacity .12s; }
 	.kb-btn-primary:hover:not(:disabled) { transform: translateY(-1px); }
 	.kb-btn-ghost, .kb-btn-danger { padding: 9px 16px; border-radius: 10px; cursor: pointer;
 		font-weight: 600; font-size: 14px; background: transparent; }

--- a/nodyx-frontend/src/lib/components/MemberScreenPreview.svelte
+++ b/nodyx-frontend/src/lib/components/MemberScreenPreview.svelte
@@ -74,7 +74,7 @@
             <img src={avatar} alt={username} class="w-4 h-4 rounded-full object-cover shrink-0"/>
         {:else}
             <div class="w-4 h-4 rounded-full shrink-0 flex items-center justify-center text-[7px] font-bold text-white"
-                 style="background: linear-gradient(135deg, #4f46e5, #0e7490)">
+                 style="background: linear-gradient(135deg, var(--nx-accent-strong), #0e7490)">
                 {username[0]?.toUpperCase()}
             </div>
         {/if}

--- a/nodyx-frontend/src/lib/components/MessageBody.svelte
+++ b/nodyx-frontend/src/lib/components/MessageBody.svelte
@@ -101,7 +101,7 @@
 		text-decoration-color: rgba(191, 219, 254, 0.85);
 	}
 	.message-body__mention {
-		color: #c4b5fd;
+		color: var(--nx-accent-2-soft2);
 		font-weight: 600;
 		text-decoration: none;
 		padding: 0 2px;

--- a/nodyx-frontend/src/lib/components/NetworkDoctor.svelte
+++ b/nodyx-frontend/src/lib/components/NetworkDoctor.svelte
@@ -168,7 +168,7 @@
     .star {
         position: absolute; top: var(--top); left: var(--left);
         width: 1px; height: 80px;
-        background: linear-gradient(to bottom, transparent, #fff, #4f46e5);
+        background: linear-gradient(to bottom, transparent, #fff, var(--nx-accent-strong));
         opacity: 0; animation: hyper-warp var(--speed) linear infinite;
         animation-delay: var(--delay);
         transform-origin: top;

--- a/nodyx-frontend/src/lib/components/NodyxCanvas.svelte
+++ b/nodyx-frontend/src/lib/components/NodyxCanvas.svelte
@@ -2088,7 +2088,7 @@
 			</span>
 			<button onclick={handleRequestAccess} disabled={accessAsked}
 				style="padding:5px 13px; border-radius:999px; font-size:12px; font-weight:600; cursor:{accessAsked ? 'default' : 'pointer'}; border:none; color:#fff; white-space:nowrap;
-				       background:{accessAsked ? 'rgba(16,185,129,.3)' : 'linear-gradient(to right,#4f46e5,#06b6d4)'};">
+				       background:{accessAsked ? 'rgba(16,185,129,.3)' : 'linear-gradient(to right,var(--nx-accent-strong),#06b6d4)'};">
 				{accessAsked ? '✓ Demande envoyée' : "Demander l'accès en édition"}
 			</button>
 		</div>
@@ -2205,7 +2205,7 @@
 					<div
 						class="w-3 h-3 rounded-full border-2 border-white shadow-lg"
 						class:canvas-cursor-speaking={cursor.speaking}
-						style="background:{cursor.speaking ? '#a855f7' : '#4ade80'};"
+						style="background:{cursor.speaking ? 'var(--nx-accent-2)' : '#4ade80'};"
 					></div>
 					<span class="absolute left-4 -top-1 whitespace-nowrap text-xs font-semibold
 					             text-white bg-gray-900/80 px-1.5 py-0.5 rounded shadow">
@@ -2376,7 +2376,7 @@
 		transition: all 0.12s;
 	}
 	.sync-btn:hover { background: rgba(255,255,255,0.05); color: #9ca3af; }
-	.sync-btn.sync-leading  { color: #a855f7; background: rgba(168,85,247,0.08); }
+	.sync-btn.sync-leading  { color: var(--nx-accent-2); background: rgba(168,85,247,0.08); }
 	.sync-btn.sync-leading:hover  { background: rgba(168,85,247,0.14); }
 	.sync-btn.sync-following { color: #22d3ee; background: rgba(34,211,238,0.08); }
 	.sync-btn.sync-following:hover { background: rgba(34,211,238,0.14); }

--- a/nodyx-frontend/src/lib/components/PollCard.svelte
+++ b/nodyx-frontend/src/lib/components/PollCard.svelte
@@ -563,7 +563,7 @@
     border-radius: 99px;
     font-weight: 600;
   }
-  .poll-type-badge { background: #7c3aed22; color: #a78bfa; border: 1px solid #7c3aed44; }
+  .poll-type-badge { background: #7c3aed22; color: var(--nx-accent-2-soft); border: 1px solid #7c3aed44; }
   .poll-status-badge.open   { background: #16a34a22; color: #4ade80; border: 1px solid #16a34a44; }
   .poll-status-badge.closed { background: #64748b22; color: #94a3b8; border: 1px solid #64748b44; }
   .poll-status-badge.anon   { background: #0f172a;   color: #60a5fa; border: 1px solid #1e3a5f44; }
@@ -592,7 +592,7 @@
     overflow: hidden;
   }
   .poll-option:not(:disabled):hover { border-color: #7c3aed88; background: var(--bg-4, #2a2a3f); }
-  .poll-option.selected             { border-color: #7c3aed; background: #7c3aed18; }
+  .poll-option.selected             { border-color: var(--nx-accent-2-strong); background: #7c3aed18; }
   .poll-option:disabled             { cursor: default; }
 
   .opt-img { width: 40px; height: 40px; object-fit: cover; border-radius: 6px; flex-shrink: 0; }
@@ -615,10 +615,10 @@
     transition: width .5s cubic-bezier(.4,0,.2,1);
     border-radius: 8px;
   }
-  .opt-pct    { font-weight: 700; font-size: 0.82rem; color: #a78bfa; position: relative; z-index: 1; }
+  .opt-pct    { font-weight: 700; font-size: 0.82rem; color: var(--nx-accent-2-soft); position: relative; z-index: 1; }
   .opt-count  { font-size: 0.75rem; color: var(--text-muted, #888); position: relative; z-index: 1; }
   .opt-radio  { font-size: 1.1rem; color: var(--text-muted, #888); }
-  .opt-radio.selected { color: #a78bfa; }
+  .opt-radio.selected { color: var(--nx-accent-2-soft); }
 
   /* ── Schedule ── */
   .schedule-best-slot {
@@ -703,9 +703,9 @@
     transition: border-color .15s, box-shadow .15s;
   }
   .ranking-item:active { cursor: grabbing; }
-  .ranking-item.dragging { opacity: 0.5; border-color: #7c3aed; }
+  .ranking-item.dragging { opacity: 0.5; border-color: var(--nx-accent-2-strong); }
 
-  .rank-pos  { font-weight: 700; color: #a78bfa; min-width: 20px; text-align: center; }
+  .rank-pos  { font-weight: 700; color: var(--nx-accent-2-soft); min-width: 20px; text-align: center; }
   .rank-drag { color: var(--text-muted, #888); font-size: 1.1rem; cursor: grab; }
   .rank-label { flex: 1; font-weight: 500; }
 
@@ -730,11 +730,11 @@
   }
   .rank-score-bar {
     height: 100%;
-    background: linear-gradient(90deg, #7c3aed, #a78bfa);
+    background: linear-gradient(90deg, var(--nx-accent-2-strong), var(--nx-accent-2-soft));
     border-radius: 99px;
     transition: width .6s cubic-bezier(.4,0,.2,1);
   }
-  .rank-score { font-weight: 700; color: #a78bfa; font-size: 0.82rem; }
+  .rank-score { font-weight: 700; color: var(--nx-accent-2-soft); font-size: 0.82rem; }
   .rank-avg   { font-size: 0.72rem; color: var(--text-muted, #888); }
 
   /* ── Actions ── */
@@ -757,7 +757,7 @@
   .btn-vote:hover, .btn-revote:hover, .btn-close-poll:hover { opacity: 0.85; }
   .btn-vote:active { transform: scale(.97); }
 
-  .btn-vote        { background: #7c3aed; color: #fff; }
+  .btn-vote        { background: var(--nx-accent-2-strong); color: #fff; }
   .btn-vote:disabled { opacity: 0.4; cursor: not-allowed; }
   .btn-revote      { background: transparent; color: var(--text-muted, #888); border: 1px solid var(--border, #333) !important; }
   .btn-close-poll  { background: transparent; color: #f87171; border: 1px solid #f8717144 !important; font-size: 0.78rem; }

--- a/nodyx-frontend/src/lib/components/PollCreator.svelte
+++ b/nodyx-frontend/src/lib/components/PollCreator.svelte
@@ -502,7 +502,7 @@
     transition: border-color .15s, background .15s;
   }
   .type-card:hover    { border-color: #7c3aed88; background: var(--bg-3, #252535); }
-  .type-card.selected { border-color: #7c3aed; background: #7c3aed18; }
+  .type-card.selected { border-color: var(--nx-accent-2-strong); background: #7c3aed18; }
 
   .type-icon    { font-size: 1.8rem; }
   .type-label   { font-weight: 700; font-size: 1rem; }
@@ -543,7 +543,7 @@
     outline: none;
     transition: border-color .15s;
   }
-  .field input:focus, .field textarea:focus { border-color: #7c3aed; }
+  .field input:focus, .field textarea:focus { border-color: var(--nx-accent-2-strong); }
   .field textarea { resize: vertical; min-height: 56px; }
 
   .sub-field { padding-left: 16px; }
@@ -558,14 +558,14 @@
     flex-direction: column;
     gap: 10px;
   }
-  .bulk-generator h4 { margin: 0; font-size: 0.82rem; color: #a78bfa; }
+  .bulk-generator h4 { margin: 0; font-size: 0.82rem; color: var(--nx-accent-2-soft); }
   .bulk-row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
   .btn-generate {
     padding: 7px 14px;
     background: #7c3aed22;
     border: 1px solid #7c3aed44;
     border-radius: 7px;
-    color: #a78bfa;
+    color: var(--nx-accent-2-soft);
     font-weight: 600;
     cursor: pointer;
     font-size: 0.82rem;
@@ -583,7 +583,7 @@
     background: #7c3aed22;
     border: 1px solid #7c3aed44;
     border-radius: 6px;
-    color: #a78bfa;
+    color: var(--nx-accent-2-soft);
     font-size: 0.78rem;
     cursor: pointer;
     transition: background .15s;
@@ -622,7 +622,7 @@
     width: 100%;
     box-sizing: border-box;
   }
-  .opt-fields input:focus { border-color: #7c3aed; }
+  .opt-fields input:focus { border-color: var(--nx-accent-2-strong); }
   .input-opt-desc { font-size: 0.8rem !important; color: var(--text-muted, #888) !important; }
 
   .sched-row-fields {
@@ -678,7 +678,7 @@
     font-size: 0.88rem;
     padding: 8px 0;
   }
-  .toggle-row input[type="checkbox"] { width: 16px; height: 16px; accent-color: #7c3aed; cursor: pointer; }
+  .toggle-row input[type="checkbox"] { width: 16px; height: 16px; accent-color: var(--nx-accent-2-strong); cursor: pointer; }
 
   .settings-recap {
     margin-top: 6px;
@@ -713,7 +713,7 @@
     font-size: 0.85rem;
     transition: border-color .15s;
   }
-  .btn-back:hover { border-color: #7c3aed; color: var(--text, #e0e0e0); }
+  .btn-back:hover { border-color: var(--nx-accent-2-strong); color: var(--text, #e0e0e0); }
 
   .footer-error {
     flex: 1;
@@ -724,7 +724,7 @@
   .btn-submit {
     margin-left: auto;
     padding: 8px 22px;
-    background: #7c3aed;
+    background: var(--nx-accent-2-strong);
     border: none;
     border-radius: 8px;
     color: #fff;

--- a/nodyx-frontend/src/lib/components/Table.svelte
+++ b/nodyx-frontend/src/lib/components/Table.svelte
@@ -358,8 +358,8 @@
 							<div class="flex items-end gap-[2.5px] transition-opacity duration-300"
 							     style="height:16px; opacity:{isSpeaking || myActive ? 1 : 0};">
 								{#each [
-									{c:'#6d28d9',d:'0.00s'},{c:'#7c3aed',d:'0.14s'},{c:'#8b5cf6',d:'0.05s'},
-									{c:'#a78bfa',d:'0.22s'},{c:'#67e8f9',d:'0.09s'},{c:'#22d3ee',d:'0.17s'},
+									{c:'var(--nx-accent-deep)',d:'0.00s'},{c:'var(--nx-accent-2-strong)',d:'0.14s'},{c:'var(--nx-accent-2-mid)',d:'0.05s'},
+									{c:'var(--nx-accent-2-soft)',d:'0.22s'},{c:'#67e8f9',d:'0.09s'},{c:'#22d3ee',d:'0.17s'},
 									{c:'#67e8f9',d:'0.03s'}
 								] as bar}
 									<div class="w-[2.5px] rounded-sm eq-bar" style="background:{bar.c}; animation-delay:{bar.d}"></div>
@@ -471,7 +471,7 @@
 					class="w-full px-4 py-3 text-sm text-gray-200 focus:outline-none mb-3"
 					style="background: rgba(255,255,255,0.04);
 					       border: 1px solid rgba(255,255,255,0.08);
-					       caret-color: #7c3aed;"
+					       caret-color: var(--nx-accent-2-strong);"
 					onkeydown={(e) => { if (e.key === 'Enter') handleJukeboxLoad() }}
 				/>
 
@@ -533,7 +533,7 @@
 			<div class="mt-0.5 pt-0.5" style="border-top: 1px solid rgba(255,255,255,0.05);">
 				<button onclick={() => toggleMutePeer(mp)}
 					class="w-full text-left px-3 py-2 text-xs flex items-center gap-2.5 hover:bg-white/[.04] transition-colors"
-					style="color: {isMuted ? '#a78bfa' : '#6b7280'};">
+					style="color: {isMuted ? 'var(--nx-accent-2-soft)' : '#6b7280'};">
 					{#if isMuted}
 						<svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" d="M19.114 5.636a9 9 0 010 12.728M16.463 8.288a5.25 5.25 0 010 7.424M6.75 8.25l4.72-4.72a.75.75 0 011.28.53v15.88a.75.75 0 01-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.01 9.01 0 012.25 12c0-.83.112-1.633.322-2.396C2.806 8.756 3.63 8.25 4.51 8.25H6.75z"/>

--- a/nodyx-frontend/src/lib/components/VoicePanel.svelte
+++ b/nodyx-frontend/src/lib/components/VoicePanel.svelte
@@ -1212,7 +1212,7 @@ input[type=range]::-webkit-slider-thumb {
     width: 16px;
     height: 16px;
     border-radius: 50%;
-    background: linear-gradient(to right, #6366f1, #8b5cf6);
+    background: linear-gradient(to right, var(--nx-accent), var(--nx-accent-2-mid));
     cursor: pointer;
     box-shadow: 0 0 10px rgba(99, 102, 241, 0.5);
     border: 2px solid rgba(255, 255, 255, 0.2);
@@ -1228,7 +1228,7 @@ input[type=range]::-moz-range-thumb {
     width: 16px;
     height: 16px;
     border-radius: 50%;
-    background: linear-gradient(to right, #6366f1, #8b5cf6);
+    background: linear-gradient(to right, var(--nx-accent), var(--nx-accent-2-mid));
     cursor: pointer;
     border: 2px solid rgba(255, 255, 255, 0.2);
     transition: all 0.2s;

--- a/nodyx-frontend/src/lib/components/VoiceRoom.svelte
+++ b/nodyx-frontend/src/lib/components/VoiceRoom.svelte
@@ -110,7 +110,7 @@
 
 	<!-- Waveform icon -->
 	<div class="shrink-0 flex items-end gap-[2px] h-4"
-	     style="color: {connected ? '#7c3aed' : '#4b5563'};">
+	     style="color: {connected ? 'var(--nx-accent-2-strong)' : '#4b5563'};">
 		<div class="w-[3px] rounded-sm" style="height: 45%; background: currentColor;"></div>
 		<div class="w-[3px] rounded-sm" style="height: 100%; background: currentColor;"></div>
 		<div class="w-[3px] rounded-sm" style="height: 65%; background: currentColor;"></div>
@@ -365,8 +365,8 @@
 	.active-amber:hover, .idle-amber:hover { color: #e0a86a !important; }
 
 	/* Violet (canvas) */
-	.active-violet { color: #a78bfa !important; background: rgba(124,58,237,0.14) !important; border-color: rgba(124,58,237,0.35) !important; }
-	.active-violet:hover { color: #c4b5fd !important; }
+	.active-violet { color: var(--nx-accent-2-soft) !important; background: rgba(124,58,237,0.14) !important; border-color: rgba(124,58,237,0.35) !important; }
+	.active-violet:hover { color: var(--nx-accent-2-soft2) !important; }
 
 	/* Blue (screen share) */
 	.active-blue   { color: #60a5fa !important; background: rgba(59,130,246,0.12) !important; border-color: rgba(59,130,246,0.3) !important; }

--- a/nodyx-frontend/src/lib/components/admin/AlertThemePreview.svelte
+++ b/nodyx-frontend/src/lib/components/admin/AlertThemePreview.svelte
@@ -188,7 +188,7 @@
 		position: absolute; inset: 0;
 		border-radius: 14px;
 		padding: 1.5px;
-		background: linear-gradient(135deg, #ec4899, #6366f1, #06b6d4, #a855f7);
+		background: linear-gradient(135deg, #ec4899, var(--nx-accent), #06b6d4, var(--nx-accent-2));
 		-webkit-mask:
 			linear-gradient(#fff 0 0) content-box,
 			linear-gradient(#fff 0 0);

--- a/nodyx-frontend/src/lib/components/admin/ChannelStyleEditor.svelte
+++ b/nodyx-frontend/src/lib/components/admin/ChannelStyleEditor.svelte
@@ -373,7 +373,7 @@
 		border: 1px solid #374151;
 		border-radius: 4px;
 	}
-	.cse-color-hex:focus { outline: none; border-color: #6366f1; }
+	.cse-color-hex:focus { outline: none; border-color: var(--nx-accent); }
 	.cse-clear {
 		width: 30px;
 		height: 30px;
@@ -428,7 +428,7 @@
 	.cse-style-btn:hover { background: #283142; color: #e2e8f0; }
 	.cse-style-btn--active {
 		background: rgba(99, 102, 241, 0.18);
-		border-color: #6366f1;
+		border-color: var(--nx-accent);
 		color: #c7d2fe;
 	}
 	.cse-emoji-input {
@@ -441,7 +441,7 @@
 		border-radius: 4px;
 		color: #e2e8f0;
 	}
-	.cse-emoji-input:focus { outline: none; border-color: #6366f1; }
+	.cse-emoji-input:focus { outline: none; border-color: var(--nx-accent); }
 
 	/* ─── Icon picker ──────────────────────────────────────────────────── */
 	.cse-icon-picker {
@@ -485,7 +485,7 @@
 	.cse-tab:hover { color: #e2e8f0; }
 	.cse-tab--active {
 		color: #c7d2fe;
-		border-bottom-color: #6366f1;
+		border-bottom-color: var(--nx-accent);
 	}
 	.cse-tab-panel {
 		max-height: 280px;
@@ -530,7 +530,7 @@
 	}
 	.cse-icon-btn--active {
 		background: rgba(99,102,241,0.2);
-		border-color: #6366f1;
+		border-color: var(--nx-accent);
 	}
 	.cse-custom {
 		display: flex;

--- a/nodyx-frontend/src/lib/components/admin/DeckEditor.svelte
+++ b/nodyx-frontend/src/lib/components/admin/DeckEditor.svelte
@@ -699,7 +699,7 @@
 		<div class="flex items-center gap-1.5 flex-wrap">
 			{#each layout.pages as p, i (p.id)}
 				{@const active = p.id === currentPageId}
-				{@const accent = p.color ? `--page-accent: ${p.color};` : '--page-accent: #818cf8;'}
+				{@const accent = p.color ? `--page-accent: ${p.color};` : '--page-accent: var(--nx-accent-soft);'}
 				<div class="group relative inline-flex items-center gap-1 transition-all
 						{active ? 'bg-gradient-to-br from-indigo-500/30 to-purple-500/20 border-indigo-400/70 shadow-lg shadow-indigo-500/20' : 'bg-slate-900/60 border-slate-700/60 hover:border-slate-600'}
 						border rounded-lg pl-1.5 pr-1 py-0.5"
@@ -708,7 +708,7 @@
 					<label class="relative cursor-pointer shrink-0" title="Choisir une couleur d'accent">
 						<span class="block w-2.5 h-2.5 rounded-full ring-1 ring-white/20"
 							style="background: var(--page-accent);"></span>
-						<input type="color" value={p.color ?? '#818cf8'}
+						<input type="color" value={p.color ?? 'var(--nx-accent-soft)'}
 							oninput={(e) => setPageColor(p.id, e.currentTarget.value)}
 							class="absolute inset-0 opacity-0 cursor-pointer w-full h-full"/>
 					</label>

--- a/nodyx-frontend/src/lib/components/admin/PlaylistSidebar.svelte
+++ b/nodyx-frontend/src/lib/components/admin/PlaylistSidebar.svelte
@@ -272,7 +272,7 @@
 
 		{#each playlists as p (p.id)}
 			{@const isSelected = selectedPlaylistId === p.id}
-			{@const accent = p.color ?? '#a78bfa'}
+			{@const accent = p.color ?? 'var(--nx-accent-2-soft)'}
 			<li class="group relative">
 				{#if editingId === p.id}
 					<div class="px-2 py-2 bg-zinc-950/60 flex flex-col gap-1.5">
@@ -281,8 +281,8 @@
 						<div class="flex items-center gap-1.5">
 							<label class="cursor-pointer relative shrink-0" title="Couleur d'accent">
 								<span class="block w-5 h-5 rounded-full ring-1 ring-white/20"
-									style="background: {editColor || '#a78bfa'};"></span>
-								<input type="color" value={editColor || '#a78bfa'}
+									style="background: {editColor || 'var(--nx-accent-2-soft)'};"></span>
+								<input type="color" value={editColor || 'var(--nx-accent-2-soft)'}
 									oninput={(e) => editColor = e.currentTarget.value}
 									class="absolute inset-0 opacity-0 cursor-pointer w-full h-full"/>
 							</label>

--- a/nodyx-frontend/src/lib/components/admin/SendToDeckModal.svelte
+++ b/nodyx-frontend/src/lib/components/admin/SendToDeckModal.svelte
@@ -169,7 +169,7 @@
 						<div class="flex items-center gap-1.5 flex-wrap">
 							{#each selectedDeck.layout.pages as p (p.id)}
 								{@const active = p.id === selectedPageId}
-								{@const accent = p.color ?? '#a78bfa'}
+								{@const accent = p.color ?? 'var(--nx-accent-2-soft)'}
 								<button type="button" onclick={() => selectedPageId = p.id}
 									class="inline-flex items-center gap-1.5 text-xs font-medium px-2 py-1 rounded-sm border transition-colors
 										{active ? 'bg-purple-500/15 border-purple-500/60 text-purple-100' : 'bg-zinc-900 border-zinc-800 text-zinc-300 hover:border-zinc-700'}">

--- a/nodyx-frontend/src/lib/components/admin/SoundLibraryPanel.svelte
+++ b/nodyx-frontend/src/lib/components/admin/SoundLibraryPanel.svelte
@@ -813,7 +813,7 @@
 																	<svg class="w-2.5 h-2.5 text-white" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>
 																{/if}
 															</span>
-															<span class="w-2 h-2 rounded-full shrink-0" style="background: {p.color ?? '#a78bfa'};"></span>
+															<span class="w-2 h-2 rounded-full shrink-0" style="background: {p.color ?? 'var(--nx-accent-2-soft)'};"></span>
 															<span class="flex-1 truncate" title={p.name}>{p.name}</span>
 															<span class="text-[10px] text-zinc-600 font-mono">{p.trackCount}</span>
 														</button>

--- a/nodyx-frontend/src/lib/components/admin/obs/AddSourceModal.svelte
+++ b/nodyx-frontend/src/lib/components/admin/obs/AddSourceModal.svelte
@@ -358,7 +358,7 @@
 							<li>
 								<button type="button" onclick={() => pickPlaylist(p)} disabled={!playlistOverlayToken}
 									class="w-full text-left flex items-center gap-3 p-2.5 rounded-md bg-zinc-900/60 border border-zinc-800 hover:border-purple-500/60 hover:bg-purple-500/5 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
-									<span class="w-2 h-2 rounded-full shrink-0" style="background: {p.color ?? '#a78bfa'};"></span>
+									<span class="w-2 h-2 rounded-full shrink-0" style="background: {p.color ?? 'var(--nx-accent-2-soft)'};"></span>
 									<div class="min-w-0 flex-1">
 										<div class="text-sm text-zinc-100 truncate">{p.name}</div>
 										<div class="text-[10px] text-zinc-600 font-mono">{p.trackCount} piste{p.trackCount > 1 ? 's' : ''}</div>

--- a/nodyx-frontend/src/lib/components/admin/obs/ObsScenesPanel.svelte
+++ b/nodyx-frontend/src/lib/components/admin/obs/ObsScenesPanel.svelte
@@ -506,7 +506,7 @@
 										class="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-left transition-colors
 											{isAct ? 'bg-purple-500/15 text-zinc-100 border-l-2 border-l-purple-500'
 											       : 'text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/40 border-l-2 border-transparent'}">
-										<span class="w-2 h-2 rounded-full shrink-0" style="background: {s.color ?? '#a78bfa'};"></span>
+										<span class="w-2 h-2 rounded-full shrink-0" style="background: {s.color ?? 'var(--nx-accent-2-soft)'};"></span>
 										<span class="flex-1 truncate" title={s.name}>{s.name}</span>
 										<span class="text-[10px] text-zinc-600 font-mono">{s.layout.sources.length}</span>
 									</button>

--- a/nodyx-frontend/src/lib/components/admin/obs/PlaceInSceneModal.svelte
+++ b/nodyx-frontend/src/lib/components/admin/obs/PlaceInSceneModal.svelte
@@ -173,7 +173,7 @@
 						<li>
 							<button type="button" onclick={() => placeIn(s)} disabled={busy}
 								class="w-full text-left flex items-center gap-3 p-2.5 rounded-md bg-zinc-900/60 border border-zinc-800 hover:border-purple-500/60 hover:bg-purple-500/5 transition-colors disabled:opacity-50">
-								<span class="w-2 h-2 rounded-full shrink-0" style="background: {s.color ?? '#a78bfa'};"></span>
+								<span class="w-2 h-2 rounded-full shrink-0" style="background: {s.color ?? 'var(--nx-accent-2-soft)'};"></span>
 								<div class="min-w-0 flex-1">
 									<div class="text-sm text-zinc-100 truncate">{s.name}</div>
 									<div class="text-[10px] text-zinc-600">{s.layout.sources.length} source{s.layout.sources.length > 1 ? 's' : ''}</div>

--- a/nodyx-frontend/src/lib/components/homepage/DynamicWidget.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/DynamicWidget.svelte
@@ -68,7 +68,7 @@
 	<!-- Skeleton pendant le chargement du JS -->
 	<div class="w-full flex items-center justify-center py-8 gap-2" style="color:#374151">
 		<div class="w-4 h-4 rounded-full border-2 animate-spin"
-		     style="border-color:rgba(167,139,250,.2); border-top-color:#a78bfa"></div>
+		     style="border-color:rgba(167,139,250,.2); border-top-color:var(--nx-accent-2-soft)"></div>
 		<span class="text-xs">Chargement du widget…</span>
 	</div>
 

--- a/nodyx-frontend/src/lib/components/homepage/GridRenderer.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/GridRenderer.svelte
@@ -205,7 +205,7 @@
 		outline-color: rgba(167,139,250,.5);
 	}
 	.gr-row--dragover {
-		outline: 2px solid #a78bfa !important;
+		outline: 2px solid var(--nx-accent-2-soft) !important;
 		background: rgba(167,139,250,.05) !important;
 	}
 
@@ -243,7 +243,7 @@
 		padding: 2px 8px;
 		font-size: 11px;
 		font-weight: 600;
-		color: #a78bfa;
+		color: var(--nx-accent-2-soft);
 		background: rgba(167,139,250,.12);
 		border: 1px solid rgba(167,139,250,.3);
 		border-radius: 3px;
@@ -263,7 +263,7 @@
 		font-size: 11px;
 		background: rgba(13,13,18,.9);
 		border: 1px solid rgba(167,139,250,.3);
-		color: #a78bfa;
+		color: var(--nx-accent-2-soft);
 		cursor: pointer;
 		border-radius: 3px;
 		height: 20px;
@@ -291,7 +291,7 @@
 		outline-offset: -1px;
 	}
 	.gr-col--selected {
-		outline: 2px solid #a78bfa !important;
+		outline: 2px solid var(--nx-accent-2-soft) !important;
 		outline-offset: -1px;
 	}
 	.gr-col--empty {
@@ -357,7 +357,7 @@
 		background: rgba(167,139,250,.1);
 		border-color: rgba(167,139,250,.5);
 	}
-	.gr-col-empty-icon { font-size: 20px; color: #a78bfa; }
+	.gr-col-empty-icon { font-size: 20px; color: var(--nx-accent-2-soft); }
 	.gr-col-empty-label { font-size: 12px; color: #e2e8f0; }
 	.gr-col-empty-hint { font-size: 10px; color: #6b7280; }
 
@@ -374,7 +374,7 @@
 		align-items: center;
 		justify-content: center;
 		font-size: 9px;
-		color: #a78bfa;
+		color: var(--nx-accent-2-soft);
 		background: rgba(167,139,250,.15);
 		border: 1px solid rgba(167,139,250,.3);
 		cursor: col-resize;
@@ -387,7 +387,7 @@
 	.gr-col--edit:hover .gr-resize-handle { opacity: 1; }
 	.gr-resize-handle:hover {
 		background: rgba(167,139,250,.35);
-		border-color: #a78bfa;
+		border-color: var(--nx-accent-2-soft);
 		opacity: 1;
 	}
 

--- a/nodyx-frontend/src/lib/components/homepage/widgets/ArticleSlideshow.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/ArticleSlideshow.svelte
@@ -364,7 +364,7 @@
 	.as-spinner {
 		width: 24px; height: 24px;
 		border: 2px solid rgba(167,139,250,.2);
-		border-top-color: #a78bfa;
+		border-top-color: var(--nx-accent-2-soft);
 		border-radius: 50%;
 		animation: spin .7s linear infinite;
 	}
@@ -415,7 +415,7 @@
 	.as-cat-line {
 		height: 1px;
 		width: 2.5rem;
-		background: linear-gradient(to right, #7c3aed, #06b6d4);
+		background: linear-gradient(to right, var(--nx-accent-2-strong), #06b6d4);
 		flex-shrink: 0;
 	}
 	.as-cat-text {
@@ -423,7 +423,7 @@
 		font-weight: 800;
 		text-transform: uppercase;
 		letter-spacing: .22em;
-		color: #a78bfa;
+		color: var(--nx-accent-2-soft);
 	}
 	.as-cat-badge {
 		font-size: 10px;
@@ -455,7 +455,7 @@
 		text-decoration: none;
 		transition: color .15s;
 	}
-	.as-title a:hover { color: #c4b5fd; }
+	.as-title a:hover { color: var(--nx-accent-2-soft2); }
 
 	/* ── Excerpt ────────────────────────────────────────────────────────────── */
 	.as-excerpt {
@@ -556,7 +556,7 @@
 		top: -1px;
 		left: 0;
 		height: 4px;
-		background: linear-gradient(to right, #7c3aed, #06b6d4);
+		background: linear-gradient(to right, var(--nx-accent-2-strong), #06b6d4);
 		transition: none;
 	}
 	.as-arrows {
@@ -578,7 +578,7 @@
 	}
 	.as-arrow:hover {
 		border-color: rgba(124,58,237,.5);
-		color: #a78bfa;
+		color: var(--nx-accent-2-soft);
 	}
 	.as-arrow svg { width: 14px; height: 14px; }
 

--- a/nodyx-frontend/src/lib/components/homepage/widgets/HeroBanner.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/HeroBanner.svelte
@@ -344,12 +344,12 @@
 	.hb-event-eyebrow {
 		display: flex; align-items: center; gap: .6rem;
 		font-size: 10px; font-weight: 800; text-transform: uppercase;
-		letter-spacing: .22em; color: #a78bfa;
+		letter-spacing: .22em; color: var(--nx-accent-2-soft);
 		font-family: 'Space Grotesk', sans-serif;
 	}
 	.hb-eyebrow-line {
 		height: 1px; width: 40px;
-		background: linear-gradient(to right, #7c3aed, #06b6d4);
+		background: linear-gradient(to right, var(--nx-accent-2-strong), #06b6d4);
 	}
 
 	.hb-identity {
@@ -375,7 +375,7 @@
 		font-family: 'Space Grotesk', sans-serif; font-weight: 800;
 		font-size: clamp(1.25rem, 2.4vw, 1.85rem);
 		line-height: 1.05; margin: 0 0 .2rem;
-		background: linear-gradient(135deg, #a78bfa 0%, #06b6d4 100%);
+		background: linear-gradient(135deg, var(--nx-accent-2-soft) 0%, #06b6d4 100%);
 		-webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
 	}
 	.hb-title--event {
@@ -400,14 +400,14 @@
 	}
 	.hb-btn:active { transform: scale(.97); }
 	.hb-btn--primary {
-		background: linear-gradient(135deg, #7c3aed, #0e7490);
+		background: linear-gradient(135deg, var(--nx-accent-2-strong), #0e7490);
 		border: 1px solid rgba(124,58,237,.45); color: #fff;
 	}
 	.hb-btn--primary:hover { filter: brightness(1.12); }
 	.hb-btn--ghost {
 		border: 1px solid rgba(255,255,255,.12); color: #9ca3af;
 	}
-	.hb-btn--ghost:hover { border-color: rgba(167,139,250,.4); color: #c4b5fd; }
+	.hb-btn--ghost:hover { border-color: rgba(167,139,250,.4); color: var(--nx-accent-2-soft2); }
 
 	/* ── Stats dock ────────────────────────────────────────────────────────── */
 	.hb-stats-dock {
@@ -428,7 +428,7 @@
 		display: flex; align-items: center; gap: 5px;
 		font-variant-numeric: tabular-nums;
 	}
-	.hb-stat--purple { color: #a78bfa; animation: numglow 4s ease-in-out infinite; }
+	.hb-stat--purple { color: var(--nx-accent-2-soft); animation: numglow 4s ease-in-out infinite; }
 	.hb-stat--green  { color: #4ade80; }
 	.hb-stat--cyan   { color: #67e8f9; }
 	.hb-stat-label {
@@ -484,12 +484,12 @@
 	}
 	.hb-live-empty svg { width: 13px; height: 13px; }
 	.hb-live-cta {
-		font-size: 11px; font-weight: 600; color: #a78bfa;
+		font-size: 11px; font-weight: 600; color: var(--nx-accent-2-soft);
 		text-decoration: none;
 		display: flex; align-items: center; gap: 4px;
 		transition: color .15s;
 	}
-	.hb-live-cta:hover { color: #c4b5fd; }
+	.hb-live-cta:hover { color: var(--nx-accent-2-soft2); }
 	.hb-live-cta svg { width: 11px; height: 11px; }
 
 	/* ── Avatars ───────────────────────────────────────────────────────────── */
@@ -519,7 +519,7 @@
 		overflow: hidden;
 	}
 	.hb-avatar-letter {
-		font-size: 11px; font-weight: 800; color: #a78bfa;
+		font-size: 11px; font-weight: 800; color: var(--nx-accent-2-soft);
 		display: flex !important; align-items: center; justify-content: center;
 	}
 	.hb-avatar:hover {

--- a/nodyx-frontend/src/lib/components/homepage/widgets/JoinCard.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/JoinCard.svelte
@@ -75,7 +75,7 @@
 		{/if}
 
 		<div class="text-xs leading-tight" style="color:#6b7280">
-			<span style="color:#a78bfa; font-weight:700">{memberCount.toLocaleString()}</span>
+			<span style="color:var(--nx-accent-2-soft); font-weight:700">{memberCount.toLocaleString()}</span>
 			{tFn('common.members')}
 			{#if showOnlineCount}
 				<span class="mx-1" style="color:#374151">·</span>
@@ -88,7 +88,7 @@
 	<!-- CTA -->
 	<a href="/auth/register"
 	   class="w-full flex items-center justify-center gap-2 py-2.5 text-sm font-bold uppercase tracking-wider text-white transition-all"
-	   style="font-family:'Space Grotesk',sans-serif; background:linear-gradient(135deg,#7c3aed,#0e7490); border:1px solid rgba(124,58,237,.4)">
+	   style="font-family:'Space Grotesk',sans-serif; background:linear-gradient(135deg,var(--nx-accent-2-strong),#0e7490); border:1px solid rgba(124,58,237,.4)">
 		{ctaText || tFn('common.join') || 'Rejoindre'}
 		<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
 			<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>

--- a/nodyx-frontend/src/lib/components/homepage/widgets/RecentThreads.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/RecentThreads.svelte
@@ -207,7 +207,7 @@
 		font-weight: 800;
 		text-transform: uppercase;
 		letter-spacing: .2em;
-		color: var(--np, #a78bfa);
+		color: var(--np, var(--nx-accent-2-soft));
 		white-space: nowrap;
 	}
 
@@ -241,7 +241,7 @@
 	}
 	.rt-avatar--sm { width: 20px; height: 20px; border-radius: 2px; }
 	.rt-avatar img  { width: 100%; height: 100%; object-fit: cover; }
-	.rt-avatar span { font-size: 13px; font-weight: 700; color: #a78bfa; }
+	.rt-avatar span { font-size: 13px; font-weight: 700; color: var(--nx-accent-2-soft); }
 	.rt-avatar--sm span { font-size: 9px; }
 
 	/* ── LIST style ─────────────────────────────────────────────────────────── */
@@ -277,7 +277,7 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
-	.rt-item:hover .rt-item-title { color: #c4b5fd; }
+	.rt-item:hover .rt-item-title { color: var(--nx-accent-2-soft2); }
 	.rt-item-title--locked { color: #6b7280 !important; }
 
 	.rt-lock { width: 11px; height: 11px; flex-shrink: 0; color: #4b5563; }
@@ -292,7 +292,7 @@
 	.rt-cat-badge {
 		font-size: 10px;
 		font-weight: 600;
-		color: var(--np, #a78bfa);
+		color: var(--np, var(--nx-accent-2-soft));
 		background: rgba(167,139,250,.1);
 		border: 1px solid rgba(167,139,250,.18);
 		padding: 0 5px;
@@ -342,7 +342,7 @@
 		font-weight: 700;
 		text-transform: uppercase;
 		letter-spacing: .12em;
-		color: var(--np, #a78bfa);
+		color: var(--np, var(--nx-accent-2-soft));
 	}
 
 	.rt-card-title {
@@ -358,7 +358,7 @@
 		margin: 0;
 		flex: 1;
 	}
-	.rt-card:hover .rt-card-title { color: #c4b5fd; }
+	.rt-card:hover .rt-card-title { color: var(--nx-accent-2-soft2); }
 
 	.rt-card-meta {
 		display: flex;

--- a/nodyx-frontend/src/lib/components/homepage/widgets/SocialLinksBar.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/SocialLinksBar.svelte
@@ -276,7 +276,7 @@
 		transition: color .15s, background .15s, transform .15s;
 	}
 	.sl-link:hover {
-		color: var(--ic, #a78bfa);
+		color: var(--ic, var(--nx-accent-2-soft));
 		background: rgba(255,255,255,.06);
 		transform: translateY(-2px);
 	}

--- a/nodyx-frontend/src/lib/components/homepage/widgets/TwitchStream.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/TwitchStream.svelte
@@ -235,7 +235,7 @@
 		<!-- Bannière fallback : main offline, on montre un autre stream -->
 		{#if isFallbackLive && widgetData?.main === null && configuredChannel !== activeChannel}
 			<div class="relative flex items-center gap-2 px-4 py-1.5 text-[10px]"
-			     style="background:rgba(145,70,255,.08); border-bottom:1px solid rgba(145,70,255,.2); color:#c4b5fd">
+			     style="background:rgba(145,70,255,.08); border-bottom:1px solid rgba(145,70,255,.2); color:var(--nx-accent-2-soft2)">
 				<svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
 					<path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"/>
 				</svg>

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -473,7 +473,7 @@
 		<meta name="twitter:image" content="{$page.url.origin}/og-image.jpg" />
 	{/if}
 	<meta name="twitter:card" content="summary_large_image" />
-	<meta name="theme-color" content="#6366f1" />
+	<meta name="theme-color" content="var(--nx-accent)" />
 	<!-- Preload all Google Font presets (avatar/username effects) -->
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
@@ -524,7 +524,7 @@
 
 		<!-- Mobile: community name logo -->
 		<a href="/" class="lg:hidden shrink-0 font-black text-sm truncate max-w-[140px]"
-		   style="font-family: 'Space Grotesk', sans-serif; background: linear-gradient(135deg, #a78bfa, #67e8f9); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; color: transparent">
+		   style="font-family: 'Space Grotesk', sans-serif; background: linear-gradient(135deg, var(--nx-accent-2-soft), #67e8f9); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; color: transparent">
 			{communityName}
 		</a>
 
@@ -532,7 +532,7 @@
 		<div class="hidden lg:flex items-center gap-1.5 flex-1 min-w-0 overflow-hidden">
 			<!-- Logo toujours visible -->
 			<a href="/" class="shrink-0 font-black text-sm"
-			   style="font-family: 'Space Grotesk', sans-serif; background: linear-gradient(135deg, #a78bfa, #67e8f9); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; color: transparent">
+			   style="font-family: 'Space Grotesk', sans-serif; background: linear-gradient(135deg, var(--nx-accent-2-soft), #67e8f9); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; color: transparent">
 				{communityName}
 			</a>
 			<!-- Breadcrumb dynamique (masqué sur la homepage) -->
@@ -582,7 +582,7 @@
 				<!-- Notifications -->
 				<a href="/notifications"
 				   class="relative p-2 transition-colors"
-				   style="color: {isActive('/notifications') ? '#a78bfa' : '#6b7280'}"
+				   style="color: {isActive('/notifications') ? 'var(--nx-accent-2-soft)' : '#6b7280'}"
 				   title={tFn('nav.notifications')}>
 					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
 						<path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/>
@@ -594,19 +594,19 @@
 				<!-- DMs -->
 				<a href="/dm"
 				   class="relative p-2 transition-colors"
-				   style="color: {isActive('/dm') ? '#a78bfa' : '#6b7280'}"
+				   style="color: {isActive('/dm') ? 'var(--nx-accent-2-soft)' : '#6b7280'}"
 				   title={tFn('nav.dm')}>
 					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
 						<path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-5l-4 4v-4z"/>
 					</svg>
 					{#if dmUnread > 0}
-						<span class="absolute top-0.5 right-0.5 min-w-[14px] h-3.5 px-0.5 flex items-center justify-center text-[9px] font-black text-white rounded-full" style="background: #7c3aed; line-height: 1">{dmUnread > 9 ? '9+' : dmUnread}</span>
+						<span class="absolute top-0.5 right-0.5 min-w-[14px] h-3.5 px-0.5 flex items-center justify-center text-[9px] font-black text-white rounded-full" style="background: var(--nx-accent-2-strong); line-height: 1">{dmUnread > 9 ? '9+' : dmUnread}</span>
 					{/if}
 				</a>
 				{#if user.role === 'owner' || user.role === 'admin'}
 					<a href="/admin"
 					   class="hidden sm:flex items-center px-2.5 h-7 text-[10px] font-black uppercase tracking-wider transition-colors"
-					   style="color: {isActive('/admin') ? '#a78bfa' : '#4b5563'}; border: 1px solid {isActive('/admin') ? 'rgba(124,58,237,.4)' : 'rgba(255,255,255,.06)'}">{tFn('nav.admin')}</a>
+					   style="color: {isActive('/admin') ? 'var(--nx-accent-2-soft)' : '#4b5563'}; border: 1px solid {isActive('/admin') ? 'rgba(124,58,237,.4)' : 'rgba(255,255,255,.06)'}">{tFn('nav.admin')}</a>
 				{/if}
 				<!-- User dropdown -->
 				<div class="relative">
@@ -618,7 +618,7 @@
 							{#if user.avatar}
 								<img src={user.avatar} alt="Avatar" class="w-6 h-6 object-cover" style="outline: 1px solid rgba(255,255,255,.15)" />
 							{:else}
-								<div class="w-6 h-6 flex items-center justify-center text-xs font-bold text-white select-none" style="background: linear-gradient(135deg, #7c3aed, #0e7490)">{user.username.charAt(0).toUpperCase()}</div>
+								<div class="w-6 h-6 flex items-center justify-center text-xs font-bold text-white select-none" style="background: linear-gradient(135deg, var(--nx-accent-2-strong), #0e7490)">{user.username.charAt(0).toUpperCase()}</div>
 							{/if}
 							<span class="absolute -bottom-0.5 -right-0.5 w-2 h-2 rounded-full" style="background: #4ade80; border: 1.5px solid #0d0d12"></span>
 						</div>
@@ -706,7 +706,7 @@
 				   style="color: #9ca3af; border: 1px solid rgba(255,255,255,.06)">{tFn('common.login')}</a>
 				<a href="/auth/register"
 				   class="px-2.5 h-6 flex items-center text-xs font-bold transition-colors"
-				   style="background: #7c3aed; color: #fff">{tFn('common.register')}</a>
+				   style="background: var(--nx-accent-2-strong); color: #fff">{tFn('common.register')}</a>
 			{/if}
 		</div>
 	</nav>
@@ -857,7 +857,7 @@
 						   style="color: {isActive(item.href) ? '#e2e8f0' : '#6b7280'}; background: {isActive(item.href) ? 'rgba(124,58,237,.12)' : 'transparent'}">
 							{#if isActive(item.href)}
 								<span class="absolute left-0 top-1 bottom-1 w-0.5"
-								      style="background: linear-gradient(to bottom, #7c3aed, #06b6d4)"></span>
+								      style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), #06b6d4)"></span>
 							{/if}
 							<svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" d={item.icon}/>
@@ -888,7 +888,7 @@
 						   style="color: {isActive(item.href) ? '#e2e8f0' : '#6b7280'}; background: {isActive(item.href) ? 'rgba(124,58,237,.12)' : 'transparent'}">
 							{#if isActive(item.href)}
 								<span class="absolute left-0 top-1 bottom-1 w-0.5"
-								      style="background: linear-gradient(to bottom, #7c3aed, #06b6d4)"></span>
+								      style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), #06b6d4)"></span>
 							{/if}
 							<svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" d={item.icon}/>
@@ -928,14 +928,14 @@
 						          {chActive ? 'lch-active' : hasUnread ? 'lch-unread' : 'lch-idle'}
 						          {chFlash ? 'lch-flash' : ''}">
 							{#if chActive}
-								<span class="absolute left-0 top-1 bottom-1 w-0.5" style="background: linear-gradient(to bottom, #7c3aed, #06b6d4)"></span>
+								<span class="absolute left-0 top-1 bottom-1 w-0.5" style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), #06b6d4)"></span>
 							{/if}
 							<span class="text-base leading-none shrink-0 inline-flex items-center justify-center">
 								<ChannelIcon
 									value={ch.icon_emoji}
 									fallback="#"
 									size={16}
-									color={ch.name_color ?? (chActive ? '#a78bfa' : hasUnread ? '#7c3aed' : '#374151')}
+									color={ch.name_color ?? (chActive ? 'var(--nx-accent-2-soft)' : hasUnread ? 'var(--nx-accent-2-strong)' : '#374151')}
 								/>
 							</span>
 							<span class="text-xs truncate flex-1" class:font-semibold={hasUnread}
@@ -967,24 +967,24 @@
 						   class="relative flex items-center gap-2.5 px-2.5 py-2 text-sm transition-all"
 						   style="color: {chActive ? '#e2e8f0' : '#4b5563'}; background: {chActive ? 'rgba(124,58,237,.12)' : 'transparent'}">
 							{#if chActive}
-								<span class="absolute left-0 top-1 bottom-1 w-0.5" style="background: linear-gradient(to bottom, #7c3aed, #06b6d4)"></span>
+								<span class="absolute left-0 top-1 bottom-1 w-0.5" style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), #06b6d4)"></span>
 							{/if}
 							{#if ch.icon_emoji}
 								<span class="lch-voice-ico inline-flex items-center justify-center">
 									<ChannelIcon
 										value={ch.icon_emoji}
 										size={14}
-										color={ch.name_color ?? (inThis ? '#4ade80' : chActive ? '#a78bfa' : '#374151')}
+										color={ch.name_color ?? (inThis ? '#4ade80' : chActive ? 'var(--nx-accent-2-soft)' : '#374151')}
 									/>
 								</span>
 							{:else}
-								<svg class="lch-voice-ico" fill="none" stroke="{ch.name_color ?? (inThis ? '#4ade80' : chActive ? '#a78bfa' : '#374151')}" stroke-width="2" viewBox="0 0 24 24">
+								<svg class="lch-voice-ico" fill="none" stroke="{ch.name_color ?? (inThis ? '#4ade80' : chActive ? 'var(--nx-accent-2-soft)' : '#374151')}" stroke-width="2" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" d="M12 18.75a6 6 0 006-6v-1.5m-6 7.5a6 6 0 01-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 01-3-3V4.5a3 3 0 116 0v8.25a3 3 0 01-3 3z"/>
 								</svg>
 							{/if}
 							<span class="text-xs truncate flex-1" style={chNameStyle(ch)}>{ch.name}</span>
 							{#if members.length > 0}
-								<span class="text-[10px] font-bold shrink-0" style="color: {inThis ? '#a78bfa' : '#374151'}">{members.length}</span>
+								<span class="text-[10px] font-bold shrink-0" style="color: {inThis ? 'var(--nx-accent-2-soft)' : '#374151'}">{members.length}</span>
 							{/if}
 						</a>
 						<!-- Membres connectés -->
@@ -994,7 +994,7 @@
 									{@const mSharing = !!(m.userId && screenSharingUserIds.has(m.userId))}
 									{@const borderColor = m.speaking ? 'rgba(74,222,128,0.6)' : m.deafened ? 'rgba(249,115,22,0.45)' : m.muted ? 'rgba(239,68,68,0.35)' : mSharing ? 'rgba(59,130,246,0.35)' : 'rgba(255,255,255,0.04)'}
 									{@const bgColor    = m.speaking ? 'rgba(74,222,128,0.07)' : m.deafened ? 'rgba(249,115,22,0.05)' : m.muted ? 'rgba(239,68,68,0.04)' : 'rgba(255,255,255,0.02)'}
-									{@const nameColor  = m.speaking ? '#86efac' : m.deafened ? '#fdba74' : m.muted ? '#fca5a5' : m.isMe ? '#c4b5fd' : '#6b7280'}
+									{@const nameColor  = m.speaking ? '#86efac' : m.deafened ? '#fdba74' : m.muted ? '#fca5a5' : m.isMe ? 'var(--nx-accent-2-soft2)' : '#6b7280'}
 									<!-- svelte-ignore a11y_no_static_element_interactions -->
 									<div class="vc-member-card relative flex items-center gap-2 px-2 py-1.5 transition-all duration-200"
 									     style="background:{bgColor}; border-left:2px solid {borderColor};"
@@ -1009,7 +1009,7 @@
 													<img src={m.avatar} alt={m.username} class="w-full h-full object-cover"/>
 												{:else}
 													<div class="w-full h-full flex items-center justify-center text-[9px] font-black text-white select-none"
-													     style="background:linear-gradient(135deg,#7c3aed,#0e7490)">
+													     style="background:linear-gradient(135deg,var(--nx-accent-2-strong),#0e7490)">
 														{m.username.charAt(0).toUpperCase()}
 													</div>
 												{/if}
@@ -1082,7 +1082,7 @@
 						<img src={user.avatar} alt="" class="w-8 h-8 object-cover" style="outline: 1px solid rgba(255,255,255,.1)" />
 					{:else}
 						<div class="w-8 h-8 flex items-center justify-center text-xs font-bold text-white select-none"
-						     style="background: linear-gradient(135deg, #7c3aed, #0e7490)">
+						     style="background: linear-gradient(135deg, var(--nx-accent-2-strong), #0e7490)">
 							{user.username.charAt(0).toUpperCase()}
 						</div>
 					{/if}
@@ -1091,7 +1091,7 @@
 				</div>
 				<div class="flex-1 min-w-0">
 					<div class="text-xs font-bold truncate" style="color: #e2e8f0; font-family: 'Space Grotesk', sans-serif">{user.username}</div>
-					<div class="text-[10px] uppercase tracking-wide" style="color: {user.role === 'owner' || user.role === 'admin' ? '#a78bfa' : '#4b5563'}; font-weight: 700">
+					<div class="text-[10px] uppercase tracking-wide" style="color: {user.role === 'owner' || user.role === 'admin' ? 'var(--nx-accent-2-soft)' : '#4b5563'}; font-weight: 700">
 						{user.role === 'owner' ? 'Owner' : user.role === 'admin' ? 'Admin' : tFn('common.member')}
 					</div>
 				</div>
@@ -1191,14 +1191,14 @@
 								class="relative w-full flex items-center gap-2.5 px-2 py-2 transition-all group"
 								style="background: {isMe ? 'rgba(124,58,237,.06)' : 'transparent'}; text-align: left">
 								<!-- Hover bar -->
-								<span class="absolute left-0 top-0.5 bottom-0.5 w-0.5 opacity-0 group-hover:opacity-100 transition-opacity" style="background: linear-gradient(to bottom, #7c3aed, #06b6d4)"></span>
+								<span class="absolute left-0 top-0.5 bottom-0.5 w-0.5 opacity-0 group-hover:opacity-100 transition-opacity" style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), #06b6d4)"></span>
 								<!-- Avatar -->
 								<div class="relative shrink-0">
 									{#if member.avatar}
 										<img src={member.avatar} alt="" class="w-7 h-7 object-cover" style="outline: 1px solid rgba(255,255,255,.08)" />
 									{:else}
 										<div class="w-7 h-7 flex items-center justify-center text-[11px] font-black text-white select-none"
-										     style="background: linear-gradient(135deg, {members[0]?.grade?.color ?? '#7c3aed'}80, #0e7490)">{member.username.charAt(0).toUpperCase()}</div>
+										     style="background: linear-gradient(135deg, {members[0]?.grade?.color ?? 'var(--nx-accent-2-strong)'}80, #0e7490)">{member.username.charAt(0).toUpperCase()}</div>
 									{/if}
 									<!-- Online dot — remplacé par icône activité si besoin -->
 									<span class="absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 flex items-center justify-center"
@@ -1218,9 +1218,9 @@
 								<div class="min-w-0 flex-1">
 									<div class="flex items-center gap-1 min-w-0">
 										<span class="text-[11px] font-semibold leading-tight truncate transition-colors group-hover:brightness-125 {buildAnimClass(member)}"
-										      style={buildNameStyle(member, isMe ? '#c4b5fd' : '#9ca3af')}>{member.username}</span>
+										      style={buildNameStyle(member, isMe ? 'var(--nx-accent-2-soft2)' : '#9ca3af')}>{member.username}</span>
 										{#if isMe}
-											<span class="shrink-0 text-[8px] font-black uppercase px-1 py-px leading-none" style="background: rgba(124,58,237,.25); color: #a78bfa">vous</span>
+											<span class="shrink-0 text-[8px] font-black uppercase px-1 py-px leading-none" style="background: rgba(124,58,237,.25); color: var(--nx-accent-2-soft)">vous</span>
 										{/if}
 									</div>
 									<!-- Activité temps réel -->
@@ -1274,7 +1274,7 @@
 								onmouseleave={() => { screenPreview = null }}
 								class="relative w-full flex items-center gap-2.5 px-2 py-2 transition-all group"
 								style="background: {isMe ? 'rgba(124,58,237,.06)' : 'transparent'}; text-align: left">
-								<span class="absolute left-0 top-0.5 bottom-0.5 w-0.5 opacity-0 group-hover:opacity-100 transition-opacity" style="background: linear-gradient(to bottom, #7c3aed, #06b6d4)"></span>
+								<span class="absolute left-0 top-0.5 bottom-0.5 w-0.5 opacity-0 group-hover:opacity-100 transition-opacity" style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), #06b6d4)"></span>
 								<div class="relative shrink-0">
 									{#if member.avatar}
 										<img src={member.avatar} alt="" class="w-7 h-7 object-cover" style="outline: 1px solid rgba(255,255,255,.08)" />
@@ -1297,9 +1297,9 @@
 								<div class="min-w-0 flex-1">
 									<div class="flex items-center gap-1 min-w-0">
 										<span class="text-[11px] font-semibold leading-tight truncate transition-colors group-hover:brightness-125 {buildAnimClass(member)}"
-										      style={buildNameStyle(member, isMe ? '#c4b5fd' : '#9ca3af')}>{member.username}</span>
+										      style={buildNameStyle(member, isMe ? 'var(--nx-accent-2-soft2)' : '#9ca3af')}>{member.username}</span>
 										{#if isMe}
-											<span class="shrink-0 text-[8px] font-black uppercase px-1 py-px leading-none" style="background: rgba(124,58,237,.25); color: #a78bfa">vous</span>
+											<span class="shrink-0 text-[8px] font-black uppercase px-1 py-px leading-none" style="background: rgba(124,58,237,.25); color: var(--nx-accent-2-soft)">vous</span>
 										{/if}
 									</div>
 									{#if isSharing || isStreaming}
@@ -1395,7 +1395,7 @@
 					<!-- Avatars fantômes -->
 					<div class="guest-ghosts">
 						{#each ['M','J','A','K','S','T','R','L'] as letter, i}
-						<div class="guest-ghost" style="--gi:{i}; --gc:{['#818cf8','#a78bfa','#34d399','#fb923c','#f472b6','#67e8f9','#facc15','#f87171'][i]}">
+						<div class="guest-ghost" style="--gi:{i}; --gc:{['var(--nx-accent-soft)','var(--nx-accent-2-soft)','#34d399','#fb923c','#f472b6','#67e8f9','#facc15','#f87171'][i]}">
 							{letter}
 						</div>
 						{/each}
@@ -1612,14 +1612,14 @@
 					<img src={evt.avatar} alt={evt.username} class="w-6 h-6 rounded-full object-cover shrink-0" />
 				{:else}
 					<div class="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold text-white shrink-0"
-					     style="background: linear-gradient(135deg, #7c3aed, #0e7490)">
+					     style="background: linear-gradient(135deg, var(--nx-accent-2-strong), #0e7490)">
 						{evt.username.charAt(0).toUpperCase()}
 					</div>
 				{/if}
 				<span class="text-xs whitespace-nowrap">
 					<span class="font-bold" style="color: #e2e8f0">{evt.username}</span>
 					<span style="color: #4b5563"> {evt.action === 'join' ? 'a rejoint' : 'a quitté'} </span>
-					<span style="color: #a78bfa"># {evt.channelName}</span>
+					<span style="color: var(--nx-accent-2-soft)"># {evt.channelName}</span>
 				</span>
 				<div class="w-4 h-4 rounded-full flex items-center justify-center shrink-0"
 				     style="background: {evt.action === 'join' ? 'rgba(74,222,128,0.15)' : 'rgba(239,68,68,0.15)'};">
@@ -1722,7 +1722,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	color: #a78bfa;
+	color: var(--nx-accent-2-soft);
 	position: relative;
 	z-index: 1;
 	transition: background 0.3s, border-color 0.3s;
@@ -1812,7 +1812,7 @@
 	border-radius: 20px;
 	background: rgba(139,92,246,0.12);
 	border: 1px solid rgba(139,92,246,0.25);
-	color: #c4b5fd;
+	color: var(--nx-accent-2-soft2);
 	font-size: 12px;
 	font-weight: 700;
 	letter-spacing: 0.02em;
@@ -1930,7 +1930,7 @@
 	height: 15px;
 	padding: 0 4px;
 	border-radius: 99px;
-	background: #7c3aed;
+	background: var(--nx-accent-2-strong);
 	color: white;
 	font-size: 8px;
 	font-weight: 800;

--- a/nodyx-frontend/src/routes/+page.svelte
+++ b/nodyx-frontend/src/routes/+page.svelte
@@ -94,7 +94,7 @@
 	.sg  { font-family: 'Space Grotesk', sans-serif; }
 	/* ── Gradient text ── */
 	.gt {
-		background: linear-gradient(135deg, #a78bfa 0%, #06b6d4 100%);
+		background: linear-gradient(135deg, var(--nx-accent-2-soft) 0%, #06b6d4 100%);
 		-webkit-background-clip: text; background-clip: text;
 		-webkit-text-fill-color: transparent; color: transparent;
 	}
@@ -123,7 +123,7 @@
 	.tile::after {
 		content: '';
 		position: absolute; bottom: 0; left: 0; right: 0; height: 2px;
-		background: linear-gradient(90deg, #7c3aed, #06b6d4);
+		background: linear-gradient(90deg, var(--nx-accent-2-strong), #06b6d4);
 		transform: scaleX(0); transform-origin: left;
 		transition: transform .3s ease;
 	}
@@ -140,7 +140,7 @@
 	.trow { position: relative; }
 	.trow::before {
 		content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 2px;
-		background: linear-gradient(to bottom, #7c3aed, #06b6d4);
+		background: linear-gradient(to bottom, var(--nx-accent-2-strong), #06b6d4);
 		transform: scaleY(0); transform-origin: center;
 		transition: transform .2s ease;
 	}
@@ -270,7 +270,7 @@
 		<!-- Stats row -->
 		<div class="flex flex-wrap items-stretch gap-0.5">
 			{#each [
-				{ value: instance.member_count.toLocaleString(), label: tFn('common.members'),  color: '#a78bfa', glow: true },
+				{ value: instance.member_count.toLocaleString(), label: tFn('common.members'),  color: 'var(--nx-accent-2-soft)', glow: true },
 				{ value: String(instance.online_count),                  label: tFn('common.online'), color: '#4ade80', online: true },
 				{ value: instance.thread_count.toLocaleString(), label: tFn('common.topics'),   color: '#67e8f9', glow: false },
 				{ value: instance.post_count.toLocaleString(),   label: tFn('nav.dm'), color: '#94a3b8', glow: false },
@@ -296,7 +296,7 @@
 				{#if data.user && (data.categories?.[0]?.slug ?? data.categories?.[0]?.id)}
 					<a href="/forum/{data.categories?.[0]?.slug ?? data.categories?.[0]?.id}/new"
 					   class="sg px-5 py-2.5 text-sm font-bold uppercase tracking-wider text-white transition-all"
-					   style="background: linear-gradient(135deg, #7c3aed 0%, #0e7490 100%); border: 1px solid rgba(124,58,237,.4)">
+					   style="background: linear-gradient(135deg, var(--nx-accent-2-strong) 0%, #0e7490 100%); border: 1px solid rgba(124,58,237,.4)">
 						{tFn('common.new_topic')}
 					</a>
 				{:else}
@@ -307,7 +307,7 @@
 					</a>
 					<a href="/auth/register"
 					   class="sg px-5 py-2.5 text-sm font-bold uppercase tracking-wider text-white transition-all"
-					   style="background: linear-gradient(135deg, #7c3aed 0%, #0e7490 100%); border: 1px solid rgba(124,58,237,.4)">
+					   style="background: linear-gradient(135deg, var(--nx-accent-2-strong) 0%, #0e7490 100%); border: 1px solid rgba(124,58,237,.4)">
 						{tFn('common.join')}
 					</a>
 				{/if}
@@ -346,14 +346,14 @@
 			<svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="#a78bfa" stroke-width="2" viewBox="0 0 24 24">
 				<path stroke-linecap="round" stroke-linejoin="round" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10l6 6v8a2 2 0 01-2 2z"/>
 			</svg>
-			<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: #a78bfa">{tFn('home.news')}</span>
+			<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: var(--nx-accent-2-soft)">{tFn('home.news')}</span>
 		</div>
 		<p class="sg text-sm font-bold leading-snug line-clamp-2 group-hover:text-violet-200 transition-colors" style="color: #e2e8f0">{heroArticle.title}</p>
 		<span class="text-[10px] mt-auto" style="color: #4b5563">{heroArticle.categoryName}</span>
 	</a>
 	{:else}
 	<div class="tile glass flex flex-col gap-2.5 p-5">
-		<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: #a78bfa">{tFn('home.news')}</span>
+		<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: var(--nx-accent-2-soft)">{tFn('home.news')}</span>
 		{tFn('common.no_article')}
 	</div>
 	{/if}
@@ -431,8 +431,8 @@
 				<!-- Category -->
 				{#if slide.categoryName}
 					<div class="flex items-center gap-3 mb-3">
-						<span class="h-px w-10" style="background: linear-gradient(to right, #7c3aed, #06b6d4)"></span>
-						<span class="sg text-[10px] font-black uppercase tracking-[.22em]" style="color: #a78bfa">{slide.categoryName}</span>
+						<span class="h-px w-10" style="background: linear-gradient(to right, var(--nx-accent-2-strong), #06b6d4)"></span>
+						<span class="sg text-[10px] font-black uppercase tracking-[.22em]" style="color: var(--nx-accent-2-soft)">{slide.categoryName}</span>
 					</div>
 				{/if}
 
@@ -482,7 +482,7 @@
 							        aria-label="Slide {i+1}">
 								{#if i === slideIndex}
 									<span class="absolute top-[-1px] left-0 h-[3px] transition-none"
-									      style="width:{progressPct}%; background: linear-gradient(to right, #7c3aed, #06b6d4)"></span>
+									      style="width:{progressPct}%; background: linear-gradient(to right, var(--nx-accent-2-strong), #06b6d4)"></span>
 								{/if}
 							</button>
 						{/each}
@@ -517,7 +517,7 @@
 		<div class="flex items-center justify-between px-5 py-3.5 shrink-0"
 		     style="border-bottom: 1px solid rgba(255,255,255,.05)">
 			<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: #6b7280">{tFn('home.forum_activity')}</span>
-			<a href="/forum" class="sg text-[10px] font-bold uppercase tracking-wide transition-colors" style="color: #4b5563" onmouseenter={e => (e.target as HTMLElement).style.color='#a78bfa'} onmouseleave={e => (e.target as HTMLElement).style.color='#4b5563'}>
+			<a href="/forum" class="sg text-[10px] font-bold uppercase tracking-wide transition-colors" style="color: #4b5563" onmouseenter={e => (e.target as HTMLElement).style.color='var(--nx-accent-2-soft)'} onmouseleave={e => (e.target as HTMLElement).style.color='#4b5563'}>
 				{tFn('common.view_all')}
 			</a>
 		</div>
@@ -530,7 +530,7 @@
 			   onmouseenter={e => (e.currentTarget as HTMLElement).style.background='rgba(255,255,255,.025)'}
 			   onmouseleave={e => (e.currentTarget as HTMLElement).style.background='transparent'}>
 				<span class="sg text-[11px] font-black tabular-nums shrink-0 mt-0.5 w-5 text-right"
-				      style="color: {i===0 ? '#a78bfa' : i===1 ? '#67e8f9' : '#374151'}">
+				      style="color: {i===0 ? 'var(--nx-accent-2-soft)' : i===1 ? '#67e8f9' : '#374151'}">
 					{String(i+1).padStart(2,'0')}
 				</span>
 				<div class="flex-1 min-w-0">
@@ -562,7 +562,7 @@
 			<a href="/forum"
 			   class="sg flex items-center justify-center gap-2 w-full py-2.5 text-[10px] font-black uppercase tracking-widest transition-all"
 			   style="color: #6b7280; border: 1px solid rgba(255,255,255,.06)"
-			   onmouseenter={e => { (e.currentTarget as HTMLElement).style.color='#a78bfa'; (e.currentTarget as HTMLElement).style.borderColor='rgba(124,58,237,.25)'; }}
+			   onmouseenter={e => { (e.currentTarget as HTMLElement).style.color='var(--nx-accent-2-soft)'; (e.currentTarget as HTMLElement).style.borderColor='rgba(124,58,237,.25)'; }}
 			   onmouseleave={e => { (e.currentTarget as HTMLElement).style.color='#6b7280'; (e.currentTarget as HTMLElement).style.borderColor='rgba(255,255,255,.06)'; }}>
 				{tFn('home.view_forum')}
 				<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
@@ -607,7 +607,7 @@
 			<div class="flex items-start justify-between gap-2 mb-4">
 				{#if thread.category_name}
 					<span class="sg text-[9px] font-black uppercase tracking-widest px-2 py-0.5"
-					      style="color: #a78bfa; background: rgba(124,58,237,.1); border: 1px solid rgba(124,58,237,.2)">
+					      style="color: var(--nx-accent-2-soft); background: rgba(124,58,237,.1); border: 1px solid rgba(124,58,237,.2)">
 						{thread.category_name}
 					</span>
 				{/if}
@@ -647,7 +647,7 @@
 <section class="px-6 py-8" style="background: #0a0a0f">
 
 	<div class="flex items-center gap-4 mb-6">
-		<span class="sg text-[10px] font-black uppercase tracking-[.22em]" style="color: #a78bfa">{tFn('home.articles')}</span>
+		<span class="sg text-[10px] font-black uppercase tracking-[.22em]" style="color: var(--nx-accent-2-soft)">{tFn('home.articles')}</span>
 		<div class="flex-1 h-px" style="background: linear-gradient(to right, rgba(124,58,237,.2), transparent)"></div>
 	</div>
 
@@ -673,8 +673,8 @@
 			<div>
 				{#if heroArticle.categoryName}
 					<div class="flex items-center gap-2 mb-2">
-						<span class="h-px w-6" style="background: #7c3aed"></span>
-						<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: #a78bfa">{heroArticle.categoryName}</span>
+						<span class="h-px w-6" style="background: var(--nx-accent-2-strong)"></span>
+						<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: var(--nx-accent-2-soft)">{heroArticle.categoryName}</span>
 					</div>
 				{/if}
 				<h3 class="sg text-xl font-extrabold leading-tight mb-2 group-hover:text-violet-200 transition-colors" style="color: #f1f5f9">{heroArticle.title}</h3>
@@ -683,10 +683,10 @@
 				{/if}
 			</div>
 			<div class="flex items-center gap-3 mt-4 pt-4" style="border-top: 1px solid rgba(255,255,255,.05)">
-				<span class="text-xs font-semibold" style="color: #a78bfa">{heroArticle.authorUsername}</span>
+				<span class="text-xs font-semibold" style="color: var(--nx-accent-2-soft)">{heroArticle.authorUsername}</span>
 				<span style="color: #374151">·</span>
 				<span class="text-xs" style="color: #4b5563">{timeAgo(heroArticle.createdAt)}</span>
-				<span class="ml-auto sg text-xs font-bold flex items-center gap-1 group-hover:text-violet-300 transition-colors" style="color: #a78bfa">
+				<span class="ml-auto sg text-xs font-bold flex items-center gap-1 group-hover:text-violet-300 transition-colors" style="color: var(--nx-accent-2-soft)">
 					Lire
 					<svg class="w-3 h-3 group-hover:translate-x-0.5 transition-transform" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
 				</span>
@@ -714,7 +714,7 @@
 			<div class="flex-1 min-w-0 flex flex-col justify-between">
 				<p class="text-xs font-bold line-clamp-2 leading-snug group-hover:text-white transition-colors" style="color: #d1d5db">{article.title}</p>
 				<div class="flex items-center gap-1.5 mt-2">
-					<span class="text-[10px] font-semibold" style="color: #a78bfa">{article.authorUsername}</span>
+					<span class="text-[10px] font-semibold" style="color: var(--nx-accent-2-soft)">{article.authorUsername}</span>
 					<span style="color: #374151">·</span>
 					<span class="text-[10px]" style="color: #4b5563">{timeAgo(article.createdAt)}</span>
 				</div>

--- a/nodyx-frontend/src/routes/admin/ai/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/ai/+page.svelte
@@ -187,7 +187,7 @@
                                     {model.name}
                                     {#if status.currentModel === model.name}
                                         <span
-                                            class="w-1.5 h-1.5 rounded-full bg-purple-400 shadow-[0_0_5px_#a855f7] animate-pulse"
+                                            class="w-1.5 h-1.5 rounded-full bg-purple-400 shadow-[0_0_5px_var(--nx-accent-2)] animate-pulse"
                                         ></span>
                                     {/if}
                                 </span>

--- a/nodyx-frontend/src/routes/admin/backups/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/backups/+page.svelte
@@ -316,7 +316,7 @@
 	<!-- Header -->
 	<div class="flex items-center justify-between mb-6">
 		<div>
-			<h1 class="text-2xl font-black" style="font-family:'Space Grotesk',sans-serif; background:linear-gradient(135deg,#a78bfa,#06b6d4); -webkit-background-clip:text; -webkit-text-fill-color:transparent; background-clip:text">
+			<h1 class="text-2xl font-black" style="font-family:'Space Grotesk',sans-serif; background:linear-gradient(135deg,var(--nx-accent-2-soft),#06b6d4); -webkit-background-clip:text; -webkit-text-fill-color:transparent; background-clip:text">
 				Sauvegardes & Restauration
 			</h1>
 			<p class="text-sm mt-1" style="color:#6b7280">
@@ -355,7 +355,7 @@
 		<button
 			onclick={() => createOpen = true}
 			class="flex items-center gap-2 px-4 py-2 text-sm font-bold transition-all"
-			style="background:linear-gradient(135deg,rgba(124,58,237,.25),rgba(6,182,212,.15)); border:1px solid rgba(124,58,237,.4); color:#a78bfa">
+			style="background:linear-gradient(135deg,rgba(124,58,237,.25),rgba(6,182,212,.15)); border:1px solid rgba(124,58,237,.4); color:var(--nx-accent-2-soft)">
 			<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
 				<path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m-8-8h16"/>
 			</svg>
@@ -388,7 +388,7 @@
 							<div class="flex items-center gap-2 flex-wrap">
 								<span class="text-sm font-mono truncate" style="color:#e2e8f0">{b.filename}</span>
 								<span class="text-[9px] font-bold uppercase px-1.5 py-0.5"
-								      style="background:rgba({sourceColor(b.source) === '#a78bfa' ? '167,139,250' : sourceColor(b.source) === '#06b6d4' ? '6,182,212' : '251,146,60'},.1); border:1px solid rgba({sourceColor(b.source) === '#a78bfa' ? '167,139,250' : sourceColor(b.source) === '#06b6d4' ? '6,182,212' : '251,146,60'},.25); color:{sourceColor(b.source)}">
+								      style="background:rgba({sourceColor(b.source) === 'var(--nx-accent-2-soft)' ? '167,139,250' : sourceColor(b.source) === '#06b6d4' ? '6,182,212' : '251,146,60'},.1); border:1px solid rgba({sourceColor(b.source) === 'var(--nx-accent-2-soft)' ? '167,139,250' : sourceColor(b.source) === '#06b6d4' ? '6,182,212' : '251,146,60'},.25); color:{sourceColor(b.source)}">
 									{sourceLabel(b.source)}
 								</span>
 								{#if verify}
@@ -477,7 +477,7 @@
 				<label class="flex items-start gap-2.5 cursor-pointer">
 					<input type="checkbox" bind:checked={createIncludeUploads}
 					       class="mt-0.5"
-					       style="accent-color:#a78bfa" />
+					       style="accent-color:var(--nx-accent-2-soft)" />
 					<div class="flex flex-col">
 						<span class="text-sm font-bold">Inclure les fichiers uploadés</span>
 						<span class="text-[10px]" style="color:#6b7280">Avatars, images, documents. Décocher = sauvegarde DB-only (plus rapide, beaucoup moins lourde).</span>
@@ -496,7 +496,7 @@
 				</button>
 				<button onclick={handleCreate} disabled={creating}
 				        class="px-4 py-1.5 text-xs font-bold disabled:opacity-50"
-				        style="background:linear-gradient(135deg,rgba(124,58,237,.25),rgba(6,182,212,.15)); border:1px solid rgba(124,58,237,.4); color:#a78bfa">
+				        style="background:linear-gradient(135deg,rgba(124,58,237,.25),rgba(6,182,212,.15)); border:1px solid rgba(124,58,237,.4); color:var(--nx-accent-2-soft)">
 					{creating ? 'Création...' : 'Créer'}
 				</button>
 			</div>
@@ -577,12 +577,12 @@
 				<div class="px-3 py-2.5" style="background:rgba(167,139,250,.05); border:1px solid rgba(167,139,250,.18)">
 					<div class="flex items-center justify-between gap-2">
 						<div class="flex flex-col gap-0.5">
-							<p class="text-[11px] font-bold" style="color:#a78bfa">Pas sûr ? Lance un test à blanc</p>
+							<p class="text-[11px] font-bold" style="color:var(--nx-accent-2-soft)">Pas sûr ? Lance un test à blanc</p>
 							<p class="text-[10px]" style="color:#6b7280">Vérifie le checksum + la structure de l'archive sans rien modifier. Aucune ligne de DB ni de fichier touché.</p>
 						</div>
 						<button onclick={handleDryRun} disabled={dryRunRunning || restoring}
 						        class="px-3 py-1.5 text-xs font-bold transition-all disabled:opacity-50 shrink-0"
-						        style="background:rgba(167,139,250,.1); border:1px solid rgba(167,139,250,.3); color:#a78bfa">
+						        style="background:rgba(167,139,250,.1); border:1px solid rgba(167,139,250,.3); color:var(--nx-accent-2-soft)">
 							{dryRunRunning ? '…' : 'Tester (dry-run)'}
 						</button>
 					</div>

--- a/nodyx-frontend/src/routes/admin/homepage/builder/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/homepage/builder/+page.svelte
@@ -1109,7 +1109,7 @@
 								/>
 							{:else if field.type === 'color'}
 								<div class="pfield-color">
-									<input type="color" value={configFields[field.key] as string ?? '#a78bfa'}
+									<input type="color" value={configFields[field.key] as string ?? 'var(--nx-accent-2-soft)'}
 										oninput={(e) => { configFields = { ...configFields, [field.key]: (e.target as HTMLInputElement).value } }}
 									/>
 									<input type="text" value={configFields[field.key] as string ?? ''}
@@ -1431,8 +1431,8 @@
 	}
 	.ptab:hover { color: #e2e8f0; }
 	.ptab--active {
-		color: #a78bfa;
-		box-shadow: inset 0 -2px 0 #a78bfa;
+		color: var(--nx-accent-2-soft);
+		box-shadow: inset 0 -2px 0 var(--nx-accent-2-soft);
 	}
 
 	.panel-body {
@@ -1456,7 +1456,7 @@
 	.panel-back {
 		background: none;
 		border: none;
-		color: #a78bfa;
+		color: var(--nx-accent-2-soft);
 		cursor: pointer;
 		font-size: 12px;
 		text-align: left;
@@ -1486,7 +1486,7 @@
 	}
 	.row-item:hover { border-color: rgba(167,139,250,.3); background: rgba(167,139,250,.05); }
 	.row-item--drag { opacity: 0.4; }
-	.row-item--dragover { border-color: #a78bfa !important; background: rgba(167,139,250,.12) !important; }
+	.row-item--dragover { border-color: var(--nx-accent-2-soft) !important; background: rgba(167,139,250,.12) !important; }
 
 	.row-item-handle {
 		font-size: 14px;
@@ -1498,7 +1498,7 @@
 		line-height: 1;
 		user-select: none;
 	}
-	.row-item-handle:hover { color: #a78bfa; }
+	.row-item-handle:hover { color: var(--nx-accent-2-soft); }
 
 	.row-item-spans {
 		flex: 1;
@@ -1534,7 +1534,7 @@
 		font-size: 10px;
 		display: flex; align-items: center; justify-content: center;
 	}
-	.riba:hover { border-color: #a78bfa; color: #a78bfa; }
+	.riba:hover { border-color: var(--nx-accent-2-soft); color: var(--nx-accent-2-soft); }
 	.riba--del:hover { border-color: #f87171; color: #f87171; }
 
 	.btn-add-row {
@@ -1542,7 +1542,7 @@
 		padding: 8px;
 		background: rgba(167,139,250,.1);
 		border: 1px dashed rgba(167,139,250,.3);
-		color: #a78bfa;
+		color: var(--nx-accent-2-soft);
 		cursor: pointer;
 		border-radius: 4px;
 		font-size: 12px;
@@ -1595,7 +1595,7 @@
 		border-radius: 50%;
 		border: 1px solid rgba(167, 139, 250, .35);
 		background: rgba(167, 139, 250, .08);
-		color: #a78bfa;
+		color: var(--nx-accent-2-soft);
 		font-size: 10px;
 		font-weight: 700;
 		line-height: 1;
@@ -1609,7 +1609,7 @@
 	.pfield-info-btn:hover {
 		background: rgba(167, 139, 250, .18);
 		border-color: rgba(167, 139, 250, .6);
-		color: #c4b5fd;
+		color: var(--nx-accent-2-soft2);
 	}
 	.pfield-info-btn[aria-expanded="true"] {
 		background: rgba(167, 139, 250, .25);
@@ -1651,7 +1651,7 @@
 
 	.pfield input[type="range"] {
 		width: 100%;
-		accent-color: #a78bfa;
+		accent-color: var(--nx-accent-2-soft);
 	}
 
 	.pfield-color {
@@ -1681,7 +1681,7 @@
 		position: relative;
 		transition: background 0.2s;
 	}
-	.ptoggle input:checked + .ptoggle-track { background: #a78bfa; }
+	.ptoggle input:checked + .ptoggle-track { background: var(--nx-accent-2-soft); }
 	.ptoggle-thumb {
 		position: absolute;
 		left: 2px; top: 2px;
@@ -1698,7 +1698,7 @@
 	/* ── Buttons ─────────────────────────────────────────────────────────────── */
 	.btn-primary {
 		padding: 7px 16px;
-		background: linear-gradient(135deg, #7c3aed, #a78bfa);
+		background: linear-gradient(135deg, var(--nx-accent-2-strong), var(--nx-accent-2-soft));
 		border: none;
 		color: white;
 		font-size: 12px;
@@ -1751,7 +1751,7 @@
 		border-radius: 4px;
 	}
 	.preview-btn:hover { border-color: rgba(167,139,250,.4); color: #e2e8f0; }
-	.preview-btn--active { background: rgba(167,139,250,.15); border-color: #a78bfa; color: #a78bfa; }
+	.preview-btn--active { background: rgba(167,139,250,.15); border-color: var(--nx-accent-2-soft); color: var(--nx-accent-2-soft); }
 
 	.toolbar-status { flex: 1; display: flex; align-items: center; gap: 6px; }
 	.unsaved-dot { width: 7px; height: 7px; border-radius: 50%; background: #f59e0b; animation: pulse 2s infinite; }
@@ -1772,11 +1772,11 @@
 	.btn-tool:hover:not(:disabled) { color: #e2e8f0; border-color: rgba(255,255,255,.2); }
 	.btn-tool:disabled { opacity: 0.5; cursor: not-allowed; }
 	.btn-tool--save { color: #e2e8f0; border-color: rgba(167,139,250,.3); }
-	.btn-tool--save:hover:not(:disabled) { background: rgba(167,139,250,.15); border-color: #a78bfa; color: #a78bfa; }
+	.btn-tool--save:hover:not(:disabled) { background: rgba(167,139,250,.15); border-color: var(--nx-accent-2-soft); color: var(--nx-accent-2-soft); }
 	.btn-tool--publish {
 		background: linear-gradient(135deg, rgba(124,58,237,.3), rgba(167,139,250,.2));
 		border-color: rgba(167,139,250,.4);
-		color: #a78bfa;
+		color: var(--nx-accent-2-soft);
 	}
 	.btn-tool--publish:hover:not(:disabled) { background: linear-gradient(135deg, rgba(124,58,237,.5), rgba(167,139,250,.35)); }
 
@@ -1880,8 +1880,8 @@
 		border-radius: 4px;
 		transition: all 0.15s;
 	}
-	.preset-btn:hover { background: rgba(167,139,250,.12); border-color: #a78bfa; }
-	.preset-preview { font-size: 10px; color: #a78bfa; letter-spacing: 1px; font-family: monospace; }
+	.preset-btn:hover { background: rgba(167,139,250,.12); border-color: var(--nx-accent-2-soft); }
+	.preset-preview { font-size: 10px; color: var(--nx-accent-2-soft); letter-spacing: 1px; font-family: monospace; }
 	.preset-label { font-size: 11px; color: #9ca3af; }
 
 	/* Widget picker */
@@ -1910,7 +1910,7 @@
 		transition: all 0.1s;
 	}
 	.fam-btn:hover { border-color: rgba(167,139,250,.4); color: #e2e8f0; }
-	.fam-btn--active { background: rgba(167,139,250,.15); border-color: #a78bfa; color: #a78bfa; }
+	.fam-btn--active { background: rgba(167,139,250,.15); border-color: var(--nx-accent-2-soft); color: var(--nx-accent-2-soft); }
 
 	.picker-grid {
 		display: grid;
@@ -1975,7 +1975,7 @@
 	.ss-src-label {
 		font-size: 11px;
 		font-weight: 700;
-		color: #a78bfa;
+		color: var(--nx-accent-2-soft);
 		white-space: nowrap;
 		flex-shrink: 0;
 	}
@@ -2005,7 +2005,7 @@
 		padding: 0;
 		transition: border-color .1s, color .1s;
 	}
-	.ss-src-btn:hover:not(:disabled) { border-color: #a78bfa; color: #a78bfa; }
+	.ss-src-btn:hover:not(:disabled) { border-color: var(--nx-accent-2-soft); color: var(--nx-accent-2-soft); }
 	.ss-src-btn:disabled { opacity: .3; cursor: default; }
 	.ss-src-btn--del:hover { border-color: #f87171 !important; color: #f87171 !important; }
 
@@ -2019,7 +2019,7 @@
 		font-size: 11px;
 		background: rgba(167,139,250,.08);
 		border: 1px solid rgba(167,139,250,.25);
-		color: #a78bfa;
+		color: var(--nx-accent-2-soft);
 		cursor: pointer;
 		border-radius: 3px;
 		transition: background .1s;

--- a/nodyx-frontend/src/routes/admin/modules/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/modules/+page.svelte
@@ -164,12 +164,12 @@
 							         : enabled
 							           ? 'bg-gray-900/80 border-gray-700/80 shadow-lg'
 							           : 'bg-gray-900/30 border-gray-800/40'}"
-							style={enabled && !isCore && !isSoon ? `box-shadow: 0 0 0 1px ${display?.color ?? '#7c3aed'}22, 0 4px 20px ${display?.color ?? '#7c3aed'}11` : ''}
+							style={enabled && !isCore && !isSoon ? `box-shadow: 0 0 0 1px ${display?.color ?? 'var(--nx-accent-2-strong)'}22, 0 4px 20px ${display?.color ?? 'var(--nx-accent-2-strong)'}11` : ''}
 						>
 							<!-- Enabled glow bar -->
 							{#if enabled && !isCore && !isSoon}
 								<div class="absolute top-0 left-0 right-0 h-px"
-								     style="background: linear-gradient(90deg, transparent, {display?.color ?? '#7c3aed'}88, transparent)"></div>
+								     style="background: linear-gradient(90deg, transparent, {display?.color ?? 'var(--nx-accent-2-strong)'}88, transparent)"></div>
 							{/if}
 
 							<div class="p-4">
@@ -213,7 +213,7 @@
 											class="relative w-11 h-6 rounded-full transition-all duration-200 shrink-0 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900
 											       {enabled ? 'focus:ring-violet-500' : 'focus:ring-gray-600'}
 											       {isSaving ? 'opacity-50 cursor-wait' : 'cursor-pointer'}"
-											style="background: {enabled ? (display?.color ?? '#7c3aed') : '#374151'}"
+											style="background: {enabled ? (display?.color ?? 'var(--nx-accent-2-strong)') : '#374151'}"
 											aria-label="{enabled ? 'Désactiver' : 'Activer'} {display?.name}"
 										>
 											<span class="absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform duration-200

--- a/nodyx-frontend/src/routes/admin/octoguard/+layout.svelte
+++ b/nodyx-frontend/src/routes/admin/octoguard/+layout.svelte
@@ -92,7 +92,7 @@
 	.og-tab:hover { color: #e2e8f0; }
 	.og-tab--active {
 		color: #f1f5f9;
-		border-bottom-color: #6366f1;
+		border-bottom-color: var(--nx-accent);
 		font-weight: 600;
 	}
 	.og-tab-icon { font-size: 14px; }

--- a/nodyx-frontend/src/routes/admin/octoguard/automod/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/octoguard/automod/+page.svelte
@@ -220,9 +220,9 @@
 	.og-page-sub { font-size: 11px; color: #64748b; margin: 2px 0 0; font-family: ui-monospace, monospace; }
 	.og-btn-primary {
 		padding: 6px 12px; font-size: 12px; color: #fff;
-		background: #6366f1; border: none; border-radius: 3px; cursor: pointer;
+		background: var(--nx-accent); border: none; border-radius: 3px; cursor: pointer;
 	}
-	.og-btn-primary:hover { background: #4f46e5; }
+	.og-btn-primary:hover { background: var(--nx-accent-strong); }
 	.og-btn-secondary {
 		padding: 6px 12px; font-size: 12px; color: #94a3b8;
 		background: transparent; border: 1px solid #374151; border-radius: 3px; cursor: pointer;

--- a/nodyx-frontend/src/routes/admin/octoguard/commands/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/octoguard/commands/+page.svelte
@@ -65,7 +65,7 @@
 	.og-h code { background: rgba(255,255,255,0.05); padding: 1px 4px; border-radius: 2px; font-size: 11px; font-family: ui-monospace, monospace; }
 	.og-btn { padding: 6px 12px; font-size: 12px; background: transparent; color: #94a3b8; border: 1px solid #374151; border-radius: 3px; cursor: pointer; }
 	.og-btn:hover { color: #e2e8f0; }
-	.og-btn-primary { padding: 6px 12px; font-size: 12px; color: #fff; background: #6366f1; border: none; border-radius: 3px; cursor: pointer; }
+	.og-btn-primary { padding: 6px 12px; font-size: 12px; color: #fff; background: var(--nx-accent); border: none; border-radius: 3px; cursor: pointer; }
 	.og-err { padding: 10px 14px; background: rgba(239,68,68,0.1); border: 1px solid rgba(239,68,68,0.3); color: #fca5a5; border-radius: 4px; font-size: 13px; margin-bottom: 12px; }
 	.og-form { display: flex; flex-direction: column; gap: 10px; padding: 14px; border: 1px solid rgba(255,255,255,0.06); border-radius: 4px; background: rgba(255,255,255,0.01); margin-bottom: 12px; }
 	.og-row { display: grid; grid-template-columns: 1fr 120px; gap: 10px; }

--- a/nodyx-frontend/src/routes/admin/octoguard/mutes/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/octoguard/mutes/+page.svelte
@@ -71,7 +71,7 @@
 	label { display: flex; flex-direction: column; gap: 4px; font-size: 11px; color: #94a3b8; }
 	input, select { padding: 6px 8px; font-size: 12px; background: #1f2937; border: 1px solid #374151; border-radius: 3px; color: #e2e8f0; font-family: ui-monospace, monospace; }
 	.og-actions { display: flex; justify-content: flex-end; }
-	.og-btn-primary { padding: 6px 12px; font-size: 12px; color: #fff; background: #6366f1; border: none; border-radius: 3px; cursor: pointer; }
+	.og-btn-primary { padding: 6px 12px; font-size: 12px; color: #fff; background: var(--nx-accent); border: none; border-radius: 3px; cursor: pointer; }
 	.og-btn-link { background: transparent; border: none; color: #94a3b8; font-size: 11px; cursor: pointer; padding: 0; }
 	.og-btn-link:hover { color: #e2e8f0; }
 	.og-table { width: 100%; border-collapse: collapse; font-size: 12px; }

--- a/nodyx-frontend/src/routes/admin/octoguard/webhook/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/octoguard/webhook/+page.svelte
@@ -58,5 +58,5 @@
 	.og-info { font-size: 11px; color: #c7d2fe; background: rgba(99,102,241,0.05); border: 1px solid rgba(99,102,241,0.2); padding: 10px 12px; border-radius: 3px; line-height: 1.6; }
 	.og-info code { background: rgba(255,255,255,0.05); padding: 1px 4px; border-radius: 2px; font-size: 10px; font-family: ui-monospace, monospace; }
 	.og-actions { display: flex; justify-content: flex-end; }
-	.og-btn-primary { padding: 6px 12px; font-size: 12px; color: #fff; background: #6366f1; border: none; border-radius: 3px; cursor: pointer; }
+	.og-btn-primary { padding: 6px 12px; font-size: 12px; color: #fff; background: var(--nx-accent); border: none; border-radius: 3px; cursor: pointer; }
 </style>

--- a/nodyx-frontend/src/routes/admin/octoguard/welcome/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/octoguard/welcome/+page.svelte
@@ -86,6 +86,6 @@
 	.og-actions { display: flex; justify-content: flex-end; }
 	.og-btn-primary {
 		padding: 6px 12px; font-size: 12px; color: #fff;
-		background: #6366f1; border: none; border-radius: 3px; cursor: pointer;
+		background: var(--nx-accent); border: none; border-radius: 3px; cursor: pointer;
 	}
 </style>

--- a/nodyx-frontend/src/routes/admin/tags/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/tags/+page.svelte
@@ -38,7 +38,7 @@
 				</div>
 				<div>
 					<label for="tag-create-color" class="block text-xs text-gray-400 mb-1">Couleur</label>
-					<input id="tag-create-color" name="color" type="color" value="#6366f1"
+					<input id="tag-create-color" name="color" type="color" value="var(--nx-accent)"
 						class="h-10 w-full rounded-lg bg-gray-800 border border-gray-700 px-1 cursor-pointer" />
 				</div>
 			</div>

--- a/nodyx-frontend/src/routes/admin/widgets/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/widgets/+page.svelte
@@ -360,7 +360,7 @@
 	<!-- Header -->
 	<div class="flex items-center justify-between mb-8">
 		<div>
-			<h1 class="text-2xl font-black" style="font-family:'Space Grotesk',sans-serif; background:linear-gradient(135deg,#a78bfa,#06b6d4); -webkit-background-clip:text; -webkit-text-fill-color:transparent; background-clip:text">
+			<h1 class="text-2xl font-black" style="font-family:'Space Grotesk',sans-serif; background:linear-gradient(135deg,var(--nx-accent-2-soft),#06b6d4); -webkit-background-clip:text; -webkit-text-fill-color:transparent; background-clip:text">
 				Widget Store
 			</h1>
 			<p class="text-sm mt-1" style="color:#6b7280">
@@ -369,7 +369,7 @@
 		</div>
 		<a href="/admin/homepage"
 		   class="flex items-center gap-2 px-4 py-2 text-sm font-bold uppercase tracking-wider transition-all"
-		   style="background:linear-gradient(135deg,rgba(124,58,237,.25),rgba(6,182,212,.15)); border:1px solid rgba(124,58,237,.4); color:#a78bfa">
+		   style="background:linear-gradient(135deg,rgba(124,58,237,.25),rgba(6,182,212,.15)); border:1px solid rgba(124,58,237,.4); color:var(--nx-accent-2-soft)">
 			<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
 				<path stroke-linecap="round" stroke-linejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
 			</svg>
@@ -505,7 +505,7 @@
 													<path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
 												</svg>
 											{:else if isActive}
-												<div class="w-2 h-2 rounded-full animate-pulse" style="background:#a78bfa"></div>
+												<div class="w-2 h-2 rounded-full animate-pulse" style="background:var(--nx-accent-2-soft)"></div>
 											{:else}
 												<div class="w-1.5 h-1.5 rounded-full" style="background:rgba(255,255,255,.1)"></div>
 											{/if}
@@ -525,18 +525,18 @@
 								<div>
 									<div class="flex items-center justify-between mb-1.5">
 										<span class="text-xs" style="color:#4b5563">Transfert en cours</span>
-										<span class="text-xs font-bold tabular-nums" style="color:#a78bfa">{uploadPct}%</span>
+										<span class="text-xs font-bold tabular-nums" style="color:var(--nx-accent-2-soft)">{uploadPct}%</span>
 									</div>
 									<div class="w-full h-1.5 rounded-full overflow-hidden" style="background:rgba(255,255,255,.06)">
 										<div class="h-full rounded-full transition-all duration-300"
-										     style="width:{uploadPct}%; background:linear-gradient(90deg,#7c3aed,#06b6d4)">
+										     style="width:{uploadPct}%; background:linear-gradient(90deg,var(--nx-accent-2-strong),#06b6d4)">
 										</div>
 									</div>
 								</div>
 							{:else}
 								<!-- Barre indéterminée pour les étapes serveur -->
 								<div class="w-full h-1.5 rounded-full overflow-hidden" style="background:rgba(255,255,255,.06)">
-									<div class="h-full rounded-full" style="background:linear-gradient(90deg,#7c3aed,#06b6d4); animation:indeterminate 1.4s ease infinite">
+									<div class="h-full rounded-full" style="background:linear-gradient(90deg,var(--nx-accent-2-strong),#06b6d4); animation:indeterminate 1.4s ease infinite">
 									</div>
 								</div>
 							{/if}
@@ -582,7 +582,7 @@
 
 				{#if loadingList}
 					<div class="px-4 py-8 flex items-center justify-center gap-2" style="color:#374151">
-						<div class="w-4 h-4 rounded-full border-2 border-t-transparent animate-spin" style="border-color:rgba(167,139,250,.3); border-top-color:#a78bfa"></div>
+						<div class="w-4 h-4 rounded-full border-2 border-t-transparent animate-spin" style="border-color:rgba(167,139,250,.3); border-top-color:var(--nx-accent-2-soft)"></div>
 						<span class="text-xs">Chargement...</span>
 					</div>
 				{:else if installed.length === 0}
@@ -766,11 +766,11 @@
 										onclick={() => installDemo(demo.id)}
 										disabled={demoInstalling}
 										class="ml-auto flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold transition-all disabled:opacity-50"
-										style="background:linear-gradient(135deg,rgba(124,58,237,.2),rgba(6,182,212,.15)); border:1px solid rgba(124,58,237,.3); color:#a78bfa"
+										style="background:linear-gradient(135deg,rgba(124,58,237,.2),rgba(6,182,212,.15)); border:1px solid rgba(124,58,237,.3); color:var(--nx-accent-2-soft)"
 									>
 										{#if demoInstalling}
 											<div class="w-3 h-3 rounded-full border-2 animate-spin"
-											     style="border-color:rgba(167,139,250,.2); border-top-color:#a78bfa"></div>
+											     style="border-color:rgba(167,139,250,.2); border-top-color:var(--nx-accent-2-soft)"></div>
 										{:else}
 											<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
 												<path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m-8-8h16"/>
@@ -899,7 +899,7 @@
 					<button
 						onclick={() => demoTab = tab.key as typeof demoTab}
 						class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold transition-all"
-						style="border:1px solid {demoTab === tab.key ? 'rgba(124,58,237,.4)' : 'transparent'}; background:{demoTab === tab.key ? 'rgba(124,58,237,.1)' : 'transparent'}; color:{demoTab === tab.key ? '#a78bfa' : '#374151'}"
+						style="border:1px solid {demoTab === tab.key ? 'rgba(124,58,237,.4)' : 'transparent'}; background:{demoTab === tab.key ? 'rgba(124,58,237,.1)' : 'transparent'}; color:{demoTab === tab.key ? 'var(--nx-accent-2-soft)' : '#374151'}"
 					>
 						<span>{tab.icon}</span>
 						<span class="font-mono">{tab.label}</span>
@@ -920,11 +920,11 @@
 							onclick={() => demoModal && installDemo(demoModal.id)}
 							disabled={demoInstalling}
 							class="flex items-center gap-1.5 px-4 py-1.5 text-xs font-bold transition-all disabled:opacity-50"
-							style="background:linear-gradient(135deg,rgba(124,58,237,.25),rgba(6,182,212,.15)); border:1px solid rgba(124,58,237,.4); color:#a78bfa"
+							style="background:linear-gradient(135deg,rgba(124,58,237,.25),rgba(6,182,212,.15)); border:1px solid rgba(124,58,237,.4); color:var(--nx-accent-2-soft)"
 						>
 							{#if demoInstalling}
 								<div class="w-3 h-3 rounded-full border-2 animate-spin"
-								     style="border-color:rgba(167,139,250,.2); border-top-color:#a78bfa"></div>
+								     style="border-color:rgba(167,139,250,.2); border-top-color:var(--nx-accent-2-soft)"></div>
 								Installation...
 							{:else}
 								<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
@@ -945,7 +945,7 @@
 						{#if demoSourceLoad}
 							<div class="flex items-center justify-center py-16 gap-3" style="color:#374151">
 								<div class="w-5 h-5 rounded-full border-2 animate-spin"
-								     style="border-color:rgba(167,139,250,.2); border-top-color:#a78bfa"></div>
+								     style="border-color:rgba(167,139,250,.2); border-top-color:var(--nx-accent-2-soft)"></div>
 								<span class="text-sm">Chargement du widget...</span>
 							</div>
 						{:else}
@@ -996,7 +996,7 @@
 						{#if demoSourceLoad}
 							<div class="flex items-center justify-center py-16 gap-3" style="color:#374151">
 								<div class="w-5 h-5 rounded-full border-2 animate-spin"
-								     style="border-color:rgba(167,139,250,.2); border-top-color:#a78bfa"></div>
+								     style="border-color:rgba(167,139,250,.2); border-top-color:var(--nx-accent-2-soft)"></div>
 							</div>
 						{:else if demoSource}
 							<div class="relative">
@@ -1019,7 +1019,7 @@
 						{#if demoSourceLoad}
 							<div class="flex items-center justify-center py-16 gap-3" style="color:#374151">
 								<div class="w-5 h-5 rounded-full border-2 animate-spin"
-								     style="border-color:rgba(167,139,250,.2); border-top-color:#a78bfa"></div>
+								     style="border-color:rgba(167,139,250,.2); border-top-color:var(--nx-accent-2-soft)"></div>
 							</div>
 						{:else if demoSource}
 							<div class="relative">

--- a/nodyx-frontend/src/routes/auth/register/+page.svelte
+++ b/nodyx-frontend/src/routes/auth/register/+page.svelte
@@ -315,10 +315,10 @@
 				<rect x="21" y="69" width="38" height="18" rx="4" fill="#020617"/>
 				<!-- LEDs -->
 				<circle cx="30" cy="78" r="3.5"
-					fill={isError ? '#ef4444' : mood === 'happy' ? '#10b981' : '#6366f1'}
+					fill={isError ? '#ef4444' : mood === 'happy' ? '#10b981' : 'var(--nx-accent)'}
 					opacity={mood === 'idle' ? '0.4' : '0.9'}/>
 				<circle cx="40" cy="78" r="3.5"
-					fill={mood === 'loading' ? '#f59e0b' : mood === 'happy' ? '#10b981' : '#6366f1'}
+					fill={mood === 'loading' ? '#f59e0b' : mood === 'happy' ? '#10b981' : 'var(--nx-accent)'}
 					opacity={mood === 'idle' ? '0.25' : '0.7'}/>
 				<circle cx="50" cy="78" r="3.5"
 					fill={mood === 'happy' ? '#10b981' : '#334155'}

--- a/nodyx-frontend/src/routes/cert-methodology/+page.svelte
+++ b/nodyx-frontend/src/routes/cert-methodology/+page.svelte
@@ -196,9 +196,9 @@
       border-radius: 6px; padding: 0.875rem 1rem;
       font-size: 0.75rem; color: #64748b; line-height: 1.8;
     ">
-      <div><span style="color:#6366f1;"># Désactiver tous les rapports CERT</span></div>
+      <div><span style="color:var(--nx-accent);"># Désactiver tous les rapports CERT</span></div>
       <div><span style="color:#475569;">CERT_EMAIL_TO=</span><span style="color:#94a3b8;">          # vide = aucun envoi</span></div>
-      <div style="margin-top:0.5rem;"><span style="color:#6366f1;"># Configurer vers ses propres équipes</span></div>
+      <div style="margin-top:0.5rem;"><span style="color:var(--nx-accent);"># Configurer vers ses propres équipes</span></div>
       <div><span style="color:#475569;">CERT_EMAIL_TO=</span><span style="color:#10b981;">security@mon-organisation.fr</span></div>
       <div><span style="color:#475569;">CERT_EMAIL_MAX_PER_DAY=</span><span style="color:#f59e0b;">3</span></div>
     </div>

--- a/nodyx-frontend/src/routes/chat/+page.svelte
+++ b/nodyx-frontend/src/routes/chat/+page.svelte
@@ -1014,7 +1014,7 @@
 					</button>
 					<!-- Channel name -->
 					<div class="flex items-center gap-2 min-w-0">
-						<span class="text-sm font-black shrink-0" style="color: #a78bfa; font-family: 'Space Grotesk', sans-serif">#</span>
+						<span class="text-sm font-black shrink-0" style="color: var(--nx-accent-2-soft); font-family: 'Space Grotesk', sans-serif">#</span>
 						<span class="text-sm font-bold truncate" style="color: #e2e8f0; font-family: 'Space Grotesk', sans-serif">{selectedChannel.name}</span>
 						{#if selectedChannel.description}
 							<span class="hidden sm:inline text-[11px] truncate" style="color: #374151; border-left: 1px solid rgba(255,255,255,.08); padding-left: 0.75rem; margin-left: 0.25rem">{selectedChannel.description}</span>
@@ -1047,7 +1047,7 @@
 			{#if pinnedMessage && showPinned}
 				<div class="shrink-0 flex items-center gap-2.5 px-4 py-1.5 text-xs" style="background: rgba(124,58,237,.06); border-bottom: 1px solid rgba(124,58,237,.15)">
 					<svg class="w-3 h-3 shrink-0" viewBox="0 0 24 24" fill="#a78bfa"><path d="M16 12V4h1V2H7v2h1v8l-2 2v2h5v6h2v-6h5v-2l-2-2z"/></svg>
-					<span class="font-black uppercase tracking-wider shrink-0 text-[10px]" style="color: #a78bfa; font-family: 'Space Grotesk', sans-serif">{tFn('chat.pinned')}</span>
+					<span class="font-black uppercase tracking-wider shrink-0 text-[10px]" style="color: var(--nx-accent-2-soft); font-family: 'Space Grotesk', sans-serif">{tFn('chat.pinned')}</span>
 					<span class="truncate flex-1" style="color: #6b7280">
 						<span class="font-semibold" style="color: #4b5563">{pinnedMessage.author_username} · </span>{pinnedMessage.content?.replace(/<[^>]*>/g, '').slice(0, 120) ?? ''}
 					</span>
@@ -1144,8 +1144,8 @@
 
 							<!-- Reply quote -->
 							{#if msg.reply_to_id && !msg.is_deleted}
-								<div class="flex items-center gap-2 mb-1.5 pl-2 py-0.5 opacity-70" style="border-left: 2px solid #7c3aed">
-									<span class="text-[10px] font-bold shrink-0" style="color: #a78bfa">{msg.reply_to_username}</span>
+								<div class="flex items-center gap-2 mb-1.5 pl-2 py-0.5 opacity-70" style="border-left: 2px solid var(--nx-accent-2-strong)">
+									<span class="text-[10px] font-bold shrink-0" style="color: var(--nx-accent-2-soft)">{msg.reply_to_username}</span>
 									<span class="text-[10px] truncate" style="color: #4b5563">{msg.reply_to_content?.replace(/<[^>]*>/g, '').slice(0, 100) ?? tFn('chat.deleted')}</span>
 								</div>
 							{/if}
@@ -1245,7 +1245,7 @@
 								<div data-picker class="relative">
 									<button onclick={() => toggleEmojiPicker(msg.id)} title="Plus…"
 									        class="w-7 h-7 flex items-center justify-center transition-colors" style="color: #4b5563"
-									        onmouseenter={(e) => (e.currentTarget as HTMLElement).style.color = '#a78bfa'}
+									        onmouseenter={(e) => (e.currentTarget as HTMLElement).style.color = 'var(--nx-accent-2-soft)'}
 									        onmouseleave={(e) => (e.currentTarget as HTMLElement).style.color = '#4b5563'}>
 										<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path stroke-linecap="round" d="M8 13s1.5 2 4 2 4-2 4-2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg>
 									</button>
@@ -1259,7 +1259,7 @@
 								<!-- Répondre -->
 								<button onclick={() => startReply(msg)} title={tFn('chat.reply')}
 								        class="w-7 h-7 flex items-center justify-center transition-colors" style="color: #4b5563"
-								        onmouseenter={(e) => (e.currentTarget as HTMLElement).style.color = '#a78bfa'}
+								        onmouseenter={(e) => (e.currentTarget as HTMLElement).style.color = 'var(--nx-accent-2-soft)'}
 								        onmouseleave={(e) => (e.currentTarget as HTMLElement).style.color = '#4b5563'}>
 									<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"/></svg>
 								</button>
@@ -1267,7 +1267,7 @@
 									<!-- Modifier -->
 									<button onclick={() => startEdit(msg)} title="Modifier"
 									        class="w-7 h-7 flex items-center justify-center transition-colors" style="color: #4b5563"
-									        onmouseenter={(e) => (e.currentTarget as HTMLElement).style.color = '#a78bfa'}
+									        onmouseenter={(e) => (e.currentTarget as HTMLElement).style.color = 'var(--nx-accent-2-soft)'}
 									        onmouseleave={(e) => (e.currentTarget as HTMLElement).style.color = '#4b5563'}>
 										<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
 									</button>
@@ -1275,9 +1275,9 @@
 								{#if isAdmin}
 									<!-- Épingler -->
 									<button onclick={() => pinMessage(msg)} title={pinnedMessage?.id === msg.id ? 'Désépingler' : 'Épingler'}
-									        class="w-7 h-7 flex items-center justify-center transition-colors" style="color: {pinnedMessage?.id === msg.id ? '#a78bfa' : '#4b5563'}"
-									        onmouseenter={(e) => (e.currentTarget as HTMLElement).style.color = '#a78bfa'}
-									        onmouseleave={(e) => (e.currentTarget as HTMLElement).style.color = pinnedMessage?.id === msg.id ? '#a78bfa' : '#4b5563'}>
+									        class="w-7 h-7 flex items-center justify-center transition-colors" style="color: {pinnedMessage?.id === msg.id ? 'var(--nx-accent-2-soft)' : '#4b5563'}"
+									        onmouseenter={(e) => (e.currentTarget as HTMLElement).style.color = 'var(--nx-accent-2-soft)'}
+									        onmouseleave={(e) => (e.currentTarget as HTMLElement).style.color = pinnedMessage?.id === msg.id ? 'var(--nx-accent-2-soft)' : '#4b5563'}>
 										<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"/></svg>
 									</button>
 								{/if}
@@ -1322,7 +1322,7 @@
 					style="background: rgba(13,13,20,0.95); border: 1px solid rgba(124,58,237,0.4); box-shadow: 0 4px 20px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.03);"
 					transition:fade={{ duration: 120 }}
 				>
-					<span class="text-xs font-semibold" style="color: #a78bfa;">
+					<span class="text-xs font-semibold" style="color: var(--nx-accent-2-soft);">
 						{#if unreadWhileScrolled > 0}{unreadWhileScrolled} nouveau{unreadWhileScrolled > 1 ? 'x' : ''}{:else}Retour en bas{/if}
 					</span>
 					<svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="#a78bfa" stroke-width="2.5" viewBox="0 0 24 24">
@@ -1344,9 +1344,9 @@
 						</div>
 						<span class="text-[10px] font-semibold italic" style="color: #4b5563">
 							{#if typingUsers.length === 1}
-								<span style="color: #a78bfa">{typingUsers[0]}</span> {tFn('chat.typing_suffix_one')}
+								<span style="color: var(--nx-accent-2-soft)">{typingUsers[0]}</span> {tFn('chat.typing_suffix_one')}
 							{:else if typingUsers.length === 2}
-								<span style="color: #a78bfa">{typingUsers[0]}</span> {tFn('chat.typing_and')} <span style="color: #a78bfa">{typingUsers[1]}</span> {tFn('chat.typing_suffix_plural')}
+								<span style="color: var(--nx-accent-2-soft)">{typingUsers[0]}</span> {tFn('chat.typing_and')} <span style="color: var(--nx-accent-2-soft)">{typingUsers[1]}</span> {tFn('chat.typing_suffix_plural')}
 							{:else}
 								{tFn('chat.typing_many')}
 							{/if}
@@ -1452,9 +1452,9 @@
 
 				<!-- Reply preview bar -->
 				{#if replyTo}
-					<div class="flex items-center gap-2.5 px-3 py-1.5 mb-2 text-xs" style="background: rgba(124,58,237,.08); border-left: 2px solid #7c3aed">
+					<div class="flex items-center gap-2.5 px-3 py-1.5 mb-2 text-xs" style="background: rgba(124,58,237,.08); border-left: 2px solid var(--nx-accent-2-strong)">
 						<svg class="w-3 h-3 shrink-0" fill="none" stroke="#a78bfa" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"/></svg>
-						<span class="font-bold shrink-0" style="color: #a78bfa">{replyTo.author_username}</span>
+						<span class="font-bold shrink-0" style="color: var(--nx-accent-2-soft)">{replyTo.author_username}</span>
 						<span class="truncate flex-1" style="color: #4b5563">{replyTo.content?.replace(/<[^>]*>/g, '').slice(0, 80) ?? ''}</span>
 						<button onclick={() => replyTo = null} title="Annuler"
 						        class="shrink-0 w-4 h-4 flex items-center justify-center text-sm leading-none transition-colors" style="color: #374151">×</button>
@@ -1495,18 +1495,18 @@
 						<button data-gif-picker onclick={() => { showGifPicker = !showGifPicker; if (showGifPicker && gifProvider) gifQuery = ''; }}
 						        title="GIF"
 						        class="w-7 h-7 flex items-center justify-center text-[10px] font-black uppercase tracking-wide transition-colors"
-						        style="color: {showGifPicker ? '#a78bfa' : '#4b5563'}; background: {showGifPicker ? 'rgba(124,58,237,.12)' : 'transparent'}">GIF</button>
+						        style="color: {showGifPicker ? 'var(--nx-accent-2-soft)' : '#4b5563'}; background: {showGifPicker ? 'rgba(124,58,237,.12)' : 'transparent'}">GIF</button>
 						<!-- Poll -->
 						<button onclick={() => showPollCreator = true} title={tFn('chat.new_poll')}
 						        class="w-7 h-7 flex items-center justify-center transition-colors" style="color: #4b5563"
-						        onmouseenter={(e) => (e.currentTarget as HTMLElement).style.color = '#a78bfa'}
+						        onmouseenter={(e) => (e.currentTarget as HTMLElement).style.color = 'var(--nx-accent-2-soft)'}
 						        onmouseleave={(e) => (e.currentTarget as HTMLElement).style.color = '#4b5563'}>
 							<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg>
 						</button>
 						<!-- Rich editor -->
 						<button onclick={() => showRichModal = true} title={tFn('chat.rich_editor')}
 						        class="w-7 h-7 flex items-center justify-center transition-colors" style="color: #4b5563"
-						        onmouseenter={(e) => (e.currentTarget as HTMLElement).style.color = '#a78bfa'}
+						        onmouseenter={(e) => (e.currentTarget as HTMLElement).style.color = 'var(--nx-accent-2-soft)'}
 						        onmouseleave={(e) => (e.currentTarget as HTMLElement).style.color = '#4b5563'}>
 							<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
 						</button>
@@ -1515,7 +1515,7 @@
 						<!-- Send -->
 						<button onclick={sendMessage} disabled={!inputText.trim() || isRateLimited}
 						        class="w-7 h-7 flex items-center justify-center transition-all disabled:opacity-30 disabled:cursor-not-allowed"
-						        style="background: {isRateLimited ? 'rgba(239,68,68,.3)' : inputText.trim() ? 'linear-gradient(135deg, #7c3aed, #0e7490)' : 'rgba(255,255,255,.06)'}; color: {inputText.trim() ? '#fff' : '#4b5563'}"
+						        style="background: {isRateLimited ? 'rgba(239,68,68,.3)' : inputText.trim() ? 'linear-gradient(135deg, var(--nx-accent-2-strong), #0e7490)' : 'rgba(255,255,255,.06)'}; color: {inputText.trim() ? '#fff' : '#4b5563'}"
 						        title={isRateLimited ? tFn('chat.antispam_loading') : tFn('chat.send')}>
 							{#if isRateLimited}
 								<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
@@ -1678,7 +1678,7 @@
 		width: 5px;
 		height: 5px;
 		border-radius: 50%;
-		background: #818cf8; /* indigo-400 */
+		background: var(--nx-accent-soft); /* indigo-400 */
 		animation: typing-bounce 1.1s infinite ease-in-out;
 	}
 	@keyframes typing-bounce {
@@ -1707,7 +1707,7 @@
 	.chat-reaction-mine {
 		background: rgba(124,58,237,.18);
 		border: 1px solid rgba(124,58,237,.45);
-		color: #c4b5fd;
+		color: var(--nx-accent-2-soft2);
 		box-shadow: 0 0 8px rgba(124,58,237,.15);
 	}
 	.chat-reaction-mine:hover {
@@ -1769,7 +1769,7 @@
 	}
 	
 	.message-row:hover {
-    border-left-color: #6366f1; /* Indigo */
+    border-left-color: var(--nx-accent); /* Indigo */
     background: linear-gradient(to right, rgba(99, 102, 241, 0.05), transparent);
 	}	
 

--- a/nodyx-frontend/src/routes/discover/+page.svelte
+++ b/nodyx-frontend/src/routes/discover/+page.svelte
@@ -355,8 +355,8 @@
 }
 
 .disc-tab--active {
-	color: #a78bfa;
-	border-bottom-color: #a78bfa;
+	color: var(--nx-accent-2-soft);
+	border-bottom-color: var(--nx-accent-2-soft);
 }
 
 .disc-tab--upcoming {
@@ -395,7 +395,7 @@
 }
 
 .disc-count-query {
-	color: #a78bfa;
+	color: var(--nx-accent-2-soft);
 }
 
 /* ── Result rows ───────────────────────────────────────────────────────────── */
@@ -420,7 +420,7 @@
 }
 
 .disc-row:hover .disc-row-title {
-	color: #c4b5fd;
+	color: var(--nx-accent-2-soft2);
 }
 
 .disc-row-meta {
@@ -443,7 +443,7 @@
 .disc-badge--instance {
 	background: rgba(139, 92, 246, 0.1);
 	border-color: rgba(139, 92, 246, 0.25);
-	color: #c4b5fd;
+	color: var(--nx-accent-2-soft2);
 }
 
 .disc-badge--event {

--- a/nodyx-frontend/src/routes/dm/+page.svelte
+++ b/nodyx-frontend/src/routes/dm/+page.svelte
@@ -219,7 +219,7 @@
 													style={i === 0 ? 'top:0;left:0' : 'bottom:0;right:0'}/>
 											{:else}
 												<div class="w-6 h-6 rounded-full bg-indigo-600/30 border-2 border-gray-950 flex items-center justify-center text-[10px] font-bold absolute"
-													style={`${i === 0 ? 'top:0;left:0' : 'bottom:0;right:0'}; color: ${p.name_color ?? '#818cf8'}`}>
+													style={`${i === 0 ? 'top:0;left:0' : 'bottom:0;right:0'}; color: ${p.name_color ?? 'var(--nx-accent-soft)'}`}>
 													{p.username[0].toUpperCase()}
 												</div>
 											{/if}
@@ -229,7 +229,7 @@
 									<img src={conv.other_avatar} alt={conv.other_username} class="w-9 h-9 rounded-full object-cover"/>
 								{:else}
 									<div class="w-9 h-9 rounded-full bg-indigo-600/20 border border-indigo-500/20 flex items-center justify-center text-sm font-bold"
-										style={conv.other_name_color ? `color: ${conv.other_name_color}` : 'color: #818cf8'}>
+										style={conv.other_name_color ? `color: ${conv.other_name_color}` : 'color: var(--nx-accent-soft)'}>
 										{(conv.other_username ?? '?')[0].toUpperCase()}
 									</div>
 								{/if}

--- a/nodyx-frontend/src/routes/dm/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/dm/[id]/+page.svelte
@@ -1143,7 +1143,7 @@
 											style={i === 0 ? 'top:0;left:0' : 'bottom:0;right:0'}/>
 									{:else}
 										<div class="w-5 h-5 rounded-full bg-indigo-600/30 border border-gray-950 flex items-center justify-center text-[9px] font-bold absolute"
-											style={`${i === 0 ? 'top:0;left:0' : 'bottom:0;right:0'}; color: ${p.name_color ?? '#818cf8'}`}>
+											style={`${i === 0 ? 'top:0;left:0' : 'bottom:0;right:0'}; color: ${p.name_color ?? 'var(--nx-accent-soft)'}`}>
 											{p.username[0].toUpperCase()}
 										</div>
 									{/if}
@@ -1153,7 +1153,7 @@
 							<img src={conv.other_avatar} alt={conv.other_username} class="w-8 h-8 rounded-full object-cover"/>
 						{:else}
 							<div class="w-8 h-8 rounded-full bg-indigo-600/20 border border-indigo-500/15 flex items-center justify-center text-xs font-bold"
-								style={conv.other_name_color ? `color: ${conv.other_name_color}` : 'color: #818cf8'}>
+								style={conv.other_name_color ? `color: ${conv.other_name_color}` : 'color: var(--nx-accent-soft)'}>
 								{(conv.other_username ?? '?')[0].toUpperCase()}
 							</div>
 						{/if}
@@ -1196,7 +1196,7 @@
 									style={i === 0 ? 'top:0;left:0' : 'bottom:0;right:0'}/>
 							{:else}
 								<div class="w-6 h-6 rounded-full bg-indigo-600/30 border-2 border-gray-950 flex items-center justify-center text-[10px] font-bold absolute"
-									style={`${i === 0 ? 'top:0;left:0' : 'bottom:0;right:0'}; color: ${p.name_color ?? '#818cf8'}`}>
+									style={`${i === 0 ? 'top:0;left:0' : 'bottom:0;right:0'}; color: ${p.name_color ?? 'var(--nx-accent-soft)'}`}>
 									{p.username[0].toUpperCase()}
 								</div>
 							{/if}
@@ -1276,7 +1276,7 @@
 						<img src={conversation.other_avatar} alt={conversation.other_username} class="w-8 h-8 rounded-full object-cover shrink-0 ring-2 ring-white/[0.06]"/>
 					{:else}
 						<div class="w-8 h-8 rounded-full bg-indigo-600/20 border border-indigo-500/20 flex items-center justify-center shrink-0 text-sm font-bold"
-							style={conversation.other_name_color ? `color: ${conversation.other_name_color}` : 'color: #818cf8'}>
+							style={conversation.other_name_color ? `color: ${conversation.other_name_color}` : 'color: var(--nx-accent-soft)'}>
 							{(conversation.other_username ?? '?')[0].toUpperCase()}
 						</div>
 					{/if}
@@ -1498,7 +1498,7 @@
 										<img src={msg.sender_avatar} alt={msg.sender_username} class="w-7 h-7 rounded-full object-cover"/>
 									{:else}
 										<div class="w-7 h-7 rounded-full bg-indigo-600/20 border border-indigo-500/15 flex items-center justify-center text-xs font-bold"
-											style={msg.sender_name_color ? `color: ${msg.sender_name_color}` : 'color: #818cf8'}>
+											style={msg.sender_name_color ? `color: ${msg.sender_name_color}` : 'color: var(--nx-accent-soft)'}>
 											{msg.sender_username[0].toUpperCase()}
 										</div>
 									{/if}
@@ -1675,13 +1675,13 @@
 							<img src={conversation.participants[0].avatar} alt="" class="w-5 h-5 rounded-full object-cover shrink-0 mb-0.5 opacity-70" />
 						{:else}
 							<div class="w-5 h-5 rounded-full shrink-0 mb-0.5 opacity-70 flex items-center justify-center text-[8px] font-bold text-white"
-							     style="background: #4f46e5">{conversation.participants[0]?.username?.[0]?.toUpperCase() ?? '?'}</div>
+							     style="background: var(--nx-accent-strong)">{conversation.participants[0]?.username?.[0]?.toUpperCase() ?? '?'}</div>
 						{/if}
 					{:else if conversation?.other_avatar}
 						<img src={conversation.other_avatar} alt="" class="w-5 h-5 rounded-full object-cover shrink-0 mb-0.5 opacity-70" />
 					{:else}
 						<div class="w-5 h-5 rounded-full shrink-0 mb-0.5 opacity-70 flex items-center justify-center text-[8px] font-bold text-white"
-						     style="background: #4f46e5">{conversation?.other_username?.[0]?.toUpperCase() ?? '?'}</div>
+						     style="background: var(--nx-accent-strong)">{conversation?.other_username?.[0]?.toUpperCase() ?? '?'}</div>
 					{/if}
 					<!-- Bulle dots -->
 					<div class="dm-typing-bubble flex items-center gap-[3px] px-3 py-2 rounded-2xl rounded-bl-sm">
@@ -1827,7 +1827,7 @@
 .e2e-banner-cta {
 	white-space: nowrap; text-align: center; padding: 7px 14px; border-radius: 9px;
 	font-size: 12.5px; font-weight: 700; color: #fff; text-decoration: none;
-	background: linear-gradient(135deg, #6366f1, #a855f7);
+	background: linear-gradient(135deg, var(--nx-accent), var(--nx-accent-2));
 }
 .e2e-banner-cta:hover { filter: brightness(1.08); }
 .e2e-banner-dismiss {
@@ -1881,7 +1881,7 @@
 .dm-drop-icon {
 	width: 56px;
 	height: 56px;
-	color: #c4b5fd;
+	color: var(--nx-accent-2-soft2);
 }
 .dm-drop-title {
 	font-size: 18px;
@@ -1907,7 +1907,7 @@
 .dm-quote-bar {
 	width: 3px;
 	border-radius: 2px;
-	background: linear-gradient(to bottom, #818cf8, #6366f1);
+	background: linear-gradient(to bottom, var(--nx-accent-soft), var(--nx-accent));
 	flex-shrink: 0;
 }
 .dm-quote-content {
@@ -1951,7 +1951,7 @@
 	width: 3px;
 	height: 28px;
 	border-radius: 2px;
-	background: linear-gradient(to bottom, #818cf8, #6366f1);
+	background: linear-gradient(to bottom, var(--nx-accent-soft), var(--nx-accent));
 	flex-shrink: 0;
 }
 .dm-reply-banner-content {
@@ -2037,7 +2037,7 @@
 	align-items: center;
 	justify-content: center;
 	background: rgba(124, 58, 237, 0.12);
-	color: #c4b5fd;
+	color: var(--nx-accent-2-soft2);
 	font-size: 38px;
 	font-weight: 800;
 	font-family: 'Space Grotesk', sans-serif;
@@ -2124,7 +2124,7 @@
 }
 @keyframes dot-bounce {
 	0%, 80%, 100% { transform: translateY(0);    background: #4b5563; }
-	40%           { transform: translateY(-5px); background: #a78bfa; }
+	40%           { transform: translateY(-5px); background: var(--nx-accent-2-soft); }
 }
 
 /* ── Emoji picker ─────────────────────────────────────────────────────────── */

--- a/nodyx-frontend/src/routes/feed/+page.svelte
+++ b/nodyx-frontend/src/routes/feed/+page.svelte
@@ -427,7 +427,7 @@
 
 							<!-- Wave progress bar -->
 							<div class="composer-wave-track">
-								<div class="composer-wave-fill" style="width: {waveWidth}%; background: {charLeft < 0 ? '#ef4444' : charLeft < 100 ? '#f59e0b' : '#6366f1'}"></div>
+								<div class="composer-wave-fill" style="width: {waveWidth}%; background: {charLeft < 0 ? '#ef4444' : charLeft < 100 ? '#f59e0b' : 'var(--nx-accent)'}"></div>
 							</div>
 							<span class="composer-char-count" style="color: {charColor}">{charLeft}</span>
 							<div class="composer-actions">
@@ -879,7 +879,7 @@
 	justify-content: center;
 }
 .composer-avatar-img   { width: 100%; height: 100%; object-fit: cover; }
-.composer-avatar-initial { font-size: 0.875rem; font-weight: 700; color: #6366f1; }
+.composer-avatar-initial { font-size: 0.875rem; font-weight: 700; color: var(--nx-accent); }
 
 .composer-body { flex: 1; min-width: 0; }
 
@@ -1018,11 +1018,11 @@
 	font-weight: 700;
 	color: white;
 	padding: 0.375rem 1rem;
-	background: #6366f1;
+	background: var(--nx-accent);
 	letter-spacing: 0.2px;
 	transition: all 0.15s;
 }
-.composer-submit:hover:not(:disabled) { background: #4f46e5; }
+.composer-submit:hover:not(:disabled) { background: var(--nx-accent-strong); }
 .composer-submit:disabled { opacity: 0.4; cursor: not-allowed; }
 
 /* ── Posts ────────────────────────────────────────────────────────────────── */
@@ -1061,7 +1061,7 @@
 	align-items: center;
 	justify-content: center;
 	background: rgba(99,102,241,0.15);
-	color: #818cf8;
+	color: var(--nx-accent-soft);
 	font-weight: 700;
 	font-size: 0.875rem;
 }
@@ -1080,7 +1080,7 @@
 	color: rgba(255,255,255,0.85);
 	transition: color 0.1s;
 }
-.post-author:hover { color: #818cf8; }
+.post-author:hover { color: var(--nx-accent-soft); }
 .post-username { font-size: 0.8rem; color: rgba(255,255,255,0.3); }
 .post-dot      { font-size: 0.8rem; color: rgba(255,255,255,0.2); }
 .post-time     { font-size: 0.75rem; color: rgba(255,255,255,0.25); }
@@ -1105,7 +1105,7 @@
 .prose-feed :global(p:last-child)   { margin-bottom: 0; }
 .prose-feed :global(strong)         { font-weight: 700; color: rgba(255,255,255,0.92); }
 .prose-feed :global(em)             { font-style: italic; }
-.prose-feed :global(a)              { color: #818cf8; text-decoration: underline; text-decoration-color: rgba(129,140,248,0.4); }
+.prose-feed :global(a)              { color: var(--nx-accent-soft); text-decoration: underline; text-decoration-color: rgba(129,140,248,0.4); }
 .prose-feed :global(a:hover)        { color: #a5b4fc; }
 .prose-feed :global(ul), .prose-feed :global(ol) { padding-left: 1.25rem; margin: 0.35em 0; }
 .prose-feed :global(li)             { margin: 0.15em 0; }
@@ -1159,7 +1159,7 @@
 .link-card-img { width: 100%; max-height: 240px; overflow: hidden; background: rgba(0,0,0,0.2); }
 .link-card-img img { width: 100%; height: 100%; max-height: 240px; object-fit: cover; display: block; }
 .link-card-body { display: flex; flex-direction: column; gap: 0.2rem; padding: 0.7rem 0.85rem; }
-.link-card-site { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.04em; color: #818cf8; font-weight: 700; }
+.link-card-site { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--nx-accent-soft); font-weight: 700; }
 .link-card-title { font-size: 0.9rem; font-weight: 700; color: rgba(255,255,255,0.92); line-height: 1.3;
 	display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
 .link-card-desc { font-size: 0.8rem; color: rgba(255,255,255,0.55); line-height: 1.4;
@@ -1291,8 +1291,8 @@
 .feed-empty-icon svg { width: 28px; height: 28px; }
 .feed-empty-title  { font-size: 1rem; font-weight: 700; color: rgba(255,255,255,0.6); margin-bottom: 0.5rem; }
 .feed-empty-sub    { font-size: 0.8rem; color: rgba(255,255,255,0.25); max-width: 300px; }
-.feed-empty-cta    { margin-top: 1.25rem; font-size: 0.8rem; font-weight: 600; color: #6366f1; transition: color 0.15s; }
-.feed-empty-cta:hover { color: #818cf8; }
+.feed-empty-cta    { margin-top: 1.25rem; font-size: 0.8rem; font-weight: 600; color: var(--nx-accent); transition: color 0.15s; }
+.feed-empty-cta:hover { color: var(--nx-accent-soft); }
 
 .feed-sentinel { padding: 2rem; display: flex; justify-content: center; }
 .feed-loader   { display: flex; gap: 0.375rem; }
@@ -1310,7 +1310,7 @@
 }
 .feed-end { font-size: 0.75rem; color: rgba(255,255,255,0.2); }
 :global(.feed-end a) { color: rgba(99,102,241,0.6); transition: color 0.15s; }
-:global(.feed-end a:hover) { color: #818cf8; }
+:global(.feed-end a:hover) { color: var(--nx-accent-soft); }
 
 /* ── Sidebar ──────────────────────────────────────────────────────────────── */
 .sidebar-card {
@@ -1338,7 +1338,7 @@
 	width: 40px; height: 40px; border-radius: 50%; overflow: hidden;
 	background: rgba(99,102,241,0.15);
 	display: flex; align-items: center; justify-content: center;
-	font-weight: 700; font-size: 0.875rem; color: #6366f1;
+	font-weight: 700; font-size: 0.875rem; color: var(--nx-accent);
 	flex-shrink: 0;
 }
 .sidebar-me-name   { font-size: 0.875rem; font-weight: 700; color: rgba(255,255,255,0.8); }
@@ -1348,7 +1348,7 @@
 	width: 36px; height: 36px; border-radius: 50%; overflow: hidden;
 	background: rgba(99,102,241,0.1);
 	display: flex; align-items: center; justify-content: center;
-	font-size: 0.8rem; font-weight: 700; color: #6366f1;
+	font-size: 0.8rem; font-weight: 700; color: var(--nx-accent);
 	flex-shrink: 0;
 }
 .sidebar-suggest-name   { display: block; font-size: 0.8rem; font-weight: 600; color: rgba(255,255,255,0.7); }
@@ -1356,7 +1356,7 @@
 .sidebar-follow-btn {
 	font-size: 0.7rem;
 	font-weight: 600;
-	color: #6366f1;
+	color: var(--nx-accent);
 	padding: 0.25rem 0.625rem;
 	border: 1px solid rgba(99,102,241,0.3);
 	transition: all 0.15s;
@@ -1387,7 +1387,7 @@
 	transition: color 0.15s;
 }
 .post-replies-btn:hover        { color: rgba(99,102,241,0.9); }
-.post-replies-btn--open        { color: #818cf8; }
+.post-replies-btn--open        { color: var(--nx-accent-soft); }
 
 .replies-thread {
 	border-left: 2px solid rgba(99,102,241,0.2);
@@ -1428,7 +1428,7 @@
 	align-items: center;
 	justify-content: center;
 	background: rgba(99,102,241,0.12);
-	color: #818cf8;
+	color: var(--nx-accent-soft);
 	font-weight: 700;
 	font-size: 0.75rem;
 }

--- a/nodyx-frontend/src/routes/garden/+page.svelte
+++ b/nodyx-frontend/src/routes/garden/+page.svelte
@@ -645,7 +645,7 @@
 	border-color: rgba(255,255,255,0.1);
 }
 .seed-badge--done {
-	color: #a78bfa;
+	color: var(--nx-accent-2-soft);
 	border-color: rgba(167,139,250,0.3);
 }
 

--- a/nodyx-frontend/src/routes/members/+page.svelte
+++ b/nodyx-frontend/src/routes/members/+page.svelte
@@ -270,7 +270,7 @@
 		cursor: pointer;
 		user-select: none;
 	}
-	.mb-toggle input { accent-color: #6366f1; }
+	.mb-toggle input { accent-color: var(--nx-accent); }
 	.mb-toggle:hover { color: #cbd5e1; }
 
 	.mb-section-label {

--- a/nodyx-frontend/src/routes/overlay/alert/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/alert/[token]/+page.svelte
@@ -489,7 +489,7 @@
 		position: absolute; inset: 0;
 		border-radius: 14px;
 		padding: 1.5px;
-		background: linear-gradient(135deg, #ec4899, #6366f1, #06b6d4, #a855f7, #ec4899);
+		background: linear-gradient(135deg, #ec4899, var(--nx-accent), #06b6d4, var(--nx-accent-2), #ec4899);
 		background-size: 300% 300%;
 		-webkit-mask:
 			linear-gradient(#fff 0 0) content-box,

--- a/nodyx-frontend/src/routes/polls/+page.svelte
+++ b/nodyx-frontend/src/routes/polls/+page.svelte
@@ -184,7 +184,7 @@
 
   .btn-new {
     padding: 8px 18px;
-    background: #7c3aed;
+    background: var(--nx-accent-2-strong);
     border: none;
     border-radius: 8px;
     color: #fff;
@@ -209,7 +209,7 @@
     transition: border-color .15s, color .15s, background .15s;
   }
   .filter-tab:hover { border-color: #7c3aed88; color: var(--text, #e0e0e0); }
-  .filter-tab.active { border-color: #7c3aed; color: #a78bfa; background: #7c3aed18; }
+  .filter-tab.active { border-color: var(--nx-accent-2-strong); color: var(--nx-accent-2-soft); background: #7c3aed18; }
 
   /* ── Empty ── */
   .empty-state {
@@ -227,7 +227,7 @@
     background: #7c3aed22;
     border: 1px solid #7c3aed44;
     border-radius: 8px;
-    color: #a78bfa;
+    color: var(--nx-accent-2-soft);
     cursor: pointer;
     font-weight: 600;
     transition: background .15s;
@@ -263,7 +263,7 @@
     padding: 2px 8px;
     border-radius: 99px;
     background: #7c3aed22;
-    color: #a78bfa;
+    color: var(--nx-accent-2-soft);
     border: 1px solid #7c3aed44;
     font-weight: 600;
     text-transform: capitalize;

--- a/nodyx-frontend/src/routes/settings/+page.svelte
+++ b/nodyx-frontend/src/routes/settings/+page.svelte
@@ -485,7 +485,7 @@
 
             <button class="sb-item {activeSection === 'network' ? 'active' : ''}"
                     onclick={() => activeSection = 'network'}>
-                <span class="sb-icon" style="background: rgba(99,102,241,0.15); color: #818cf8">
+                <span class="sb-icon" style="background: rgba(99,102,241,0.15); color: var(--nx-accent-soft)">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
                     </svg>
@@ -495,7 +495,7 @@
 
             <button class="sb-item {activeSection === 'notifications' ? 'active' : ''}"
                     onclick={() => activeSection = 'notifications'}>
-                <span class="sb-icon" style="background: rgba(139,92,246,0.15); color: #a78bfa">
+                <span class="sb-icon" style="background: rgba(139,92,246,0.15); color: var(--nx-accent-2-soft)">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/>
                     </svg>
@@ -538,7 +538,7 @@
 
             <button class="sb-item {activeSection === 'encryption' ? 'active' : ''}"
                     onclick={() => activeSection = 'encryption'}>
-                <span class="sb-icon" style="background: rgba(99,102,241,0.12); color: #818cf8">
+                <span class="sb-icon" style="background: rgba(99,102,241,0.12); color: var(--nx-accent-soft)">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
                     </svg>
@@ -561,7 +561,7 @@
 
             <button class="sb-item {activeSection === 'connected-accounts' ? 'active' : ''}"
                     onclick={() => activeSection = 'connected-accounts'}>
-                <span class="sb-icon" style="background: rgba(124,58,237,0.12); color: #a78bfa">
+                <span class="sb-icon" style="background: rgba(124,58,237,0.12); color: var(--nx-accent-2-soft)">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
                     </svg>
@@ -612,7 +612,7 @@
 
         <!-- ═══ RÉSEAU ══════════════════════════════════════════════════════ -->
         {#if activeSection === 'network'}
-        <div class="s-pane" style="--accent: #818cf8; --accent-bg: rgba(99,102,241,0.08); --accent-border: rgba(99,102,241,0.2)">
+        <div class="s-pane" style="--accent: var(--nx-accent-soft); --accent-bg: rgba(99,102,241,0.08); --accent-border: rgba(99,102,241,0.2)">
             <div class="s-pane-header">
                 <div class="s-pane-icon" style="background: var(--accent-bg); border-color: var(--accent-border); color: var(--accent)">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
@@ -632,7 +632,7 @@
 
         <!-- ═══ NOTIFICATIONS ════════════════════════════════════════════════ -->
         {#if activeSection === 'notifications'}
-        <div class="s-pane" style="--accent: #a78bfa; --accent-bg: rgba(139,92,246,0.08); --accent-border: rgba(139,92,246,0.2)">
+        <div class="s-pane" style="--accent: var(--nx-accent-2-soft); --accent-bg: rgba(139,92,246,0.08); --accent-border: rgba(139,92,246,0.2)">
             <div class="s-pane-header">
                 <div class="s-pane-icon" style="background: var(--accent-bg); border-color: var(--accent-border); color: var(--accent)">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
@@ -928,7 +928,7 @@
 
         <!-- ═══ MESSAGES CHIFFRÉS (sauvegarde de clé E2E) ════════════════════ -->
         {#if activeSection === 'encryption' && $page.data.user}
-        <div class="s-pane" style="--accent: #818cf8; --accent-bg: rgba(99,102,241,0.08); --accent-border: rgba(99,102,241,0.2)">
+        <div class="s-pane" style="--accent: var(--nx-accent-soft); --accent-bg: rgba(99,102,241,0.08); --accent-border: rgba(99,102,241,0.2)">
             <div class="s-pane-header">
                 <div class="s-pane-icon" style="background: var(--accent-bg); border-color: var(--accent-border); color: var(--accent)">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
@@ -1046,7 +1046,7 @@
 
         <!-- ═══ COMPTES LIÉS ══════════════════════════════════════════════════ -->
         {#if activeSection === 'connected-accounts'}
-        <div class="s-pane" style="--accent: #a78bfa; --accent-bg: rgba(124,58,237,0.08); --accent-border: rgba(124,58,237,0.2)">
+        <div class="s-pane" style="--accent: var(--nx-accent-2-soft); --accent-bg: rgba(124,58,237,0.08); --accent-border: rgba(124,58,237,0.2)">
             <div class="s-pane-header">
                 <div class="s-pane-icon" style="background: var(--accent-bg); border-color: var(--accent-border); color: var(--accent)">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
@@ -1061,7 +1061,7 @@
 
             <div class="s-card" style="padding: 20px">
                 <div style="display: flex; gap: 16px; align-items: flex-start;">
-                    <div style="width: 44px; height: 44px; border-radius: 10px; background: linear-gradient(135deg,#9146ff,#7c3aed); display:flex; align-items:center; justify-content:center; font-size: 22px; flex-shrink: 0;">
+                    <div style="width: 44px; height: 44px; border-radius: 10px; background: linear-gradient(135deg,#9146ff,var(--nx-accent-2-strong)); display:flex; align-items:center; justify-content:center; font-size: 22px; flex-shrink: 0;">
                         🎬
                     </div>
                     <div style="flex: 1; min-width: 0;">
@@ -1075,7 +1075,7 @@
                         </div>
                         <p style="margin: 6px 0 0; font-size: 13px; color: #94a3b8; line-height: 1.5;">
                             {#if twitchLink}
-                                {tFn('settings.connected.twitch_connected_pre')} <strong style="color:#a78bfa;">@{twitchLink.twitchLogin}</strong>{tFn('settings.connected.twitch_connected_post')}
+                                {tFn('settings.connected.twitch_connected_pre')} <strong style="color:var(--nx-accent-2-soft);">@{twitchLink.twitchLogin}</strong>{tFn('settings.connected.twitch_connected_post')}
                             {:else}
                                 {tFn('settings.connected.twitch_unlinked_desc')}
                             {/if}
@@ -1104,9 +1104,9 @@
                                 <button
                                     onclick={connectTwitch}
                                     disabled={twitchConnecting}
-                                    style="font-size: 13px; font-weight: 500; padding: 8px 16px; border-radius: 8px; background: #7c3aed; border: 1px solid #7c3aed; color: #fff; cursor: pointer; transition: background 0.15s; display: inline-flex; align-items: center; gap: 8px;"
-                                    onmouseenter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = '#6d28d9' }}
-                                    onmouseleave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = '#7c3aed' }}
+                                    style="font-size: 13px; font-weight: 500; padding: 8px 16px; border-radius: 8px; background: var(--nx-accent-2-strong); border: 1px solid var(--nx-accent-2-strong); color: #fff; cursor: pointer; transition: background 0.15s; display: inline-flex; align-items: center; gap: 8px;"
+                                    onmouseenter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--nx-accent-deep)' }}
+                                    onmouseleave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--nx-accent-2-strong)' }}
                                 >
                                     {#if twitchConnecting}
                                         <span style="display: inline-block; animation: spin 1s linear infinite;">◌</span> {tFn('settings.connected.redirecting')}
@@ -1262,7 +1262,7 @@
             <!-- ── Sous-section : Notifications Streamer (Twitch) ── -->
             {#if isStreamerNotifVisible()}
             {@const cur = $streamerNotifSettings}
-            <div class="s-pane-header" style="margin-top: 28px; --accent:#a855f7; --accent-bg:rgba(168,85,247,0.10); --accent-border:rgba(168,85,247,0.25)">
+            <div class="s-pane-header" style="margin-top: 28px; --accent:var(--nx-accent-2); --accent-bg:rgba(168,85,247,0.10); --accent-border:rgba(168,85,247,0.25)">
                 <div class="s-pane-icon" style="background: var(--accent-bg); border-color: var(--accent-border); color: var(--accent)">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
                         <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/>
@@ -1303,7 +1303,7 @@
                             oninput={(e) => streamerNotifSettings.update(s => ({ ...s, volume: parseFloat((e.target as HTMLInputElement).value) }))}
                             class="sound-slider"
                         />
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="color:#a855f7;flex-shrink:0">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="color:var(--nx-accent-2);flex-shrink:0">
                             <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07M19.07 4.93a10 10 0 0 1 0 14.14"/>
                         </svg>
                         <span class="sound-vol-label">{Math.round(cur.volume * 100)}%</span>
@@ -1547,7 +1547,7 @@
 }
 .sb-version { font-size: 11px; color: #1f2937; font-family: monospace; }
 .sb-docs-link { font-size: 11px; color: #374151; text-decoration: none; transition: color 150ms; }
-.sb-docs-link:hover { color: #6366f1; }
+.sb-docs-link:hover { color: var(--nx-accent); }
 
 /* ── Main content ────────────────────────────────────────────────────────── */
 .settings-main {
@@ -1629,7 +1629,7 @@
     transition: background 200ms;
     flex-shrink: 0;
 }
-.s-toggle.on  { background: #6366f1; }
+.s-toggle.on  { background: var(--nx-accent); }
 .s-toggle.off { background: rgba(255,255,255,0.1); }
 .s-toggle:disabled { opacity: 0.4; cursor: not-allowed; }
 
@@ -1781,7 +1781,7 @@
 }
 
 .s-hint-text { font-size: 12px; color: #374151; line-height: 1.6; margin: 0; }
-:global(.s-hint-text code) { color: #6366f1; background: rgba(99,102,241,0.1); padding: 1px 5px; border-radius: 4px; }
+:global(.s-hint-text code) { color: var(--nx-accent); background: rgba(99,102,241,0.1); padding: 1px 5px; border-radius: 4px; }
 
 .s-field-error { font-size: 11px; color: #f87171; margin-top: 6px; }
 
@@ -1820,7 +1820,7 @@
     flex-shrink: 0;
     font-size: 13px;
     font-weight: 800;
-    color: #818cf8;
+    color: var(--nx-accent-soft);
 }
 .s-instance-logo img { width: 100%; height: 100%; object-fit: cover; }
 
@@ -1843,7 +1843,7 @@
     border-radius: 50%;
     background: rgba(99,102,241,0.15);
     border: 1px solid rgba(99,102,241,0.3);
-    color: #818cf8;
+    color: var(--nx-accent-soft);
     font-size: 12px;
     font-weight: 800;
     display: flex;
@@ -1866,7 +1866,7 @@
     margin-top: 10px;
     font-size: 11px;
     font-family: monospace;
-    color: #818cf8;
+    color: var(--nx-accent-soft);
     background: rgba(99,102,241,0.08);
     padding: 10px 14px;
     border-radius: 8px;
@@ -2042,7 +2042,7 @@
     width: 16px;
     height: 16px;
     border: 2px solid rgba(255,255,255,0.1);
-    border-top-color: #818cf8;
+    border-top-color: var(--nx-accent-soft);
     border-radius: 50%;
     animation: spin 0.7s linear infinite;
     display: block;

--- a/nodyx-frontend/src/routes/soundboard/+page.svelte
+++ b/nodyx-frontend/src/routes/soundboard/+page.svelte
@@ -390,7 +390,7 @@
 						</button>
 						{#each playlists as p (p.id)}
 							{@const isOn = selectedPlaylistId === p.id}
-							{@const accent = p.color ?? '#a78bfa'}
+							{@const accent = p.color ?? 'var(--nx-accent-2-soft)'}
 							<button type="button" onclick={() => selectedPlaylistId = p.id}
 								class="text-xs inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border transition-colors {isOn
 									? 'border-purple-500/60 text-zinc-100 font-medium'

--- a/nodyx-frontend/src/routes/status/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/status/[id]/+page.svelte
@@ -138,7 +138,7 @@
 
 <style>
 	.s-wrap { max-width: 600px; margin: 0 auto; padding: 1rem 1rem 4rem; }
-	.s-back { display: inline-block; margin-bottom: 1rem; color: #818cf8; text-decoration: none; font-size: 0.875rem; }
+	.s-back { display: inline-block; margin-bottom: 1rem; color: var(--nx-accent-soft); text-decoration: none; font-size: 0.875rem; }
 	.s-back:hover { text-decoration: underline; }
 	.s-card { border: 1px solid rgba(255,255,255,0.08); border-radius: 16px; background: rgba(255,255,255,0.02); padding: 1.1rem; margin-bottom: 0.75rem; }
 	.s-card--reply { margin-left: 1rem; background: rgba(255,255,255,0.01); }
@@ -152,7 +152,7 @@
 	.s-link { display: block; margin-top: 0.6rem; border: 1px solid rgba(255,255,255,0.1); border-radius: 12px; overflow: hidden; text-decoration: none; }
 	.s-link-img { width: 100%; max-height: 220px; object-fit: cover; display: block; }
 	.s-link-body { padding: 0.6rem 0.8rem; display: flex; flex-direction: column; gap: 0.2rem; }
-	.s-link-site { font-size: 0.7rem; text-transform: uppercase; color: #818cf8; font-weight: 700; }
+	.s-link-site { font-size: 0.7rem; text-transform: uppercase; color: var(--nx-accent-soft); font-weight: 700; }
 	.s-link-title { font-weight: 700; color: rgba(255,255,255,0.9); font-size: 0.9rem; }
 	.s-quoted { display: block; margin-top: 0.6rem; padding: 0.7rem 0.85rem; border: 1px solid rgba(255,255,255,0.1); border-radius: 12px; text-decoration: none; }
 	.s-quoted:hover { background: rgba(255,255,255,0.03); }

--- a/nodyx-frontend/src/routes/users/[username]/+page.svelte
+++ b/nodyx-frontend/src/routes/users/[username]/+page.svelte
@@ -459,8 +459,8 @@
 							class="profile-action-btn profile-follow-btn"
 							class:profile-follow-btn--following={following}
 							style={following
-								? 'background: rgba(99,102,241,0.15); border-color: rgba(99,102,241,0.5); color: #818cf8'
-								: 'background: #6366f1; border-color: #6366f1; color: white'}
+								? 'background: rgba(99,102,241,0.15); border-color: rgba(99,102,241,0.5); color: var(--nx-accent-soft)'
+								: 'background: var(--nx-accent); border-color: var(--nx-accent); color: white'}
 						>
 							{#if followLoading}
 								<span class="profile-follow-dot"></span>
@@ -526,7 +526,7 @@
 		<div class="relative h-3 rounded-full overflow-hidden" style="background: color-mix(in srgb, var(--p-accent) 12%, rgba(0,0,0,0.3))">
 			<div
 				class="profile-xp-bar h-full rounded-full"
-				style="width: {levelProgress}%; background: linear-gradient(90deg, color-mix(in srgb, var(--p-accent) 70%, #8b5cf6), var(--p-accent))"
+				style="width: {levelProgress}%; background: linear-gradient(90deg, color-mix(in srgb, var(--p-accent) 70%, var(--nx-accent-2-mid)), var(--p-accent))"
 			></div>
 		</div>
 

--- a/nodyx-frontend/src/routes/users/[username]/card/+page.svelte
+++ b/nodyx-frontend/src/routes/users/[username]/card/+page.svelte
@@ -536,7 +536,7 @@
 
 .xp-fill {
 	height: 100%;
-	background: linear-gradient(90deg, #6366f1, #a855f7);
+	background: linear-gradient(90deg, var(--nx-accent), var(--nx-accent-2));
 	position: relative;
 	transition: width 0.8s cubic-bezier(0.16, 1, 0.3, 1);
 }
@@ -548,7 +548,7 @@
 	width: 6px;
 	height: 6px;
 	border-radius: 50%;
-	background: #a855f7;
+	background: var(--nx-accent-2);
 	box-shadow: 0 0 8px 3px rgba(168, 85, 247, 0.6);
 	animation: glow-pulse 1.8s ease-in-out infinite;
 }

--- a/nodyx-frontend/src/routes/wiki/+page.svelte
+++ b/nodyx-frontend/src/routes/wiki/+page.svelte
@@ -264,8 +264,8 @@
 }
 
 .wiki-cat--active {
-	color: #a78bfa;
-	border-bottom-color: #a78bfa;
+	color: var(--nx-accent-2-soft);
+	border-bottom-color: var(--nx-accent-2-soft);
 }
 
 /* ── Body ───────────────────────────────────────────────────────────────────── */
@@ -296,7 +296,7 @@
 }
 
 .wiki-card:hover .wiki-card-title {
-	color: #c4b5fd;
+	color: var(--nx-accent-2-soft2);
 }
 
 .wiki-card-cat {
@@ -400,12 +400,12 @@
 
 .wiki-empty-link {
 	font-size: 0.8125rem;
-	color: #a78bfa;
+	color: var(--nx-accent-2-soft);
 	text-decoration: none;
 	transition: color 0.15s;
 }
 
 .wiki-empty-link:hover {
-	color: #c4b5fd;
+	color: var(--nx-accent-2-soft2);
 }
 </style>


### PR DESCRIPTION
Remplace **345 couleurs indigo/violet en dur** par `var(--nx-accent*)` dans **64 composants**.

- Palette définie dans `app.css :root`, défauts = hex historiques -> **nodyx.org rend à l'identique**.
- Une instance surcharge `--nx-*` (via `theme_css` posé par l'owner) -> ses couleurs s'appliquent sur **toute l'app** (chrome, cards, boutons, dégradés), plus seulement le grid builder.
- Blocs `<script>` (JS/Canvas) et attributs SVG `fill=` laissés intacts (`var()` inopérant dans ces contextes).

Lot 2 du chantier theming (lot 1 = #165, cascade owner -> membre). Supprime la dette des couleurs en dur pour toutes les futures instances.