### PR TITLE
feat(theme): tokeniser cyan + glows rgba

### DIFF
--- a/nodyx-frontend/src/app.css
+++ b/nodyx-frontend/src/app.css
@@ -23,6 +23,13 @@ html, body {
   --nx-accent-2-mid:    #8b5cf6;  /* violet-500 */
   --nx-accent-2-soft:   #a78bfa;  /* violet-400 */
   --nx-accent-2-soft2:  #c4b5fd;  /* violet-300 */
+  --nx-cyan:            #06b6d4;  /* cyan-500 : 3e couleur (accent widgets) */
+  --nx-cyan-soft:       #67e8f9;  /* cyan-300 */
+  --nx-cyan-deep:       #0e7490;  /* cyan-700 */
+  /* Triplets RGB pour les glows rgba() (override par instance) */
+  --nx-accent-rgb:      99 102 241;   /* indigo-500 */
+  --nx-accent-2-rgb:    124 58 237;   /* violet-600 */
+  --nx-cyan-rgb:        6 182 212;    /* cyan-500 */
 }
 
 /* ── Theme CSS vars (définis dynamiquement par +layout.svelte via appVars) ──

--- a/nodyx-frontend/src/lib/components/AudioRecorder.svelte
+++ b/nodyx-frontend/src/lib/components/AudioRecorder.svelte
@@ -329,18 +329,18 @@
 	}
 	.ar-btn-cancel:hover { background: rgba(255,255,255,.06); color: #e5e7eb; }
 	.ar-btn-send {
-		background: rgba(99, 102, 241, 0.18);
+		background: rgb(var(--nx-accent-rgb) / 0.18);
 		color: #a5b4fc;
 	}
-	.ar-btn-send:hover { background: rgba(99, 102, 241, 0.32); color: #c7d2fe; }
+	.ar-btn-send:hover { background: rgb(var(--nx-accent-rgb) / 0.32); color: #c7d2fe; }
 
 	.ar-preview {
 		display: inline-flex;
 		align-items: center;
 		gap: 8px;
 		padding: 5px 8px;
-		background: rgba(99, 102, 241, 0.06);
-		border: 1px solid rgba(99, 102, 241, 0.18);
+		background: rgb(var(--nx-accent-rgb) / 0.06);
+		border: 1px solid rgb(var(--nx-accent-rgb) / 0.18);
 		border-radius: 12px;
 		max-width: 100%;
 	}
@@ -352,8 +352,8 @@
 		align-items: center;
 		gap: 8px;
 		padding: 6px 12px;
-		background: rgba(99, 102, 241, 0.08);
-		border: 1px solid rgba(99, 102, 241, 0.22);
+		background: rgb(var(--nx-accent-rgb) / 0.08);
+		border: 1px solid rgb(var(--nx-accent-rgb) / 0.22);
 		border-radius: 999px;
 		color: #c7d2fe;
 		font-size: 12px;

--- a/nodyx-frontend/src/lib/components/CanvasBottomBar.svelte
+++ b/nodyx-frontend/src/lib/components/CanvasBottomBar.svelte
@@ -186,7 +186,7 @@
 		-webkit-backdrop-filter: blur(24px);
 		border: 1px solid rgba(255,255,255,0.07);
 		border-radius: 12px;
-		box-shadow: 0 4px 20px rgba(0,0,0,0.4), 0 0 0 1px rgba(124,58,237,0.05);
+		box-shadow: 0 4px 20px rgba(0,0,0,0.4), 0 0 0 1px rgb(var(--nx-accent-2-rgb) / 0.05);
 		user-select: none;
 	}
 
@@ -231,10 +231,10 @@
 		color: #4b5563;
 	}
 	.bar-btn.toggle.on {
-		background: rgba(124,58,237,0.18);
+		background: rgb(var(--nx-accent-2-rgb) / 0.18);
 		color: var(--nx-accent-2-soft);
 	}
-	.bar-btn.toggle.on:hover { background: rgba(124,58,237,0.25); }
+	.bar-btn.toggle.on:hover { background: rgb(var(--nx-accent-2-rgb) / 0.25); }
 
 	.toggle-label { font-size: 11px; font-weight: 500; }
 

--- a/nodyx-frontend/src/lib/components/CanvasLeftToolbar.svelte
+++ b/nodyx-frontend/src/lib/components/CanvasLeftToolbar.svelte
@@ -134,7 +134,7 @@
 		border: 1px solid rgba(255,255,255,0.07);
 		border-radius: 16px;
 		box-shadow:
-			0 0 0 1px rgba(124, 58, 237, 0.08),
+			0 0 0 1px rgb(var(--nx-accent-2-rgb) / 0.08),
 			0 8px 32px rgba(0,0,0,0.5),
 			0 2px 8px rgba(0,0,0,0.4);
 		user-select: none;
@@ -177,7 +177,7 @@
 	.tool-btn.active {
 		background: linear-gradient(135deg, var(--nx-accent-deep), var(--nx-accent-2-strong));
 		color: white;
-		box-shadow: 0 0 0 1px rgba(124,58,237,0.4), 0 4px 12px rgba(124,58,237,0.35);
+		box-shadow: 0 0 0 1px rgb(var(--nx-accent-2-rgb) / 0.4), 0 4px 12px rgb(var(--nx-accent-2-rgb) / 0.35);
 	}
 
 	.tool-btn svg {

--- a/nodyx-frontend/src/lib/components/CanvasRightPanel.svelte
+++ b/nodyx-frontend/src/lib/components/CanvasRightPanel.svelte
@@ -253,7 +253,7 @@
 	.badge {
 		font-size: 9px;
 		font-weight: 700;
-		background: rgba(124,58,237,0.25);
+		background: rgb(var(--nx-accent-2-rgb) / 0.25);
 		color: var(--nx-accent-2-soft);
 		padding: 1px 5px;
 		border-radius: 20px;
@@ -279,7 +279,7 @@
 		transition: background 0.1s;
 	}
 	.peer:hover { background: rgba(255,255,255,0.03); }
-	.peer.me { background: rgba(124,58,237,0.06); }
+	.peer.me { background: rgb(var(--nx-accent-2-rgb) / 0.06); }
 
 	.avatar {
 		position: relative;
@@ -419,8 +419,8 @@
 		border: 1px solid rgba(255,255,255,0.05);
 	}
 	.msg-bubble.mine {
-		background: linear-gradient(135deg, rgba(109,40,217,0.5), rgba(124,58,237,0.4));
-		border-color: rgba(124,58,237,0.3);
+		background: linear-gradient(135deg, rgba(109,40,217,0.5), rgb(var(--nx-accent-2-rgb) / 0.4));
+		border-color: rgb(var(--nx-accent-2-rgb) / 0.3);
 		border-radius: 12px 12px 4px 12px;
 		color: #ede9fe;
 	}
@@ -457,7 +457,7 @@
 		line-height: 1.4;
 		transition: border-color 0.15s;
 	}
-	.chat-input:focus { border-color: rgba(124,58,237,0.4); }
+	.chat-input:focus { border-color: rgb(var(--nx-accent-2-rgb) / 0.4); }
 	.chat-input::placeholder { color: #374151; }
 
 	.send-btn {
@@ -473,9 +473,9 @@
 		justify-content: center;
 		flex-shrink: 0;
 		transition: all 0.15s;
-		box-shadow: 0 2px 8px rgba(124,58,237,0.3);
+		box-shadow: 0 2px 8px rgb(var(--nx-accent-2-rgb) / 0.3);
 	}
-	.send-btn:hover:not(:disabled) { transform: scale(1.05); box-shadow: 0 4px 12px rgba(124,58,237,0.4); }
+	.send-btn:hover:not(:disabled) { transform: scale(1.05); box-shadow: 0 4px 12px rgb(var(--nx-accent-2-rgb) / 0.4); }
 	.send-btn:disabled { opacity: 0.3; cursor: not-allowed; box-shadow: none; }
 	.send-btn svg { width: 15px; height: 15px; }
 </style>

--- a/nodyx-frontend/src/lib/components/CanvasTopBar.svelte
+++ b/nodyx-frontend/src/lib/components/CanvasTopBar.svelte
@@ -398,7 +398,7 @@
 		-webkit-backdrop-filter: blur(24px);
 		border: 1px solid rgba(255,255,255,0.07);
 		border-radius: 14px;
-		box-shadow: 0 4px 24px rgba(0,0,0,0.5), 0 0 0 1px rgba(124,58,237,0.06);
+		box-shadow: 0 4px 24px rgba(0,0,0,0.5), 0 0 0 1px rgb(var(--nx-accent-2-rgb) / 0.06);
 		user-select: none;
 		white-space: nowrap;
 		max-width: calc(100vw - 140px);
@@ -497,7 +497,7 @@
 		transition: all 0.1s;
 	}
 	.fmt-btn:hover { background: rgba(255,255,255,0.06); color: white; }
-	.fmt-btn.on { background: rgba(124,58,237,0.25); color: var(--nx-accent-2-soft); }
+	.fmt-btn.on { background: rgb(var(--nx-accent-2-rgb) / 0.25); color: var(--nx-accent-2-soft); }
 	.italic-btn { font-style: italic; }
 	.underline-btn { text-decoration: underline; }
 	.strike-btn { text-decoration: line-through; }
@@ -516,7 +516,7 @@
 		transition: all 0.1s;
 	}
 	.icon-btn:hover { background: rgba(255,255,255,0.06); color: white; }
-	.icon-btn.on { background: rgba(124,58,237,0.25); color: var(--nx-accent-2-soft); }
+	.icon-btn.on { background: rgb(var(--nx-accent-2-rgb) / 0.25); color: var(--nx-accent-2-soft); }
 
 	.size-val {
 		font-size: 12px;
@@ -539,7 +539,7 @@
 		transition: all 0.1s;
 	}
 	.font-btn:hover { background: rgba(255,255,255,0.06); color: #d1d5db; }
-	.font-btn.on { background: rgba(124,58,237,0.2); color: var(--nx-accent-2-soft); }
+	.font-btn.on { background: rgb(var(--nx-accent-2-rgb) / 0.2); color: var(--nx-accent-2-soft); }
 
 	.fill-toggle {
 		width: 28px;
@@ -555,7 +555,7 @@
 		transition: all 0.1s;
 	}
 	.fill-toggle:hover { background: rgba(255,255,255,0.08); color: #d1d5db; }
-	.fill-toggle.on { background: rgba(124,58,237,0.2); color: var(--nx-accent-2-soft); }
+	.fill-toggle.on { background: rgb(var(--nx-accent-2-rgb) / 0.2); color: var(--nx-accent-2-soft); }
 
 	.width-btn {
 		width: 28px;
@@ -570,7 +570,7 @@
 		transition: all 0.1s;
 	}
 	.width-btn:hover { background: rgba(255,255,255,0.06); }
-	.width-btn.selected { background: rgba(124,58,237,0.25); }
+	.width-btn.selected { background: rgb(var(--nx-accent-2-rgb) / 0.25); }
 	.width-btn.sm { width: 24px; height: 24px; }
 
 	.width-dot {
@@ -594,5 +594,5 @@
 		transition: all 0.1s;
 	}
 	.dash-btn:hover { background: rgba(255,255,255,0.06); color: #d1d5db; }
-	.dash-btn.on { background: rgba(124,58,237,0.2); color: var(--nx-accent-2-soft); }
+	.dash-btn.on { background: rgb(var(--nx-accent-2-rgb) / 0.2); color: var(--nx-accent-2-soft); }
 </style>

--- a/nodyx-frontend/src/lib/components/ChannelSidebar.svelte
+++ b/nodyx-frontend/src/lib/components/ChannelSidebar.svelte
@@ -303,7 +303,7 @@
 		border-radius: 20px !important;
 	}
 	.custom-scrollbar:hover::-webkit-scrollbar-thumb {
-		background-color: rgba(99, 102, 241, 0.4) !important;
+		background-color: rgb(var(--nx-accent-rgb) / 0.4) !important;
 	}
 
 	/* ── Channel item base ─────────────────────────────────────────────────── */
@@ -318,27 +318,27 @@
 
 	.ch-active {
 		color: #e2e8f0;
-		background: rgba(124,58,237,.14);
+		background: rgb(var(--nx-accent-2-rgb) / .14);
 		box-shadow: inset 2px 0 0 var(--nx-accent-2-strong);
 	}
 
 	/* ── Unread state: bioluminescent breathing glow ───────────────────────── */
 	.ch-unread {
 		color: #e2e8f0;
-		background: rgba(99,102,241,.07);
-		box-shadow: inset 2px 0 0 rgba(124,58,237,.7);
+		background: rgb(var(--nx-accent-rgb) / .07);
+		box-shadow: inset 2px 0 0 rgb(var(--nx-accent-2-rgb) / .7);
 		animation: ch-breathe 2.8s ease-in-out infinite;
 	}
-	.ch-unread:hover { background: rgba(99,102,241,.14); }
+	.ch-unread:hover { background: rgb(var(--nx-accent-rgb) / .14); }
 
 	@keyframes ch-breathe {
 		0%,100% {
-			box-shadow: inset 2px 0 0 rgba(124,58,237,.55), 0 0 0 rgba(99,102,241,0);
-			background: rgba(99,102,241,.06);
+			box-shadow: inset 2px 0 0 rgb(var(--nx-accent-2-rgb) / .55), 0 0 0 rgb(var(--nx-accent-rgb) / 0);
+			background: rgb(var(--nx-accent-rgb) / .06);
 		}
 		50% {
-			box-shadow: inset 2px 0 0 rgba(167,139,250,.95), 0 0 14px rgba(99,102,241,.14);
-			background: rgba(99,102,241,.11);
+			box-shadow: inset 2px 0 0 rgba(167,139,250,.95), 0 0 14px rgb(var(--nx-accent-rgb) / .14);
+			background: rgb(var(--nx-accent-rgb) / .11);
 		}
 	}
 
@@ -350,9 +350,9 @@
 		background: linear-gradient(
 			90deg,
 			transparent 0%,
-			rgba(99,102,241,.22) 35%,
+			rgb(var(--nx-accent-rgb) / .22) 35%,
 			rgba(167,139,250,.30) 50%,
-			rgba(99,102,241,.22) 65%,
+			rgb(var(--nx-accent-rgb) / .22) 65%,
 			transparent 100%
 		);
 		transform: translateX(-110%);

--- a/nodyx-frontend/src/lib/components/CommandPalette.svelte
+++ b/nodyx-frontend/src/lib/components/CommandPalette.svelte
@@ -318,7 +318,7 @@
   background: #0b0b0f;
   border: 1px solid rgba(255, 255, 255, 0.07);
   box-shadow:
-    0 0 0 1px rgba(99, 102, 241, 0.05),
+    0 0 0 1px rgb(var(--nx-accent-rgb) / 0.05),
     0 24px 60px rgba(0, 0, 0, 0.85),
     0 4px 16px rgba(0, 0, 0, 0.5);
   animation: kp-in 120ms cubic-bezier(0.16, 1, 0.3, 1) both;
@@ -418,7 +418,7 @@
 }
 
 .kp-item--active {
-  background: rgba(99, 102, 241, 0.07);
+  background: rgb(var(--nx-accent-rgb) / 0.07);
   border-left-color: rgb(99, 102, 241);
   color: rgba(255, 255, 255, 0.92);
 }
@@ -430,7 +430,7 @@
 }
 
 .kp-item--active .kp-icon {
-  color: rgba(99, 102, 241, 0.9);
+  color: rgb(var(--nx-accent-rgb) / 0.9);
 }
 
 .kp-label {
@@ -453,7 +453,7 @@
 }
 
 .kp-item--active .kp-sub {
-  color: rgba(99, 102, 241, 0.5);
+  color: rgb(var(--nx-accent-rgb) / 0.5);
 }
 
 /* ── Empty ───────────────────────────────────────────────────────────────── */

