### PR TITLE
feat(feed): temps réel (posts, likes, réactions, reshares, réponses)

### DIFF
--- a/nodyx-core/src/routes/social.ts
+++ b/nodyx-core/src/routes/social.ts
@@ -216,8 +216,15 @@ export default async function socialRoutes(app: FastifyInstance) {
       WHERE sp.id = $1
     `, [ins.rows[0].id, userId])
 
-    // Notify followers in real-time
-    io?.to(`user:${userId}`).emit('feed:new', post.rows[0])
+    // Temps réel : diffusion à TOUS les membres en ligne (room 'presence'),
+    // pas seulement à l'auteur. Un post racine apparaît dans le fil ; une
+    // réponse met à jour le compteur de réponses du parent.
+    if (reply_to_id) {
+      const rc = await db.query('SELECT replies_count FROM status_posts WHERE id = $1', [reply_to_id])
+      io?.to('presence').emit('feed:count', { id: reply_to_id, replies_count: rc.rows[0]?.replies_count })
+    } else {
+      io?.to('presence').emit('feed:new', post.rows[0])
+    }
 
     return reply.code(201).send(post.rows[0])
   })
@@ -243,6 +250,13 @@ export default async function socialRoutes(app: FastifyInstance) {
     // Réputation : suppression d'un statut = -2 (anti-farming)
     await awardPoints(userId, -REPUTATION.SOCIAL_POST)
 
+    // Temps réel : retrait du post chez tous + MAJ compteur de réponses du parent
+    io?.to('presence').emit('feed:delete', { id: del.rows[0].id })
+    if (del.rows[0].reply_to_id) {
+      const rc = await db.query('SELECT replies_count FROM status_posts WHERE id = $1', [del.rows[0].reply_to_id])
+      io?.to('presence').emit('feed:count', { id: del.rows[0].reply_to_id, replies_count: rc.rows[0]?.replies_count })
+    }
+
     return reply.send({ ok: true })
   })
 
@@ -264,6 +278,7 @@ export default async function socialRoutes(app: FastifyInstance) {
       [id]
     )
 
+    io?.to('presence').emit('feed:count', { id, likes_count: result.rows[0]?.likes_count })
     return reply.send({ ok: true, likes_count: result.rows[0]?.likes_count })
   })
 
@@ -277,10 +292,11 @@ export default async function socialRoutes(app: FastifyInstance) {
     )
 
     if (del.rows[0]) {
-      await db.query(
-        'UPDATE status_posts SET likes_count = GREATEST(0, likes_count - 1) WHERE id = $1',
+      const r = await db.query<{ likes_count: number }>(
+        'UPDATE status_posts SET likes_count = GREATEST(0, likes_count - 1) WHERE id = $1 RETURNING likes_count',
         [id]
       )
+      io?.to('presence').emit('feed:count', { id, likes_count: r.rows[0]?.likes_count })
     }
 
     return reply.send({ ok: true })
@@ -312,6 +328,7 @@ export default async function socialRoutes(app: FastifyInstance) {
         [id]
       )
       likes_count = r.rows[0]?.likes_count
+      io?.to('presence').emit('feed:count', { id, likes_count })
     }
     return reply.send({ ok: true, likes_count })
   })
@@ -333,14 +350,23 @@ export default async function socialRoutes(app: FastifyInstance) {
       'SELECT id FROM status_posts WHERE author_id = $1 AND reshare_of = $2',
       [userId, targetId]
     )
+    const emitReshareCount = async () => {
+      const c = await db.query<{ n: number }>(
+        'SELECT COUNT(*)::int AS n FROM status_posts WHERE reshare_of = $1', [targetId]
+      )
+      io?.to('presence').emit('feed:count', { id: targetId, reshares_count: c.rows[0]?.n })
+    }
+
     if (existing.rows[0]) {
       await db.query('DELETE FROM status_posts WHERE id = $1', [existing.rows[0].id])
+      await emitReshareCount()
       return reply.send({ ok: true, reshared: false })
     }
     await db.query(
       "INSERT INTO status_posts (author_id, content, reshare_of) VALUES ($1, '', $2)",
       [userId, targetId]
     )
+    await emitReshareCount()
     return reply.send({ ok: true, reshared: true })
   })
 

--- a/nodyx-frontend/src/routes/feed/+page.svelte
+++ b/nodyx-frontend/src/routes/feed/+page.svelte
@@ -5,6 +5,8 @@
 	import { apiFetch } from '$lib/api'
 	import { onMount, untrack } from 'svelte'
 	import NodyxEditor from '$lib/components/editor/NodyxEditor.svelte'
+	import { socket as socketStore } from '$lib/socket'
+	import type { Socket } from 'socket.io-client'
 
 	const tFn = $derived($t)
 
@@ -290,6 +292,37 @@
 		}, { rootMargin: '200px' })
 		if (sentinel) obs.observe(sentinel)
 		return () => obs.disconnect()
+	})
+
+	// ── Temps réel : on reflète live ce que font les autres membres ──────────────
+	// Le backend diffuse vers la room 'presence' (tous les membres en ligne).
+	// Les MAJ de compteurs sont idempotentes (on POSE la valeur, pas +1) pour ne
+	// pas double-compter avec l'optimistic UI de l'auteur de l'action.
+	onMount(() => {
+		const onNew = (post: any) => {
+			// Nouveau post : on l'ajoute en tête (sauf onglet Abonnements, et si déjà présent)
+			if (scope === 'discover' && post?.id && !posts.some(p => p.id === post.id)) {
+				posts = [post, ...posts]
+			}
+		}
+		const onDelete = ({ id }: { id: string }) => { posts = posts.filter(p => p.id !== id) }
+		const onCount = (d: { id: string; likes_count?: number; replies_count?: number; reshares_count?: number }) => {
+			posts = posts.map(p => (p.id === d.id || p.reshare_of === d.id)
+				? { ...p,
+					...(d.likes_count    !== undefined ? { likes_count:    d.likes_count }    : {}),
+					...(d.replies_count  !== undefined ? { replies_count:  d.replies_count }  : {}),
+					...(d.reshares_count !== undefined ? { reshares_count: d.reshares_count } : {}) }
+				: p)
+		}
+		let bound: Socket | null = null
+		const detach = (s: Socket) => { s.off('feed:new', onNew); s.off('feed:delete', onDelete); s.off('feed:count', onCount) }
+		const unsub = socketStore.subscribe((s) => {
+			if (s === bound) return
+			if (bound) detach(bound)
+			if (s) { s.on('feed:new', onNew); s.on('feed:delete', onDelete); s.on('feed:count', onCount) }
+			bound = s
+		})
+		return () => { unsub(); if (bound) detach(bound) }
 	})
 </script>
 


### PR DESCRIPTION
**Bug** : le feed social n'était pas temps-réel. À deux sur une instance, les actions de l'un n'apparaissaient pas chez l'autre sans rafraîchir.

**Cause** : le backend n'émettait `feed:new` qu'à l'auteur (`user:${id}`), et le frontend **n'écoutait aucun event**.

**Fix** :
- **Backend** (`social.ts`) : diffusion vers la room `presence` (tous les membres en ligne) sur création / suppression / like / unlike / réaction / reshare / réponse. Events : `feed:new`, `feed:delete`, `feed:count` (compteurs likes/replies/reshares en valeur absolue).
- **Frontend** (`feed`) : écoute via le store socket, MAJ **idempotentes** (on pose la valeur, pas +1) pour ne pas double-compter avec l'optimistic UI ; dédup par id ; nouveaux posts en tête (onglet Découvrir).

Profite à nodyx.org **et** sleemstudio (code partagé).