### PR TITLE
fix(voice): mémoriser le volume par utilisateur (survit refresh)

### DIFF
--- a/nodyx-frontend/src/lib/components/VoicePanel.svelte
+++ b/nodyx-frontend/src/lib/components/VoicePanel.svelte
@@ -6,6 +6,7 @@
         startScreenShare, stopScreenShare, screenShareStore, remoteScreenStore,
         type VoicePeer, type PeerStats, type NetQuality,
     } from '$lib/voice'
+    import { getPeerVolume, savePeerVolume } from '$lib/voiceSettings'
 
     import VoiceSettings    from './VoiceSettings.svelte'
     import ScreenShareModal from './ScreenShareModal.svelte'
@@ -79,7 +80,7 @@
             const peer = peers.find(p => p.socketId === target.socketId)
             if (peer) {
                 selectedPeer = peer
-                if (!(peer.socketId in peerVolumes)) peerVolumes[peer.socketId] = 100
+                if (!(peer.socketId in peerVolumes)) peerVolumes[peer.socketId] = getPeerVolume(peer.userId)
                 selfInfo = null
             }
         }
@@ -87,7 +88,7 @@
 
     function openPeerPanel(peer: VoicePeer) {
         selectedPeer = selectedPeer?.socketId === peer.socketId ? null : peer
-        if (!(peer.socketId in peerVolumes)) peerVolumes[peer.socketId] = 100
+        if (!(peer.socketId in peerVolumes)) peerVolumes[peer.socketId] = getPeerVolume(peer.userId)
     }
 
     function closePanel() { selectedPeer = null }
@@ -95,6 +96,9 @@
     function onVolumeChange(socketId: string, v: number) {
         peerVolumes[socketId] = v
         setPeerVolume(socketId, v / 100)
+        // Mémorise par userId (survit refresh/reconnexion)
+        const peer = peers.find(p => p.socketId === socketId)
+        if (peer?.userId) savePeerVolume(peer.userId, v)
     }
 
     // ── Qualité réseau ────────────────────────────────────────────

--- a/nodyx-frontend/src/lib/voice.ts
+++ b/nodyx-frontend/src/lib/voice.ts
@@ -6,7 +6,7 @@
  */
 import { writable, derived, get } from 'svelte/store'
 import type { Socket } from 'socket.io-client'
-import { voiceSettingsStore, type VoiceSettings } from './voiceSettings'
+import { voiceSettingsStore, getPeerVolume, type VoiceSettings } from './voiceSettings'
 import { p2pManager } from './p2p'
 export { voiceSettingsStore } from './voiceSettings'
 export type { VoiceSettings } from './voiceSettings'
@@ -528,7 +528,9 @@ function createPeerAudio(socketId: string, stream: MediaStream): void {
   const audioEl     = new Audio()
   audioEl.srcObject = stream
   audioEl.autoplay  = true
-  audioEl.volume    = 1.0
+  // Volume mémorisé pour CET utilisateur (par userId → survit refresh/reconnexion)
+  const peer = get(voiceStore).peers.find(p => p.socketId === socketId)
+  audioEl.volume    = peer?.userId ? getPeerVolume(peer.userId) / 100 : 1.0
   audioEl.play().catch(() => {
     // Chrome desktop bloque l'autoplay si le contexte geste-utilisateur a expiré.
     // On réessaie au prochain clic ou frappe clavier (une seule fois suffit).

--- a/nodyx-frontend/src/lib/voiceSettings.ts
+++ b/nodyx-frontend/src/lib/voiceSettings.ts
@@ -63,3 +63,25 @@ voiceSettingsStore.subscribe(v => {
     localStorage.setItem('nodyx:voiceSettings', JSON.stringify(v))
   }
 })
+
+// ── Volume par utilisateur (mémorisé entre sessions) ──────────────────────────
+// Indexé par userId (STABLE) et non par socketId (qui change à chaque connexion) :
+// le volume qu'on attribue à quelqu'un survit ainsi au refresh et aux reconnexions.
+const PEER_VOL_KEY = 'nodyx:peerVolumes'
+
+export function loadPeerVolumes(): Record<string, number> {
+  if (typeof localStorage === 'undefined') return {}
+  try { return JSON.parse(localStorage.getItem(PEER_VOL_KEY) || '{}') } catch { return {} }
+}
+
+export function getPeerVolume(userId: string): number {
+  const v = loadPeerVolumes()[userId]
+  return typeof v === 'number' ? v : 100
+}
+
+export function savePeerVolume(userId: string, volume: number): void {
+  if (typeof localStorage === 'undefined' || !userId) return
+  const all = loadPeerVolumes()
+  all[userId] = volume
+  try { localStorage.setItem(PEER_VOL_KEY, JSON.stringify(all)) } catch { /* quota */ }
+}


### PR DESCRIPTION
Le volume qu'on attribue à un autre membre était indexé par **socketId** (éphémère, change à chaque connexion) et gardé **en mémoire** seulement -> il repassait à 100 au refresh ou à la reconnexion du peer.

Fix : persistance par **userId** (stable) en localStorage (`nodyx:peerVolumes`) via `getPeerVolume`/`savePeerVolume`. Appliqué :
- à la création de l'audio du peer (`createPeerAudio`, dès qu'il se connecte),
- comme valeur par défaut du slider dans VoicePanel,
- sauvegardé à chaque changement de volume.

Le son attribué à quelqu'un survit maintenant au refresh et aux reconnexions. (Bug #6 de la liste sleemstudio.)