### PR TITLE
fix(cache): no-cache sur les pages HTML SSR (anti-home figée)

### DIFF
--- a/nodyx-frontend/src/hooks.server.ts
+++ b/nodyx-frontend/src/hooks.server.ts
@@ -20,6 +20,16 @@ export const handle: Handle = async ({ event, resolve }) => {
 		response.headers.set('cache-control', 'no-cache, no-store, must-revalidate');
 		response.headers.set('pragma',         'no-cache');
 		response.headers.set('expires',        '0');
+	} else if (
+		!response.headers.has('cache-control') &&
+		(response.headers.get('content-type') ?? '').includes('text/html')
+	) {
+		// Pages SSR (HTML) : jamais servies périmées par le navigateur / SW / CDN.
+		// Sans en-tête, certains navigateurs cachent l'HTML de façon heuristique
+		// -> page d'accueil figée ("grid builder inactif") en arrivant d'une autre
+		// instance (navigation same-site). no-cache force une revalidation à chaque
+		// navigation : le serveur renvoie toujours l'HTML SSR frais.
+		response.headers.set('cache-control', 'no-cache, must-revalidate');
 	}
 	return response;
 };


### PR DESCRIPTION
**Symptôme** : en arrivant sur nodyx.org **depuis une autre instance** (`*.nodyx.org` via l'annuaire, navigation same-site), la home s'affichait figée avec le **grid builder inactif**, nécessitant plusieurs hard-refresh. Depuis un moteur de recherche (cross-site) : aucun souci.

**Diagnostic** : le serveur rend **toujours** le grid (SSR vérifié sur 17 contextes : referer, cookie étranger, sec-fetch, etc.). Le coupable est le **cache client** : les pages SSR n'avaient **aucun `Cache-Control`**, donc certains navigateurs cachaient l'HTML de façon heuristique (plus agressive en same-site).

**Fix** : `handle` pose `cache-control: no-cache, must-revalidate` sur les réponses `text/html` sans en-tête existant -> revalidation à chaque navigation, HTML SSR toujours frais. Complète le rechargement transparent du SW (#179).