### PR TITLE
feat(library): bouton de fichier stylé à l'upload

### DIFF
--- a/nodyx-frontend/src/lib/locales/de.json
+++ b/nodyx-frontend/src/lib/locales/de.json
@@ -1,4 +1,6 @@
 {
+  "library.choose_file": "Datei wählen",
+  "library.no_file": "Keine Datei",
   "library.emoji_help": "PNG, GIF oder WebP · transparenter Hintergrund empfohlen · quadratisch, ~128 px genügt (über 1024 px verkleinert). Animierte GIF und WebP möglich. Auto-optimiert zu WebP, max 12 MB.",
   "emoji.frequent": "Häufig",
   "emoji.search_placeholder": "Emoji suchen…",

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -1,4 +1,6 @@
 {
+  "library.choose_file": "Choose a file",
+  "library.no_file": "No file",
   "library.emoji_help": "PNG, GIF or WebP · transparent background recommended · square, ~128 px is enough (auto-shrunk above 1024 px). Animated GIF and WebP supported. Auto-optimized to WebP, 12 MB max.",
   "emoji.frequent": "Frequent",
   "emoji.search_placeholder": "Search emoji…",

--- a/nodyx-frontend/src/lib/locales/es.json
+++ b/nodyx-frontend/src/lib/locales/es.json
@@ -1,4 +1,6 @@
 {
+  "library.choose_file": "Elegir archivo",
+  "library.no_file": "Ningún archivo",
   "library.emoji_help": "PNG, GIF o WebP · fondo transparente recomendado · cuadrado, ~128 px basta (se reduce por encima de 1024 px). GIF y WebP animados aceptados. Optimizado a WebP, máx 12 MB.",
   "emoji.frequent": "Frecuentes",
   "emoji.search_placeholder": "Buscar emoji…",

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -1,4 +1,6 @@
 {
+  "library.choose_file": "Choisir un fichier",
+  "library.no_file": "Aucun fichier",
   "library.emoji_help": "PNG, GIF ou WebP · fond transparent conseillé · carré, ~128 px suffit (réduit auto au-delà de 1024 px). GIF et WebP animés acceptés. Optimisé automatiquement en WebP, max 12 Mo.",
   "emoji.frequent": "Fréquents",
   "emoji.search_placeholder": "Rechercher un emoji…",

--- a/nodyx-frontend/src/lib/locales/pt-PT.json
+++ b/nodyx-frontend/src/lib/locales/pt-PT.json
@@ -1,4 +1,6 @@
 {
+  "library.choose_file": "Escolher ficheiro",
+  "library.no_file": "Nenhum ficheiro",
   "library.emoji_help": "PNG, GIF ou WebP · fundo transparente recomendado · quadrado, ~128 px chega (reduzido acima de 1024 px). GIF e WebP animados aceites. Otimizado para WebP, máx 12 MB.",
   "emoji.frequent": "Frequentes",
   "emoji.search_placeholder": "Procurar emoji…",

--- a/nodyx-frontend/src/lib/locales/ru.json
+++ b/nodyx-frontend/src/lib/locales/ru.json
@@ -1,4 +1,6 @@
 {
+  "library.choose_file": "Выбрать файл",
+  "library.no_file": "Файл не выбран",
   "library.emoji_help": "PNG, GIF или WebP · прозрачный фон · квадрат, ~128 px достаточно (уменьшается свыше 1024 px). Анимированные GIF и WebP поддерживаются. Оптимизируется в WebP, макс 12 МБ.",
   "emoji.frequent": "Частые",
   "emoji.search_placeholder": "Поиск эмодзи…",

--- a/nodyx-frontend/src/routes/library/+page.svelte
+++ b/nodyx-frontend/src/routes/library/+page.svelte
@@ -197,11 +197,14 @@
 		{/if}
 		<form onsubmit={submitUpload} class="lib-upload-form">
 			<div class="lib-upload-file-row">
-				<label class="lib-field lib-field--grow">
+				<div class="lib-field lib-field--grow">
 					<span class="lib-label">Fichier *</span>
-					<input type="file" onchange={onFileChange} accept="image/*,audio/*" required
-						class="lib-file-input" />
-				</label>
+					<label class="lib-file-btn">
+						<input type="file" onchange={onFileChange} accept="image/*,audio/*" class="lib-file-native" />
+						<span class="lib-file-cta">📁 {tFn('library.choose_file')}</span>
+						<span class="lib-file-name" class:lib-file-name--empty={!uploadFile}>{uploadFile ? uploadFile.name : tFn('library.no_file')}</span>
+					</label>
+				</div>
 				{#if uploadPreview}
 					<img src={uploadPreview} alt="preview" class="lib-preview-thumb" />
 				{/if}
@@ -614,10 +617,51 @@
 	appearance: none;
 }
 
-.lib-file-input {
-	font-size: 0.8125rem;
-	color: rgba(255, 255, 255, 0.6);
+/* Bouton de fichier stylé (masque l'input natif moche) */
+.lib-file-native {
+	position: absolute;
+	width: 1px; height: 1px;
+	opacity: 0;
+	overflow: hidden;
 }
+.lib-file-btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.7rem;
+	cursor: pointer;
+	margin-top: 0.35rem;
+	max-width: 100%;
+}
+.lib-file-cta {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.5rem 0.9rem;
+	border-radius: 8px;
+	font-size: 0.85rem;
+	font-weight: 600;
+	color: #fff;
+	white-space: nowrap;
+	background: rgb(var(--nx-accent-2-rgb) / 0.22);
+	border: 1px solid rgb(var(--nx-accent-2-rgb) / 0.4);
+	transition: background 0.15s, border-color 0.15s;
+}
+.lib-file-btn:hover .lib-file-cta {
+	background: rgb(var(--nx-accent-2-rgb) / 0.32);
+	border-color: var(--nx-accent-2-soft);
+}
+.lib-file-native:focus-visible + .lib-file-cta {
+	outline: 2px solid var(--nx-accent-2-soft);
+	outline-offset: 2px;
+}
+.lib-file-name {
+	font-size: 0.82rem;
+	color: rgba(255, 255, 255, 0.85);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.lib-file-name--empty { color: rgba(255, 255, 255, 0.4); }
 
 .lib-preview-thumb {
 	width: 72px;


### PR DESCRIPTION
L'input `type=file` natif ("Choisir un fichier / Aucun fichier choisi") était moche. Remplacé par un **bouton stylé** (accent) + le **nom du fichier** choisi à côté. Input natif masqué (accessible via le label, focus-visible géré), i18n `library.choose_file`/`no_file` (6 langues). `required` retiré (validation manuelle déjà en place).