### PR TITLE
feat(emojis): recherche + Fréquents (scale 100+)

### DIFF
--- a/nodyx-frontend/src/lib/components/EmojiPicker.svelte
+++ b/nodyx-frontend/src/lib/components/EmojiPicker.svelte
@@ -2,19 +2,18 @@
 	import { onMount } from 'svelte';
 	import { t } from '$lib/i18n';
 	import { customEmojisStore, loadCustomEmojis, type CustomEmoji } from '$lib/customEmojis';
+	import { emojiUsageStore, topEmojis } from '$lib/emojiUsage';
 
-	type Props = {
-		onselect: (emoji: string) => void;
-	};
-
+	type Props = { onselect: (emoji: string) => void };
 	let { onselect }: Props = $props();
 	const tFn = $derived($t);
 
 	let activeCategory = $state(0);
+	let query = $state('');
 
 	const custom = $derived($customEmojisStore);
 	const hasCustom = $derived(custom.length > 0);
-
+	const usage = $derived($emojiUsageStore);
 	onMount(() => { loadCustomEmojis(); });
 
 	const UNICODE = [
@@ -28,62 +27,81 @@
 		{ label: '✅', name: 'Symboles', emojis: ['✅','❌','⚠️','💯','🔴','🟠','🟡','🟢','🔵','🟣','⚫','⚪','🟤','🆕','🆓','🆗','🆙','🆒','ℹ️','🔔','🔕','📢','📣','🔊','🔇','🔀','🔁','🔂','▶️','⏸️','⏭️','⏮️','⏩','⏪','⬆️','⬇️','⬅️','➡️','↕️','↔️','🔄','♻️','🚫','⛔','❓','❗','‼️','⁉️','💤','🔅','🔆','📶','📳','📴','📵','📱','🔐','🔏'] },
 	];
 
-	// Onglet Custom (emojis de la bibliothèque) en TÊTE si présent
-	type Tab =
-		| { type: 'custom';  label: string; name: string; items: CustomEmoji[] }
-		| { type: 'unicode'; label: string; name: string; items: string[] };
+	// Item de rendu unifié (image custom OU glyphe unicode)
+	type Item = { key: string; display: 'img' | 'text'; src?: string; char?: string; sel: string; title: string };
+	const customItem  = (e: CustomEmoji): Item => ({ key: 'c:' + e.shortcode, display: 'img',  src: e.url, sel: `:${e.shortcode}:`, title: `:${e.shortcode}:` });
+	const unicodeItem = (ch: string): Item      => ({ key: 'u:' + ch,         display: 'text', char: ch,  sel: ch,                title: ch });
 
+	const customBySc = $derived(new Map(custom.map(e => [e.shortcode, e])));
+
+	// Fréquents : les plus utilisés par CE membre (custom + unicode mélangés)
+	const freqItems = $derived(
+		topEmojis(usage, 24)
+			.map(k => {
+				if (k.startsWith(':') && k.endsWith(':')) { const e = customBySc.get(k.slice(1, -1)); return e ? customItem(e) : null; }
+				return unicodeItem(k);
+			})
+			.filter((x): x is Item => x !== null)
+	);
+
+	type Tab = { type: 'freq' | 'custom' | 'unicode'; label: string; name: string; items: Item[] };
 	const tabs = $derived<Tab[]>([
-		...(hasCustom ? [{ type: 'custom' as const, label: '⭐', name: tFn('emoji.custom'), items: custom }] : []),
-		...UNICODE.map(c => ({ type: 'unicode' as const, label: c.label, name: c.name, items: c.emojis })),
+		...(freqItems.length > 0 ? [{ type: 'freq' as const,   label: '🕘', name: tFn('emoji.frequent'), items: freqItems }] : []),
+		...(hasCustom            ? [{ type: 'custom' as const, label: '⭐', name: tFn('emoji.custom'),   items: custom.map(customItem) }] : []),
+		...UNICODE.map(c => ({ type: 'unicode' as const, label: c.label, name: c.name, items: c.emojis.map(unicodeItem) })),
 	]);
-
 	const activeTab = $derived(tabs[activeCategory] ?? tabs[0]);
+
+	// Recherche : filtre les emojis CUSTOM (le vrai besoin quand il y en a 100+)
+	const searchItems = $derived(
+		query.trim()
+			? custom.filter(e => e.shortcode.includes(query.trim().toLowerCase()) || e.name.toLowerCase().includes(query.trim().toLowerCase())).map(customItem)
+			: []
+	);
+	const searching = $derived(query.trim().length > 0);
+	const gridItems = $derived(searching ? searchItems : (activeTab?.items ?? []));
 </script>
 
 <div class="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl overflow-hidden" style="width: 288px;">
