### PR TITLE
chore(status): élargir la page du post à 780px

### DIFF
--- a/nodyx-frontend/src/routes/status/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/status/[id]/+page.svelte
@@ -201,7 +201,7 @@
 </div>
 
 <style>
-	.s-wrap { max-width: 680px; margin: 0 auto; padding: 1.25rem 1rem 5rem; }
+	.s-wrap { max-width: 780px; margin: 0 auto; padding: 1.25rem 1rem 5rem; }
 	.s-back { display: inline-block; margin-bottom: 1rem; color: var(--nx-accent-soft); text-decoration: none; font-size: 0.875rem; }
 	.s-back:hover { text-decoration: underline; }
 	.s-card { border: 1px solid rgba(255,255,255,0.08); border-radius: 16px; background: rgba(255,255,255,0.02); padding: 1.1rem; margin-bottom: 0.75rem; }


### PR DESCRIPTION
Largeur de `/status/:id` portée de 680px à 780px (il y a de la place à l'écran).