### PR TITLE
feat(emojis): raccourci texte perso à l'upload + fiche

### DIFF
--- a/nodyx-core/src/routes/assets.ts
+++ b/nodyx-core/src/routes/assets.ts
@@ -94,6 +94,9 @@ export default async function assetRoutes(app: FastifyInstance) {
     const description = (data.fields['description'] as { value?: string } | undefined)?.value?.trim()
     const assetType   = (data.fields['asset_type']  as { value?: string } | undefined)?.value?.trim() as AssetType | undefined
     const tagsRaw     = (data.fields['tags']        as { value?: string } | undefined)?.value
+    // Raccourci texte personnalisé (emoji) : :shortcode: — optionnel, sinon dérivé du nom.
+    const shortcodeRaw = (data.fields['shortcode']  as { value?: string } | undefined)?.value
+    const shortcode    = shortcodeRaw ? shortcodeRaw.toLowerCase().replace(/[^a-z0-9_]/g, '').slice(0, 50) : ''
 
     if (!name)      return reply.code(400).send({ error: 'Le champ "name" est requis.' })
     if (!assetType || !VALID_TYPES.includes(assetType)) {
@@ -136,6 +139,14 @@ export default async function assetRoutes(app: FastifyInstance) {
         description:      description || undefined,
         tags,
       })
+      // Emoji : mémoriser le raccourci texte perso dans metadata (sinon dérivé du nom)
+      if (assetType === 'emoji' && shortcode) {
+        await db.query(
+          `UPDATE community_assets SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object('shortcode', $2::text) WHERE id = $1`,
+          [asset.id, shortcode]
+        ).catch(() => {})
+        ;(asset as { metadata?: Record<string, unknown> }).metadata = { ...((asset as { metadata?: Record<string, unknown> }).metadata ?? {}), shortcode }
+      }
       return reply.code(201).send({ asset })
     } catch (err: unknown) {
       app.log.error(err)

--- a/nodyx-core/src/routes/instance.ts
+++ b/nodyx-core/src/routes/instance.ts
@@ -466,15 +466,16 @@ export default async function instanceRoutes(app: FastifyInstance) {
   // Utilisables dans les messages via :shortcode: (dérivé du nom de l'asset).
   app.get('/emojis', { preHandler: [rateLimit] }, async (_request, reply) => {
     try {
-      const { rows } = await db.query<{ name: string; file_path: string }>(
-        `SELECT name, file_path FROM community_assets
+      const { rows } = await db.query<{ name: string; file_path: string; metadata: { shortcode?: string } | null }>(
+        `SELECT name, file_path, metadata FROM community_assets
          WHERE asset_type = 'emoji' AND is_public = true AND is_banned = false
          ORDER BY name ASC LIMIT 500`
       )
       const emojis = rows
         .map(r => ({
           name: r.name,
-          shortcode: r.name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, ''),
+          // Raccourci personnalisé (metadata.shortcode) sinon dérivé du nom
+          shortcode: (r.metadata?.shortcode || r.name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')),
           url: `/uploads/${r.file_path}`,
         }))
         .filter(e => e.shortcode.length > 0)

--- a/nodyx-frontend/src/lib/locales/de.json
+++ b/nodyx-frontend/src/lib/locales/de.json
@@ -1,4 +1,6 @@
 {
+  "library.emoji_shortcode": "Text-Kürzel",
+  "library.emoji_shortcode_ph": "rat — optional, sonst aus dem Namen",
   "chat.emoji": "Emoji",
   "emoji.custom": "Eigene",
   "common.back": "Zurück",

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -1,4 +1,6 @@
 {
+  "library.emoji_shortcode": "Text shortcut",
+  "library.emoji_shortcode_ph": "rat — optional, otherwise from the name",
   "chat.emoji": "Emoji",
   "emoji.custom": "Custom",
   "common.back": "Back",

--- a/nodyx-frontend/src/lib/locales/es.json
+++ b/nodyx-frontend/src/lib/locales/es.json
@@ -1,4 +1,6 @@
 {
+  "library.emoji_shortcode": "Atajo de texto",
+  "library.emoji_shortcode_ph": "rat — opcional, si no del nombre",
   "chat.emoji": "Emoji",
   "emoji.custom": "Personalizados",
   "common.back": "Volver",

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -1,4 +1,6 @@
 {
+  "library.emoji_shortcode": "Raccourci texte",
+  "library.emoji_shortcode_ph": "rat — optionnel, sinon dérivé du nom",
   "chat.emoji": "Emoji",
   "emoji.custom": "Perso",
   "common.back": "Retour",

--- a/nodyx-frontend/src/lib/locales/pt-PT.json
+++ b/nodyx-frontend/src/lib/locales/pt-PT.json
@@ -1,4 +1,6 @@
 {
+  "library.emoji_shortcode": "Atalho de texto",
+  "library.emoji_shortcode_ph": "rat — opcional, senão do nome",
   "chat.emoji": "Emoji",
   "emoji.custom": "Personalizados",
   "common.back": "Voltar",

--- a/nodyx-frontend/src/lib/locales/ru.json
+++ b/nodyx-frontend/src/lib/locales/ru.json
@@ -1,4 +1,6 @@
 {
+  "library.emoji_shortcode": "Текстовый код",
+  "library.emoji_shortcode_ph": "rat — иначе из имени",
   "chat.emoji": "Эмодзи",
   "emoji.custom": "Свои",
   "common.back": "Назад",

--- a/nodyx-frontend/src/routes/library/+page.svelte
+++ b/nodyx-frontend/src/routes/library/+page.svelte
@@ -3,8 +3,11 @@
 	import { goto } from '$app/navigation'
 	import { page } from '$app/state'
 	import { PUBLIC_API_URL } from '$env/static/public'
+	import { t } from '$lib/i18n'
 
 	let { data }: { data: PageData } = $props()
+
+	const tFn = $derived($t)
 
 	const token = $derived((page.data as any).token as string | null)
 
@@ -39,6 +42,7 @@
 	let uploadDescription = $state('')
 	let uploadType        = $state('sticker')
 	let uploadTags        = $state('')
+	let uploadShortcode   = $state('')   // emoji : raccourci texte perso (:code:)
 	let uploadFile        = $state<File | null>(null)
 	let uploadPreview     = $state<string | null>(null)
 
@@ -110,6 +114,7 @@
 		form.append('description', uploadDescription)
 		form.append('asset_type',  uploadType)
 		form.append('tags',        uploadTags)
+		if (uploadType === 'emoji') form.append('shortcode', uploadShortcode)
 		form.append('file',        uploadFile) // must be last — @fastify/multipart only sees fields before the file
 
 		const res = await fetch(`${PUBLIC_API_URL}/api/v1/assets`, {
@@ -226,7 +231,14 @@
 				<input id="lib-tags" bind:value={uploadTags} placeholder="pixel-art, doré, frame"
 					class="lib-input" />
 			</div>
-			{#if currentTypeTip}
+			{#if uploadType === 'emoji'}
+					<div class="lib-field lib-field--full">
+						<label for="lib-shortcode" class="lib-label">{tFn('library.emoji_shortcode')}</label>
+						<input id="lib-shortcode" bind:value={uploadShortcode} maxlength="50"
+							placeholder={tFn('library.emoji_shortcode_ph')} class="lib-input" />
+					</div>
+				{/if}
+				{#if currentTypeTip}
 				<div class="lib-tip lib-field--full">
 					<span class="lib-tip-icon">💡</span>
 					<div class="lib-tip-body">

--- a/nodyx-frontend/src/routes/library/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/library/[id]/+page.svelte
@@ -23,6 +23,21 @@
 	}
 	const equipField  = $derived(EQUIPPABLE[asset.asset_type] ?? null)
 	const canEquip    = $derived(!!equipField && !!me)
+
+	// Emoji : raccourci texte (:shortcode:) — perso (metadata) sinon dérivé du nom
+	const emojiShortcode = $derived(
+		asset.asset_type === 'emoji'
+			? ((asset.metadata as { shortcode?: string } | null)?.shortcode
+				|| asset.name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, ''))
+			: ''
+	)
+	let copiedCode = $state(false)
+	function copyShortcode() {
+		navigator.clipboard?.writeText(`:${emojiShortcode}:`).then(() => {
+			copiedCode = true
+			setTimeout(() => (copiedCode = false), 1200)
+		}).catch(() => {})
+	}
 	const equipLabel  = $derived(
 		asset.asset_type === 'frame'  ? 'Équiper comme cadre'   :
 		asset.asset_type === 'banner' ? 'Équiper comme bannière' :
@@ -173,6 +188,13 @@
 						&nbsp;·&nbsp; {(asset.file_size / 1024).toFixed(1)} Ko
 						&nbsp;·&nbsp; {asset.downloads} téléchargement{asset.downloads !== 1 ? 's' : ''}
 					</p>
+					{#if emojiShortcode}
+						<button onclick={copyShortcode} title={copiedCode ? 'Copié !' : 'Copier le raccourci'}
+							class="mt-2 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-sm bg-white/[0.06] border border-white/10 hover:border-white/25 transition-colors">
+							<span class="font-mono" style="color: var(--nx-accent-soft)">:{emojiShortcode}:</span>
+							<span style="color: {copiedCode ? '#4ade80' : '#6b7280'}">{copiedCode ? '✓' : '⧉'}</span>
+						</button>
+					{/if}
 				</div>
 				<div class="flex gap-2 shrink-0">
 					{#if canEquip}
@@ -183,15 +205,6 @@
 							       {equipped ? 'bg-gray-700 cursor-default' : 'bg-emerald-700 hover:bg-emerald-600'}"
 						>
 							{equipping ? '…' : equipped ? '✓ Équipé' : equipLabel}
-						</button>
-					{/if}
-					{#if me}
-						<button
-							onclick={startWhisper}
-							disabled={whispering}
-							class="px-4 py-2 rounded-lg bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-sm font-semibold text-gray-200 transition-colors"
-						>
-							{whispering ? '…' : '🤫 Chuchoter'}
 						</button>
 					{/if}
 					<button


### PR DESCRIPTION
Suite de la feature emojis custom (demande Lapersonne).

- **Upload emoji** : champ optionnel **Raccourci texte** (i18n `library.emoji_shortcode`, 6 langues) -> stocké dans `community_assets.metadata.shortcode` (sanitisé `[a-z0-9_]`, minuscules). Sans lui, le shortcode reste dérivé du nom.
- **`/instance/emojis`** : `metadata.shortcode` prioritaire, sinon dérivé.
- **Fiche biblio** : affiche `:shortcode:` (badge copiable) pour les emojis.
- **Fiche biblio** : bouton **Chuchoter** retiré (jugé inutile pour l'instant).

Casse : shortcode normalisé en minuscules au stockage + rendu case-insensitive (`:RAT:` = `:rat:`). NB : la page biblio est en français en dur (dette i18n pré-existante) ; mon nouveau champ est i18n.