### PR TITLE
feat(library): aide format/taille à l'upload d'emoji

### DIFF
--- a/nodyx-frontend/src/lib/locales/de.json
+++ b/nodyx-frontend/src/lib/locales/de.json
@@ -1,4 +1,5 @@
 {
+  "library.emoji_help": "PNG, GIF oder WebP · transparenter Hintergrund empfohlen · quadratisch, ~128 px genügt (über 1024 px verkleinert). Animierte GIF und WebP möglich. Auto-optimiert zu WebP, max 12 MB.",
   "emoji.frequent": "Häufig",
   "emoji.search_placeholder": "Emoji suchen…",
   "emoji.no_result": "Kein Emoji",

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -1,4 +1,5 @@
 {
+  "library.emoji_help": "PNG, GIF or WebP · transparent background recommended · square, ~128 px is enough (auto-shrunk above 1024 px). Animated GIF and WebP supported. Auto-optimized to WebP, 12 MB max.",
   "emoji.frequent": "Frequent",
   "emoji.search_placeholder": "Search emoji…",
   "emoji.no_result": "No emoji",

--- a/nodyx-frontend/src/lib/locales/es.json
+++ b/nodyx-frontend/src/lib/locales/es.json
@@ -1,4 +1,5 @@
 {
+  "library.emoji_help": "PNG, GIF o WebP · fondo transparente recomendado · cuadrado, ~128 px basta (se reduce por encima de 1024 px). GIF y WebP animados aceptados. Optimizado a WebP, máx 12 MB.",
   "emoji.frequent": "Frecuentes",
   "emoji.search_placeholder": "Buscar emoji…",
   "emoji.no_result": "Sin emoji",

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -1,4 +1,5 @@
 {
+  "library.emoji_help": "PNG, GIF ou WebP · fond transparent conseillé · carré, ~128 px suffit (réduit auto au-delà de 1024 px). GIF et WebP animés acceptés. Optimisé automatiquement en WebP, max 12 Mo.",
   "emoji.frequent": "Fréquents",
   "emoji.search_placeholder": "Rechercher un emoji…",
   "emoji.no_result": "Aucun emoji",

--- a/nodyx-frontend/src/lib/locales/pt-PT.json
+++ b/nodyx-frontend/src/lib/locales/pt-PT.json
@@ -1,4 +1,5 @@
 {
+  "library.emoji_help": "PNG, GIF ou WebP · fundo transparente recomendado · quadrado, ~128 px chega (reduzido acima de 1024 px). GIF e WebP animados aceites. Otimizado para WebP, máx 12 MB.",
   "emoji.frequent": "Frequentes",
   "emoji.search_placeholder": "Procurar emoji…",
   "emoji.no_result": "Sem emoji",

--- a/nodyx-frontend/src/lib/locales/ru.json
+++ b/nodyx-frontend/src/lib/locales/ru.json
@@ -1,4 +1,5 @@
 {
+  "library.emoji_help": "PNG, GIF или WebP · прозрачный фон · квадрат, ~128 px достаточно (уменьшается свыше 1024 px). Анимированные GIF и WebP поддерживаются. Оптимизируется в WebP, макс 12 МБ.",
   "emoji.frequent": "Частые",
   "emoji.search_placeholder": "Поиск эмодзи…",
   "emoji.no_result": "Нет эмодзи",

--- a/nodyx-frontend/src/routes/library/+page.svelte
+++ b/nodyx-frontend/src/routes/library/+page.svelte
@@ -238,7 +238,13 @@
 							placeholder={tFn('library.emoji_shortcode_ph')} class="lib-input" />
 					</div>
 				{/if}
-				{#if currentTypeTip}
+				{#if uploadType === 'emoji'}
+					<div class="lib-tip lib-field--full">
+						<span class="lib-tip-icon">😀</span>
+						<div class="lib-tip-body">{tFn('library.emoji_help')}</div>
+					</div>
+				{/if}
+				{#if currentTypeTip && uploadType !== 'emoji'}
 				<div class="lib-tip lib-field--full">
 					<span class="lib-tip-icon">💡</span>
 					<div class="lib-tip-body">


### PR DESCRIPTION
Encart explicatif (i18n, 6 langues) affiché à l'upload d'un **emoji** : formats acceptés (PNG/GIF/WebP), fond transparent conseillé, carré ~128 px (réduit auto >1024 px), animés OK, auto-optimisé WebP, max 12 Mo. Reflète le traitement réel du backend (sharp fit inside 1024 + webp). Remplace le tip générique pour le type emoji.