### PR TITLE
feat(theme): effet de fond d'instance (pluie Matrix optionnelle)

### DIFF
--- a/nodyx-core/src/routes/instance.ts
+++ b/nodyx-core/src/routes/instance.ts
@@ -106,7 +106,7 @@ export default async function instanceRoutes(app: FastifyInstance) {
       //  - theme_vars : thème structuré (--p-bg/--p-accent…), base de la cascade
       //  - theme_css  : surcharge CSS libre (variables Tailwind) en complément
       db.query<{ key: string; value: string | null }>(
-        `SELECT key, value FROM instance_settings WHERE key IN ('theme_css','theme_vars')`
+        `SELECT key, value FROM instance_settings WHERE key IN ('theme_css','theme_vars','theme_effect')`
       ).catch(() => ({ rows: [] as { key: string; value: string | null }[] })),
     ])
 
@@ -135,6 +135,7 @@ export default async function instanceRoutes(app: FastifyInstance) {
         if (!raw) return null
         try { return JSON.parse(raw) } catch { return null }
       })(),
+      theme_effect: themeRes.rows.find(r => r.key === 'theme_effect')?.value ?? null,
       demo_mode:    process.env.NODYX_DEMO_MODE === 'true',
     })
   })

--- a/nodyx-frontend/src/lib/components/MatrixRain.svelte
+++ b/nodyx-frontend/src/lib/components/MatrixRain.svelte
@@ -1,0 +1,103 @@
+<!--
+  MatrixRain — pluie de caractères façon console, en fond.
+  Pensée pour être SUBTILE (pas agressive) : têtes de colonne claires (halo
+  vert->blanc), traîne verte qui s'efface, cadence réduite, et désactivée si
+  l'utilisateur a demandé "moins d'animations" (prefers-reduced-motion).
+  Montée uniquement quand l'instance a theme_effect === 'matrix'.
+  Le canvas est fixe, derrière le contenu (z-index -1), et n'intercepte rien.
+-->
+<script lang="ts">
+	import { onMount } from 'svelte'
+
+	// Glyphes : katakana demi-chasse + chiffres + hexa (l'alphabet "Matrix")
+	const GLYPHS = 'ｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜ0123456789ABCDEF'
+	const FONT = 16        // taille de glyphe (px)
+	const STEP_MS = 70     // cadence : ~14 fps, défilement lent et calme
+	const HEAD = 'rgba(220,255,235,0.95)'  // tête claire = halo vert->blanc
+	const TAIL = 'rgba(46,230,115,'        // traîne verte (+ alpha)
+
+	let canvas: HTMLCanvasElement
+
+	onMount(() => {
+		const reduce = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+		const ctx = canvas.getContext('2d')
+		if (!ctx) return
+
+		let drops: number[] = []
+		let raf = 0
+		let last = 0
+		let running = true
+
+		function resize() {
+			const dpr = Math.min(window.devicePixelRatio || 1, 2)
+			canvas.width = Math.floor(innerWidth * dpr)
+			canvas.height = Math.floor(innerHeight * dpr)
+			canvas.style.width = innerWidth + 'px'
+			canvas.style.height = innerHeight + 'px'
+			ctx!.setTransform(dpr, 0, 0, dpr, 0, 0)
+			ctx!.font = `${FONT}px monospace`
+			ctx!.textBaseline = 'top'
+			const cols = Math.ceil(innerWidth / FONT)
+			drops = Array.from({ length: cols }, () => Math.floor((Math.random() * -innerHeight) / FONT))
+		}
+
+		function frame(now: number) {
+			if (!running) return
+			raf = requestAnimationFrame(frame)
+			if (now - last < STEP_MS) return
+			last = now
+
+			// Voile sombre semi-transparent : efface progressivement (la traîne)
+			ctx!.fillStyle = 'rgba(8,13,9,0.10)'
+			ctx!.fillRect(0, 0, innerWidth, innerHeight)
+
+			for (let i = 0; i < drops.length; i++) {
+				const x = i * FONT
+				const y = drops[i] * FONT
+				const ch = GLYPHS[(Math.random() * GLYPHS.length) | 0]
+				if (y > 0) {
+					// glyphe juste derrière la tête, vert plus doux
+					ctx!.fillStyle = TAIL + '0.35)'
+					ctx!.fillText(GLYPHS[(Math.random() * GLYPHS.length) | 0], x, y - FONT)
+				}
+				// tête de colonne, claire
+				ctx!.fillStyle = HEAD
+				ctx!.fillText(ch, x, y)
+
+				if (y > innerHeight && Math.random() > 0.975) drops[i] = 0
+				else drops[i]++
+			}
+		}
+
+		resize()
+		window.addEventListener('resize', resize)
+
+		if (reduce) {
+			// Mouvement coupé : un rendu statique très léger, une seule passe
+			ctx.fillStyle = TAIL + '0.18)'
+			for (let i = 0; i < drops.length; i++) {
+				ctx.fillText(GLYPHS[(Math.random() * GLYPHS.length) | 0], i * FONT, (Math.random() * innerHeight))
+			}
+		} else {
+			raf = requestAnimationFrame(frame)
+		}
+
+		return () => {
+			running = false
+			cancelAnimationFrame(raf)
+			window.removeEventListener('resize', resize)
+		}
+	})
+</script>
+
+<canvas bind:this={canvas} class="matrix-rain" aria-hidden="true"></canvas>
+
+<style>
+	.matrix-rain {
+		position: fixed;
+		inset: 0;
+		z-index: -1;          /* derrière le contenu (root transparent) */
+		pointer-events: none; /* n'intercepte aucun clic */
+		opacity: 0.5;         /* subtil, pas agressif */
+	}
+</style>

