### PR TITLE
fix(admin): diagnostic réseau, test TURN avec credentials frais via l'API

### DIFF
--- a/nodyx-core/src/routes/instance.ts
+++ b/nodyx-core/src/routes/instance.ts
@@ -18,6 +18,7 @@ import * as CommunityModel from '../models/community'
 import * as ThreadModel from '../models/thread'
 import * as TagModel from '../models/tag'
 import { io } from '../socket/io'
+import { buildIceServers } from '../socket/voice'
 
 // ── ESY Key (lazy-loaded once from disk) ─────────────────────────────────────
 
@@ -483,6 +484,15 @@ export default async function instanceRoutes(app: FastifyInstance) {
     } catch {
       return reply.send({ emojis: [] })
     }
+  })
+
+  // GET /api/v1/instance/ice-servers — serveurs ICE avec credentials TURN FRAIS
+  // Même générateur que voice:init (credentials éphémères HMAC, TTL 24h).
+  // Consommé par le diagnostic réseau admin : des credentials statiques figés au
+  // build expirent en <24h et rendent tout test TURN menteur. Authentifié : les
+  // credentials sont liés au userId (comme en vocal), pas de secret exposé.
+  app.get('/ice-servers', { preHandler: [rateLimit, requireAuth] }, async (request, reply) => {
+    return reply.send({ iceServers: buildIceServers(request.user!.userId) })
   })
 
   // GET /api/v1/instance/announcement — active announcement (public)

--- a/nodyx-core/src/socket/voice.ts
+++ b/nodyx-core/src/socket/voice.ts
@@ -29,7 +29,9 @@ const JUKEBOX_STATE_MAX = 10_240
 // Dynamic time-limited credentials (nodyx-turn / coturn use-auth-secret style).
 // TURN_SECRET + TURN_PUBLIC_IP env vars — set by install.sh.
 
