### PR TITLE
fix(emojis): ne pas rendre :shortcode: dans du code

### DIFF
--- a/nodyx-frontend/src/lib/customEmojis.ts
+++ b/nodyx-frontend/src/lib/customEmojis.ts
@@ -22,9 +22,12 @@ export async function loadCustomEmojis(fetchFn: typeof fetch = fetch): Promise<v
 	}
 }
 
+const SEN = String.fromCharCode(0)   // sentinel improbable dans du HTML
+
 /**
  * Remplace les :shortcode: connus par leur image. Ne touche qu'aux shortcodes
  * EXISTANTS (map.get), donc "15:30:45" ou une URL ne sont jamais altérés.
+ * Le contenu des <code>/<pre> est protégé : dans du code, :rat: reste littéral.
  * S'applique au HTML déjà rendu (après linkify).
  */
 export function renderCustomEmojis(html: string, list?: CustomEmoji[]): string {
@@ -32,9 +35,19 @@ export function renderCustomEmojis(html: string, list?: CustomEmoji[]): string {
 	list = list ?? get(customEmojisStore)
 	if (list.length === 0) return html
 	const map = new Map(list.map(e => [e.shortcode, e]))
-	return html.replace(/:([a-z0-9_]{1,50}):/gi, (m, code) => {
+
+	// Protège <code>…</code> et <pre>…</pre> (on n'y transforme PAS les shortcodes)
+	const stash: string[] = []
+	let out = html.replace(/<(code|pre)\b[^>]*>[\s\S]*?<\/\1>/gi, (m) => {
+		stash.push(m)
+		return SEN + (stash.length - 1) + SEN
+	})
+
+	out = out.replace(/:([a-z0-9_]{1,50}):/gi, (m, code) => {
 		const e = map.get(String(code).toLowerCase())
 		if (!e) return m
 		return `<img class="nx-emoji" src="${e.url}" alt=":${e.shortcode}:" title=":${e.shortcode}:" draggable="false">`
 	})
+
+	return out.replace(new RegExp(SEN + '(\\d+)' + SEN, 'g'), (_, i) => stash[Number(i)])
 }


### PR DESCRIPTION
`:rat:` était converti en image même dans un bloc/inline **code**. `renderCustomEmojis` protège désormais le contenu des `<code>` et `<pre>` (sentinel) -> dans du code, `:rat:` reste littéral.