--- a/nodyx-frontend/src/routes/+layout.server.ts
+++ b/nodyx-frontend/src/routes/+layout.server.ts
@@ -81,6 +81,8 @@ export const load: LayoutServerLoad = async ({ fetch, cookies, request, url }) =
 	const themeCss: string | null    = infoJson?.theme_css   ?? null;
 	// Thème imposé par l'owner de l'instance (base de la cascade ; un membre peut le surcharger via son profil)
 	const instanceTheme: Record<string, unknown> | null = infoJson?.theme_vars ?? null;
+	// Effet de fond optionnel posé par l'owner (ex 'matrix' = pluie de caractères)
+	const instanceEffect: string | null = infoJson?.theme_effect ?? null;
 
 	// Toutes les instances du réseau (directory), filtre l'instance courante
 	const allInstances: Array<{
@@ -89,7 +91,7 @@ export const load: LayoutServerLoad = async ({ fetch, cookies, request, url }) =
 	}> = (((directoryJson as any)?.instances) ?? []).filter((i: { slug: string }) => i.slug !== currentSlug);
 
 	if (!token || !userRes?.ok) {
-		return { user: null, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount: 0, token: null, networkInstances: [], directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion, themeCss, instanceTheme };
+		return { user: null, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount: 0, token: null, networkInstances: [], directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion, themeCss, instanceTheme, instanceEffect };
 	}
 
 	const { user } = await userRes.json();
@@ -119,5 +121,5 @@ export const load: LayoutServerLoad = async ({ fetch, cookies, request, url }) =
 	const linkedSlugs: string[] = user.linked_instances ?? [];
 	const networkInstances = allInstances.filter(i => linkedSlugs.includes(i.slug));
 
-	return { user, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount, token: token || null, appTheme, networkInstances, directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion, themeCss, instanceTheme };
+	return { user, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount, token: token || null, appTheme, networkInstances, directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion, themeCss, instanceTheme, instanceEffect };
 };

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -14,6 +14,7 @@
 	import { buildNameStyle, buildAnimClass, ensureFontLoaded, GOOGLE_FONTS_URL } from '$lib/nameEffects';
 	import VoicePanel from '$lib/components/VoicePanel.svelte';
 	import CommandPalette from '$lib/components/CommandPalette.svelte';
+	import MatrixRain from '$lib/components/MatrixRain.svelte';
 	import MemberScreenPreview from '$lib/components/MemberScreenPreview.svelte';
 	import MaintenanceBanner from '$lib/components/MaintenanceBanner.svelte';
 	import NodyxVersionBadge from '$lib/components/NodyxVersionBadge.svelte';
@@ -119,6 +120,8 @@
 
 	// App-wide theme — cascade : défaut → thème d'INSTANCE (owner, son univers) → thème du MEMBRE (override perso)
 	const appVars = $derived(themeToVars(resolveTheme((data as any).appTheme, (data as any).instanceTheme)))
+	// Effet de fond posé par l'owner (ex 'matrix' = pluie de caractères derrière le contenu)
+	const hasMatrix = $derived((data as any).instanceEffect === 'matrix')
 
 	// All community members (for offline section in presence sidebar)
 	let allMembers = $state<{ user_id: string; username: string; avatar: string | null }[]>([])
@@ -489,7 +492,8 @@
 	<!-- Overlay OBS : aucun chrome Nodyx, juste la page transparente. -->
 	{@render children()}
 {:else}
-<div class="min-h-screen flex flex-col" style="{appVars}; background: var(--p-bg); color: var(--p-text)">
+{#if hasMatrix}<MatrixRain />{/if}
+<div class="min-h-screen flex flex-col" style="{appVars}; background: {hasMatrix ? 'transparent' : 'var(--p-bg)'}; color: var(--p-text)">
 
 	<!-- Listener Streamer Hub : joue les sons de notif pour les admins/owners. -->
 	{#if data.user?.role}


### PR DESCRIPTION
L'owner peut poser `theme_effect='matrix'` (dans `instance_settings`) -> le frontend monte un `<canvas>` de pluie de caractères **derrière le contenu** :
- têtes de colonne claires = halo vert->blanc (cohérent avec le thème)
- cadence lente (~14 fps), **subtile, pas agressive**
- respecte `prefers-reduced-motion` (statique si l'user a coupé les animations)
- `pointer-events: none`, `z-index: -1` (n'intercepte rien)

Le root passe en fond transparent quand l'effet est actif. Sans `theme_effect` : aucun changement (nodyx.org intact). Effet scopé par instance.