--- a/nodyx-frontend/src/lib/components/E2EKeyBackup.svelte
+++ b/nodyx-frontend/src/lib/components/E2EKeyBackup.svelte
@@ -291,7 +291,7 @@
 	.kb-hint { font-size: 12px; color: #64748b; line-height: 1.4; }
 
 	.kb-info { display: flex; flex-direction: column; gap: 8px;
-		background: rgba(99,102,241,.06); border: 1px solid rgba(99,102,241,.16);
+		background: rgb(var(--nx-accent-rgb) / .06); border: 1px solid rgb(var(--nx-accent-rgb) / .16);
 		border-radius: 12px; padding: 12px 14px; }
 	.kb-info-row { display: flex; gap: 10px; font-size: 13px; color: #c7d2fe; line-height: 1.45; }
 	.kb-info-row span:first-child { flex-shrink: 0; }
@@ -299,9 +299,9 @@
 	.kb-note { font-size: 13px; color: #cbd5e1; line-height: 1.45; }
 	.kb-gen { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
 	.kb-btn-soft { padding: 8px 14px; border-radius: 10px; cursor: pointer; font-weight: 600; font-size: 13px;
-		color: #c7d2fe; background: rgba(99,102,241,.12); border: 1px solid rgba(99,102,241,.25);
+		color: #c7d2fe; background: rgb(var(--nx-accent-rgb) / .12); border: 1px solid rgb(var(--nx-accent-rgb) / .25);
 		transition: background .15s; }
-	.kb-btn-soft:hover { background: rgba(99,102,241,.2); }
+	.kb-btn-soft:hover { background: rgb(var(--nx-accent-rgb) / .2); }
 	.kb-copy { padding: 8px 12px; border-radius: 10px; cursor: pointer; font-weight: 600; font-size: 13px;
 		color: #cbd5e1; background: transparent; border: 1px solid rgba(148,163,184,.3); }
 	.kb-examples { font-size: 12px; color: #94a3b8; line-height: 1.5; }

--- a/nodyx-frontend/src/lib/components/ExternalLinkWarning.svelte
+++ b/nodyx-frontend/src/lib/components/ExternalLinkWarning.svelte
@@ -361,7 +361,7 @@
 		border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 	}
 	.elg-section--education {
-		background: rgba(99, 102, 241, 0.03);
+		background: rgb(var(--nx-accent-rgb) / 0.03);
 	}
 	.elg-section-title {
 		font-size: 11px;
@@ -385,7 +385,7 @@
 	}
 	.elg-flag--high   { background: rgba(239, 68, 68, 0.08); border-color: rgba(239, 68, 68, 0.22); color: #fecaca; }
 	.elg-flag--medium { background: rgba(234, 179, 8, 0.06); border-color: rgba(234, 179, 8, 0.20); color: #fde68a; }
-	.elg-flag--low    { background: rgba(99, 102, 241, 0.06); border-color: rgba(99, 102, 241, 0.20); color: #c7d2fe; }
+	.elg-flag--low    { background: rgb(var(--nx-accent-rgb) / 0.06); border-color: rgb(var(--nx-accent-rgb) / 0.20); color: #c7d2fe; }
 	.elg-flag-icon { flex-shrink: 0; font-size: 16px; line-height: 1.2; }
 	.elg-flag-message { font-weight: 600; margin-bottom: 2px; }
 	.elg-flag-detail  { font-size: 12px; opacity: 0.8; line-height: 1.5; }
@@ -443,7 +443,7 @@
 		width: 18px;
 		height: 18px;
 		border-radius: 50%;
-		background: rgba(99, 102, 241, 0.18);
+		background: rgb(var(--nx-accent-rgb) / 0.18);
 		color: #a5b4fc;
 		font-size: 10px;
 		font-weight: 700;

--- a/nodyx-frontend/src/lib/components/FollowList.svelte
+++ b/nodyx-frontend/src/lib/components/FollowList.svelte
@@ -155,7 +155,7 @@
 		width: 36px; height: 36px;
 		border-radius: 4px;
 		object-fit: cover;
-		background: rgba(99, 102, 241, 0.08);
+		background: rgb(var(--nx-accent-rgb) / 0.08);
 		flex-shrink: 0;
 	}
 	.fl-avatar--init {

--- a/nodyx-frontend/src/lib/components/MemberScreenPreview.svelte
+++ b/nodyx-frontend/src/lib/components/MemberScreenPreview.svelte
@@ -74,7 +74,7 @@
             <img src={avatar} alt={username} class="w-4 h-4 rounded-full object-cover shrink-0"/>
         {:else}
             <div class="w-4 h-4 rounded-full shrink-0 flex items-center justify-center text-[7px] font-bold text-white"
-                 style="background: linear-gradient(135deg, var(--nx-accent-strong), #0e7490)">
+                 style="background: linear-gradient(135deg, var(--nx-accent-strong), var(--nx-cyan-deep))">
                 {username[0]?.toUpperCase()}
             </div>
         {/if}

--- a/nodyx-frontend/src/lib/components/MessageBody.svelte
+++ b/nodyx-frontend/src/lib/components/MessageBody.svelte
@@ -140,8 +140,8 @@
 		gap: 8px;
 		padding: 6px 10px;
 		margin: 4px 0;
-		background: rgba(99, 102, 241, 0.06);
-		border: 1px solid rgba(99, 102, 241, 0.18);
+		background: rgb(var(--nx-accent-rgb) / 0.06);
+		border: 1px solid rgb(var(--nx-accent-rgb) / 0.18);
 		border-radius: 999px;
 		max-width: 100%;
 	}

--- a/nodyx-frontend/src/lib/components/NodyxCanvas.svelte
+++ b/nodyx-frontend/src/lib/components/NodyxCanvas.svelte
@@ -2088,7 +2088,7 @@
 			</span>
 			<button onclick={handleRequestAccess} disabled={accessAsked}
 				style="padding:5px 13px; border-radius:999px; font-size:12px; font-weight:600; cursor:{accessAsked ? 'default' : 'pointer'}; border:none; color:#fff; white-space:nowrap;
-				       background:{accessAsked ? 'rgba(16,185,129,.3)' : 'linear-gradient(to right,var(--nx-accent-strong),#06b6d4)'};">
+				       background:{accessAsked ? 'rgba(16,185,129,.3)' : 'linear-gradient(to right,var(--nx-accent-strong),var(--nx-cyan))'};">
 				{accessAsked ? '✓ Demande envoyée' : "Demander l'accès en édition"}
 			</button>
 		</div>
@@ -2357,7 +2357,7 @@
 		border: 1px solid rgba(255,255,255,0.07);
 		border-radius: 10px;
 		overflow: hidden;
-		box-shadow: 0 4px 20px rgba(0,0,0,0.5), 0 0 0 1px rgba(124,58,237,0.06);
+		box-shadow: 0 4px 20px rgba(0,0,0,0.5), 0 0 0 1px rgb(var(--nx-accent-2-rgb) / 0.06);
 	}
 	.minimap-wrap canvas {
 		border-bottom: 1px solid rgba(255,255,255,0.05);

--- a/nodyx-frontend/src/lib/components/ScreenShareModal.svelte
+++ b/nodyx-frontend/src/lib/components/ScreenShareModal.svelte
@@ -52,11 +52,11 @@
 
     <!-- Card -->
     <div class="relative w-full max-w-md overflow-hidden animate-in fade-in zoom-in-95 duration-200 rounded-2xl"
-         style="background: #0a0a12; border: 1px solid rgba(99,102,241,0.2); box-shadow: 0 25px 60px rgba(0,0,0,0.6);">
+         style="background: #0a0a12; border: 1px solid rgb(var(--nx-accent-rgb) / 0.2); box-shadow: 0 25px 60px rgba(0,0,0,0.6);">
 
         <!-- Top accent line -->
         <div class="absolute top-0 left-0 right-0 h-px"
-             style="background: linear-gradient(90deg, transparent, rgba(99,102,241,0.6), transparent)"></div>
+             style="background: linear-gradient(90deg, transparent, rgb(var(--nx-accent-rgb) / 0.6), transparent)"></div>
 
         <!-- Header -->
         <div class="flex items-center justify-between px-6 pt-6 pb-4"
@@ -86,8 +86,8 @@
                         onclick={() => selectedSurface = src.surface}
                         class="flex flex-col items-center gap-2.5 p-4 rounded-xl transition-all duration-150"
                         style="
-                            border: 2px solid {selectedSurface === src.surface ? 'rgba(99,102,241,0.6)' : 'rgba(255,255,255,0.05)'};
-                            background: {selectedSurface === src.surface ? 'rgba(99,102,241,0.08)' : 'rgba(255,255,255,0.02)'};
+                            border: 2px solid {selectedSurface === src.surface ? 'rgb(var(--nx-accent-rgb) / 0.6)' : 'rgba(255,255,255,0.05)'};
+                            background: {selectedSurface === src.surface ? 'rgb(var(--nx-accent-rgb) / 0.08)' : 'rgba(255,255,255,0.02)'};
                         "
                     >
                         <span class="text-2xl leading-none">{src.icon}</span>
@@ -113,8 +113,8 @@
                             onclick={() => selectedQuality = q.id}
                             class="flex flex-col items-center py-2.5 rounded-lg transition-all"
                             style="
-                                border: 1px solid {selectedQuality === q.id ? 'rgba(99,102,241,0.5)' : 'rgba(255,255,255,0.05)'};
-                                background: {selectedQuality === q.id ? 'rgba(99,102,241,0.08)' : 'rgba(255,255,255,0.02)'};
+                                border: 1px solid {selectedQuality === q.id ? 'rgb(var(--nx-accent-rgb) / 0.5)' : 'rgba(255,255,255,0.05)'};
+                                background: {selectedQuality === q.id ? 'rgb(var(--nx-accent-rgb) / 0.08)' : 'rgba(255,255,255,0.02)'};
                             "
                         >
                             <span class="text-xs font-bold {q.color}">{q.label}</span>
@@ -133,8 +133,8 @@
                             onclick={() => selectedFps = fps}
                             class="flex-1 py-1.5 rounded-lg text-xs font-bold transition-all"
                             style="
-                                border: 1px solid {selectedFps === fps ? 'rgba(99,102,241,0.5)' : 'rgba(255,255,255,0.05)'};
-                                background: {selectedFps === fps ? 'rgba(99,102,241,0.08)' : 'rgba(255,255,255,0.02)'};
+                                border: 1px solid {selectedFps === fps ? 'rgb(var(--nx-accent-rgb) / 0.5)' : 'rgba(255,255,255,0.05)'};
+                                background: {selectedFps === fps ? 'rgb(var(--nx-accent-rgb) / 0.08)' : 'rgba(255,255,255,0.02)'};
                                 color: {selectedFps === fps ? 'rgb(165,180,252)' : 'rgb(107,114,128)'};
                             "
                         >

--- a/nodyx-frontend/src/lib/components/StageView.svelte
+++ b/nodyx-frontend/src/lib/components/StageView.svelte
@@ -200,8 +200,8 @@
                             onclick={() => focusedId = entry.id}
                             class="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-medium shrink-0 transition-all"
                             style="
-                                border: 1px solid {focusedId === entry.id ? 'rgba(99,102,241,0.5)' : 'rgba(255,255,255,0.06)'};
-                                background: {focusedId === entry.id ? 'rgba(99,102,241,0.12)' : 'rgba(255,255,255,0.03)'};
+                                border: 1px solid {focusedId === entry.id ? 'rgb(var(--nx-accent-rgb) / 0.5)' : 'rgba(255,255,255,0.06)'};
+                                background: {focusedId === entry.id ? 'rgb(var(--nx-accent-rgb) / 0.12)' : 'rgba(255,255,255,0.03)'};
                                 color: {focusedId === entry.id ? 'rgb(165,180,252)' : 'rgb(107,114,128)'};
                             "
                         >

--- a/nodyx-frontend/src/lib/components/Table.svelte
+++ b/nodyx-frontend/src/lib/components/Table.svelte
@@ -174,14 +174,14 @@
 	<div class="absolute inset-0 pointer-events-none overflow-hidden">
 		<!-- Static orbs -->
 		<div class="absolute -top-64 -left-64 w-[700px] h-[700px]"
-		     style="background: radial-gradient(circle, rgba(124,58,237,0.05) 0%, transparent 65%); filter: blur(80px);"></div>
+		     style="background: radial-gradient(circle, rgb(var(--nx-accent-2-rgb) / 0.05) 0%, transparent 65%); filter: blur(80px);"></div>
 		<div class="absolute -bottom-64 -right-64 w-[700px] h-[700px]"
-		     style="background: radial-gradient(circle, rgba(6,182,212,0.04) 0%, transparent 65%); filter: blur(80px);"></div>
+		     style="background: radial-gradient(circle, rgb(var(--nx-cyan-rgb) / 0.04) 0%, transparent 65%); filter: blur(80px);"></div>
 		<!-- Audio-reactive center glow -->
 		<div class="absolute inset-0 flex items-center justify-center"
 		     style="opacity: {(0.3 + _myLevel * 0.7).toFixed(2)}; transition: opacity 80ms linear;">
 			<div class="w-[600px] h-[600px]"
-			     style="background: radial-gradient(circle, rgba(124,58,237,0.08) 0%, transparent 55%); filter: blur(100px);"></div>
+			     style="background: radial-gradient(circle, rgb(var(--nx-accent-2-rgb) / 0.08) 0%, transparent 55%); filter: blur(100px);"></div>
 		</div>
 	</div>
 
@@ -204,14 +204,14 @@
 				<!-- Halo rings -->
 				<div class="absolute inset-0 rounded-full join-ring"></div>
 				<div class="absolute inset-0 rounded-full join-ring" style="animation-delay: 0.8s;"></div>
-				<div class="absolute inset-[10px] rounded-full join-ring" style="animation-delay: 0.4s; border-color: rgba(6,182,212,0.3);"></div>
+				<div class="absolute inset-[10px] rounded-full join-ring" style="animation-delay: 0.4s; border-color: rgb(var(--nx-cyan-rgb) / 0.3);"></div>
 
 				<!-- Button disk -->
 				<div class="relative w-36 h-36 rounded-full flex flex-col items-center justify-center gap-2.5
 				            group-hover:scale-105 transition-all duration-300"
-				     style="background: linear-gradient(145deg, rgba(124,58,237,0.25) 0%, rgba(6,182,212,0.12) 100%);
-				            border: 1px solid rgba(124,58,237,0.45);
-				            box-shadow: 0 0 60px rgba(124,58,237,0.18), 0 0 0 1px rgba(255,255,255,0.04), inset 0 1px 0 rgba(255,255,255,0.06);">
+				     style="background: linear-gradient(145deg, rgb(var(--nx-accent-2-rgb) / 0.25) 0%, rgb(var(--nx-cyan-rgb) / 0.12) 100%);
+				            border: 1px solid rgb(var(--nx-accent-2-rgb) / 0.45);
+				            box-shadow: 0 0 60px rgb(var(--nx-accent-2-rgb) / 0.18), 0 0 0 1px rgba(255,255,255,0.04), inset 0 1px 0 rgba(255,255,255,0.06);">
 					<svg class="w-10 h-10" fill="none" stroke="white" stroke-width="1.5" viewBox="0 0 24 24" style="opacity:0.9;">
 						<path stroke-linecap="round" stroke-linejoin="round" d="M12 18.75a6 6 0 006-6v-1.5m-6 7.5a6 6 0 01-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 01-3-3V4.5a3 3 0 116 0v8.25a3 3 0 01-3 3z"/>
 					</svg>
@@ -251,7 +251,7 @@
 						class="player-card relative flex flex-col items-center gap-5 py-8 px-5 transition-all duration-200 overflow-hidden"
 						style="
 							background: {isSpeaking || myActive
-								? 'linear-gradient(160deg, rgba(124,58,237,0.13) 0%, rgba(6,182,212,0.06) 100%)'
+								? 'linear-gradient(160deg, rgb(var(--nx-accent-2-rgb) / 0.13) 0%, rgb(var(--nx-cyan-rgb) / 0.06) 100%)'
 								: 'linear-gradient(160deg, rgba(13,13,22,0.95) 0%, rgba(9,9,18,0.98) 100%)'};
 							border: 1px solid rgba(124,58,237,{borderOpacity});
 							box-shadow: 0 0 {shadowSize}px rgba(124,58,237,{shadowAlpha}),
@@ -269,15 +269,15 @@
 						{/if}
 
 						<!-- Corner decorations — cyberpunk style -->
-						<div class="absolute top-0 left-0 w-4 h-4 pointer-events-none" style="border-top:1px solid rgba(124,58,237,0.4);border-left:1px solid rgba(124,58,237,0.4)"></div>
-						<div class="absolute top-0 right-0 w-4 h-4 pointer-events-none" style="border-top:1px solid rgba(6,182,212,0.3);border-right:1px solid rgba(6,182,212,0.3)"></div>
-						<div class="absolute bottom-0 left-0 w-4 h-4 pointer-events-none" style="border-bottom:1px solid rgba(6,182,212,0.3);border-left:1px solid rgba(6,182,212,0.3)"></div>
-						<div class="absolute bottom-0 right-0 w-4 h-4 pointer-events-none" style="border-bottom:1px solid rgba(124,58,237,0.4);border-right:1px solid rgba(124,58,237,0.4)"></div>
+						<div class="absolute top-0 left-0 w-4 h-4 pointer-events-none" style="border-top:1px solid rgb(var(--nx-accent-2-rgb) / 0.4);border-left:1px solid rgb(var(--nx-accent-2-rgb) / 0.4)"></div>
+						<div class="absolute top-0 right-0 w-4 h-4 pointer-events-none" style="border-top:1px solid rgb(var(--nx-cyan-rgb) / 0.3);border-right:1px solid rgb(var(--nx-cyan-rgb) / 0.3)"></div>
+						<div class="absolute bottom-0 left-0 w-4 h-4 pointer-events-none" style="border-bottom:1px solid rgb(var(--nx-cyan-rgb) / 0.3);border-left:1px solid rgb(var(--nx-cyan-rgb) / 0.3)"></div>
+						<div class="absolute bottom-0 right-0 w-4 h-4 pointer-events-none" style="border-bottom:1px solid rgb(var(--nx-accent-2-rgb) / 0.4);border-right:1px solid rgb(var(--nx-accent-2-rgb) / 0.4)"></div>
 
 						<!-- "Vous" chip — top-left -->
 						{#if p.isMe}
 							<div class="absolute top-2.5 left-3 px-1.5 py-px pointer-events-none"
-							     style="background:rgba(124,58,237,0.14);border:1px solid rgba(124,58,237,0.35)">
+							     style="background:rgb(var(--nx-accent-2-rgb) / 0.14);border:1px solid rgb(var(--nx-accent-2-rgb) / 0.35)">
 								<span class="text-[8px] font-black uppercase tracking-[0.15em]" style="color:rgba(167,139,250,0.85)">Vous</span>
 							</div>
 						{/if}
@@ -308,8 +308,8 @@
 
 							<!-- Outer speak rings (peers) -->
 							{#if isSpeaking && !p.isMe}
-								<div class="absolute rounded-full speak-ring" style="inset:-10px; border:1.5px solid rgba(124,58,237,0.3)"></div>
-								<div class="absolute rounded-full speak-ring" style="inset:-18px; border:1px solid rgba(6,182,212,0.15); animation-delay:0.6s"></div>
+								<div class="absolute rounded-full speak-ring" style="inset:-10px; border:1.5px solid rgb(var(--nx-accent-2-rgb) / 0.3)"></div>
+								<div class="absolute rounded-full speak-ring" style="inset:-18px; border:1px solid rgb(var(--nx-cyan-rgb) / 0.15); animation-delay:0.6s"></div>
 							{/if}
 
 							{#if p.avatar}
@@ -326,8 +326,8 @@
 							{:else}
 								<div class="w-[88px] h-[88px] rounded-full flex items-center justify-center text-3xl font-black text-white relative z-10"
 								     style="
-								         background: linear-gradient(145deg, rgba(124,58,237,0.4) 0%, rgba(6,182,212,0.2) 100%);
-								         border: 1px solid rgba(124,58,237,0.35);
+								         background: linear-gradient(145deg, rgb(var(--nx-accent-2-rgb) / 0.4) 0%, rgb(var(--nx-cyan-rgb) / 0.2) 100%);
+								         border: 1px solid rgb(var(--nx-accent-2-rgb) / 0.35);
 								         box-shadow: 0 0 0 {ringSize}px rgba(124,58,237,{ringAlpha}),
 								                     0 6px 28px rgba(0,0,0,0.85);
 								         transition: box-shadow 60ms linear;
@@ -359,8 +359,8 @@
 							     style="height:16px; opacity:{isSpeaking || myActive ? 1 : 0};">
 								{#each [
 									{c:'var(--nx-accent-deep)',d:'0.00s'},{c:'var(--nx-accent-2-strong)',d:'0.14s'},{c:'var(--nx-accent-2-mid)',d:'0.05s'},
-									{c:'var(--nx-accent-2-soft)',d:'0.22s'},{c:'#67e8f9',d:'0.09s'},{c:'#22d3ee',d:'0.17s'},
-									{c:'#67e8f9',d:'0.03s'}
+									{c:'var(--nx-accent-2-soft)',d:'0.22s'},{c:'var(--nx-cyan-soft)',d:'0.09s'},{c:'#22d3ee',d:'0.17s'},
+									{c:'var(--nx-cyan-soft)',d:'0.03s'}
 								] as bar}
 									<div class="w-[2.5px] rounded-sm eq-bar" style="background:{bar.c}; animation-delay:{bar.d}"></div>
 								{/each}
@@ -568,7 +568,7 @@
 <style>
 	/* ── Player card ────────────────────────────────────────────────────── */
 	.player-card[role="button"]:hover {
-		background: linear-gradient(160deg, rgba(124,58,237,0.09) 0%, rgba(6,182,212,0.04) 100%) !important;
+		background: linear-gradient(160deg, rgb(var(--nx-accent-2-rgb) / 0.09) 0%, rgb(var(--nx-cyan-rgb) / 0.04) 100%) !important;
 	}
 
 	/* Animated scan line at card top */
@@ -588,7 +588,7 @@
 		100% { transform: scale(1.7); opacity: 0;   }
 	}
 	.join-ring {
-		border: 1px solid rgba(124, 58, 237, 0.35);
+		border: 1px solid rgb(var(--nx-accent-2-rgb) / 0.35);
 		animation: join-ring-pulse 2.2s ease-out infinite;
 	}
 

--- a/nodyx-frontend/src/lib/components/VoicePanel.svelte
+++ b/nodyx-frontend/src/lib/components/VoicePanel.svelte
@@ -638,7 +638,7 @@
                                 style="left: {rect.left + rect.width/2}px; 
                                        top: {rect.top - 30}px;
                                        transform: translateX(-50%);
-                                       box-shadow: 0 0 15px rgba(99, 102, 241, 0.3);"
+                                       box-shadow: 0 0 15px rgb(var(--nx-accent-rgb) / 0.3);"
                             >
                                 <span class="flex items-center gap-1.5">
                                     <span class="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse"></span>
@@ -1214,14 +1214,14 @@ input[type=range]::-webkit-slider-thumb {
     border-radius: 50%;
     background: linear-gradient(to right, var(--nx-accent), var(--nx-accent-2-mid));
     cursor: pointer;
-    box-shadow: 0 0 10px rgba(99, 102, 241, 0.5);
+    box-shadow: 0 0 10px rgb(var(--nx-accent-rgb) / 0.5);
     border: 2px solid rgba(255, 255, 255, 0.2);
     transition: all 0.2s;
 }
 
 input[type=range]::-webkit-slider-thumb:hover {
     transform: scale(1.2);
-    box-shadow: 0 0 15px rgba(99, 102, 241, 0.8);
+    box-shadow: 0 0 15px rgb(var(--nx-accent-rgb) / 0.8);
 }
 
 input[type=range]::-moz-range-thumb {
@@ -1236,7 +1236,7 @@ input[type=range]::-moz-range-thumb {
 
 input[type=range]::-moz-range-thumb:hover {
     transform: scale(1.2);
-    box-shadow: 0 0 15px rgba(99, 102, 241, 0.8);
+    box-shadow: 0 0 15px rgb(var(--nx-accent-rgb) / 0.8);
 }
 
 

--- a/nodyx-frontend/src/lib/components/VoiceRoom.svelte
+++ b/nodyx-frontend/src/lib/components/VoiceRoom.svelte
@@ -129,7 +129,7 @@
 	{#if connected}
 		<div class="ml-auto flex items-center gap-1.5 shrink-0">
 			<span class="flex items-center gap-1 text-[10px] font-bold uppercase tracking-[0.15em]"
-			      style="color: rgba(124,58,237,0.7);">
+			      style="color: rgb(var(--nx-accent-2-rgb) / 0.7);">
 				<span class="w-1.5 h-1.5 rounded-full bg-violet-500/80 animate-pulse shrink-0"></span>
 				{peerCount} connecté{peerCount > 1 ? 's' : ''}
 			</span>
@@ -365,7 +365,7 @@
 	.active-amber:hover, .idle-amber:hover { color: #e0a86a !important; }
 
 	/* Violet (canvas) */
-	.active-violet { color: var(--nx-accent-2-soft) !important; background: rgba(124,58,237,0.14) !important; border-color: rgba(124,58,237,0.35) !important; }
+	.active-violet { color: var(--nx-accent-2-soft) !important; background: rgb(var(--nx-accent-2-rgb) / 0.14) !important; border-color: rgb(var(--nx-accent-2-rgb) / 0.35) !important; }
 	.active-violet:hover { color: var(--nx-accent-2-soft2) !important; }
 
 	/* Blue (screen share) */

--- a/nodyx-frontend/src/lib/components/admin/AlertBoxConfigEditor.svelte
+++ b/nodyx-frontend/src/lib/components/admin/AlertBoxConfigEditor.svelte
@@ -281,7 +281,7 @@
 					<div class="flex gap-1.5">
 						<input type="color" bind:value={config.customTheme.accentColor}
 							class="w-9 h-8 rounded border border-slate-700/60 bg-slate-950 cursor-pointer"/>
-						<input type="text" bind:value={config.customTheme.accentColor} placeholder="#06b6d4"
+						<input type="text" bind:value={config.customTheme.accentColor} placeholder="var(--nx-cyan)"
 							class="flex-1 rounded bg-slate-950 border border-slate-700/60 focus:border-cyan-500/60 focus:ring-2 focus:ring-cyan-500/20 px-2.5 py-1.5 text-xs text-white placeholder-slate-700 outline-none font-mono transition-colors"/>
 					</div>
 				</label>

--- a/nodyx-frontend/src/lib/components/admin/AlertThemePreview.svelte
+++ b/nodyx-frontend/src/lib/components/admin/AlertThemePreview.svelte
@@ -188,7 +188,7 @@
 		position: absolute; inset: 0;
 		border-radius: 14px;
 		padding: 1.5px;
-		background: linear-gradient(135deg, #ec4899, var(--nx-accent), #06b6d4, var(--nx-accent-2));
+		background: linear-gradient(135deg, #ec4899, var(--nx-accent), var(--nx-cyan), var(--nx-accent-2));
 		-webkit-mask:
 			linear-gradient(#fff 0 0) content-box,
 			linear-gradient(#fff 0 0);
@@ -201,7 +201,7 @@
 	.theme-holographic .alert-eyebrow {
 		font-size: 10px; font-weight: 700; text-transform: uppercase;
 		letter-spacing: 0.14em; margin-bottom: 4px;
-		background: linear-gradient(90deg, #ec4899, #06b6d4);
+		background: linear-gradient(90deg, #ec4899, var(--nx-cyan));
 		background-clip: text;
 		-webkit-background-clip: text;
 		color: transparent;

--- a/nodyx-frontend/src/lib/components/admin/ChannelStyleEditor.svelte
+++ b/nodyx-frontend/src/lib/components/admin/ChannelStyleEditor.svelte
@@ -427,7 +427,7 @@
 	}
 	.cse-style-btn:hover { background: #283142; color: #e2e8f0; }
 	.cse-style-btn--active {
-		background: rgba(99, 102, 241, 0.18);
+		background: rgb(var(--nx-accent-rgb) / 0.18);
 		border-color: var(--nx-accent);
 		color: #c7d2fe;
 	}
@@ -525,11 +525,11 @@
 		padding: 0;
 	}
 	.cse-icon-btn:hover {
-		background: rgba(99,102,241,0.1);
+		background: rgb(var(--nx-accent-rgb) / 0.1);
 		transform: scale(1.08);
 	}
 	.cse-icon-btn--active {
-		background: rgba(99,102,241,0.2);
+		background: rgb(var(--nx-accent-rgb) / 0.2);
 		border-color: var(--nx-accent);
 	}
 	.cse-custom {

--- a/nodyx-frontend/src/lib/components/admin/GoalBarConfigEditor.svelte
+++ b/nodyx-frontend/src/lib/components/admin/GoalBarConfigEditor.svelte
@@ -213,7 +213,7 @@
 			<div class="flex gap-1.5">
 				<input id="goal-accent" type="color" bind:value={config.accentColor}
 					class="w-10 h-10 rounded border border-slate-700/60 bg-slate-950 cursor-pointer"/>
-				<input type="text" bind:value={config.accentColor} placeholder="#06b6d4" maxlength="7"
+				<input type="text" bind:value={config.accentColor} placeholder="var(--nx-cyan)" maxlength="7"
 					class="flex-1 rounded-lg bg-slate-950 border border-slate-700/60 focus:border-cyan-500/60 focus:ring-2 focus:ring-cyan-500/20 px-3 py-2 text-sm text-white outline-none transition-colors font-mono"/>
 			</div>
 		</div>

--- a/nodyx-frontend/src/lib/components/admin/TickerThemePreview.svelte
+++ b/nodyx-frontend/src/lib/components/admin/TickerThemePreview.svelte
@@ -30,7 +30,7 @@
 <div class="preview-wrap">
 	<div class="ticker theme-{theme}" style={customStyle()}>
 		<div class="ticker-track">
-			<div class="token" style="--accent: #06b6d4">
+			<div class="token" style="--accent: var(--nx-cyan)">
 				<div class="icon-orb">
 					<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
 				</div>
@@ -154,7 +154,7 @@
 
 	.theme-neon {
 		--bar-bg: #050511;
-		border-top: 2px solid #06b6d4;
+		border-top: 2px solid var(--nx-cyan);
 	}
 	.theme-neon .token {
 		background: rgba(255, 255, 255, 0.02);

--- a/nodyx-frontend/src/lib/components/homepage/GridRenderer.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/GridRenderer.svelte
@@ -333,8 +333,8 @@
 		white-space: nowrap;
 	}
 	.gr-col-overlay-btn--add {
-		background: rgba(6,182,212,.15);
-		border-color: rgba(6,182,212,.3);
+		background: rgb(var(--nx-cyan-rgb) / .15);
+		border-color: rgb(var(--nx-cyan-rgb) / .3);
 	}
 
 	/* ── Empty column slot ─────────────────────────────────────────────────── */

--- a/nodyx-frontend/src/lib/components/homepage/widgets/ArticleSlideshow.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/ArticleSlideshow.svelte
@@ -346,7 +346,7 @@
 		position: absolute;
 		bottom: 0; left: 0;
 		width: 320px; height: 200px;
-		background: radial-gradient(ellipse at bottom left, rgba(124,58,237,.18), transparent 70%);
+		background: radial-gradient(ellipse at bottom left, rgb(var(--nx-accent-2-rgb) / .18), transparent 70%);
 		pointer-events: none;
 	}
 
@@ -382,16 +382,16 @@
 	.as-play svg {
 		width: 64px; height: 64px;
 		color: rgba(255,255,255,.85);
-		background: rgba(124,58,237,.35);
+		background: rgb(var(--nx-accent-2-rgb) / .35);
 		border-radius: 50%;
 		padding: 14px;
-		border: 2px solid rgba(124,58,237,.5);
+		border: 2px solid rgb(var(--nx-accent-2-rgb) / .5);
 		transition: transform .15s, background .15s;
-		filter: drop-shadow(0 4px 24px rgba(124,58,237,.4));
+		filter: drop-shadow(0 4px 24px rgb(var(--nx-accent-2-rgb) / .4));
 	}
 	.as-play:hover svg {
 		transform: scale(1.08);
-		background: rgba(124,58,237,.55);
+		background: rgb(var(--nx-accent-2-rgb) / .55);
 	}
 
 	/* ── Content ────────────────────────────────────────────────────────────── */
@@ -415,7 +415,7 @@
 	.as-cat-line {
 		height: 1px;
 		width: 2.5rem;
-		background: linear-gradient(to right, var(--nx-accent-2-strong), #06b6d4);
+		background: linear-gradient(to right, var(--nx-accent-2-strong), var(--nx-cyan));
 		flex-shrink: 0;
 	}
 	.as-cat-text {
@@ -428,9 +428,9 @@
 	.as-cat-badge {
 		font-size: 10px;
 		font-weight: 700;
-		color: #06b6d4;
-		background: rgba(6,182,212,.12);
-		border: 1px solid rgba(6,182,212,.25);
+		color: var(--nx-cyan);
+		background: rgb(var(--nx-cyan-rgb) / .12);
+		border: 1px solid rgb(var(--nx-cyan-rgb) / .25);
 		padding: 1px 7px;
 		border-radius: 3px;
 	}
@@ -485,8 +485,8 @@
 	.as-avatar {
 		width: 28px; height: 28px;
 		overflow: hidden;
-		background: rgba(124,58,237,.3);
-		outline: 1.5px solid rgba(124,58,237,.4);
+		background: rgb(var(--nx-accent-2-rgb) / .3);
+		outline: 1.5px solid rgb(var(--nx-accent-2-rgb) / .4);
 		outline-offset: 1px;
 		border-radius: 2px;
 		display: flex;
@@ -512,14 +512,14 @@
 		letter-spacing: .1em;
 		color: #fff;
 		text-decoration: none;
-		background: linear-gradient(135deg, rgba(124,58,237,.55), rgba(6,182,212,.25));
-		border: 1px solid rgba(124,58,237,.45);
+		background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .55), rgb(var(--nx-cyan-rgb) / .25));
+		border: 1px solid rgb(var(--nx-accent-2-rgb) / .45);
 		transition: background .15s, border-color .15s;
 		white-space: nowrap;
 	}
 	.as-cta:hover {
-		background: linear-gradient(135deg, rgba(124,58,237,.75), rgba(6,182,212,.4));
-		border-color: rgba(124,58,237,.7);
+		background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .75), rgb(var(--nx-cyan-rgb) / .4));
+		border-color: rgb(var(--nx-accent-2-rgb) / .7);
 	}
 	.as-cta svg { width: 14px; height: 14px; transition: transform .15s; }
 	.as-cta:hover svg { transform: translateX(3px); }
@@ -556,7 +556,7 @@
 		top: -1px;
 		left: 0;
 		height: 4px;
-		background: linear-gradient(to right, var(--nx-accent-2-strong), #06b6d4);
+		background: linear-gradient(to right, var(--nx-accent-2-strong), var(--nx-cyan));
 		transition: none;
 	}
 	.as-arrows {
@@ -577,7 +577,7 @@
 		border-radius: 2px;
 	}
 	.as-arrow:hover {
-		border-color: rgba(124,58,237,.5);
+		border-color: rgb(var(--nx-accent-2-rgb) / .5);
 		color: var(--nx-accent-2-soft);
 	}
 	.as-arrow svg { width: 14px; height: 14px; }

--- a/nodyx-frontend/src/lib/components/homepage/widgets/ArticlesShowcase.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/ArticlesShowcase.svelte
@@ -392,7 +392,7 @@
 	/* ─── Common cover placeholder + badges ────────────────────────────────── */
 	.as-cover-placeholder {
 		width: 100%; height: 100%;
-		background: linear-gradient(135deg, rgba(124,58,237,.15), rgba(14,116,144,.12));
+		background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .15), rgba(14,116,144,.12));
 		position: relative;
 	}
 	.as-cover-placeholder::after {

--- a/nodyx-frontend/src/lib/components/homepage/widgets/HeroBanner.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/HeroBanner.svelte
@@ -294,19 +294,19 @@
 	.hb-orb--tl {
 		top: -160px; left: -80px;
 		width: 500px; height: 500px;
-		background: radial-gradient(circle, rgba(124,58,237,.16) 0%, transparent 65%);
+		background: radial-gradient(circle, rgb(var(--nx-accent-2-rgb) / .16) 0%, transparent 65%);
 	}
 	.hb-orb--br {
 		bottom: -80px; right: 0;
 		width: 380px; height: 380px;
-		background: radial-gradient(circle, rgba(6,182,212,.09) 0%, transparent 65%);
+		background: radial-gradient(circle, rgb(var(--nx-cyan-rgb) / .09) 0%, transparent 65%);
 	}
 	.hb-deco-letter {
 		position: absolute; right: 6%; top: 50%; transform: translateY(-50%);
 		font-family: 'Space Grotesk', sans-serif; font-weight: 800;
 		font-size: clamp(120px, 18vw, 260px);
 		line-height: 1;
-		background: linear-gradient(135deg, rgba(124,58,237,.45) 0%, rgba(6,182,212,.18) 50%, transparent 80%);
+		background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .45) 0%, rgb(var(--nx-cyan-rgb) / .18) 50%, transparent 80%);
 		-webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
 		user-select: none; pointer-events: none; opacity: .7;
 	}
@@ -349,7 +349,7 @@
 	}
 	.hb-eyebrow-line {
 		height: 1px; width: 40px;
-		background: linear-gradient(to right, var(--nx-accent-2-strong), #06b6d4);
+		background: linear-gradient(to right, var(--nx-accent-2-strong), var(--nx-cyan));
 	}
 
 	.hb-identity {
@@ -359,7 +359,7 @@
 	.hb-logo {
 		width: 48px; height: 48px;
 		object-fit: cover; flex-shrink: 0;
-		outline: 2px solid rgba(124,58,237,.45);
+		outline: 2px solid rgb(var(--nx-accent-2-rgb) / .45);
 		outline-offset: 2px;
 	}
 	.hb-logo-fallback {
@@ -367,15 +367,15 @@
 		display: flex; align-items: center; justify-content: center;
 		font-family: 'Space Grotesk', sans-serif; font-weight: 900;
 		font-size: 1.3rem; color: #fff;
-		background: linear-gradient(135deg, rgba(124,58,237,.4), rgba(6,182,212,.15));
-		border: 1px solid rgba(124,58,237,.3);
+		background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .4), rgb(var(--nx-cyan-rgb) / .15));
+		border: 1px solid rgb(var(--nx-accent-2-rgb) / .3);
 	}
 
 	.hb-title {
 		font-family: 'Space Grotesk', sans-serif; font-weight: 800;
 		font-size: clamp(1.25rem, 2.4vw, 1.85rem);
 		line-height: 1.05; margin: 0 0 .2rem;
-		background: linear-gradient(135deg, var(--nx-accent-2-soft) 0%, #06b6d4 100%);
+		background: linear-gradient(135deg, var(--nx-accent-2-soft) 0%, var(--nx-cyan) 100%);
 		-webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
 	}
 	.hb-title--event {
@@ -400,8 +400,8 @@
 	}
 	.hb-btn:active { transform: scale(.97); }
 	.hb-btn--primary {
-		background: linear-gradient(135deg, var(--nx-accent-2-strong), #0e7490);
-		border: 1px solid rgba(124,58,237,.45); color: #fff;
+		background: linear-gradient(135deg, var(--nx-accent-2-strong), var(--nx-cyan-deep));
+		border: 1px solid rgb(var(--nx-accent-2-rgb) / .45); color: #fff;
 	}
 	.hb-btn--primary:hover { filter: brightness(1.12); }
 	.hb-btn--ghost {
@@ -430,7 +430,7 @@
 	}
 	.hb-stat--purple { color: var(--nx-accent-2-soft); animation: numglow 4s ease-in-out infinite; }
 	.hb-stat--green  { color: #4ade80; }
-	.hb-stat--cyan   { color: #67e8f9; }
+	.hb-stat--cyan   { color: var(--nx-cyan-soft); }
 	.hb-stat-label {
 		font-size: .65rem; font-weight: 700;
 		text-transform: uppercase; letter-spacing: .16em;

--- a/nodyx-frontend/src/lib/components/homepage/widgets/JoinCard.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/JoinCard.svelte
@@ -61,7 +61,7 @@
 			<div class="flex -space-x-2">
 				{#each recentAvatars.slice(0, 5) as u}
 					<div class="w-7 h-7 rounded-full overflow-hidden shrink-0"
-					     style="background:rgba(124,58,237,.3); border:2px solid #0d0d12; outline:1px solid rgba(124,58,237,.25)">
+					     style="background:rgb(var(--nx-accent-2-rgb) / .3); border:2px solid #0d0d12; outline:1px solid rgb(var(--nx-accent-2-rgb) / .25)">
 						{#if u.avatar_url}
 							<img src={u.avatar_url} alt={u.username} class="w-full h-full object-cover" />
 						{:else}
@@ -88,7 +88,7 @@
 	<!-- CTA -->
 	<a href="/auth/register"
 	   class="w-full flex items-center justify-center gap-2 py-2.5 text-sm font-bold uppercase tracking-wider text-white transition-all"
-	   style="font-family:'Space Grotesk',sans-serif; background:linear-gradient(135deg,var(--nx-accent-2-strong),#0e7490); border:1px solid rgba(124,58,237,.4)">
+	   style="font-family:'Space Grotesk',sans-serif; background:linear-gradient(135deg,var(--nx-accent-2-strong),var(--nx-cyan-deep)); border:1px solid rgb(var(--nx-accent-2-rgb) / .4)">
 		{ctaText || tFn('common.join') || 'Rejoindre'}
 		<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
 			<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>

--- a/nodyx-frontend/src/lib/components/homepage/widgets/StatsBar.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/StatsBar.svelte
@@ -126,8 +126,8 @@
 
 <style>
 	@keyframes sglow {
-		0%,100% { text-shadow: 0 0 0 rgba(124,58,237,0); }
-		50%      { text-shadow: 0 0 20px rgba(124,58,237,.5); }
+		0%,100% { text-shadow: 0 0 0 rgb(var(--nx-accent-2-rgb) / 0); }
+		50%      { text-shadow: 0 0 20px rgb(var(--nx-accent-2-rgb) / .5); }
 	}
 	.sglow { animation: sglow 4s ease-in-out infinite; }
 

--- a/nodyx-frontend/src/lib/components/homepage/widgets/TwitchStream.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/TwitchStream.svelte
@@ -257,7 +257,7 @@
 				{#if !iframeLoaded}
 					<!-- Skeleton loader pulse -->
 					<div class="absolute inset-0 flex items-center justify-center"
-					     style="background:linear-gradient(135deg, rgba(124,58,237,.08), rgba(14,116,144,.08))">
+					     style="background:linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .08), rgba(14,116,144,.08))">
 						<div class="flex flex-col items-center gap-3">
 							<div class="w-8 h-8 rounded-full border-2 animate-spin"
 							     style="border-color:rgba(145,70,255,.2); border-top-color:{accent}"></div>
@@ -322,7 +322,7 @@
 			transparent 0deg,
 			var(--accent) 80deg,
 			transparent 160deg,
-			#0e7490 240deg,
+			var(--nx-cyan-deep) 240deg,
 			transparent 320deg,
 			transparent 360deg
 		);

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -524,7 +524,7 @@
 
 		<!-- Mobile: community name logo -->
 		<a href="/" class="lg:hidden shrink-0 font-black text-sm truncate max-w-[140px]"
-		   style="font-family: 'Space Grotesk', sans-serif; background: linear-gradient(135deg, var(--nx-accent-2-soft), #67e8f9); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; color: transparent">
+		   style="font-family: 'Space Grotesk', sans-serif; background: linear-gradient(135deg, var(--nx-accent-2-soft), var(--nx-cyan-soft)); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; color: transparent">
 			{communityName}
 		</a>
 
@@ -532,7 +532,7 @@
 		<div class="hidden lg:flex items-center gap-1.5 flex-1 min-w-0 overflow-hidden">
 			<!-- Logo toujours visible -->
 			<a href="/" class="shrink-0 font-black text-sm"
-			   style="font-family: 'Space Grotesk', sans-serif; background: linear-gradient(135deg, var(--nx-accent-2-soft), #67e8f9); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; color: transparent">
+			   style="font-family: 'Space Grotesk', sans-serif; background: linear-gradient(135deg, var(--nx-accent-2-soft), var(--nx-cyan-soft)); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; color: transparent">
 				{communityName}
 			</a>
 			<!-- Breadcrumb dynamique (masqué sur la homepage) -->
@@ -606,19 +606,19 @@
 				{#if user.role === 'owner' || user.role === 'admin'}
 					<a href="/admin"
 					   class="hidden sm:flex items-center px-2.5 h-7 text-[10px] font-black uppercase tracking-wider transition-colors"
-					   style="color: {isActive('/admin') ? 'var(--nx-accent-2-soft)' : '#4b5563'}; border: 1px solid {isActive('/admin') ? 'rgba(124,58,237,.4)' : 'rgba(255,255,255,.06)'}">{tFn('nav.admin')}</a>
+					   style="color: {isActive('/admin') ? 'var(--nx-accent-2-soft)' : '#4b5563'}; border: 1px solid {isActive('/admin') ? 'rgb(var(--nx-accent-2-rgb) / .4)' : 'rgba(255,255,255,.06)'}">{tFn('nav.admin')}</a>
 				{/if}
 				<!-- User dropdown -->
 				<div class="relative">
 					<button onclick={() => dropdownOpen = !dropdownOpen}
 					        class="flex items-center gap-2 px-2 h-8 transition-colors group ml-1"
-					        style="border: 1px solid {dropdownOpen ? 'rgba(124,58,237,.4)' : 'rgba(255,255,255,.07)'}; background: {dropdownOpen ? 'rgba(124,58,237,.08)' : 'rgba(255,255,255,.04)'}"
+					        style="border: 1px solid {dropdownOpen ? 'rgb(var(--nx-accent-2-rgb) / .4)' : 'rgba(255,255,255,.07)'}; background: {dropdownOpen ? 'rgb(var(--nx-accent-2-rgb) / .08)' : 'rgba(255,255,255,.04)'}"
 					        aria-haspopup="true" aria-expanded={dropdownOpen}>
 						<div class="relative shrink-0">
 							{#if user.avatar}
 								<img src={user.avatar} alt="Avatar" class="w-6 h-6 object-cover" style="outline: 1px solid rgba(255,255,255,.15)" />
 							{:else}
-								<div class="w-6 h-6 flex items-center justify-center text-xs font-bold text-white select-none" style="background: linear-gradient(135deg, var(--nx-accent-2-strong), #0e7490)">{user.username.charAt(0).toUpperCase()}</div>
+								<div class="w-6 h-6 flex items-center justify-center text-xs font-bold text-white select-none" style="background: linear-gradient(135deg, var(--nx-accent-2-strong), var(--nx-cyan-deep))">{user.username.charAt(0).toUpperCase()}</div>
 							{/if}
 							<span class="absolute -bottom-0.5 -right-0.5 w-2 h-2 rounded-full" style="background: #4ade80; border: 1.5px solid #0d0d12"></span>
 						</div>
@@ -854,10 +854,10 @@
 						].filter(i => i.show) as item}
 						<a href={item.href}
 						   class="relative flex items-center gap-2.5 px-2.5 py-2 text-sm transition-all"
-						   style="color: {isActive(item.href) ? '#e2e8f0' : '#6b7280'}; background: {isActive(item.href) ? 'rgba(124,58,237,.12)' : 'transparent'}">
+						   style="color: {isActive(item.href) ? '#e2e8f0' : '#6b7280'}; background: {isActive(item.href) ? 'rgb(var(--nx-accent-2-rgb) / .12)' : 'transparent'}">
 							{#if isActive(item.href)}
 								<span class="absolute left-0 top-1 bottom-1 w-0.5"
-								      style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), #06b6d4)"></span>
+								      style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), var(--nx-cyan))"></span>
 							{/if}
 							<svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" d={item.icon}/>
@@ -885,10 +885,10 @@
 						].filter(i => i.show) as item}
 						<a href={item.href}
 						   class="relative flex items-center gap-2.5 px-2.5 py-2 text-sm transition-all"
-						   style="color: {isActive(item.href) ? '#e2e8f0' : '#6b7280'}; background: {isActive(item.href) ? 'rgba(124,58,237,.12)' : 'transparent'}">
+						   style="color: {isActive(item.href) ? '#e2e8f0' : '#6b7280'}; background: {isActive(item.href) ? 'rgb(var(--nx-accent-2-rgb) / .12)' : 'transparent'}">
 							{#if isActive(item.href)}
 								<span class="absolute left-0 top-1 bottom-1 w-0.5"
-								      style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), #06b6d4)"></span>
+								      style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), var(--nx-cyan))"></span>
 							{/if}
 							<svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" d={item.icon}/>
@@ -928,7 +928,7 @@
 						          {chActive ? 'lch-active' : hasUnread ? 'lch-unread' : 'lch-idle'}
 						          {chFlash ? 'lch-flash' : ''}">
 							{#if chActive}
-								<span class="absolute left-0 top-1 bottom-1 w-0.5" style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), #06b6d4)"></span>
+								<span class="absolute left-0 top-1 bottom-1 w-0.5" style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), var(--nx-cyan))"></span>
 							{/if}
 							<span class="text-base leading-none shrink-0 inline-flex items-center justify-center">
 								<ChannelIcon
@@ -965,9 +965,9 @@
 							: (vcMembers[ch.id] ?? []).map((m: any) => ({ ...m, speaking: false, muted: false, deafened: false, isMe: false, userId: m.userId ?? null, socketId: null }))}
 						<a href="/chat?channel={ch.id}"
 						   class="relative flex items-center gap-2.5 px-2.5 py-2 text-sm transition-all"
-						   style="color: {chActive ? '#e2e8f0' : '#4b5563'}; background: {chActive ? 'rgba(124,58,237,.12)' : 'transparent'}">
+						   style="color: {chActive ? '#e2e8f0' : '#4b5563'}; background: {chActive ? 'rgb(var(--nx-accent-2-rgb) / .12)' : 'transparent'}">
 							{#if chActive}
-								<span class="absolute left-0 top-1 bottom-1 w-0.5" style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), #06b6d4)"></span>
+								<span class="absolute left-0 top-1 bottom-1 w-0.5" style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), var(--nx-cyan))"></span>
 							{/if}
 							{#if ch.icon_emoji}
 								<span class="lch-voice-ico inline-flex items-center justify-center">
@@ -1009,7 +1009,7 @@
 													<img src={m.avatar} alt={m.username} class="w-full h-full object-cover"/>
 												{:else}
 													<div class="w-full h-full flex items-center justify-center text-[9px] font-black text-white select-none"
-													     style="background:linear-gradient(135deg,var(--nx-accent-2-strong),#0e7490)">
+													     style="background:linear-gradient(135deg,var(--nx-accent-2-strong),var(--nx-cyan-deep))">
 														{m.username.charAt(0).toUpperCase()}
 													</div>
 												{/if}
@@ -1082,7 +1082,7 @@
 						<img src={user.avatar} alt="" class="w-8 h-8 object-cover" style="outline: 1px solid rgba(255,255,255,.1)" />
 					{:else}
 						<div class="w-8 h-8 flex items-center justify-center text-xs font-bold text-white select-none"
-						     style="background: linear-gradient(135deg, var(--nx-accent-2-strong), #0e7490)">
+						     style="background: linear-gradient(135deg, var(--nx-accent-2-strong), var(--nx-cyan-deep))">
 							{user.username.charAt(0).toUpperCase()}
 						</div>
 					{/if}
@@ -1189,16 +1189,16 @@
 								onmouseenter={isSharing && !isMe ? (e: MouseEvent) => showScreenPreview(e, member.userId, member.username, member.avatar, 'left') : undefined}
 								onmouseleave={() => { screenPreview = null }}
 								class="relative w-full flex items-center gap-2.5 px-2 py-2 transition-all group"
-								style="background: {isMe ? 'rgba(124,58,237,.06)' : 'transparent'}; text-align: left">
+								style="background: {isMe ? 'rgb(var(--nx-accent-2-rgb) / .06)' : 'transparent'}; text-align: left">
 								<!-- Hover bar -->
-								<span class="absolute left-0 top-0.5 bottom-0.5 w-0.5 opacity-0 group-hover:opacity-100 transition-opacity" style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), #06b6d4)"></span>
+								<span class="absolute left-0 top-0.5 bottom-0.5 w-0.5 opacity-0 group-hover:opacity-100 transition-opacity" style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), var(--nx-cyan))"></span>
 								<!-- Avatar -->
 								<div class="relative shrink-0">
 									{#if member.avatar}
 										<img src={member.avatar} alt="" class="w-7 h-7 object-cover" style="outline: 1px solid rgba(255,255,255,.08)" />
 									{:else}
 										<div class="w-7 h-7 flex items-center justify-center text-[11px] font-black text-white select-none"
-										     style="background: linear-gradient(135deg, {members[0]?.grade?.color ?? 'var(--nx-accent-2-strong)'}80, #0e7490)">{member.username.charAt(0).toUpperCase()}</div>
+										     style="background: linear-gradient(135deg, {members[0]?.grade?.color ?? 'var(--nx-accent-2-strong)'}80, var(--nx-cyan-deep))">{member.username.charAt(0).toUpperCase()}</div>
 									{/if}
 									<!-- Online dot — remplacé par icône activité si besoin -->
 									<span class="absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 flex items-center justify-center"
@@ -1220,7 +1220,7 @@
 										<span class="text-[11px] font-semibold leading-tight truncate transition-colors group-hover:brightness-125 {buildAnimClass(member)}"
 										      style={buildNameStyle(member, isMe ? 'var(--nx-accent-2-soft2)' : '#9ca3af')}>{member.username}</span>
 										{#if isMe}
-											<span class="shrink-0 text-[8px] font-black uppercase px-1 py-px leading-none" style="background: rgba(124,58,237,.25); color: var(--nx-accent-2-soft)">vous</span>
+											<span class="shrink-0 text-[8px] font-black uppercase px-1 py-px leading-none" style="background: rgb(var(--nx-accent-2-rgb) / .25); color: var(--nx-accent-2-soft)">vous</span>
 										{/if}
 									</div>
 									<!-- Activité temps réel -->
@@ -1273,14 +1273,14 @@
 								onmouseenter={isSharing && !isMe ? (e: MouseEvent) => showScreenPreview(e, member.userId, member.username, member.avatar, 'left') : undefined}
 								onmouseleave={() => { screenPreview = null }}
 								class="relative w-full flex items-center gap-2.5 px-2 py-2 transition-all group"
-								style="background: {isMe ? 'rgba(124,58,237,.06)' : 'transparent'}; text-align: left">
-								<span class="absolute left-0 top-0.5 bottom-0.5 w-0.5 opacity-0 group-hover:opacity-100 transition-opacity" style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), #06b6d4)"></span>
+								style="background: {isMe ? 'rgb(var(--nx-accent-2-rgb) / .06)' : 'transparent'}; text-align: left">
+								<span class="absolute left-0 top-0.5 bottom-0.5 w-0.5 opacity-0 group-hover:opacity-100 transition-opacity" style="background: linear-gradient(to bottom, var(--nx-accent-2-strong), var(--nx-cyan))"></span>
 								<div class="relative shrink-0">
 									{#if member.avatar}
 										<img src={member.avatar} alt="" class="w-7 h-7 object-cover" style="outline: 1px solid rgba(255,255,255,.08)" />
 									{:else}
 										<div class="w-7 h-7 flex items-center justify-center text-[11px] font-black text-white select-none"
-										     style="background: linear-gradient(135deg, #7c3aed80, #0e7490)">{member.username.charAt(0).toUpperCase()}</div>
+										     style="background: linear-gradient(135deg, #7c3aed80, var(--nx-cyan-deep))">{member.username.charAt(0).toUpperCase()}</div>
 									{/if}
 									<span class="absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 flex items-center justify-center" style="background: #0d0d12">
 										{#if isSharing}
@@ -1299,7 +1299,7 @@
 										<span class="text-[11px] font-semibold leading-tight truncate transition-colors group-hover:brightness-125 {buildAnimClass(member)}"
 										      style={buildNameStyle(member, isMe ? 'var(--nx-accent-2-soft2)' : '#9ca3af')}>{member.username}</span>
 										{#if isMe}
-											<span class="shrink-0 text-[8px] font-black uppercase px-1 py-px leading-none" style="background: rgba(124,58,237,.25); color: var(--nx-accent-2-soft)">vous</span>
+											<span class="shrink-0 text-[8px] font-black uppercase px-1 py-px leading-none" style="background: rgb(var(--nx-accent-2-rgb) / .25); color: var(--nx-accent-2-soft)">vous</span>
 										{/if}
 									</div>
 									{#if isSharing || isStreaming}
@@ -1395,7 +1395,7 @@
 					<!-- Avatars fantômes -->
 					<div class="guest-ghosts">
 						{#each ['M','J','A','K','S','T','R','L'] as letter, i}
-						<div class="guest-ghost" style="--gi:{i}; --gc:{['var(--nx-accent-soft)','var(--nx-accent-2-soft)','#34d399','#fb923c','#f472b6','#67e8f9','#facc15','#f87171'][i]}">
+						<div class="guest-ghost" style="--gi:{i}; --gc:{['var(--nx-accent-soft)','var(--nx-accent-2-soft)','#34d399','#fb923c','#f472b6','var(--nx-cyan-soft)','#facc15','#f87171'][i]}">
 							{letter}
 						</div>
 						{/each}
@@ -1612,7 +1612,7 @@
 					<img src={evt.avatar} alt={evt.username} class="w-6 h-6 rounded-full object-cover shrink-0" />
 				{:else}
 					<div class="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold text-white shrink-0"
-					     style="background: linear-gradient(135deg, var(--nx-accent-2-strong), #0e7490)">
+					     style="background: linear-gradient(135deg, var(--nx-accent-2-strong), var(--nx-cyan-deep))">
 						{evt.username.charAt(0).toUpperCase()}
 					</div>
 				{/if}
@@ -1881,25 +1881,25 @@
 
 .lch-active {
 	color: #e2e8f0;
-	background: rgba(124,58,237,.12);
+	background: rgb(var(--nx-accent-2-rgb) / .12);
 }
 
 .lch-unread {
 	color: #e2e8f0;
-	background: rgba(99,102,241,.07);
-	box-shadow: inset 2px 0 0 rgba(124,58,237,.65);
+	background: rgb(var(--nx-accent-rgb) / .07);
+	box-shadow: inset 2px 0 0 rgb(var(--nx-accent-2-rgb) / .65);
 	animation: lch-breathe 2.8s ease-in-out infinite;
 }
-.lch-unread:hover { background: rgba(99,102,241,.13); }
+.lch-unread:hover { background: rgb(var(--nx-accent-rgb) / .13); }
 
 @keyframes lch-breathe {
 	0%,100% {
-		box-shadow: inset 2px 0 0 rgba(124,58,237,.5);
-		background: rgba(99,102,241,.06);
+		box-shadow: inset 2px 0 0 rgb(var(--nx-accent-2-rgb) / .5);
+		background: rgb(var(--nx-accent-rgb) / .06);
 	}
 	50% {
-		box-shadow: inset 2px 0 0 rgba(167,139,250,.95), 0 0 12px rgba(99,102,241,.12);
-		background: rgba(99,102,241,.11);
+		box-shadow: inset 2px 0 0 rgba(167,139,250,.95), 0 0 12px rgb(var(--nx-accent-rgb) / .12);
+		background: rgb(var(--nx-accent-rgb) / .11);
 	}
 }
 
@@ -1910,9 +1910,9 @@
 	background: linear-gradient(
 		90deg,
 		transparent 0%,
-		rgba(99,102,241,.2) 35%,
+		rgb(var(--nx-accent-rgb) / .2) 35%,
 		rgba(167,139,250,.28) 50%,
-		rgba(99,102,241,.2) 65%,
+		rgb(var(--nx-accent-rgb) / .2) 65%,
 		transparent 100%
 	);
 	transform: translateX(-110%);

--- a/nodyx-frontend/src/routes/+page.svelte
+++ b/nodyx-frontend/src/routes/+page.svelte
@@ -94,7 +94,7 @@
 	.sg  { font-family: 'Space Grotesk', sans-serif; }
 	/* ── Gradient text ── */
 	.gt {
-		background: linear-gradient(135deg, var(--nx-accent-2-soft) 0%, #06b6d4 100%);
+		background: linear-gradient(135deg, var(--nx-accent-2-soft) 0%, var(--nx-cyan) 100%);
 		-webkit-background-clip: text; background-clip: text;
 		-webkit-text-fill-color: transparent; color: transparent;
 	}
@@ -104,7 +104,7 @@
 		font-weight: 800;
 		font-size: clamp(140px, 20vw, 280px);
 		line-height: 1;
-		background: linear-gradient(135deg, rgba(124,58,237,.5) 0%, rgba(6,182,212,.2) 50%, transparent 80%);
+		background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .5) 0%, rgb(var(--nx-cyan-rgb) / .2) 50%, transparent 80%);
 		-webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
 		pointer-events: none; user-select: none;
 	}
@@ -116,14 +116,14 @@
 		backdrop-filter: blur(8px);
 		transition: background .2s, border-color .2s;
 	}
-	.glass:hover { background: rgba(255,255,255,.06); border-color: rgba(124,58,237,.3); }
+	.glass:hover { background: rgba(255,255,255,.06); border-color: rgb(var(--nx-accent-2-rgb) / .3); }
 
 	/* ── Module tile ── */
 	.tile { position: relative; overflow: hidden; }
 	.tile::after {
 		content: '';
 		position: absolute; bottom: 0; left: 0; right: 0; height: 2px;
-		background: linear-gradient(90deg, var(--nx-accent-2-strong), #06b6d4);
+		background: linear-gradient(90deg, var(--nx-accent-2-strong), var(--nx-cyan));
 		transform: scaleX(0); transform-origin: left;
 		transition: transform .3s ease;
 	}
@@ -140,7 +140,7 @@
 	.trow { position: relative; }
 	.trow::before {
 		content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 2px;
-		background: linear-gradient(to bottom, var(--nx-accent-2-strong), #06b6d4);
+		background: linear-gradient(to bottom, var(--nx-accent-2-strong), var(--nx-cyan));
 		transform: scaleY(0); transform-origin: center;
 		transition: transform .2s ease;
 	}
@@ -148,8 +148,8 @@
 
 	/* ── Stat glow ── */
 	@keyframes sglow {
-		0%,100% { text-shadow: 0 0 0 rgba(124,58,237,0); }
-		50%      { text-shadow: 0 0 20px rgba(124,58,237,.5); }
+		0%,100% { text-shadow: 0 0 0 rgb(var(--nx-accent-2-rgb) / 0); }
+		50%      { text-shadow: 0 0 20px rgb(var(--nx-accent-2-rgb) / .5); }
 	}
 	.sglow { animation: sglow 4s ease-in-out infinite; }
 
@@ -177,8 +177,8 @@
 	.dotbg {
 		background-color: #05050a;
 		background-image:
-			radial-gradient(circle at 15% 40%, rgba(124,58,237,.1) 0%, transparent 45%),
-			radial-gradient(circle at 85% 15%, rgba(6,182,212,.07) 0%, transparent 35%),
+			radial-gradient(circle at 15% 40%, rgb(var(--nx-accent-2-rgb) / .1) 0%, transparent 45%),
+			radial-gradient(circle at 85% 15%, rgb(var(--nx-cyan-rgb) / .07) 0%, transparent 35%),
 			radial-gradient(rgba(255,255,255,.035) 1px, transparent 1px);
 		background-size: 100%, 100%, 28px 28px;
 	}
@@ -190,7 +190,7 @@
 	}
 	.card-hover::after {
 		content: ''; position: absolute; bottom: 0; left: 0; right: 0; height: 1px;
-		background: linear-gradient(90deg, transparent, rgba(124,58,237,.5), transparent);
+		background: linear-gradient(90deg, transparent, rgb(var(--nx-accent-2-rgb) / .5), transparent);
 		opacity: 0; transition: opacity .3s;
 	}
 	.card-hover:hover::after { opacity: 1; }
@@ -237,9 +237,9 @@
 
 	<!-- Orbs -->
 	<div class="absolute -top-40 -left-20 w-[500px] h-[500px] rounded-full pointer-events-none"
-	     style="background: radial-gradient(circle, rgba(124,58,237,.14) 0%, transparent 65%)"></div>
+	     style="background: radial-gradient(circle, rgb(var(--nx-accent-2-rgb) / .14) 0%, transparent 65%)"></div>
 	<div class="absolute -bottom-20 right-0 w-96 h-96 rounded-full pointer-events-none"
-	     style="background: radial-gradient(circle, rgba(6,182,212,.08) 0%, transparent 65%)"></div>
+	     style="background: radial-gradient(circle, rgb(var(--nx-cyan-rgb) / .08) 0%, transparent 65%)"></div>
 
 	<!-- Decorative letter -->
 	<div class="deco-letter absolute right-6 top-1/2 -translate-y-1/2 opacity-70 select-none pointer-events-none" aria-hidden="true">{heroLetter}</div>
@@ -250,10 +250,10 @@
 		<div class="flex items-center gap-5">
 			{#if instance.logo_url}
 				<img src={instance.logo_url} alt={instance.name}
-				     class="w-12 h-12 object-cover shrink-0" style="outline: 2px solid rgba(124,58,237,.5); outline-offset: 2px" />
+				     class="w-12 h-12 object-cover shrink-0" style="outline: 2px solid rgb(var(--nx-accent-2-rgb) / .5); outline-offset: 2px" />
 			{:else}
 				<div class="w-12 h-12 flex items-center justify-center shrink-0 sg text-xl font-black text-white"
-				     style="background: linear-gradient(135deg, rgba(124,58,237,.4), rgba(6,182,212,.15)); border: 1px solid rgba(124,58,237,.3)">
+				     style="background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .4), rgb(var(--nx-cyan-rgb) / .15)); border: 1px solid rgb(var(--nx-accent-2-rgb) / .3)">
 					{heroLetter}
 				</div>
 			{/if}
@@ -272,7 +272,7 @@
 			{#each [
 				{ value: instance.member_count.toLocaleString(), label: tFn('common.members'),  color: 'var(--nx-accent-2-soft)', glow: true },
 				{ value: String(instance.online_count),                  label: tFn('common.online'), color: '#4ade80', online: true },
-				{ value: instance.thread_count.toLocaleString(), label: tFn('common.topics'),   color: '#67e8f9', glow: false },
+				{ value: instance.thread_count.toLocaleString(), label: tFn('common.topics'),   color: 'var(--nx-cyan-soft)', glow: false },
 				{ value: instance.post_count.toLocaleString(),   label: tFn('nav.dm'), color: '#94a3b8', glow: false },
 			] as stat}
 				<div class="flex flex-col items-center justify-center px-6 py-2 gap-0.5"
@@ -296,7 +296,7 @@
 				{#if data.user && (data.categories?.[0]?.slug ?? data.categories?.[0]?.id)}
 					<a href="/forum/{data.categories?.[0]?.slug ?? data.categories?.[0]?.id}/new"
 					   class="sg px-5 py-2.5 text-sm font-bold uppercase tracking-wider text-white transition-all"
-					   style="background: linear-gradient(135deg, var(--nx-accent-2-strong) 0%, #0e7490 100%); border: 1px solid rgba(124,58,237,.4)">
+					   style="background: linear-gradient(135deg, var(--nx-accent-2-strong) 0%, var(--nx-cyan-deep) 100%); border: 1px solid rgb(var(--nx-accent-2-rgb) / .4)">
 						{tFn('common.new_topic')}
 					</a>
 				{:else}
@@ -307,7 +307,7 @@
 					</a>
 					<a href="/auth/register"
 					   class="sg px-5 py-2.5 text-sm font-bold uppercase tracking-wider text-white transition-all"
-					   style="background: linear-gradient(135deg, var(--nx-accent-2-strong) 0%, #0e7490 100%); border: 1px solid rgba(124,58,237,.4)">
+					   style="background: linear-gradient(135deg, var(--nx-accent-2-strong) 0%, var(--nx-cyan-deep) 100%); border: 1px solid rgb(var(--nx-accent-2-rgb) / .4)">
 						{tFn('common.join')}
 					</a>
 				{/if}
@@ -366,14 +366,14 @@
 			<svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="#67e8f9" stroke-width="2" viewBox="0 0 24 24">
 				<path stroke-linecap="round" stroke-linejoin="round" d="M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a2 2 0 01-2-2v-6a2 2 0 012-2h8z"/>
 			</svg>
-			<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: #67e8f9">{tFn('home.forum')}</span>
+			<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: var(--nx-cyan-soft)">{tFn('home.forum')}</span>
 		</div>
 		<p class="sg text-sm font-bold leading-snug line-clamp-2 group-hover:text-cyan-200 transition-colors" style="color: #e2e8f0">{recentThreads[0].title}</p>
 		<span class="text-[10px] mt-auto" style="color: #4b5563">{recentThreads[0].category_name}</span>
 	</a>
 	{:else}
 	<a href="/forum" class="tile glass flex flex-col gap-2.5 p-5">
-		<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: #67e8f9">{tFn('home.forum')}</span>
+		<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: var(--nx-cyan-soft)">{tFn('home.forum')}</span>
 		{tFn('home.view_discussions')}
 	</a>
 	{/if}
@@ -425,13 +425,13 @@
 
 			<!-- Violet glow bottom-left -->
 			<div class="absolute bottom-0 left-0 w-72 h-48 pointer-events-none"
-			     style="background: radial-gradient(ellipse at bottom left, rgba(124,58,237,.2), transparent 70%)"></div>
+			     style="background: radial-gradient(ellipse at bottom left, rgb(var(--nx-accent-2-rgb) / .2), transparent 70%)"></div>
 
 			<div class="relative z-10 h-full flex flex-col justify-end p-8 pb-10">
 				<!-- Category -->
 				{#if slide.categoryName}
 					<div class="flex items-center gap-3 mb-3">
-						<span class="h-px w-10" style="background: linear-gradient(to right, var(--nx-accent-2-strong), #06b6d4)"></span>
+						<span class="h-px w-10" style="background: linear-gradient(to right, var(--nx-accent-2-strong), var(--nx-cyan))"></span>
 						<span class="sg text-[10px] font-black uppercase tracking-[.22em]" style="color: var(--nx-accent-2-soft)">{slide.categoryName}</span>
 					</div>
 				{/if}
@@ -449,7 +449,7 @@
 				<!-- Meta + CTA -->
 				<div class="flex items-center gap-5">
 					<div class="flex items-center gap-2.5">
-						<div class="w-7 h-7 overflow-hidden shrink-0" style="background: rgba(124,58,237,.3); outline: 1.5px solid rgba(124,58,237,.4); outline-offset: 1px">
+						<div class="w-7 h-7 overflow-hidden shrink-0" style="background: rgb(var(--nx-accent-2-rgb) / .3); outline: 1.5px solid rgb(var(--nx-accent-2-rgb) / .4); outline-offset: 1px">
 							{#if slide.authorAvatar}
 								<img src={slide.authorAvatar} alt="" class="w-full h-full object-cover" />
 							{:else}
@@ -464,7 +464,7 @@
 					</div>
 					<a href="/forum/{slide.categoryId}/{slide.id}"
 					   class="sg ml-auto group flex items-center gap-2 px-5 py-2.5 text-sm font-bold uppercase tracking-wider text-white transition-all"
-					   style="background: linear-gradient(135deg, rgba(124,58,237,.55), rgba(6,182,212,.25)); border: 1px solid rgba(124,58,237,.45)">
+					   style="background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .55), rgb(var(--nx-cyan-rgb) / .25)); border: 1px solid rgb(var(--nx-accent-2-rgb) / .45)">
 						{tFn('common.read_article')}
 						<svg class="w-3.5 h-3.5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
@@ -482,7 +482,7 @@
 							        aria-label="Slide {i+1}">
 								{#if i === slideIndex}
 									<span class="absolute top-[-1px] left-0 h-[3px] transition-none"
-									      style="width:{progressPct}%; background: linear-gradient(to right, var(--nx-accent-2-strong), #06b6d4)"></span>
+									      style="width:{progressPct}%; background: linear-gradient(to right, var(--nx-accent-2-strong), var(--nx-cyan))"></span>
 								{/if}
 							</button>
 						{/each}
@@ -491,7 +491,7 @@
 							        class="w-8 h-8 flex items-center justify-center transition-all"
 							        style="border: 1px solid rgba(255,255,255,.08); color: #6b7280"
 							        aria-label={tFn('common.back')}
-							        onmouseenter={e => (e.currentTarget as HTMLElement).style.borderColor='rgba(124,58,237,.5)'}
+							        onmouseenter={e => (e.currentTarget as HTMLElement).style.borderColor='rgb(var(--nx-accent-2-rgb) / .5)'}
 							        onmouseleave={e => (e.currentTarget as HTMLElement).style.borderColor='rgba(255,255,255,.08)'}>
 								<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/></svg>
 							</button>
@@ -499,7 +499,7 @@
 							        class="w-8 h-8 flex items-center justify-center transition-all"
 							        style="border: 1px solid rgba(255,255,255,.08); color: #6b7280"
 							        aria-label="Suivant"
-							        onmouseenter={e => (e.currentTarget as HTMLElement).style.borderColor='rgba(124,58,237,.5)'}
+							        onmouseenter={e => (e.currentTarget as HTMLElement).style.borderColor='rgb(var(--nx-accent-2-rgb) / .5)'}
 							        onmouseleave={e => (e.currentTarget as HTMLElement).style.borderColor='rgba(255,255,255,.08)'}>
 								<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
 							</button>
@@ -530,7 +530,7 @@
 			   onmouseenter={e => (e.currentTarget as HTMLElement).style.background='rgba(255,255,255,.025)'}
 			   onmouseleave={e => (e.currentTarget as HTMLElement).style.background='transparent'}>
 				<span class="sg text-[11px] font-black tabular-nums shrink-0 mt-0.5 w-5 text-right"
-				      style="color: {i===0 ? 'var(--nx-accent-2-soft)' : i===1 ? '#67e8f9' : '#374151'}">
+				      style="color: {i===0 ? 'var(--nx-accent-2-soft)' : i===1 ? 'var(--nx-cyan-soft)' : '#374151'}">
 					{String(i+1).padStart(2,'0')}
 				</span>
 				<div class="flex-1 min-w-0">
@@ -538,7 +538,7 @@
 						{thread.title}
 					</p>
 					<div class="flex items-center gap-2 mt-1.5">
-						<div class="w-4 h-4 overflow-hidden shrink-0" style="background: rgba(124,58,237,.35)">
+						<div class="w-4 h-4 overflow-hidden shrink-0" style="background: rgb(var(--nx-accent-2-rgb) / .35)">
 							{#if thread.author_avatar}
 								<img src={thread.author_avatar} alt="" class="w-full h-full object-cover" />
 							{:else}
@@ -562,7 +562,7 @@
 			<a href="/forum"
 			   class="sg flex items-center justify-center gap-2 w-full py-2.5 text-[10px] font-black uppercase tracking-widest transition-all"
 			   style="color: #6b7280; border: 1px solid rgba(255,255,255,.06)"
-			   onmouseenter={e => { (e.currentTarget as HTMLElement).style.color='var(--nx-accent-2-soft)'; (e.currentTarget as HTMLElement).style.borderColor='rgba(124,58,237,.25)'; }}
+			   onmouseenter={e => { (e.currentTarget as HTMLElement).style.color='var(--nx-accent-2-soft)'; (e.currentTarget as HTMLElement).style.borderColor='rgb(var(--nx-accent-2-rgb) / .25)'; }}
 			   onmouseleave={e => { (e.currentTarget as HTMLElement).style.color='#6b7280'; (e.currentTarget as HTMLElement).style.borderColor='rgba(255,255,255,.06)'; }}>
 				{tFn('home.view_forum')}
 				<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
@@ -588,10 +588,10 @@
 <section class="px-6 py-8" style="border-bottom: 1px solid rgba(255,255,255,.05); background: #08080d">
 
 	<div class="flex items-center gap-4 mb-6">
-		<span class="sg text-[10px] font-black uppercase tracking-[.22em]" style="color: #67e8f9">{tFn('home.latest_topics')}</span>
-		<div class="flex-1 h-px" style="background: linear-gradient(to right, rgba(6,182,212,.2), transparent)"></div>
+		<span class="sg text-[10px] font-black uppercase tracking-[.22em]" style="color: var(--nx-cyan-soft)">{tFn('home.latest_topics')}</span>
+		<div class="flex-1 h-px" style="background: linear-gradient(to right, rgb(var(--nx-cyan-rgb) / .2), transparent)"></div>
 		<a href="/forum" class="sg text-[10px] font-bold uppercase tracking-widest transition-colors" style="color: #4b5563"
-		   onmouseenter={e => (e.target as HTMLElement).style.color='#67e8f9'} onmouseleave={e => (e.target as HTMLElement).style.color='#4b5563'}>
+		   onmouseenter={e => (e.target as HTMLElement).style.color='var(--nx-cyan-soft)'} onmouseleave={e => (e.target as HTMLElement).style.color='#4b5563'}>
 			{tFn('common.see_all')}
 		</a>
 	</div>
@@ -601,13 +601,13 @@
 		<a href="/forum/{thread.category_id}/{thread.id}"
 		   class="card-hover group flex flex-col p-5 transition-all duration-250"
 		   style="background: #12121a; border: 1px solid rgba(255,255,255,.06)"
-		   onmouseenter={e => (e.currentTarget as HTMLElement).style.borderColor='rgba(124,58,237,.25)'}
+		   onmouseenter={e => (e.currentTarget as HTMLElement).style.borderColor='rgb(var(--nx-accent-2-rgb) / .25)'}
 		   onmouseleave={e => (e.currentTarget as HTMLElement).style.borderColor='rgba(255,255,255,.06)'}>
 
 			<div class="flex items-start justify-between gap-2 mb-4">
 				{#if thread.category_name}
 					<span class="sg text-[9px] font-black uppercase tracking-widest px-2 py-0.5"
-					      style="color: var(--nx-accent-2-soft); background: rgba(124,58,237,.1); border: 1px solid rgba(124,58,237,.2)">
+					      style="color: var(--nx-accent-2-soft); background: rgb(var(--nx-accent-2-rgb) / .1); border: 1px solid rgb(var(--nx-accent-2-rgb) / .2)">
 						{thread.category_name}
 					</span>
 				{/if}
@@ -624,7 +624,7 @@
 			</h4>
 
 			<div class="flex items-center gap-2 pt-4" style="border-top: 1px solid rgba(255,255,255,.05)">
-				<div class="w-6 h-6 overflow-hidden shrink-0" style="background: rgba(124,58,237,.3); outline: 1px solid rgba(255,255,255,.07)">
+				<div class="w-6 h-6 overflow-hidden shrink-0" style="background: rgb(var(--nx-accent-2-rgb) / .3); outline: 1px solid rgba(255,255,255,.07)">
 					{#if thread.author_avatar}
 						<img src={thread.author_avatar} alt="" class="w-full h-full object-cover" />
 					{:else}
@@ -648,7 +648,7 @@
 
 	<div class="flex items-center gap-4 mb-6">
 		<span class="sg text-[10px] font-black uppercase tracking-[.22em]" style="color: var(--nx-accent-2-soft)">{tFn('home.articles')}</span>
-		<div class="flex-1 h-px" style="background: linear-gradient(to right, rgba(124,58,237,.2), transparent)"></div>
+		<div class="flex-1 h-px" style="background: linear-gradient(to right, rgb(var(--nx-accent-2-rgb) / .2), transparent)"></div>
 	</div>
 
 	<!-- Hero article -->
@@ -656,7 +656,7 @@
 	<a href="/forum/{heroArticle.categoryId}/{heroArticle.id}"
 	   class="card-hover group flex flex-col sm:flex-row overflow-hidden mb-3 transition-all duration-250"
 	   style="background: #12121a; border: 1px solid rgba(255,255,255,.06)"
-	   onmouseenter={e => (e.currentTarget as HTMLElement).style.borderColor='rgba(124,58,237,.25)'}
+	   onmouseenter={e => (e.currentTarget as HTMLElement).style.borderColor='rgb(var(--nx-accent-2-rgb) / .25)'}
 	   onmouseleave={e => (e.currentTarget as HTMLElement).style.borderColor='rgba(255,255,255,.06)'}>
 		<div class="sm:w-64 h-44 sm:h-auto shrink-0 overflow-hidden relative">
 			{#if heroArticle.imageUrl}
@@ -702,13 +702,13 @@
 		<a href="/forum/{article.categoryId}/{article.id}"
 		   class="card-hover group flex gap-4 p-4 transition-all duration-250"
 		   style="background: #12121a; border: 1px solid rgba(255,255,255,.06)"
-		   onmouseenter={e => (e.currentTarget as HTMLElement).style.borderColor='rgba(124,58,237,.2)'}
+		   onmouseenter={e => (e.currentTarget as HTMLElement).style.borderColor='rgb(var(--nx-accent-2-rgb) / .2)'}
 		   onmouseleave={e => (e.currentTarget as HTMLElement).style.borderColor='rgba(255,255,255,.06)'}>
 			{#if article.imageUrl}
 				<img src={article.imageUrl} alt="" class="w-20 h-14 object-cover shrink-0 group-hover:opacity-90 transition-opacity" style="opacity:.7" />
 			{:else}
-				<div class="w-20 h-14 shrink-0 flex items-center justify-center" style="background: rgba(124,58,237,.08); border: 1px solid rgba(255,255,255,.05)">
-					<span class="sg text-xl font-black" style="color: rgba(124,58,237,.35)">{heroLetter}</span>
+				<div class="w-20 h-14 shrink-0 flex items-center justify-center" style="background: rgb(var(--nx-accent-2-rgb) / .08); border: 1px solid rgba(255,255,255,.05)">
+					<span class="sg text-xl font-black" style="color: rgb(var(--nx-accent-2-rgb) / .35)">{heroLetter}</span>
 				</div>
 			{/if}
 			<div class="flex-1 min-w-0 flex flex-col justify-between">
@@ -736,14 +736,14 @@
 		<div class="flex items-end justify-between mb-6">
 			<div>
 				<div class="flex items-center gap-2 mb-1">
-					<span class="text-[10px] font-bold tracking-widest uppercase" style="color: #06b6d4">Agenda</span>
+					<span class="text-[10px] font-bold tracking-widest uppercase" style="color: var(--nx-cyan)">Agenda</span>
 				</div>
 				<h2 class="text-xl font-bold text-white">Prochains événements</h2>
 			</div>
 			<a href="/calendar" class="flex items-center gap-1.5 text-xs font-medium transition-colors"
-				style="color: #06b6d4"
-				onmouseenter={e => (e.currentTarget as HTMLElement).style.color='#67e8f9'}
-				onmouseleave={e => (e.currentTarget as HTMLElement).style.color='#06b6d4'}>
+				style="color: var(--nx-cyan)"
+				onmouseenter={e => (e.currentTarget as HTMLElement).style.color='var(--nx-cyan-soft)'}
+				onmouseleave={e => (e.currentTarget as HTMLElement).style.color='var(--nx-cyan)'}>
 				Voir tout
 				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
@@ -760,7 +760,7 @@
 				{@const time = ev.is_all_day ? (instance.language === 'fr' ? 'Journée entière' : 'All day') : d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
 				<a href="/calendar" class="group relative flex flex-col rounded-2xl overflow-hidden transition-all duration-200"
 					style="background: rgba(255,255,255,.04); border: 1px solid rgba(255,255,255,.07);"
-					onmouseenter={e => { (e.currentTarget as HTMLElement).style.borderColor = 'rgba(6,182,212,.35)'; (e.currentTarget as HTMLElement).style.background = 'rgba(6,182,212,.06)' }}
+					onmouseenter={e => { (e.currentTarget as HTMLElement).style.borderColor = 'rgb(var(--nx-cyan-rgb) / .35)'; (e.currentTarget as HTMLElement).style.background = 'rgb(var(--nx-cyan-rgb) / .06)' }}
 					onmouseleave={e => { (e.currentTarget as HTMLElement).style.borderColor = 'rgba(255,255,255,.07)'; (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,.04)' }}>
 
 					<!-- Cover or date block -->
@@ -770,7 +770,7 @@
 							<div class="absolute inset-0" style="background: linear-gradient(to top, rgba(0,0,0,.6) 0%, transparent 60%)"></div>
 							<!-- Date badge -->
 							<div class="absolute top-2.5 left-2.5 flex flex-col items-center justify-center w-11 h-11 rounded-xl text-white font-bold"
-								style="background: rgba(6,182,212,.85); backdrop-filter: blur(4px)">
+								style="background: rgb(var(--nx-cyan-rgb) / .85); backdrop-filter: blur(4px)">
 								<span class="text-base leading-none">{day}</span>
 								<span class="text-[9px] uppercase tracking-wider opacity-90">{mon}</span>
 							</div>
@@ -779,11 +779,11 @@
 						<!-- Date block (no cover) -->
 						<div class="flex items-center gap-3 px-4 pt-4 pb-2">
 							<div class="flex flex-col items-center justify-center w-11 h-11 rounded-xl shrink-0 font-bold text-white"
-								style="background: linear-gradient(135deg, #0891b2, #06b6d4)">
+								style="background: linear-gradient(135deg, #0891b2, var(--nx-cyan))">
 								<span class="text-base leading-none">{day}</span>
 								<span class="text-[9px] uppercase tracking-wider opacity-90">{mon}</span>
 							</div>
-							<div class="h-px flex-1" style="background: rgba(6,182,212,.2)"></div>
+							<div class="h-px flex-1" style="background: rgb(var(--nx-cyan-rgb) / .2)"></div>
 						</div>
 					{/if}
 
@@ -800,10 +800,10 @@
 							</div>
 						{/if}
 						<div class="flex items-center justify-between mt-auto pt-1.5">
-							<span class="text-[10px] font-medium" style="color: #06b6d4">{time}</span>
+							<span class="text-[10px] font-medium" style="color: var(--nx-cyan)">{time}</span>
 							{#if ev.rsvp_enabled}
 								<span class="text-[10px] px-1.5 py-0.5 rounded-full font-medium"
-									style="background: rgba(6,182,212,.15); color: #67e8f9; border: 1px solid rgba(6,182,212,.25)">
+									style="background: rgb(var(--nx-cyan-rgb) / .15); color: var(--nx-cyan-soft); border: 1px solid rgb(var(--nx-cyan-rgb) / .25)">
 									RSVP
 								</span>
 							{/if}

--- a/nodyx-frontend/src/routes/admin/backups/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/backups/+page.svelte
@@ -316,7 +316,7 @@
 	<!-- Header -->
 	<div class="flex items-center justify-between mb-6">
 		<div>
-			<h1 class="text-2xl font-black" style="font-family:'Space Grotesk',sans-serif; background:linear-gradient(135deg,var(--nx-accent-2-soft),#06b6d4); -webkit-background-clip:text; -webkit-text-fill-color:transparent; background-clip:text">
+			<h1 class="text-2xl font-black" style="font-family:'Space Grotesk',sans-serif; background:linear-gradient(135deg,var(--nx-accent-2-soft),var(--nx-cyan)); -webkit-background-clip:text; -webkit-text-fill-color:transparent; background-clip:text">
 				Sauvegardes & Restauration
 			</h1>
 			<p class="text-sm mt-1" style="color:#6b7280">
@@ -355,7 +355,7 @@
 		<button
 			onclick={() => createOpen = true}
 			class="flex items-center gap-2 px-4 py-2 text-sm font-bold transition-all"
-			style="background:linear-gradient(135deg,rgba(124,58,237,.25),rgba(6,182,212,.15)); border:1px solid rgba(124,58,237,.4); color:var(--nx-accent-2-soft)">
+			style="background:linear-gradient(135deg,rgb(var(--nx-accent-2-rgb) / .25),rgb(var(--nx-cyan-rgb) / .15)); border:1px solid rgb(var(--nx-accent-2-rgb) / .4); color:var(--nx-accent-2-soft)">
 			<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
 				<path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m-8-8h16"/>
 			</svg>
@@ -388,7 +388,7 @@
 							<div class="flex items-center gap-2 flex-wrap">
 								<span class="text-sm font-mono truncate" style="color:#e2e8f0">{b.filename}</span>
 								<span class="text-[9px] font-bold uppercase px-1.5 py-0.5"
-								      style="background:rgba({sourceColor(b.source) === 'var(--nx-accent-2-soft)' ? '167,139,250' : sourceColor(b.source) === '#06b6d4' ? '6,182,212' : '251,146,60'},.1); border:1px solid rgba({sourceColor(b.source) === 'var(--nx-accent-2-soft)' ? '167,139,250' : sourceColor(b.source) === '#06b6d4' ? '6,182,212' : '251,146,60'},.25); color:{sourceColor(b.source)}">
+								      style="background:rgba({sourceColor(b.source) === 'var(--nx-accent-2-soft)' ? '167,139,250' : sourceColor(b.source) === 'var(--nx-cyan)' ? '6,182,212' : '251,146,60'},.1); border:1px solid rgba({sourceColor(b.source) === 'var(--nx-accent-2-soft)' ? '167,139,250' : sourceColor(b.source) === 'var(--nx-cyan)' ? '6,182,212' : '251,146,60'},.25); color:{sourceColor(b.source)}">
 									{sourceLabel(b.source)}
 								</span>
 								{#if verify}
@@ -496,7 +496,7 @@
 				</button>
 				<button onclick={handleCreate} disabled={creating}
 				        class="px-4 py-1.5 text-xs font-bold disabled:opacity-50"
-				        style="background:linear-gradient(135deg,rgba(124,58,237,.25),rgba(6,182,212,.15)); border:1px solid rgba(124,58,237,.4); color:var(--nx-accent-2-soft)">
+				        style="background:linear-gradient(135deg,rgb(var(--nx-accent-2-rgb) / .25),rgb(var(--nx-cyan-rgb) / .15)); border:1px solid rgb(var(--nx-accent-2-rgb) / .4); color:var(--nx-accent-2-soft)">
 					{creating ? 'Création...' : 'Créer'}
 				</button>
 			</div>

--- a/nodyx-frontend/src/routes/admin/homepage/builder/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/homepage/builder/+page.svelte
@@ -1567,9 +1567,9 @@
 	.col-mgr-del:hover { color: #f87171; }
 	.btn-add-col {
 		padding: 4px 8px;
-		background: rgba(6,182,212,.1);
-		border: 1px dashed rgba(6,182,212,.3);
-		color: #06b6d4;
+		background: rgb(var(--nx-cyan-rgb) / .1);
+		border: 1px dashed rgb(var(--nx-cyan-rgb) / .3);
+		color: var(--nx-cyan);
 		cursor: pointer;
 		border-radius: 3px;
 		font-size: 11px;
@@ -1774,11 +1774,11 @@
 	.btn-tool--save { color: #e2e8f0; border-color: rgba(167,139,250,.3); }
 	.btn-tool--save:hover:not(:disabled) { background: rgba(167,139,250,.15); border-color: var(--nx-accent-2-soft); color: var(--nx-accent-2-soft); }
 	.btn-tool--publish {
-		background: linear-gradient(135deg, rgba(124,58,237,.3), rgba(167,139,250,.2));
+		background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .3), rgba(167,139,250,.2));
 		border-color: rgba(167,139,250,.4);
 		color: var(--nx-accent-2-soft);
 	}
-	.btn-tool--publish:hover:not(:disabled) { background: linear-gradient(135deg, rgba(124,58,237,.5), rgba(167,139,250,.35)); }
+	.btn-tool--publish:hover:not(:disabled) { background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .5), rgba(167,139,250,.35)); }
 
 	.draft-banner {
 		padding: 8px 16px;

--- a/nodyx-frontend/src/routes/admin/octoguard/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/octoguard/+page.svelte
@@ -158,7 +158,7 @@
 		color: inherit;
 		transition: background .1s linear, border-color .1s linear;
 	}
-	.og-stat-card:hover { background: rgba(255, 255, 255, 0.03); border-color: rgba(99, 102, 241, 0.3); }
+	.og-stat-card:hover { background: rgba(255, 255, 255, 0.03); border-color: rgb(var(--nx-accent-rgb) / 0.3); }
 	.og-stat-card--warn { border-left: 3px solid #fb923c; }
 	.og-stat-num {
 		font-size: 28px;

--- a/nodyx-frontend/src/routes/admin/octoguard/automod/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/octoguard/automod/+page.svelte
@@ -308,7 +308,7 @@
 		color: #94a3b8;
 		font-family: ui-monospace, monospace;
 	}
-	.og-rule-badge--action { background: rgba(99, 102, 241, 0.15); color: #a5b4fc; }
+	.og-rule-badge--action { background: rgb(var(--nx-accent-rgb) / 0.15); color: #a5b4fc; }
 	.og-rule-badge--dry { background: rgba(251, 146, 60, 0.15); color: #fb923c; }
 	.og-rule-actions {
 		margin-left: auto;

--- a/nodyx-frontend/src/routes/admin/octoguard/reports/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/octoguard/reports/+page.svelte
@@ -57,7 +57,7 @@
 	.og-filters { display: flex; gap: 4px; margin-bottom: 16px; }
 	.og-filter { padding: 4px 10px; font-size: 11px; color: #94a3b8; text-decoration: none; border-radius: 2px; background: rgba(255,255,255,0.02); font-family: ui-monospace, monospace; }
 	.og-filter:hover { background: rgba(255,255,255,0.05); color: #e2e8f0; }
-	.og-filter.active { background: rgba(99,102,241,0.15); color: #a5b4fc; }
+	.og-filter.active { background: rgb(var(--nx-accent-rgb) / 0.15); color: #a5b4fc; }
 	.og-err { padding: 10px 14px; background: rgba(239,68,68,0.1); border: 1px solid rgba(239,68,68,0.3); color: #fca5a5; border-radius: 4px; font-size: 13px; margin-bottom: 12px; }
 	.og-reports { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 8px; }
 	.og-report { padding: 12px; border: 1px solid rgba(255,255,255,0.06); border-radius: 4px; background: rgba(255,255,255,0.01); }
@@ -72,7 +72,7 @@
 	.og-report-actions input { flex: 1; min-width: 200px; padding: 6px 8px; font-size: 12px; background: #1f2937; border: 1px solid #374151; border-radius: 3px; color: #e2e8f0; }
 	.og-btn-link { padding: 4px 10px; font-size: 11px; background: transparent; border: 1px solid #374151; color: #94a3b8; border-radius: 3px; cursor: pointer; }
 	.og-btn-link:hover { color: #e2e8f0; }
-	.og-btn-link--accent { border-color: rgba(99,102,241,0.3); color: #a5b4fc; }
+	.og-btn-link--accent { border-color: rgb(var(--nx-accent-rgb) / 0.3); color: #a5b4fc; }
 	.og-btn-link--danger:hover { color: #fca5a5; border-color: rgba(239,68,68,0.3); }
 	.og-report-status { font-size: 11px; color: #64748b; font-family: ui-monospace, monospace; }
 	.og-empty { padding: 24px; text-align: center; color: #64748b; font-size: 13px; border: 1px dashed rgba(255,255,255,0.08); border-radius: 4px; }

--- a/nodyx-frontend/src/routes/admin/octoguard/webhook/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/octoguard/webhook/+page.svelte
@@ -55,7 +55,7 @@
 	label { display: flex; flex-direction: column; gap: 4px; font-size: 11px; color: #94a3b8; }
 	input { padding: 6px 8px; font-size: 12px; background: #1f2937; border: 1px solid #374151; border-radius: 3px; color: #e2e8f0; font-family: ui-monospace, monospace; }
 	.og-checkbox { flex-direction: row; align-items: center; color: #cbd5e1; font-size: 12px; }
-	.og-info { font-size: 11px; color: #c7d2fe; background: rgba(99,102,241,0.05); border: 1px solid rgba(99,102,241,0.2); padding: 10px 12px; border-radius: 3px; line-height: 1.6; }
+	.og-info { font-size: 11px; color: #c7d2fe; background: rgb(var(--nx-accent-rgb) / 0.05); border: 1px solid rgb(var(--nx-accent-rgb) / 0.2); padding: 10px 12px; border-radius: 3px; line-height: 1.6; }
 	.og-info code { background: rgba(255,255,255,0.05); padding: 1px 4px; border-radius: 2px; font-size: 10px; font-family: ui-monospace, monospace; }
 	.og-actions { display: flex; justify-content: flex-end; }
 	.og-btn-primary { padding: 6px 12px; font-size: 12px; color: #fff; background: var(--nx-accent); border: none; border-radius: 3px; cursor: pointer; }

--- a/nodyx-frontend/src/routes/admin/octoguard/welcome/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/octoguard/welcome/+page.svelte
@@ -77,8 +77,8 @@
 	.og-checkbox { flex-direction: row; align-items: center; color: #cbd5e1; font-size: 12px; }
 	.og-info {
 		padding: 10px 12px;
-		background: rgba(99,102,241,0.05);
-		border: 1px solid rgba(99,102,241,0.2);
+		background: rgb(var(--nx-accent-rgb) / 0.05);
+		border: 1px solid rgb(var(--nx-accent-rgb) / 0.2);
 		border-radius: 3px;
 		font-size: 11px;
 		color: #c7d2fe;

--- a/nodyx-frontend/src/routes/admin/widgets/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/widgets/+page.svelte
@@ -360,7 +360,7 @@
 	<!-- Header -->
 	<div class="flex items-center justify-between mb-8">
 		<div>
-			<h1 class="text-2xl font-black" style="font-family:'Space Grotesk',sans-serif; background:linear-gradient(135deg,var(--nx-accent-2-soft),#06b6d4); -webkit-background-clip:text; -webkit-text-fill-color:transparent; background-clip:text">
+			<h1 class="text-2xl font-black" style="font-family:'Space Grotesk',sans-serif; background:linear-gradient(135deg,var(--nx-accent-2-soft),var(--nx-cyan)); -webkit-background-clip:text; -webkit-text-fill-color:transparent; background-clip:text">
 				Widget Store
 			</h1>
 			<p class="text-sm mt-1" style="color:#6b7280">
@@ -369,7 +369,7 @@
 		</div>
 		<a href="/admin/homepage"
 		   class="flex items-center gap-2 px-4 py-2 text-sm font-bold uppercase tracking-wider transition-all"
-		   style="background:linear-gradient(135deg,rgba(124,58,237,.25),rgba(6,182,212,.15)); border:1px solid rgba(124,58,237,.4); color:var(--nx-accent-2-soft)">
+		   style="background:linear-gradient(135deg,rgb(var(--nx-accent-2-rgb) / .25),rgb(var(--nx-cyan-rgb) / .15)); border:1px solid rgb(var(--nx-accent-2-rgb) / .4); color:var(--nx-accent-2-soft)">
 			<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
 				<path stroke-linecap="round" stroke-linejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
 			</svg>
@@ -396,7 +396,7 @@
 							role="button"
 							tabindex="0"
 							class="relative flex flex-col items-center justify-center gap-3 py-8 px-4 transition-all cursor-pointer"
-							style="border:2px dashed {dragging ? 'rgba(124,58,237,.6)' : 'rgba(255,255,255,.08)'}; background:{dragging ? 'rgba(124,58,237,.05)' : 'transparent'}"
+							style="border:2px dashed {dragging ? 'rgb(var(--nx-accent-2-rgb) / .6)' : 'rgba(255,255,255,.08)'}; background:{dragging ? 'rgb(var(--nx-accent-2-rgb) / .05)' : 'transparent'}"
 							ondragover={(e) => { e.preventDefault(); dragging = true }}
 							ondragleave={() => dragging = false}
 							ondrop={onDrop}
@@ -404,7 +404,7 @@
 							onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') document.getElementById('widget-file-input')?.click() }}
 						>
 							<div class="w-12 h-12 rounded-full flex items-center justify-center"
-							     style="background:rgba(124,58,237,.1); border:1px solid rgba(124,58,237,.2)">
+							     style="background:rgb(var(--nx-accent-2-rgb) / .1); border:1px solid rgb(var(--nx-accent-2-rgb) / .2)">
 								<svg class="w-6 h-6" fill="none" stroke="#a78bfa" stroke-width="1.5" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"/>
 								</svg>
@@ -496,10 +496,10 @@
 									{@const isDone    = i < current}
 									{@const isActive  = s.key === step}
 									<div class="flex items-center gap-3 px-3 py-2 transition-all"
-									     style="background:{isActive ? 'rgba(124,58,237,.08)' : 'transparent'}; border:1px solid {isActive ? 'rgba(124,58,237,.2)' : 'transparent'}">
+									     style="background:{isActive ? 'rgb(var(--nx-accent-2-rgb) / .08)' : 'transparent'}; border:1px solid {isActive ? 'rgb(var(--nx-accent-2-rgb) / .2)' : 'transparent'}">
 										<!-- Icône étape -->
 										<div class="w-5 h-5 rounded-full flex items-center justify-center shrink-0"
-										     style="background:{isDone ? 'rgba(74,222,128,.15)' : isActive ? 'rgba(124,58,237,.2)' : 'rgba(255,255,255,.04)'}; border:1px solid {isDone ? 'rgba(74,222,128,.3)' : isActive ? 'rgba(124,58,237,.4)' : 'rgba(255,255,255,.06)'}">
+										     style="background:{isDone ? 'rgba(74,222,128,.15)' : isActive ? 'rgb(var(--nx-accent-2-rgb) / .2)' : 'rgba(255,255,255,.04)'}; border:1px solid {isDone ? 'rgba(74,222,128,.3)' : isActive ? 'rgb(var(--nx-accent-2-rgb) / .4)' : 'rgba(255,255,255,.06)'}">
 											{#if isDone}
 												<svg class="w-2.5 h-2.5" fill="none" stroke="#4ade80" stroke-width="3" viewBox="0 0 24 24">
 													<path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
@@ -529,14 +529,14 @@
 									</div>
 									<div class="w-full h-1.5 rounded-full overflow-hidden" style="background:rgba(255,255,255,.06)">
 										<div class="h-full rounded-full transition-all duration-300"
-										     style="width:{uploadPct}%; background:linear-gradient(90deg,var(--nx-accent-2-strong),#06b6d4)">
+										     style="width:{uploadPct}%; background:linear-gradient(90deg,var(--nx-accent-2-strong),var(--nx-cyan))">
 										</div>
 									</div>
 								</div>
 							{:else}
 								<!-- Barre indéterminée pour les étapes serveur -->
 								<div class="w-full h-1.5 rounded-full overflow-hidden" style="background:rgba(255,255,255,.06)">
-									<div class="h-full rounded-full" style="background:linear-gradient(90deg,var(--nx-accent-2-strong),#06b6d4); animation:indeterminate 1.4s ease infinite">
+									<div class="h-full rounded-full" style="background:linear-gradient(90deg,var(--nx-accent-2-strong),var(--nx-cyan)); animation:indeterminate 1.4s ease infinite">
 									</div>
 								</div>
 							{/if}
@@ -651,7 +651,7 @@
 					<span class="text-base">🎁</span>
 					<span class="font-bold text-sm text-white">Widgets de démonstration</span>
 					<span class="ml-1 text-xs px-1.5 py-0.5 font-bold"
-					      style="background:rgba(6,182,212,.08); border:1px solid rgba(6,182,212,.18); color:#06b6d4">
+					      style="background:rgb(var(--nx-cyan-rgb) / .08); border:1px solid rgb(var(--nx-cyan-rgb) / .18); color:var(--nx-cyan)">
 						Prêts à installer
 					</span>
 					<span class="ml-auto text-xs" style="color:#374151">{demos.length} disponible{demos.length > 1 ? 's' : ''}</span>
@@ -662,7 +662,7 @@
 						{@const alreadyInstalled = installedIds.has(demo.id)}
 						{@const color = FAMILY_COLORS[demo.manifest.family ?? ''] ?? '#6b7280'}
 						<div class="flex flex-col gap-3 p-4 transition-all"
-						     style="background:rgba(6,182,212,.025); border:1px solid rgba(6,182,212,.1)">
+						     style="background:rgb(var(--nx-cyan-rgb) / .025); border:1px solid rgb(var(--nx-cyan-rgb) / .1)">
 
 							<!-- Header -->
 							<div class="flex items-start justify-between gap-2">
@@ -732,7 +732,7 @@
 								<button
 									onclick={() => openDemoModal(demo)}
 									class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold transition-all"
-									style="background:rgba(6,182,212,.08); border:1px solid rgba(6,182,212,.2); color:#06b6d4"
+									style="background:rgb(var(--nx-cyan-rgb) / .08); border:1px solid rgb(var(--nx-cyan-rgb) / .2); color:var(--nx-cyan)"
 								>
 									<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
 										<path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
@@ -766,7 +766,7 @@
 										onclick={() => installDemo(demo.id)}
 										disabled={demoInstalling}
 										class="ml-auto flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold transition-all disabled:opacity-50"
-										style="background:linear-gradient(135deg,rgba(124,58,237,.2),rgba(6,182,212,.15)); border:1px solid rgba(124,58,237,.3); color:var(--nx-accent-2-soft)"
+										style="background:linear-gradient(135deg,rgb(var(--nx-accent-2-rgb) / .2),rgb(var(--nx-cyan-rgb) / .15)); border:1px solid rgb(var(--nx-accent-2-rgb) / .3); color:var(--nx-accent-2-soft)"
 									>
 										{#if demoInstalling}
 											<div class="w-3 h-3 rounded-full border-2 animate-spin"
@@ -854,7 +854,7 @@
 	>
 		<div class="w-full max-w-3xl flex flex-col max-h-[90vh]"
 			role="dialog" aria-modal="true" tabindex="-1"
-		     style="background:#0d0d12; border:1px solid rgba(255,255,255,.1); box-shadow:0 0 60px rgba(124,58,237,.15)">
+		     style="background:#0d0d12; border:1px solid rgba(255,255,255,.1); box-shadow:0 0 60px rgb(var(--nx-accent-2-rgb) / .15)">
 
 			<!-- Modal header -->
 			<div class="flex items-center gap-3 px-5 py-4 shrink-0" style="border-bottom:1px solid rgba(255,255,255,.06)">
@@ -899,7 +899,7 @@
 					<button
 						onclick={() => demoTab = tab.key as typeof demoTab}
 						class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold transition-all"
-						style="border:1px solid {demoTab === tab.key ? 'rgba(124,58,237,.4)' : 'transparent'}; background:{demoTab === tab.key ? 'rgba(124,58,237,.1)' : 'transparent'}; color:{demoTab === tab.key ? 'var(--nx-accent-2-soft)' : '#374151'}"
+						style="border:1px solid {demoTab === tab.key ? 'rgb(var(--nx-accent-2-rgb) / .4)' : 'transparent'}; background:{demoTab === tab.key ? 'rgb(var(--nx-accent-2-rgb) / .1)' : 'transparent'}; color:{demoTab === tab.key ? 'var(--nx-accent-2-soft)' : '#374151'}"
 					>
 						<span>{tab.icon}</span>
 						<span class="font-mono">{tab.label}</span>
@@ -920,7 +920,7 @@
 							onclick={() => demoModal && installDemo(demoModal.id)}
 							disabled={demoInstalling}
 							class="flex items-center gap-1.5 px-4 py-1.5 text-xs font-bold transition-all disabled:opacity-50"
-							style="background:linear-gradient(135deg,rgba(124,58,237,.25),rgba(6,182,212,.15)); border:1px solid rgba(124,58,237,.4); color:var(--nx-accent-2-soft)"
+							style="background:linear-gradient(135deg,rgb(var(--nx-accent-2-rgb) / .25),rgb(var(--nx-cyan-rgb) / .15)); border:1px solid rgb(var(--nx-accent-2-rgb) / .4); color:var(--nx-accent-2-soft)"
 						>
 							{#if demoInstalling}
 								<div class="w-3 h-3 rounded-full border-2 animate-spin"

--- a/nodyx-frontend/src/routes/auth/login/+page.svelte
+++ b/nodyx-frontend/src/routes/auth/login/+page.svelte
@@ -172,7 +172,7 @@
 	<h1 class="text-2xl font-bold text-white mb-6">{tFn('auth.login.title')}</h1>
 
 	{#if data.demoMode}
-	<div class="mb-6 rounded-xl border p-4" style="border-color: rgba(99,102,241,0.4); background: rgba(99,102,241,0.06)">
+	<div class="mb-6 rounded-xl border p-4" style="border-color: rgb(var(--nx-accent-rgb) / 0.4); background: rgb(var(--nx-accent-rgb) / 0.06)">
 		<p class="text-sm font-semibold text-white mb-2">{tFn('auth.demo.title')}</p>
 		<p class="text-xs mb-3" style="color: rgb(156,163,175)">
 			{tFn('auth.demo.description')}
@@ -180,7 +180,7 @@
 		<div class="space-y-1.5 text-xs mb-2">
 			{#each ['alice', 'bob', 'charlie', 'admin'] as u}
 			<div class="rounded-lg px-3 py-2 flex items-center justify-between gap-2"
-				style="background: rgba(0,0,0,0.25); border: 1px solid rgba(99,102,241,0.2)">
+				style="background: rgba(0,0,0,0.25); border: 1px solid rgb(var(--nx-accent-rgb) / 0.2)">
 				<span class="font-mono text-white shrink-0">{u}@demo.nodyx.org</span>
 				<span class="shrink-0" style="color: rgb(156,163,175)">demo1234</span>
 			</div>

--- a/nodyx-frontend/src/routes/chat/+page.svelte
+++ b/nodyx-frontend/src/routes/chat/+page.svelte
@@ -1045,7 +1045,7 @@
 
 			<!-- Pinned message banner -->
 			{#if pinnedMessage && showPinned}
-				<div class="shrink-0 flex items-center gap-2.5 px-4 py-1.5 text-xs" style="background: rgba(124,58,237,.06); border-bottom: 1px solid rgba(124,58,237,.15)">
+				<div class="shrink-0 flex items-center gap-2.5 px-4 py-1.5 text-xs" style="background: rgb(var(--nx-accent-2-rgb) / .06); border-bottom: 1px solid rgb(var(--nx-accent-2-rgb) / .15)">
 					<svg class="w-3 h-3 shrink-0" viewBox="0 0 24 24" fill="#a78bfa"><path d="M16 12V4h1V2H7v2h1v8l-2 2v2h5v6h2v-6h5v-2l-2-2z"/></svg>
 					<span class="font-black uppercase tracking-wider shrink-0 text-[10px]" style="color: var(--nx-accent-2-soft); font-family: 'Space Grotesk', sans-serif">{tFn('chat.pinned')}</span>
 					<span class="truncate flex-1" style="color: #6b7280">
@@ -1110,7 +1110,7 @@
 										class="w-9 h-9 object-cover" style="outline: 1px solid rgba(255,255,255,.07)" />
 								{:else}
 									<div class="w-9 h-9 flex items-center justify-center font-black text-[11px] text-white select-none"
-									     style="background: linear-gradient(135deg, #7c3aed80, #0e7490)">
+									     style="background: linear-gradient(135deg, #7c3aed80, var(--nx-cyan-deep))">
 										{msg.author_username.charAt(0).toUpperCase()}
 									</div>
 								{/if}
@@ -1305,7 +1305,7 @@
 
 				{#if messages.length === 0}
 					<div class="flex flex-col items-center justify-center gap-3 mt-16 px-8">
-						<div class="w-12 h-12 flex items-center justify-center" style="background: rgba(124,58,237,.08); border: 1px solid rgba(124,58,237,.15)">
+						<div class="w-12 h-12 flex items-center justify-center" style="background: rgb(var(--nx-accent-2-rgb) / .08); border: 1px solid rgb(var(--nx-accent-2-rgb) / .15)">
 							<svg class="w-6 h-6" fill="none" stroke="#7c3aed" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
 						</div>
 						<p class="text-sm font-semibold text-center" style="color: #4b5563; font-family: 'Space Grotesk', sans-serif">{tFn('chat.no_messages')}</p>
@@ -1319,7 +1319,7 @@
 				<button
 					onclick={() => scrollToBottom()}
 					class="absolute bottom-3 right-4 z-10 flex items-center gap-2 pl-3 pr-2.5 py-1.5 transition-all duration-200 scroll-bottom-btn"
-					style="background: rgba(13,13,20,0.95); border: 1px solid rgba(124,58,237,0.4); box-shadow: 0 4px 20px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.03);"
+					style="background: rgba(13,13,20,0.95); border: 1px solid rgb(var(--nx-accent-2-rgb) / 0.4); box-shadow: 0 4px 20px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.03);"
 					transition:fade={{ duration: 120 }}
 				>
 					<span class="text-xs font-semibold" style="color: var(--nx-accent-2-soft);">
@@ -1452,7 +1452,7 @@
 
 				<!-- Reply preview bar -->
 				{#if replyTo}
-					<div class="flex items-center gap-2.5 px-3 py-1.5 mb-2 text-xs" style="background: rgba(124,58,237,.08); border-left: 2px solid var(--nx-accent-2-strong)">
+					<div class="flex items-center gap-2.5 px-3 py-1.5 mb-2 text-xs" style="background: rgb(var(--nx-accent-2-rgb) / .08); border-left: 2px solid var(--nx-accent-2-strong)">
 						<svg class="w-3 h-3 shrink-0" fill="none" stroke="#a78bfa" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"/></svg>
 						<span class="font-bold shrink-0" style="color: var(--nx-accent-2-soft)">{replyTo.author_username}</span>
 						<span class="truncate flex-1" style="color: #4b5563">{replyTo.content?.replace(/<[^>]*>/g, '').slice(0, 80) ?? ''}</span>
@@ -1495,7 +1495,7 @@
 						<button data-gif-picker onclick={() => { showGifPicker = !showGifPicker; if (showGifPicker && gifProvider) gifQuery = ''; }}
 						        title="GIF"
 						        class="w-7 h-7 flex items-center justify-center text-[10px] font-black uppercase tracking-wide transition-colors"
-						        style="color: {showGifPicker ? 'var(--nx-accent-2-soft)' : '#4b5563'}; background: {showGifPicker ? 'rgba(124,58,237,.12)' : 'transparent'}">GIF</button>
+						        style="color: {showGifPicker ? 'var(--nx-accent-2-soft)' : '#4b5563'}; background: {showGifPicker ? 'rgb(var(--nx-accent-2-rgb) / .12)' : 'transparent'}">GIF</button>
 						<!-- Poll -->
 						<button onclick={() => showPollCreator = true} title={tFn('chat.new_poll')}
 						        class="w-7 h-7 flex items-center justify-center transition-colors" style="color: #4b5563"
@@ -1515,7 +1515,7 @@
 						<!-- Send -->
 						<button onclick={sendMessage} disabled={!inputText.trim() || isRateLimited}
 						        class="w-7 h-7 flex items-center justify-center transition-all disabled:opacity-30 disabled:cursor-not-allowed"
-						        style="background: {isRateLimited ? 'rgba(239,68,68,.3)' : inputText.trim() ? 'linear-gradient(135deg, var(--nx-accent-2-strong), #0e7490)' : 'rgba(255,255,255,.06)'}; color: {inputText.trim() ? '#fff' : '#4b5563'}"
+						        style="background: {isRateLimited ? 'rgba(239,68,68,.3)' : inputText.trim() ? 'linear-gradient(135deg, var(--nx-accent-2-strong), var(--nx-cyan-deep))' : 'rgba(255,255,255,.06)'}; color: {inputText.trim() ? '#fff' : '#4b5563'}"
 						        title={isRateLimited ? tFn('chat.antispam_loading') : tFn('chat.send')}>
 							{#if isRateLimited}
 								<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
@@ -1666,8 +1666,8 @@
 		to   { opacity: 1; transform: translateY(0); }
 	}
 	.scroll-bottom-btn:hover {
-		border-color: rgba(124, 58, 237, 0.7) !important;
-		box-shadow: 0 4px 20px rgba(0,0,0,0.5), 0 0 12px rgba(124,58,237,0.15) !important;
+		border-color: rgb(var(--nx-accent-2-rgb) / 0.7) !important;
+		box-shadow: 0 4px 20px rgba(0,0,0,0.5), 0 0 12px rgb(var(--nx-accent-2-rgb) / 0.15) !important;
 	}
 
 	/* ── P2P animations ───────────────────────────────────────────────────── */
@@ -1705,14 +1705,14 @@
 		color: #e2e8f0;
 	}
 	.chat-reaction-mine {
-		background: rgba(124,58,237,.18);
-		border: 1px solid rgba(124,58,237,.45);
+		background: rgb(var(--nx-accent-2-rgb) / .18);
+		border: 1px solid rgb(var(--nx-accent-2-rgb) / .45);
 		color: var(--nx-accent-2-soft2);
-		box-shadow: 0 0 8px rgba(124,58,237,.15);
+		box-shadow: 0 0 8px rgb(var(--nx-accent-2-rgb) / .15);
 	}
 	.chat-reaction-mine:hover {
-		background: rgba(124,58,237,.08);
-		border-color: rgba(124,58,237,.2);
+		background: rgb(var(--nx-accent-2-rgb) / .08);
+		border-color: rgb(var(--nx-accent-2-rgb) / .2);
 	}
 	@keyframes chat-pill-in {
 		from { transform: scale(0); opacity: 0; }
@@ -1770,7 +1770,7 @@
 	
 	.message-row:hover {
     border-left-color: var(--nx-accent); /* Indigo */
-    background: linear-gradient(to right, rgba(99, 102, 241, 0.05), transparent);
+    background: linear-gradient(to right, rgb(var(--nx-accent-rgb) / 0.05), transparent);
 	}	
 
     /* Style pour le contenu des messages (Rich Text) */
@@ -1810,12 +1810,12 @@
     }
 
     .custom-scrollbar:hover::-webkit-scrollbar-thumb {
-        background-color: rgba(99, 102, 241, 0.4) !important;
+        background-color: rgb(var(--nx-accent-rgb) / 0.4) !important;
     }
 
     /* 3. On l'illumine un peu au survol pour le côté Nodyx */
     .custom-scrollbar:hover::-webkit-scrollbar-thumb {
-        background-color: rgba(99, 102, 241, 0.4); /* Indigo translucide */
+        background-color: rgb(var(--nx-accent-rgb) / 0.4); /* Indigo translucide */
     }
     /* Animation de pulsation pour le vocal */
     @keyframes pulse-subtle {

--- a/nodyx-frontend/src/routes/dm/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/dm/[id]/+page.svelte
@@ -1815,7 +1815,7 @@
 	margin: 10px 20px 0;
 	padding: 12px 14px;
 	border-radius: 12px;
-	background: linear-gradient(135deg, rgba(99,102,241,.12), rgba(168,85,247,.1));
+	background: linear-gradient(135deg, rgb(var(--nx-accent-rgb) / .12), rgba(168,85,247,.1));
 	border: 1px solid rgba(129,140,248,.28);
 }
 .e2e-banner-icon { font-size: 20px; line-height: 1.2; flex-shrink: 0; }
@@ -1857,7 +1857,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background: rgba(99, 102, 241, 0.18);
+	background: rgb(var(--nx-accent-rgb) / 0.18);
 	backdrop-filter: blur(6px);
 	-webkit-backdrop-filter: blur(6px);
 	pointer-events: none;
@@ -1874,7 +1874,7 @@
 	gap: 12px;
 	padding: 32px 48px;
 	background: rgba(15, 15, 22, 0.85);
-	border: 2px dashed rgba(124, 58, 237, 0.6);
+	border: 2px dashed rgb(var(--nx-accent-2-rgb) / 0.6);
 	border-radius: 14px;
 	box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
 }
@@ -1900,7 +1900,7 @@
 	gap: 8px;
 	padding: 6px 10px 6px 8px;
 	margin-bottom: 4px;
-	background: rgba(99, 102, 241, 0.06);
+	background: rgb(var(--nx-accent-rgb) / 0.06);
 	border-radius: 8px 8px 8px 2px;
 	max-width: 100%;
 }
@@ -1938,8 +1938,8 @@
 	align-items: center;
 	margin-bottom: 8px;
 	padding: 8px 10px;
-	background: rgba(99, 102, 241, 0.08);
-	border: 1px solid rgba(99, 102, 241, 0.18);
+	background: rgb(var(--nx-accent-rgb) / 0.08);
+	border: 1px solid rgb(var(--nx-accent-rgb) / 0.18);
 	border-radius: 10px;
 	animation: dm-reply-banner-in .15s ease-out;
 }
@@ -1981,7 +1981,7 @@
 	cursor: pointer;
 	transition: background .15s, color .15s;
 }
-.dm-reply-banner-close:hover { background: rgba(99, 102, 241, 0.12); color: #c7d2fe; }
+.dm-reply-banner-close:hover { background: rgb(var(--nx-accent-rgb) / 0.12); color: #c7d2fe; }
 
 /* ── Hero d'ouverture ─────────────────────────────────────────────────────── */
 .dm-hero-overlay {
@@ -2029,14 +2029,14 @@
 	object-fit: cover;
 	box-shadow:
 		0 0 0 3px rgba(255, 255, 255, 0.06),
-		0 0 32px rgba(124, 58, 237, 0.25),
+		0 0 32px rgb(var(--nx-accent-2-rgb) / 0.25),
 		0 8px 24px rgba(0, 0, 0, 0.4);
 }
 .dm-hero-avatar--initials {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background: rgba(124, 58, 237, 0.12);
+	background: rgb(var(--nx-accent-2-rgb) / 0.12);
 	color: var(--nx-accent-2-soft2);
 	font-size: 38px;
 	font-weight: 800;
@@ -2086,19 +2086,19 @@
 	cursor: pointer;
 }
 .dm-reaction-pill:hover {
-	border-color: rgba(99,102,241,.4);
-	background: rgba(99,102,241,.12);
+	border-color: rgb(var(--nx-accent-rgb) / .4);
+	background: rgb(var(--nx-accent-rgb) / .12);
 	color: #e2e8f0;
 	transform: scale(1.08);
 }
 .dm-reaction-mine {
-	border-color: rgba(99,102,241,.5);
-	background: rgba(99,102,241,.18);
+	border-color: rgb(var(--nx-accent-rgb) / .5);
+	background: rgb(var(--nx-accent-rgb) / .18);
 	color: #c7d2fe;
 }
 .dm-reaction-mine:hover {
-	background: rgba(99,102,241,.08);
-	border-color: rgba(99,102,241,.25);
+	background: rgb(var(--nx-accent-rgb) / .08);
+	border-color: rgb(var(--nx-accent-rgb) / .25);
 }
 @keyframes pill-pop {
 	from { transform: scale(0); opacity: 0; }

--- a/nodyx-frontend/src/routes/feed/+page.svelte
+++ b/nodyx-frontend/src/routes/feed/+page.svelte
@@ -780,8 +780,8 @@
 }
 .feed-explore-btn:hover {
 	color: rgba(255,255,255,0.8);
-	border-color: rgba(99,102,241,0.4);
-	background: rgba(99,102,241,0.08);
+	border-color: rgb(var(--nx-accent-rgb) / 0.4);
+	background: rgb(var(--nx-accent-rgb) / 0.08);
 }
 
 /* ── Layout ───────────────────────────────────────────────────────────────── */
@@ -821,7 +821,7 @@
 }
 .feed-tab:hover { color: rgba(255,255,255,0.8); }
 .feed-tab--active {
-	background: linear-gradient(135deg, rgba(124,58,237,0.25), rgba(6,182,212,0.2));
+	background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / 0.25), rgb(var(--nx-cyan-rgb) / 0.2));
 	color: #fff;
 }
 .feed-sidebar { width: 260px; flex-shrink: 0; display: flex; flex-direction: column; gap: 1rem; position: sticky; top: 68px; }
@@ -841,8 +841,8 @@
 	transition: border-color 0.2s, background 0.2s;
 }
 .composer--active {
-	border-color: rgba(99,102,241,0.3);
-	background: rgba(99,102,241,0.04);
+	border-color: rgb(var(--nx-accent-rgb) / 0.3);
+	background: rgb(var(--nx-accent-rgb) / 0.04);
 }
 
 .composer-reply-banner {
@@ -850,12 +850,12 @@
 	align-items: center;
 	gap: 0.5rem;
 	font-size: 0.7rem;
-	color: rgba(99,102,241,0.7);
+	color: rgb(var(--nx-accent-rgb) / 0.7);
 	margin-bottom: 0.75rem;
 	padding-bottom: 0.75rem;
 	border-bottom: 1px solid rgba(255,255,255,0.06);
 }
-:global(.composer-reply-banner strong) { color: rgba(99,102,241,0.9); }
+:global(.composer-reply-banner strong) { color: rgb(var(--nx-accent-rgb) / 0.9); }
 .composer-reply-close {
 	margin-left: auto;
 	color: rgba(255,255,255,0.3);
@@ -873,7 +873,7 @@
 	flex-shrink: 0;
 	border-radius: 50%;
 	overflow: hidden;
-	background: rgba(99,102,241,0.15);
+	background: rgb(var(--nx-accent-rgb) / 0.15);
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -1037,12 +1037,12 @@
 }
 .post-card:first-child { border-top: 1px solid rgba(255,255,255,0.06); }
 .post-card:hover { background: rgba(255,255,255,0.03); }
-.post-card--resonant { border-left-color: rgba(99,102,241,0.3); }
+.post-card--resonant { border-left-color: rgb(var(--nx-accent-rgb) / 0.3); }
 
 .post-resonance-glow {
 	position: absolute;
 	inset: 0;
-	background: linear-gradient(90deg, rgba(99,102,241,0.08), transparent 40%);
+	background: linear-gradient(90deg, rgb(var(--nx-accent-rgb) / 0.08), transparent 40%);
 	pointer-events: none;
 }
 
@@ -1060,7 +1060,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background: rgba(99,102,241,0.15);
+	background: rgb(var(--nx-accent-rgb) / 0.15);
 	color: var(--nx-accent-soft);
 	font-weight: 700;
 	font-size: 0.875rem;
@@ -1119,7 +1119,7 @@
 .prose-feed :global(h2) { font-size: 1.05em; }
 .prose-feed :global(h3) { font-size: 0.95em; }
 .prose-feed :global(blockquote) {
-	border-left: 3px solid rgba(99,102,241,0.5);
+	border-left: 3px solid rgb(var(--nx-accent-rgb) / 0.5);
 	padding-left: 0.75rem;
 	color: rgba(255,255,255,0.5);
 	font-style: italic;
@@ -1155,7 +1155,7 @@
 	background: rgba(255,255,255,0.02);
 	transition: border-color 0.15s, background 0.15s;
 }
-.link-card:hover { border-color: rgba(124,58,237,0.5); background: rgba(255,255,255,0.04); }
+.link-card:hover { border-color: rgb(var(--nx-accent-2-rgb) / 0.5); background: rgba(255,255,255,0.04); }
 .link-card-img { width: 100%; max-height: 240px; overflow: hidden; background: rgba(0,0,0,0.2); }
 .link-card-img img { width: 100%; height: 100%; max-height: 240px; object-fit: cover; display: block; }
 .link-card-body { display: flex; flex-direction: column; gap: 0.2rem; padding: 0.7rem 0.85rem; }
@@ -1211,7 +1211,7 @@
 	font-size: 0.8rem; line-height: 1.4; transition: background 0.12s, border-color 0.12s;
 }
 .reaction-chip:hover { background: rgba(255,255,255,0.08); }
-.reaction-chip--mine { background: rgba(124,58,237,0.22); border-color: rgba(124,58,237,0.6); }
+.reaction-chip--mine { background: rgb(var(--nx-accent-2-rgb) / 0.22); border-color: rgb(var(--nx-accent-2-rgb) / 0.6); }
 .reaction-chip-e { font-size: 0.9rem; }
 .reaction-chip-n { font-weight: 700; color: rgba(255,255,255,0.7); }
 
@@ -1232,7 +1232,7 @@
 .quoted-post:hover { background: rgba(255,255,255,0.04); border-color: rgba(255,255,255,0.18); }
 .quoted-head { display: flex; align-items: center; gap: 0.4rem; margin-bottom: 0.35rem; }
 .quoted-avatar { width: 20px; height: 20px; border-radius: 999px; object-fit: cover; }
-.quoted-avatar--i { display: inline-flex; align-items: center; justify-content: center; background: rgba(124,58,237,0.3); color: #fff; font-size: 0.65rem; font-weight: 700; }
+.quoted-avatar--i { display: inline-flex; align-items: center; justify-content: center; background: rgb(var(--nx-accent-2-rgb) / 0.3); color: #fff; font-size: 0.65rem; font-weight: 700; }
 .quoted-name { font-weight: 700; color: rgba(255,255,255,0.9); font-size: 0.85rem; }
 .quoted-handle { color: rgba(255,255,255,0.4); font-size: 0.8rem; }
 .quoted-body { font-size: 0.875rem; color: rgba(255,255,255,0.8); }
@@ -1259,7 +1259,7 @@
 	transition: transform 0.1s, background 0.1s;
 }
 .reaction-pick:hover { transform: scale(1.3); background: rgba(255,255,255,0.08); }
-.reaction-pick--mine { background: rgba(124,58,237,0.3); }
+.reaction-pick--mine { background: rgb(var(--nx-accent-2-rgb) / 0.3); }
 
 /* Ripple animation on like */
 .post-resonance-btn--active .resonance-icon {
@@ -1298,7 +1298,7 @@
 .feed-loader   { display: flex; gap: 0.375rem; }
 .feed-loader span {
 	width: 6px; height: 6px;
-	background: rgba(99,102,241,0.5);
+	background: rgb(var(--nx-accent-rgb) / 0.5);
 	border-radius: 50%;
 	animation: feed-bounce 1.2s ease-in-out infinite;
 }
@@ -1309,7 +1309,7 @@
 	40%           { transform: scale(1);   opacity: 1; }
 }
 .feed-end { font-size: 0.75rem; color: rgba(255,255,255,0.2); }
-:global(.feed-end a) { color: rgba(99,102,241,0.6); transition: color 0.15s; }
+:global(.feed-end a) { color: rgb(var(--nx-accent-rgb) / 0.6); transition: color 0.15s; }
 :global(.feed-end a:hover) { color: var(--nx-accent-soft); }
 
 /* ── Sidebar ──────────────────────────────────────────────────────────────── */
@@ -1336,7 +1336,7 @@
 .sidebar-me:hover { opacity: 0.8; }
 .sidebar-me-avatar {
 	width: 40px; height: 40px; border-radius: 50%; overflow: hidden;
-	background: rgba(99,102,241,0.15);
+	background: rgb(var(--nx-accent-rgb) / 0.15);
 	display: flex; align-items: center; justify-content: center;
 	font-weight: 700; font-size: 0.875rem; color: var(--nx-accent);
 	flex-shrink: 0;
@@ -1346,7 +1346,7 @@
 
 .sidebar-suggest-avatar {
 	width: 36px; height: 36px; border-radius: 50%; overflow: hidden;
-	background: rgba(99,102,241,0.1);
+	background: rgb(var(--nx-accent-rgb) / 0.1);
 	display: flex; align-items: center; justify-content: center;
 	font-size: 0.8rem; font-weight: 700; color: var(--nx-accent);
 	flex-shrink: 0;
@@ -1358,11 +1358,11 @@
 	font-weight: 600;
 	color: var(--nx-accent);
 	padding: 0.25rem 0.625rem;
-	border: 1px solid rgba(99,102,241,0.3);
+	border: 1px solid rgb(var(--nx-accent-rgb) / 0.3);
 	transition: all 0.15s;
 	white-space: nowrap;
 }
-.sidebar-follow-btn:hover { background: rgba(99,102,241,0.1); }
+.sidebar-follow-btn:hover { background: rgb(var(--nx-accent-rgb) / 0.1); }
 
 .sidebar-card--links {
 	display: flex;
@@ -1383,16 +1383,16 @@
 	gap: 0.3rem;
 	font-size: 0.75rem;
 	font-weight: 600;
-	color: rgba(99,102,241,0.6);
+	color: rgb(var(--nx-accent-rgb) / 0.6);
 	transition: color 0.15s;
 }
-.post-replies-btn:hover        { color: rgba(99,102,241,0.9); }
+.post-replies-btn:hover        { color: rgb(var(--nx-accent-rgb) / 0.9); }
 .post-replies-btn--open        { color: var(--nx-accent-soft); }
 
 .replies-thread {
-	border-left: 2px solid rgba(99,102,241,0.2);
+	border-left: 2px solid rgb(var(--nx-accent-rgb) / 0.2);
 	margin-left: 1.25rem;
-	background: rgba(99,102,241,0.02);
+	background: rgb(var(--nx-accent-rgb) / 0.02);
 }
 
 .reply-card {
@@ -1427,7 +1427,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background: rgba(99,102,241,0.12);
+	background: rgb(var(--nx-accent-rgb) / 0.12);
 	color: var(--nx-accent-soft);
 	font-weight: 700;
 	font-size: 0.75rem;

--- a/nodyx-frontend/src/routes/library/+page.svelte
+++ b/nodyx-frontend/src/routes/library/+page.svelte
@@ -401,7 +401,7 @@
 }
 
 .lib-search-input:focus {
-	border-color: rgba(99, 102, 241, 0.5);
+	border-color: rgb(var(--nx-accent-rgb) / 0.5);
 }
 
 .lib-search-btn {
@@ -423,7 +423,7 @@
 
 .lib-upload-btn {
 	padding: 7px 14px;
-	background: rgba(99, 102, 241, 0.85);
+	background: rgb(var(--nx-accent-rgb) / 0.85);
 	border: none;
 	color: #fff;
 	font-size: 0.8125rem;
@@ -492,8 +492,8 @@
 }
 
 .lib-filter-btn--active {
-	background: rgba(99, 102, 241, 0.15);
-	border-color: rgba(99, 102, 241, 0.35);
+	background: rgb(var(--nx-accent-rgb) / 0.15);
+	border-color: rgb(var(--nx-accent-rgb) / 0.35);
 	color: #a5b4fc;
 }
 
@@ -589,7 +589,7 @@
 .lib-input:focus,
 .lib-select:focus,
 .lib-textarea:focus {
-	border-color: rgba(99, 102, 241, 0.5);
+	border-color: rgb(var(--nx-accent-rgb) / 0.5);
 }
 
 .lib-select {
@@ -613,8 +613,8 @@
 	display: flex;
 	gap: 10px;
 	padding: 10px 14px;
-	background: rgba(99, 102, 241, 0.06);
-	border: 1px solid rgba(99, 102, 241, 0.15);
+	background: rgb(var(--nx-accent-rgb) / 0.06);
+	border: 1px solid rgb(var(--nx-accent-rgb) / 0.15);
 	font-size: 0.75rem;
 	color: #a5b4fc;
 }
@@ -647,7 +647,7 @@
 
 .lib-submit-btn {
 	padding: 8px 18px;
-	background: rgba(99, 102, 241, 0.85);
+	background: rgb(var(--nx-accent-rgb) / 0.85);
 	border: none;
 	color: #fff;
 	font-size: 0.8125rem;

--- a/nodyx-frontend/src/routes/members/+page.svelte
+++ b/nodyx-frontend/src/routes/members/+page.svelte
@@ -230,8 +230,8 @@
 		border-radius: 4px;
 	}
 	.mb-search:focus-within {
-		border-color: rgba(99, 102, 241, 0.35);
-		background: rgba(99, 102, 241, 0.04);
+		border-color: rgb(var(--nx-accent-rgb) / 0.35);
+		background: rgb(var(--nx-accent-rgb) / 0.04);
 	}
 	.mb-search-icon { width: 14px; height: 14px; color: #475569; flex-shrink: 0; }
 	.mb-search-input {
@@ -255,7 +255,7 @@
 		font-family: inherit;
 		cursor: pointer;
 	}
-	.mb-sort:focus { outline: 1px solid rgba(99, 102, 241, 0.4); outline-offset: -1px; }
+	.mb-sort:focus { outline: 1px solid rgb(var(--nx-accent-rgb) / 0.4); outline-offset: -1px; }
 
 	.mb-toggle {
 		display: inline-flex;
@@ -313,7 +313,7 @@
 		height: 36px;
 		border-radius: 4px;
 		object-fit: cover;
-		background: rgba(99, 102, 241, 0.08);
+		background: rgb(var(--nx-accent-rgb) / 0.08);
 		display: block;
 	}
 	.mb-avatar--init {
@@ -362,7 +362,7 @@
 		text-transform: uppercase;
 		letter-spacing: 0.04em;
 		padding: 2px 6px;
-		border: 1px solid rgba(99, 102, 241, 0.3);
+		border: 1px solid rgb(var(--nx-accent-rgb) / 0.3);
 		color: #a5b4fc;
 		border-radius: 3px;
 		font-family: ui-monospace, SFMono-Regular, monospace;

--- a/nodyx-frontend/src/routes/overlay/alert/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/alert/[token]/+page.svelte
@@ -476,8 +476,8 @@
 		position: absolute; inset: 0;
 		background: linear-gradient(115deg,
 			rgba(236, 72, 153, 0.18) 0%,
-			rgba(99, 102, 241, 0.18) 25%,
-			rgba(6, 182, 212, 0.18) 50%,
+			rgb(var(--nx-accent-rgb) / 0.18) 25%,
+			rgb(var(--nx-cyan-rgb) / 0.18) 50%,
 			rgba(168, 85, 247, 0.18) 75%,
 			rgba(236, 72, 153, 0.18) 100%);
 		background-size: 300% 100%;
@@ -489,7 +489,7 @@
 		position: absolute; inset: 0;
 		border-radius: 14px;
 		padding: 1.5px;
-		background: linear-gradient(135deg, #ec4899, var(--nx-accent), #06b6d4, var(--nx-accent-2), #ec4899);
+		background: linear-gradient(135deg, #ec4899, var(--nx-accent), var(--nx-cyan), var(--nx-accent-2), #ec4899);
 		background-size: 300% 300%;
 		-webkit-mask:
 			linear-gradient(#fff 0 0) content-box,
@@ -508,7 +508,7 @@
 	.theme-holographic .alert-eyebrow {
 		font-size: 10px; font-weight: 700; text-transform: uppercase;
 		letter-spacing: 0.14em; margin-bottom: 4px;
-		background: linear-gradient(90deg, #ec4899, #06b6d4);
+		background: linear-gradient(90deg, #ec4899, var(--nx-cyan));
 		background-clip: text;
 		-webkit-background-clip: text;
 		color: transparent;

--- a/nodyx-frontend/src/routes/overlay/board/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/board/[token]/+page.svelte
@@ -262,7 +262,7 @@
 	.card {
 		--card-bg:   rgba(15, 23, 42, 0.94);
 		--text-color: #f1f5f9;
-		--accent:     #06b6d4;
+		--accent:     var(--nx-cyan);
 		background: var(--card-bg);
 		backdrop-filter: blur(12px);
 		border-radius: 20px;

--- a/nodyx-frontend/src/routes/overlay/clips/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/clips/[token]/+page.svelte
@@ -242,7 +242,7 @@
 		padding: 32px;
 	}
 	.activation-gate:hover { background: linear-gradient(135deg, rgba(15, 23, 42, 0.86), rgba(8, 12, 26, 0.86)); }
-	.play-icon { width: 48px; height: 48px; color: #06b6d4; opacity: 0.95; }
+	.play-icon { width: 48px; height: 48px; color: var(--nx-cyan); opacity: 0.95; }
 	.gate-text { text-align: center; max-width: 480px; }
 	.gate-title { font-size: 20px; font-weight: 700; margin-bottom: 6px; color: #fff; }
 	.gate-sub { font-size: 13px; color: #94a3b8; line-height: 1.5; }
@@ -293,7 +293,7 @@
 		right: 24px;
 		padding: 12px 16px;
 		background: linear-gradient(90deg, rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0.45));
-		border-left: 3px solid #06b6d4;
+		border-left: 3px solid var(--nx-cyan);
 		border-radius: 6px;
 		backdrop-filter: blur(8px);
 		color: #f1f5f9;
@@ -306,7 +306,7 @@
 		font-weight: 700;
 		text-transform: uppercase;
 		letter-spacing: 0.14em;
-		color: #06b6d4;
+		color: var(--nx-cyan);
 		margin-bottom: 4px;
 	}
 

--- a/nodyx-frontend/src/routes/settings/+page.svelte
+++ b/nodyx-frontend/src/routes/settings/+page.svelte
@@ -485,7 +485,7 @@
 
             <button class="sb-item {activeSection === 'network' ? 'active' : ''}"
                     onclick={() => activeSection = 'network'}>
-                <span class="sb-icon" style="background: rgba(99,102,241,0.15); color: var(--nx-accent-soft)">
+                <span class="sb-icon" style="background: rgb(var(--nx-accent-rgb) / 0.15); color: var(--nx-accent-soft)">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
                     </svg>
@@ -508,7 +508,7 @@
 
             <button class="sb-item {activeSection === 'instances' ? 'active' : ''}"
                     onclick={() => activeSection = 'instances'}>
-                <span class="sb-icon" style="background: rgba(6,182,212,0.12); color: #67e8f9">
+                <span class="sb-icon" style="background: rgb(var(--nx-cyan-rgb) / 0.12); color: var(--nx-cyan-soft)">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/>
                     </svg>
@@ -538,7 +538,7 @@
 
             <button class="sb-item {activeSection === 'encryption' ? 'active' : ''}"
                     onclick={() => activeSection = 'encryption'}>
-                <span class="sb-icon" style="background: rgba(99,102,241,0.12); color: var(--nx-accent-soft)">
+                <span class="sb-icon" style="background: rgb(var(--nx-accent-rgb) / 0.12); color: var(--nx-accent-soft)">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
                     </svg>
@@ -561,7 +561,7 @@
 
             <button class="sb-item {activeSection === 'connected-accounts' ? 'active' : ''}"
                     onclick={() => activeSection = 'connected-accounts'}>
-                <span class="sb-icon" style="background: rgba(124,58,237,0.12); color: var(--nx-accent-2-soft)">
+                <span class="sb-icon" style="background: rgb(var(--nx-accent-2-rgb) / 0.12); color: var(--nx-accent-2-soft)">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
                     </svg>
@@ -612,7 +612,7 @@
 
         <!-- ═══ RÉSEAU ══════════════════════════════════════════════════════ -->
         {#if activeSection === 'network'}
-        <div class="s-pane" style="--accent: var(--nx-accent-soft); --accent-bg: rgba(99,102,241,0.08); --accent-border: rgba(99,102,241,0.2)">
+        <div class="s-pane" style="--accent: var(--nx-accent-soft); --accent-bg: rgb(var(--nx-accent-rgb) / 0.08); --accent-border: rgb(var(--nx-accent-rgb) / 0.2)">
             <div class="s-pane-header">
                 <div class="s-pane-icon" style="background: var(--accent-bg); border-color: var(--accent-border); color: var(--accent)">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
@@ -696,7 +696,7 @@
 
         <!-- ═══ INSTANCES ════════════════════════════════════════════════════ -->
         {#if activeSection === 'instances'}
-        <div class="s-pane" style="--accent: #67e8f9; --accent-bg: rgba(6,182,212,0.08); --accent-border: rgba(6,182,212,0.2)">
+        <div class="s-pane" style="--accent: var(--nx-cyan-soft); --accent-bg: rgb(var(--nx-cyan-rgb) / 0.08); --accent-border: rgb(var(--nx-cyan-rgb) / 0.2)">
             <div class="s-pane-header">
                 <div class="s-pane-icon" style="background: var(--accent-bg); border-color: var(--accent-border); color: var(--accent)">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
@@ -928,7 +928,7 @@
 
         <!-- ═══ MESSAGES CHIFFRÉS (sauvegarde de clé E2E) ════════════════════ -->
         {#if activeSection === 'encryption' && $page.data.user}
-        <div class="s-pane" style="--accent: var(--nx-accent-soft); --accent-bg: rgba(99,102,241,0.08); --accent-border: rgba(99,102,241,0.2)">
+        <div class="s-pane" style="--accent: var(--nx-accent-soft); --accent-bg: rgb(var(--nx-accent-rgb) / 0.08); --accent-border: rgb(var(--nx-accent-rgb) / 0.2)">
             <div class="s-pane-header">
                 <div class="s-pane-icon" style="background: var(--accent-bg); border-color: var(--accent-border); color: var(--accent)">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
@@ -1046,7 +1046,7 @@
 
         <!-- ═══ COMPTES LIÉS ══════════════════════════════════════════════════ -->
         {#if activeSection === 'connected-accounts'}
-        <div class="s-pane" style="--accent: var(--nx-accent-2-soft); --accent-bg: rgba(124,58,237,0.08); --accent-border: rgba(124,58,237,0.2)">
+        <div class="s-pane" style="--accent: var(--nx-accent-2-soft); --accent-bg: rgb(var(--nx-accent-2-rgb) / 0.08); --accent-border: rgb(var(--nx-accent-2-rgb) / 0.2)">
             <div class="s-pane-header">
                 <div class="s-pane-icon" style="background: var(--accent-bg); border-color: var(--accent-border); color: var(--accent)">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
@@ -1495,7 +1495,7 @@
 }
 .sb-item:hover { background: rgba(255,255,255,0.04); color: #9ca3af; }
 .sb-item.active {
-    background: rgba(99,102,241,0.12);
+    background: rgb(var(--nx-accent-rgb) / 0.12);
     color: #e0e7ff;
 }
 .sb-item.active .sb-icon { opacity: 1; }
@@ -1523,7 +1523,7 @@
 .sb-badge {
     font-size: 10px;
     font-weight: 700;
-    background: rgba(99,102,241,0.2);
+    background: rgb(var(--nx-accent-rgb) / 0.2);
     color: #a5b4fc;
     padding: 1px 6px;
     border-radius: 5px;
@@ -1680,16 +1680,16 @@
     border-radius: 6px;
     font-size: 13px;
     font-weight: 600;
-    background: rgba(99,102,241,0.15);
+    background: rgb(var(--nx-accent-rgb) / 0.15);
     color: #a5b4fc;
-    border: 1px solid rgba(99,102,241,0.3);
+    border: 1px solid rgb(var(--nx-accent-rgb) / 0.3);
     cursor: pointer;
     transition: all 150ms;
     flex-shrink: 0;
 }
 .s-primary-btn:hover:not(:disabled) {
-    background: rgba(99,102,241,0.25);
-    border-color: rgba(99,102,241,0.5);
+    background: rgb(var(--nx-accent-rgb) / 0.25);
+    border-color: rgb(var(--nx-accent-rgb) / 0.5);
     color: #c7d2fe;
 }
 .s-primary-btn:disabled { opacity: 0.4; cursor: not-allowed; }
@@ -1747,7 +1747,7 @@
     transition: border-color 150ms;
 }
 .s-input::placeholder { color: #374151; }
-.s-input:focus { border-color: rgba(99,102,241,0.5); background: rgba(255,255,255,0.06); }
+.s-input:focus { border-color: rgb(var(--nx-accent-rgb) / 0.5); background: rgba(255,255,255,0.06); }
 
 /* ── Banners ─────────────────────────────────────────────────────────────── */
 .s-info-banner {
@@ -1781,7 +1781,7 @@
 }
 
 .s-hint-text { font-size: 12px; color: #374151; line-height: 1.6; margin: 0; }
-:global(.s-hint-text code) { color: var(--nx-accent); background: rgba(99,102,241,0.1); padding: 1px 5px; border-radius: 4px; }
+:global(.s-hint-text code) { color: var(--nx-accent); background: rgb(var(--nx-accent-rgb) / 0.1); padding: 1px 5px; border-radius: 4px; }
 
 .s-field-error { font-size: 11px; color: #f87171; margin-top: 6px; }
 
@@ -1811,8 +1811,8 @@
     width: 36px;
     height: 36px;
     border-radius: 6px;
-    background: rgba(99,102,241,0.12);
-    border: 1px solid rgba(99,102,241,0.2);
+    background: rgb(var(--nx-accent-rgb) / 0.12);
+    border: 1px solid rgb(var(--nx-accent-rgb) / 0.2);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1841,8 +1841,8 @@
     width: 28px;
     height: 28px;
     border-radius: 50%;
-    background: rgba(99,102,241,0.15);
-    border: 1px solid rgba(99,102,241,0.3);
+    background: rgb(var(--nx-accent-rgb) / 0.15);
+    border: 1px solid rgb(var(--nx-accent-rgb) / 0.3);
     color: var(--nx-accent-soft);
     font-size: 12px;
     font-weight: 800;
@@ -1867,10 +1867,10 @@
     font-size: 11px;
     font-family: monospace;
     color: var(--nx-accent-soft);
-    background: rgba(99,102,241,0.08);
+    background: rgb(var(--nx-accent-rgb) / 0.08);
     padding: 10px 14px;
     border-radius: 8px;
-    border: 1px solid rgba(99,102,241,0.15);
+    border: 1px solid rgb(var(--nx-accent-rgb) / 0.15);
     word-break: break-all;
     line-height: 1.6;
 }

--- a/nodyx-frontend/src/routes/status/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/status/[id]/+page.svelte
@@ -144,7 +144,7 @@
 	.s-card--reply { margin-left: 1rem; background: rgba(255,255,255,0.01); }
 	.s-head { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.6rem; }
 	.s-avatar { width: 42px; height: 42px; border-radius: 999px; object-fit: cover; display: block; }
-	.s-avatar--i { display: inline-flex; align-items: center; justify-content: center; background: rgba(124,58,237,0.3); color: #fff; font-weight: 700; }
+	.s-avatar--i { display: inline-flex; align-items: center; justify-content: center; background: rgb(var(--nx-accent-2-rgb) / 0.3); color: #fff; font-weight: 700; }
 	.s-name { font-weight: 700; color: #fff; text-decoration: none; }
 	.s-handle { display: block; color: rgba(255,255,255,0.45); font-size: 0.8rem; }
 	.s-text { color: rgba(255,255,255,0.9); font-size: 0.95rem; line-height: 1.55; }
@@ -173,6 +173,6 @@
 	.s-backdrop { position: fixed; inset: 0; z-index: 40; }
 	.s-chips { display: flex; flex-wrap: wrap; gap: 0.3rem; margin-top: 0.6rem; }
 	.s-chip { font-size: 0.8rem; padding: 0.1rem 0.5rem; border-radius: 999px; border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.04); }
-	.s-chip--mine { background: rgba(124,58,237,0.22); border-color: rgba(124,58,237,0.6); }
+	.s-chip--mine { background: rgb(var(--nx-accent-2-rgb) / 0.22); border-color: rgb(var(--nx-accent-2-rgb) / 0.6); }
 	.s-replies-title { font-size: 0.95rem; font-weight: 700; color: rgba(255,255,255,0.8); margin: 1.2rem 0 0.6rem; }
 </style>

--- a/nodyx-frontend/src/routes/users/[username]/+page.svelte
+++ b/nodyx-frontend/src/routes/users/[username]/+page.svelte
@@ -437,7 +437,7 @@
 				{#if isOwnProfile}
 					<div class="flex items-center gap-2">
 						<a href="/users/{profile.username}/card" target="_blank" class="profile-action-btn"
-						   style="background: rgba(99,102,241,0.12); border-color: rgba(99,102,241,0.3)"
+						   style="background: rgb(var(--nx-accent-rgb) / 0.12); border-color: rgb(var(--nx-accent-rgb) / 0.3)"
 						   title={tFn('user.share_card')}>
 							<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
@@ -459,7 +459,7 @@
 							class="profile-action-btn profile-follow-btn"
 							class:profile-follow-btn--following={following}
 							style={following
-								? 'background: rgba(99,102,241,0.15); border-color: rgba(99,102,241,0.5); color: var(--nx-accent-soft)'
+								? 'background: rgb(var(--nx-accent-rgb) / 0.15); border-color: rgb(var(--nx-accent-rgb) / 0.5); color: var(--nx-accent-soft)'
 								: 'background: var(--nx-accent); border-color: var(--nx-accent); color: white'}
 						>
 							{#if followLoading}

--- a/nodyx-frontend/src/routes/users/[username]/card/+page.svelte
+++ b/nodyx-frontend/src/routes/users/[username]/card/+page.svelte
@@ -347,7 +347,7 @@
 	content: '';
 	position: absolute;
 	inset: 0;
-	background-image: radial-gradient(rgba(99,102,241,0.08) 1px, transparent 1px);
+	background-image: radial-gradient(rgb(var(--nx-accent-rgb) / 0.08) 1px, transparent 1px);
 	background-size: 28px 28px;
 	pointer-events: none;
 }
@@ -358,7 +358,7 @@
 	background: #0c0c14;
 	border: 1px solid rgba(255, 255, 255, 0.07);
 	box-shadow:
-		0 0 0 1px rgba(99, 102, 241, 0.06),
+		0 0 0 1px rgb(var(--nx-accent-rgb) / 0.06),
 		0 32px 80px rgba(0, 0, 0, 0.8),
 		0 8px 24px rgba(0, 0, 0, 0.5);
 	overflow: hidden;
@@ -429,13 +429,13 @@
 
 .ring-outer {
 	inset: -5px;
-	border: 1.5px solid rgba(99, 102, 241, 0.2);
+	border: 1.5px solid rgb(var(--nx-accent-rgb) / 0.2);
 	animation: ring-breathe 4s ease-in-out infinite;
 }
 
 .ring-mid {
 	inset: -1px;
-	border: 1.5px solid rgba(99, 102, 241, 0.55);
+	border: 1.5px solid rgb(var(--nx-accent-rgb) / 0.55);
 }
 
 @keyframes ring-breathe {
@@ -721,16 +721,16 @@
 	font-size: 0.72rem;
 	font-weight: 600;
 	color: rgba(255, 255, 255, 0.7);
-	background: rgba(99, 102, 241, 0.12);
-	border: 1px solid rgba(99, 102, 241, 0.3);
+	background: rgb(var(--nx-accent-rgb) / 0.12);
+	border: 1px solid rgb(var(--nx-accent-rgb) / 0.3);
 	cursor: pointer;
 	font-family: inherit;
 	transition: background 0.12s, border-color 0.12s, color 0.12s;
 }
 
 .btn-copy:hover {
-	background: rgba(99, 102, 241, 0.2);
-	border-color: rgba(99, 102, 241, 0.5);
+	background: rgb(var(--nx-accent-rgb) / 0.2);
+	border-color: rgb(var(--nx-accent-rgb) / 0.5);
 	color: rgba(255, 255, 255, 0.9);
 }
 


### PR DESCRIPTION
Sweep v2 : **436 remplacements / 53 fichiers**. Les widgets homepage (HeroBanner, stats, cards) étaient en **cyan** (`#06b6d4`, `#67e8f9`) + **glows rgba** (`rgba(124,58,237)` violet, `rgba(6,182,212)` cyan), non couverts par le 1er sweep -> d'où l'absence d'effet visuel sur la homepage.

- cyan -> `var(--nx-cyan*)`
- glows -> `rgb(var(--nx-*-rgb) / alpha)` (triplets RGB tokenisés)
- défauts = couleurs historiques -> **nodyx.org identique**

Complète le chantier theming (#165 cascade, #166 accents). Couvre enfin la palette réelle des widgets.