-	<!-- Category tabs -->
-	<div class="flex border-b border-gray-800 bg-gray-950/80">
-		{#each tabs as cat, i}
-			{#if cat.type === 'custom'}
-				<!-- Onglet des emojis de l'instance : mis en avant (accent + label) -->
-				<button
-					onclick={() => (activeCategory = i)}
-					title={cat.name}
-					class="flex items-center gap-1 px-2.5 py-2 text-xs font-bold uppercase tracking-wide border-r border-gray-800 transition-colors {activeCategory === i
-						? 'text-white'
-						: 'text-gray-300 hover:text-white'}"
-					style="background: rgb(var(--nx-accent-2-rgb) / {activeCategory === i ? '0.28' : '0.16'}); box-shadow: inset 0 -2px 0 var(--nx-accent-2-soft)"
-				><span class="text-sm">{cat.label}</span> {cat.name}</button>
-			{:else}
-				<button
-					onclick={() => (activeCategory = i)}
-					title={cat.name}
-					class="flex-1 py-2 text-base transition-colors {activeCategory === i
-						? 'bg-gray-800/80 text-white'
-						: 'text-gray-500 hover:text-gray-300 hover:bg-gray-900'}"
-				>{cat.label}</button>
-			{/if}
-		{/each}
+	<!-- Recherche -->
+	<div class="p-1.5 border-b border-gray-800">
+		<input
+			bind:value={query}
+			placeholder={tFn('emoji.search_placeholder')}
+			class="w-full px-2.5 py-1.5 text-sm rounded-md bg-gray-950 border border-gray-800 outline-none focus:border-gray-600"
+			style="color: #e2e8f0" />
 	</div>
 
