### PR TITLE
fix(turn): plage de ports relais bornée + build hmac 0.13 + CI workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,10 +121,13 @@ jobs:
         with:
           workspaces: nodyx-p2p
 
-      - name: cargo build -p nodyx-server
+      # Build + test TOUT le workspace (pas seulement nodyx-server) : un build
+      # limité à un crate laissait passer en silence des crates cassés — c'est
+      # exactement comme ça qu'un bump hmac 0.13 a cassé nexus-turn sans alerte.
+      - name: cargo build --workspace
         working-directory: nodyx-p2p
-        run: cargo build -p nodyx-server
+        run: cargo build --workspace
 
-      - name: cargo test -p nodyx-server — 18 tests attendus
+      - name: cargo test --workspace
         working-directory: nodyx-p2p
-        run: cargo test -p nodyx-server
+        run: cargo test --workspace

--- a/nodyx-p2p/crates/nexus-turn/src/auth.rs
+++ b/nodyx-p2p/crates/nexus-turn/src/auth.rs
@@ -9,7 +9,9 @@
 // RFC 5389 §15.4 / RFC 5766 §10.2
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
-use hmac::{Hmac, Mac};
+// hmac 0.13 : `new_from_slice` est fourni par `KeyInit` (déplacé depuis `Mac`) ;
+// `update`/`finalize` restent sur `Mac`. Les deux sont nécessaires.
+use hmac::{Hmac, KeyInit, Mac};
 use md5::Md5;
 use md5::Digest as Md5Digest;
 use sha1::Sha1;

--- a/nodyx-p2p/crates/nexus-turn/src/main.rs
+++ b/nodyx-p2p/crates/nexus-turn/src/main.rs
@@ -61,6 +61,16 @@ enum Commands {
         /// Credential TTL in seconds (default 24h)
         #[arg(long, env = "TURN_TTL", default_value = "86400")]
         ttl: u64,
+
+        /// Lowest relay UDP port. MUST match the firewall's open range
+        /// (installer: `ufw allow 49152:65535/udp`). The TURN server owns its
+        /// relay range instead of relying on the OS ephemeral range.
+        #[arg(long, env = "TURN_MIN_PORT", default_value = "49152")]
+        min_port: u16,
+
+        /// Highest relay UDP port. MUST match the firewall's open range.
+        #[arg(long, env = "TURN_MAX_PORT", default_value = "65535")]
+        max_port: u16,
     },
 }
 
