### PR TITLE
fix(stats): exclure les users système du compteur de membres

### DIFF
--- a/nodyx-core/src/routes/instance.ts
+++ b/nodyx-core/src/routes/instance.ts
@@ -93,7 +93,7 @@ export default async function instanceRoutes(app: FastifyInstance) {
     const communityId = await getCommunityId()
 
     const [memberRes, threadRes, postRes, presenceSockets, brandingRes, themeRes] = await Promise.all([
-      db.query(`SELECT COUNT(*)::int AS count FROM users`),
+      db.query(`SELECT COUNT(*)::int AS count FROM users WHERE is_system = false`),
       db.query(`SELECT COUNT(*)::int AS count FROM threads`),
       db.query(`SELECT COUNT(*)::int AS count FROM posts`),
       io ? io.in('presence').fetchSockets() : Promise.resolve([]),

--- a/nodyx-core/src/scheduler.ts
+++ b/nodyx-core/src/scheduler.ts
@@ -21,7 +21,7 @@ async function pingDirectory(io: Server) {
   if (!token) return
 
   try {
-    const membersResult = await db.query('SELECT COUNT(*) AS count FROM users WHERE id NOT IN (SELECT user_id FROM community_bans)')
+    const membersResult = await db.query('SELECT COUNT(*) AS count FROM users WHERE is_system = false AND id NOT IN (SELECT user_id FROM community_bans)')
     const members = parseInt(membersResult.rows[0]?.count ?? '0', 10)
     // Deduplicate by userId — same approach as instance.ts online_count
     const presenceSockets = await io.in('presence').fetchSockets()


### PR DESCRIPTION
`member_count` comptait **tous** les users, y compris **OctoGuard** (`is_system=true`) -> "3 membres au lieu de 2". La liste des membres (`/instance/members`) excluait déjà `is_system`, donc le compteur était incohérent avec elle. Ajout de `WHERE is_system = false` dans `/instance/info` et le ping annuaire. Profite à toutes les instances.