### PR TITLE
fix(emojis): onglets du picker tronqués

### DIFF
--- a/nodyx-frontend/src/lib/components/EmojiPicker.svelte
+++ b/nodyx-frontend/src/lib/components/EmojiPicker.svelte
@@ -74,7 +74,7 @@
 
 	<!-- Onglets (masqués pendant la recherche) -->
 	{#if !searching}
-		<div class="flex border-b border-gray-800 bg-gray-950/80 overflow-x-auto" style="scrollbar-width: none">
+		<div class="flex border-b border-gray-800 bg-gray-950/80">
 			{#each tabs as cat, i}
 				{#if cat.type === 'custom'}
 					<button onclick={() => (activeCategory = i)} title={cat.name}
@@ -83,7 +83,7 @@
 					><span class="text-sm">{cat.label}</span> {cat.name}</button>
 				{:else}
 					<button onclick={() => (activeCategory = i)} title={cat.name}
-						class="{cat.type === 'freq' ? 'px-2.5' : 'flex-1'} py-2 text-base shrink-0 transition-colors {activeCategory === i ? 'bg-gray-800/80 text-white' : 'text-gray-500 hover:text-gray-300 hover:bg-gray-900'}"
+						class="{cat.type === 'freq' ? 'px-2.5 shrink-0' : 'flex-1 min-w-0'} py-2 text-base transition-colors {activeCategory === i ? 'bg-gray-800/80 text-white' : 'text-gray-500 hover:text-gray-300 hover:bg-gray-900'}"
 					>{cat.label}</button>
 				{/if}
 			{/each}


### PR DESCRIPTION
La barre d'onglets du picker débordait à droite et était coupée (onglets en `shrink-0` + `overflow-x-auto` scrollbar cachée = clip). Fix : onglets unicode en `flex-1 min-w-0` (partagent l'espace, rétrécissent), Fréquents + Perso fixes, plus d'overflow horizontal. Tout tient sur une ligne dans les 288px.