-function buildIceServers(userId: string): object[] {
+// Exporté : réutilisé par GET /api/v1/instance/ice-servers (diagnostic admin),
+// pour que tout consommateur reçoive des credentials FRAIS (jamais de statique).
+export function buildIceServers(userId: string): object[] {
   const secret   = process.env.TURN_SECRET
   const ip       = process.env.TURN_PUBLIC_IP
   const port     = process.env.TURN_PORT || '3478'

--- a/nodyx-frontend/src/lib/utils/networkTester.ts
+++ b/nodyx-frontend/src/lib/utils/networkTester.ts
@@ -1,30 +1,48 @@
-import { 
-    PUBLIC_TURN_URL, 
-    PUBLIC_TURN_USERNAME, 
-    PUBLIC_TURN_CREDENTIAL 
+import {
+    PUBLIC_TURN_URL,
+    PUBLIC_TURN_USERNAME,
+    PUBLIC_TURN_CREDENTIAL
 } from '$env/static/public';
 
 /**
  * Nodyx Network Diagnostic Engine
  * Analyse la connectivité WebRTC (UDP, STUN, TURN)
+ *
+ * Les serveurs ICE viennent de l'API (`/instance/ice-servers`) : mêmes
+ * credentials TURN éphémères que le vocal (HMAC, TTL 24h). Les variables
+ * PUBLIC_TURN_* figées au build ne servent que de repli : des credentials
+ * statiques expirent en <24h et faisaient afficher RELAY OFFLINE à tort.
+ * Zéro STUN tiers : nexus-turn répond au STUN (et un serveur turn: fournit
+ * aussi les candidats srflx), pas besoin de Google.
  */
-export async function runNetworkDiagnostic(onUpdate: (results: any) => void) {
-    
-    // Définition explicite du type pour satisfaire TypeScript
-    const iceServers: RTCIceServer[] = [
-        { urls: 'stun:stun.l.google.com:19302' }
-    ];
 
-    // On ajoute ton serveur TURN seulement si l'URL est définie
-    if (PUBLIC_TURN_URL) {
-        iceServers.push({
-            urls: PUBLIC_TURN_URL,
-            username: PUBLIC_TURN_USERNAME,
-            credential: PUBLIC_TURN_CREDENTIAL
+async function fetchFreshIceServers(token: string | null): Promise<RTCIceServer[]> {
+    if (!token) return [];
+    try {
+        const res = await fetch('/api/v1/instance/ice-servers', {
+            headers: { Authorization: `Bearer ${token}` }
         });
+        if (!res.ok) return [];
+        const data = await res.json();
+        return Array.isArray(data.iceServers) ? data.iceServers : [];
+    } catch {
+        return [];
     }
+}
 
-    const pc = new RTCPeerConnection({ iceServers });
+function staticFallbackIceServers(): RTCIceServer[] {
+    if (!PUBLIC_TURN_URL) return [];
+    return [{
+        urls: PUBLIC_TURN_URL,
+        username: PUBLIC_TURN_USERNAME,
+        credential: PUBLIC_TURN_CREDENTIAL
+    }];
+}
+
+export async function runNetworkDiagnostic(
+    onUpdate: (results: any) => void,
+    token: string | null = null
+) {
 
     let results = {
         udp: false,
@@ -35,6 +53,20 @@ export async function runNetworkDiagnostic(onUpdate: (results: any) => void) {
         error: null as string | null
     };
 
+    // Credentials frais d'abord ; repli statique si l'API est injoignable.
+    let iceServers = await fetchFreshIceServers(token);
+    if (iceServers.length === 0) {
+        iceServers = staticFallbackIceServers();
+    }
+    if (iceServers.length === 0) {
+        results.status = 'error';
+        results.error = "Aucun serveur ICE configuré (TURN_PUBLIC_IP absent côté core ?)";
+        onUpdate({ ...results });
+        return;
+    }
+
+    const pc = new RTCPeerConnection({ iceServers });
+
     pc.onicecandidate = (event) => {
         if (event.candidate) {
             const c = event.candidate.candidate;
@@ -43,7 +75,7 @@ export async function runNetworkDiagnostic(onUpdate: (results: any) => void) {
 
             if (c.includes('typ srflx')) results.p2p = true;
             if (c.includes('typ relay')) results.relay = true;
-            
+
             onUpdate({ ...results });
         } else {
             results.status = 'finished';

--- a/nodyx-frontend/src/routes/admin/status/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/status/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { runNetworkDiagnostic } from '$lib/utils/networkTester';
+    import { page } from '$app/stores';
     import { fade, fly } from 'svelte/transition';
 
     type CheckKeys = 'P2P' | 'RELAY' | 'UDP' | 'SIGNAL';
@@ -40,7 +41,10 @@
         visualChecks = { P2P: 'SCANNING', RELAY: 'WAIT', UDP: 'WAIT', SIGNAL: 'SCANNING' };
         
         addLog("Initialisation du diagnostic réseau...");
-        runNetworkDiagnostic((res) => { diag = res; });
+        // Token : le test récupère des credentials TURN FRAIS via l'API
+        // (les statiques de build expirent en <24h → RELAY OFFLINE menteur).
+        const token = $page.data.token as string | null;
+        runNetworkDiagnostic((res) => { diag = res; }, token);
 
         // Séquence synchronisée avec ton UI
         await new Promise(r => setTimeout(r, 800));


### PR DESCRIPTION
La tuile **RELAY** de `/admin/status` affichait OFFLINE en permanence : le testeur utilisait `PUBLIC_TURN_*` **figés au build**, alors que nexus-turn n'accepte que des credentials **éphémères** (HMAC, TTL 24h). Tout credential statique expire donc en <24h : le test mentait, quel que soit l'état réel du TURN.

- **core** : `buildIceServers` exporté + `GET /api/v1/instance/ice-servers` (rateLimit + requireAuth). Même générateur que `voice:init`, credentials liés au userId, aucun secret exposé.
- **frontend** : `networkTester` récupère les serveurs ICE frais via l'API (repli statique si l'API échoue), la page passe `$page.data.token`.
- **souveraineté** : suppression du STUN Google du testeur (nexus-turn répond au STUN, et un serveur `turn:` fournit aussi les candidats srflx). Zéro service tiers, aligné avec le vocal réel.

Après ça, la tuile RELAY dit la vérité : ACTIF = une vraie allocation TURN a réussi sur le serveur, OFFLINE = vrai problème.

tsc clean, **364 tests core verts**, svelte-check 0 erreur.