-	<!-- Emoji grid -->
+	<!-- Onglets (masqués pendant la recherche) -->
+	{#if !searching}
+		<div class="flex border-b border-gray-800 bg-gray-950/80 overflow-x-auto" style="scrollbar-width: none">
+			{#each tabs as cat, i}
+				{#if cat.type === 'custom'}
+					<button onclick={() => (activeCategory = i)} title={cat.name}
+						class="flex items-center gap-1 px-2.5 py-2 text-xs font-bold uppercase tracking-wide shrink-0 border-r border-gray-800 transition-colors {activeCategory === i ? 'text-white' : 'text-gray-300 hover:text-white'}"
+						style="background: rgb(var(--nx-accent-2-rgb) / {activeCategory === i ? '0.28' : '0.16'}); box-shadow: inset 0 -2px 0 var(--nx-accent-2-soft)"
+					><span class="text-sm">{cat.label}</span> {cat.name}</button>
+				{:else}
+					<button onclick={() => (activeCategory = i)} title={cat.name}
+						class="{cat.type === 'freq' ? 'px-2.5' : 'flex-1'} py-2 text-base shrink-0 transition-colors {activeCategory === i ? 'bg-gray-800/80 text-white' : 'text-gray-500 hover:text-gray-300 hover:bg-gray-900'}"
+					>{cat.label}</button>
+				{/if}
+			{/each}
+		</div>
+	{/if}
+
+	<!-- Grille -->
 	<div class="p-1.5 grid grid-cols-8 gap-0 max-h-52 overflow-y-auto" style="scrollbar-width:thin; scrollbar-color: rgba(255,255,255,0.1) transparent;">
-		{#if activeTab?.type === 'custom'}
-			{#each activeTab.items as e (e.shortcode)}
-				<button
-					onclick={() => onselect(`:${e.shortcode}:`)}
-					title={`:${e.shortcode}:`}
-					class="p-1.5 rounded hover:bg-gray-700 transition-colors flex items-center justify-center"
-				><img src={e.url} alt={`:${e.shortcode}:`} class="w-6 h-6 object-contain" draggable="false" /></button>
-			{/each}
-		{:else if activeTab}
-			{#each activeTab.items as emoji}
-				<button
-					onclick={() => onselect(emoji)}
-					class="text-xl p-1.5 rounded hover:bg-gray-700 transition-colors leading-none text-center"
-				>{emoji}</button>
-			{/each}
+		{#each gridItems as it (it.key)}
+			<button onclick={() => onselect(it.sel)} title={it.title}
+				class="p-1.5 rounded hover:bg-gray-700 transition-colors flex items-center justify-center {it.display === 'text' ? 'text-xl leading-none' : ''}">
+				{#if it.display === 'img'}
+					<img src={it.src} alt={it.title} class="w-6 h-6 object-contain" draggable="false" />
+				{:else}{it.char}{/if}
+			</button>
+		{/each}
+		{#if gridItems.length === 0}
+			<div class="col-span-8 py-6 text-center text-xs text-gray-600">{tFn('emoji.no_result')}</div>
 		{/if}
 	</div>
 </div>

--- a/nodyx-frontend/src/lib/emojiUsage.ts
+++ b/nodyx-frontend/src/lib/emojiUsage.ts
@@ -1,0 +1,34 @@
+/**
+ * Suivi d'usage des emojis PAR UTILISATEUR (localStorage).
+ * Sert à afficher "Fréquents" et à peupler la barre de réaction rapide avec les
+ * emojis que CE membre utilise le plus. Personnel, auto, zéro backend, scale à
+ * 100+ emojis custom sans curation ni vote.
+ * Clé = un emoji unicode ('🔥') OU un shortcode custom (':rat:').
+ */
+import { writable } from 'svelte/store'
+
+const KEY = 'nodyx:emojiUsage'
+
+function load(): Record<string, number> {
+	if (typeof localStorage === 'undefined') return {}
+	try { return JSON.parse(localStorage.getItem(KEY) || '{}') } catch { return {} }
+}
+
+export const emojiUsageStore = writable<Record<string, number>>(load())
+
+export function bumpEmoji(emoji: string): void {
+	if (typeof localStorage === 'undefined' || !emoji) return
+	emojiUsageStore.update(u => {
+		const next = { ...u, [emoji]: (u[emoji] || 0) + 1 }
+		try { localStorage.setItem(KEY, JSON.stringify(next)) } catch { /* quota */ }
+		return next
+	})
+}
+
+/** Emojis les plus utilisés (clé), du plus au moins fréquent, limité à n. */
+export function topEmojis(usage: Record<string, number>, n: number): string[] {
+	return Object.entries(usage)
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, n)
+		.map(([e]) => e)
+}

--- a/nodyx-frontend/src/lib/locales/de.json
+++ b/nodyx-frontend/src/lib/locales/de.json
@@ -1,4 +1,7 @@
 {
+  "emoji.frequent": "Häufig",
+  "emoji.search_placeholder": "Emoji suchen…",
+  "emoji.no_result": "Kein Emoji",
   "library.emoji_shortcode": "Text-Kürzel",
   "library.emoji_shortcode_ph": "rat — optional, sonst aus dem Namen",
   "chat.emoji": "Emoji",

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -1,4 +1,7 @@
 {
+  "emoji.frequent": "Frequent",
+  "emoji.search_placeholder": "Search emoji…",
+  "emoji.no_result": "No emoji",
   "library.emoji_shortcode": "Text shortcut",
   "library.emoji_shortcode_ph": "rat — optional, otherwise from the name",
   "chat.emoji": "Emoji",

--- a/nodyx-frontend/src/lib/locales/es.json
+++ b/nodyx-frontend/src/lib/locales/es.json
@@ -1,4 +1,7 @@
 {
+  "emoji.frequent": "Frecuentes",
+  "emoji.search_placeholder": "Buscar emoji…",
+  "emoji.no_result": "Sin emoji",
   "library.emoji_shortcode": "Atajo de texto",
   "library.emoji_shortcode_ph": "rat — opcional, si no del nombre",
   "chat.emoji": "Emoji",

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -1,4 +1,7 @@
 {
+  "emoji.frequent": "Fréquents",
+  "emoji.search_placeholder": "Rechercher un emoji…",
+  "emoji.no_result": "Aucun emoji",
   "library.emoji_shortcode": "Raccourci texte",
   "library.emoji_shortcode_ph": "rat — optionnel, sinon dérivé du nom",
   "chat.emoji": "Emoji",

--- a/nodyx-frontend/src/lib/locales/pt-PT.json
+++ b/nodyx-frontend/src/lib/locales/pt-PT.json
@@ -1,4 +1,7 @@
 {
+  "emoji.frequent": "Frequentes",
+  "emoji.search_placeholder": "Procurar emoji…",
+  "emoji.no_result": "Sem emoji",
   "library.emoji_shortcode": "Atalho de texto",
   "library.emoji_shortcode_ph": "rat — opcional, senão do nome",
   "chat.emoji": "Emoji",

--- a/nodyx-frontend/src/lib/locales/ru.json
+++ b/nodyx-frontend/src/lib/locales/ru.json
@@ -1,4 +1,7 @@
 {
+  "emoji.frequent": "Частые",
+  "emoji.search_placeholder": "Поиск эмодзи…",
+  "emoji.no_result": "Нет эмодзи",
   "library.emoji_shortcode": "Текстовый код",
   "library.emoji_shortcode_ph": "rat — иначе из имени",
   "chat.emoji": "Эмодзи",

--- a/nodyx-frontend/src/routes/chat/+page.svelte
+++ b/nodyx-frontend/src/routes/chat/+page.svelte
@@ -10,6 +10,7 @@
 	import NodyxEditor from '$lib/components/editor/NodyxEditor.svelte';
 	import EmojiPicker from '$lib/components/EmojiPicker.svelte';
 	import { loadCustomEmojis, renderCustomEmojis, customEmojisStore } from '$lib/customEmojis';
+	import { bumpEmoji, emojiUsageStore, topEmojis } from '$lib/emojiUsage';
 	import ChannelSidebar from '$lib/components/ChannelSidebar.svelte';
 	import PollCard    from '$lib/components/PollCard.svelte';
 	import PollCreator from '$lib/components/PollCreator.svelte';
@@ -26,6 +27,16 @@
 	import { playMessage, playMention } from '$lib/sounds';
 	const tFn = $derived($t)
 	const customEmojis = $derived($customEmojisStore)   // réactif : re-rend au chargement des emojis
+	// Barre au survol : les emojis custom que CE membre utilise le plus (sinon les premiers)
+	const hoverBarEmojis = $derived.by(() => {
+		const bySc = new Map(customEmojis.map(e => [e.shortcode, e]))
+		const top = topEmojis($emojiUsageStore, 20)
+			.filter(k => k.startsWith(':') && k.endsWith(':'))
+			.map(k => bySc.get(k.slice(1, -1)))
+			.filter((e): e is (typeof customEmojis)[number] => !!e)
+		const seen = new Set(top.map(e => e.shortcode))
+		return [...top, ...customEmojis.filter(e => !seen.has(e.shortcode))].slice(0, 6)
+	})
 
 	let { data }: { data: PageData } = $props();
 
@@ -142,6 +153,7 @@
 
 	// Insère un emoji (unicode ou :shortcode:) dans la zone de saisie au curseur
 	function insertIntoInput(text: string) {
+		bumpEmoji(text);   // usage perso (Fréquents + barre rapide)
 		const ta = document.getElementById('chat-input') as HTMLTextAreaElement | null;
 		if (!ta) { inputText += text; return; }
 		const start = ta.selectionStart ?? inputText.length;
@@ -903,6 +915,7 @@
 
 	function reactTo(messageId: string, emoji: string) {
 		if (!s) return;
+		bumpEmoji(emoji);   // usage perso (Fréquents + barre rapide)
 		messages = applyReactionOptimistic(messages, messageId, emoji, userId);
 		flashReaction(messageId, emoji);
 		p2pManager.send({ type: 'p2p:reaction', messageId, emoji, userId, username: currentUsername });
@@ -1288,7 +1301,7 @@
 								style="background: #0d0d12; border: 1px solid rgba(255,255,255,.08)"
 							>
 								<!-- Emojis Perso (instance) en tête, direct au survol -->
-									{#each customEmojis.slice(0, 6) as ce (ce.shortcode)}
+									{#each hoverBarEmojis as ce (ce.shortcode)}
 										<button
 											onclick={() => reactTo(msg.id, `:${ce.shortcode}:`)}
 											title={`:${ce.shortcode}:`}


### PR DESCRIPTION
Réponse au souci soulevé (Lapersonne) : avec 100+ emojis custom, on ne peut pas tout afficher au survol, et un système d'upvote serait sur-ingénieré. Choix : **perso-fréquents (auto) + recherche**, pattern Discord/Slack, zéro vote, zéro backend.

- **EmojiPicker** : **recherche** (filtre les customs par shortcode/nom) + onglet **Fréquents** (les plus utilisés par CE membre), rendu unifié image/texte, état vide. i18n `emoji.frequent`/`search`/`no_result` (6 langues).
- **emojiUsage.ts** : suivi d'usage **par utilisateur** (localStorage) ; `bumpEmoji` au niveau des actions (`reactTo`, `insertIntoInput`) → pas de double comptage.
- **Barre rapide au survol** : affiche les emojis custom les **plus utilisés** par le membre (sinon les premiers).

L'usage EST le vote (honnête, sans triche). Épingle owner "à la une" = évolution future simple si besoin.