@@ -79,7 +89,10 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Server { udp_port, public_ip, realm, secret, ttl } => {
+        Commands::Server { udp_port, public_ip, realm, secret, ttl, min_port, max_port } => {
+            if min_port > max_port {
+                anyhow::bail!("TURN relay range invalide : min_port ({min_port}) > max_port ({max_port})");
+            }
             let bind_addr: SocketAddr = (std::net::Ipv4Addr::UNSPECIFIED, udp_port).into();
             let socket = Arc::new(
                 UdpSocket::bind(bind_addr)
@@ -103,12 +116,16 @@ async fn main() -> Result<()> {
                 public_ip,
                 ttl,
                 nonce,
+                relay_min_port: min_port,
+                relay_max_port: max_port,
             });
 
             info!(
-                "nodyx-turn v{} — STUN/TURN on udp:{udp_port} + tcp:{udp_port} | public_ip={}",
+                "nodyx-turn v{} — STUN/TURN on udp:{udp_port} + tcp:{udp_port} | public_ip={} | relay {}-{}",
                 env!("CARGO_PKG_VERSION"),
-                cfg.public_ip
+                cfg.public_ip,
+                cfg.relay_min_port,
+                cfg.relay_max_port,
             );
 
             // Run UDP and TCP listeners concurrently on the shared registry.

--- a/nodyx-p2p/crates/nexus-turn/src/server.rs
+++ b/nodyx-p2p/crates/nexus-turn/src/server.rs
@@ -13,6 +13,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream, UdpSocket};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
+use rand::Rng;
 
 use crate::allocation::{spawn_eviction_task, Allocation, Registry};
 use crate::auth::{compute_message_integrity, extract_mi_input, mi_key, validate_credentials, verify_message_integrity};
@@ -100,6 +101,12 @@ pub struct TurnConfig {
     pub public_ip:   IpAddr,
     pub ttl:         u64,
     pub nonce:       String,
+    /// Relay UDP port range [min, max]. Un serveur TURN POSSÈDE sa plage relais
+    /// pour que le firewall ouvre exactement celle-ci (ufw 49152:65535/udp), au
+    /// lieu d'un bind éphémère dont le succès dépend par chance de la plage
+    /// `net.ipv4.ip_local_port_range` de l'OS. Cf handle_allocate / bind_relay_socket.
+    pub relay_min_port: u16,
+    pub relay_max_port: u16,
 }
 
 // ── UDP server ────────────────────────────────────────────────────────────────
@@ -261,6 +268,28 @@ async fn handle_binding(sink: &ResponseSink, msg: StunMessage, src: SocketAddr) 
 
 // ── TURN Allocate ─────────────────────────────────────────────────────────────
 
+/// Lie un socket UDP relais DANS la plage configurée [min, max], au lieu du port
+/// éphémère de l'OS. C'est la conception correcte d'un serveur TURN : il détient
+/// sa plage relais → le firewall ouvre exactement cette plage, sans dépendre par
+/// chance de `net.ipv4.ip_local_port_range`. Départ aléatoire + balayage circulaire
+/// pour répartir les allocations ; sonde toute la plage avant d'abandonner.
+async fn bind_relay_socket(cfg: &TurnConfig) -> std::io::Result<UdpSocket> {
+    let (min, max) = (cfg.relay_min_port, cfg.relay_max_port);
+    let span: u32 = (max as u32) - (min as u32) + 1;
+    let start: u32 = rand::thread_rng().gen_range(0..span);
+    let mut last_err: Option<std::io::Error> = None;
+    for i in 0..span {
+        let port = (min as u32 + (start + i) % span) as u16;
+        match UdpSocket::bind((cfg.public_ip, port)).await {
+            Ok(sock) => return Ok(sock),
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::AddrInUse, "no free relay port in range")
+    }))
+}
+
 async fn handle_allocate(
     sink:     &ResponseSink,
     registry: &Registry,
@@ -331,12 +360,17 @@ async fn handle_allocate(
         .unwrap_or(DEFAULT_LIFETIME)
         .min(MAX_LIFETIME);
 
-    // Bind a relay UDP socket (OS assigns port from system ephemeral range)
-    let relay_socket = match UdpSocket::bind((cfg.public_ip, 0u16)).await {
+    // Bind a relay UDP socket within the configured relay range (matches the
+    // firewall's open UDP range — see bind_relay_socket).
+    let relay_socket = match bind_relay_socket(cfg).await {
         Ok(s) => Arc::new(s),
         Err(e) => {
-            warn!("TURN: failed to bind relay socket: {e}");
-            send_error(sink, &msg, src, 500, "Server Error", None).await;
+            warn!(
+                "TURN: no free relay port in {}-{}: {e}",
+                cfg.relay_min_port, cfg.relay_max_port
+            );
+            // RFC 5766 §6.2 : 508 Insufficient Capacity when no relay port is free.
+            send_error(sink, &msg, src, 508, "Insufficient Capacity", None).await;
             return;
         }
     };
@@ -671,7 +705,7 @@ async fn send_error(
 
 fn derive_password(username: &str, secret: &[u8]) -> String {
     use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
-    use hmac::{Hmac, Mac};
+    use hmac::{Hmac, KeyInit, Mac};   // hmac 0.13 : new_from_slice sur KeyInit
     use sha1::Sha1;
     type HmacSha1 = Hmac<Sha1>;
     let mut mac = HmacSha1::new_from_slice(secret).expect("HMAC accepts any key");
@@ -694,4 +728,48 @@ fn random_txid() -> [u8; 12] {
     let mut txid = [0u8; 12];
     rand::thread_rng().fill_bytes(&mut txid);
     txid
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg_with_range(ip: IpAddr, min: u16, max: u16) -> TurnConfig {
+        TurnConfig {
+            realm:          "test".into(),
+            secret:         b"secret".to_vec(),
+            public_ip:      ip,
+            ttl:            3600,
+            nonce:          "nonce".into(),
+            relay_min_port: min,
+            relay_max_port: max,
+        }
+    }
+
+    /// Le port relais est TOUJOURS lié dans la plage configurée (le point du fix :
+    /// ne plus dépendre de la plage éphémère de l'OS).
+    #[tokio::test]
+    async fn relay_port_is_within_configured_range() {
+        let ip: IpAddr = "127.0.0.1".parse().unwrap();
+        let (min, max) = (49152u16, 65535u16);
+        let cfg = cfg_with_range(ip, min, max);
+        let sock = bind_relay_socket(&cfg).await.expect("un port libre existe dans 49152-65535");
+        let port = sock.local_addr().unwrap().port();
+        assert!(port >= min && port <= max, "port {port} hors de [{min},{max}]");
+    }
+
+    /// Plage entièrement occupée → erreur (508 côté protocole), pas de panique ni
+    /// de repli hors plage.
+    #[tokio::test]
+    async fn exhausted_range_returns_error() {
+        let ip: IpAddr = "127.0.0.1".parse().unwrap();
+        // On squatte un port libre connu, puis on restreint la plage à CE seul port.
+        let squatter = UdpSocket::bind((ip, 0u16)).await.unwrap();
+        let taken = squatter.local_addr().unwrap().port();
+        let cfg = cfg_with_range(ip, taken, taken);
+        assert!(
+            bind_relay_socket(&cfg).await.is_err(),
+            "plage d'un seul port déjà pris → doit échouer"
+        );
+    }
 }


### PR DESCRIPTION
Trois corrections liées sur **nexus-turn** (STUN/TURN Rust), découvertes en creusant l'intuition de Jonathan sur un ancien bridage de ports.

### 1. Plage de ports relais (le fond)
`nexus-turn` liait ses relais avec `bind(public_ip, 0)` → **port éphémère OS**. Le firewall n'ouvre que 49152-65535 (hérité de l'ancien coturn). Sur un OS au défaut kernel (`ip_local_port_range` = 32768-60999), **~58% des allocations relais tombent hors firewall → vocal cassé par intermittence** (NAT symétrique/mobile). nodyx.org n'y échappait que via un réglage sysctl manuel fragile.
**Fix** : un serveur TURN **possède** sa plage. Args `--min-port`/`--max-port` (défauts = firewall), `bind_relay_socket` sonde la plage (départ aléatoire + balayage circulaire). Découple de `ip_local_port_range`, répare les auto-hébergeurs d'office.

### 2. Build cassé (hmac 0.13)
Cargo.toml demandait `hmac 0.13` mais le code importait `new_from_slice` via `Mac` (déplacé sur `KeyInit`). **nexus-turn ne compilait plus depuis le bump** ; le binaire prod (28/03) tourne encore en 0.12. Fix : `use hmac::{Hmac, KeyInit, Mac}`. HMAC-SHA1 identique → **zéro impact credentials**.

### 3. Trou de CI
Le job `nodyx-p2p` ne buildait que `nodyx-server` → les casses de nexus-turn/gossip/relay/sfu passaient **en silence** (c'est comme ça que 2. n'a pas été vu). Passage à `cargo build/test --workspace`.

**Workspace : 52 tests verts** (dont 2 nouveaux : port dans la plage / plage épuisée).