### PR TITLE
feat(sfu): P1 lot 1, le port apprend le signaling (blobs opaques) + WebRtcTransport réels

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,21 @@
+NOTICE — Composants tiers embarqués ou distribués avec Nodyx
+=============================================================
+
+Nodyx est publié sous licence AGPL-3.0 (voir LICENSE). Les composants tiers
+suivants conservent leur licence et leur notice de copyright d'origine :
+
+mediasoup (moteur média du SFU : worker C++ + crate Rust de contrôle)
+---------------------------------------------------------------------
+  https://mediasoup.org
+  Licence : ISC
+  Copyright (c) Iñaki Baz Castillo <ibc@aliax.net>
+
+  Le worker mediasoup embarque des portions de libwebrtc :
+  Copyright (c) 2011, The WebRTC project authors. All rights reserved.
+  Licence : BSD-3-Clause
+
+ed25519-dalek (signatures Ed25519 : nodyx-gossip, identité des nœuds)
+---------------------------------------------------------------------
+  https://github.com/dalek-cryptography/curve25519-dalek
+  Licence : BSD-3-Clause
+  Copyright (c) isis agora lovecruft, Henry de Valence

--- a/SPECS/NODYX_SFU_CDC.md
+++ b/SPECS/NODYX_SFU_CDC.md
@@ -305,16 +305,22 @@ Bénéfice concret du découplage : le jour du swap full-Rust, **`VoiceService` 
 
 ```rust
 /// Tout le contrôle Rust (signaling, salons, hybride, fédération) parle À ÇA,
-/// jamais à mediasoup directement.
+/// jamais à mediasoup directement. Les données de signaling (ICE/DTLS/RTP chez
+/// mediasoup, SDP chez un autre moteur) transitent en `SignalingBlob` OPAQUES :
+/// le métier les transporte entre client et moteur sans jamais les lire.
 trait MediaEngine {
-    async fn create_room(&self, room: RoomId) -> RouterHandle;
-    async fn create_transport(&self, r: &RouterHandle, p: ParticipantId) -> TransportHandle;
-    async fn produce(&self, t: &TransportHandle, track: TrackKind) -> ProducerId;
-    async fn consume(&self, t: &TransportHandle, prod: ProducerId) -> ConsumerId;
-    async fn set_preferred_layer(&self, c: &ConsumerId, layer: Layer);
-    async fn pipe_to_remote(&self, prod: ProducerId, node: NodeId) -> PipeHandle; // fédération
-    async fn stats(&self, scope: StatsScope) -> EngineStats;
-    // close = géré par Drop (RAII Rust)
+    async fn create_room(&self, room: RoomId) -> Result<RouterHandle>;
+    async fn room_capabilities(&self, r: &RouterHandle) -> Result<SignalingBlob>;   // device.load client
+    async fn create_transport(&self, r: &RouterHandle, p: ParticipantId) -> Result<TransportHandle>;
+    async fn transport_params(&self, t: &TransportHandle) -> Result<SignalingBlob>; // ICE/DTLS → client
+    async fn connect_transport(&self, t: &TransportHandle, client: &SignalingBlob) -> Result<()>;
+    async fn produce(&self, t: &TransportHandle, kind: TrackKind, client: &SignalingBlob) -> Result<ProducerId>;
+    async fn consume(&self, t: &TransportHandle, prod: &ProducerId, client_caps: &SignalingBlob)
+        -> Result<(ConsumerId, SignalingBlob)>;                                     // params → client
+    async fn set_preferred_layer(&self, c: &ConsumerId, layer: Layer) -> Result<()>;
+    async fn pipe_to_remote(&self, prod: &ProducerId, node: &NodeId) -> Result<PipeHandle>; // fédération
+    async fn stats(&self, scope: StatsScope) -> Result<EngineStats>;
+    async fn close_room(&self, r: RouterHandle) -> Result<()>;
 }
 ```
 

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/Cargo.lock
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/Cargo.lock
@@ -799,6 +799,8 @@ version = "0.1.0"
 dependencies = [
  "mediasoup",
  "nodyx-sfu",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/Cargo.toml
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/Cargo.toml
@@ -7,6 +7,10 @@ description = "Spike §15 du CDC SFU : MediasoupEngine impl MediaEngine, DERRIER
 # Dépendances ASSUMÉES ici (et seulement ici) : c'est l'adaptateur moteur.
 # L'abstraction nodyx-sfu reste zéro-dep. Cf CDC §18 (trois étages).
 [dependencies]
-nodyx-sfu = { path = "../nodyx-sfu" }
-mediasoup = "0.18"
-tokio     = { version = "1", features = ["rt-multi-thread", "macros"] }
+nodyx-sfu  = { path = "../nodyx-sfu" }
+mediasoup  = "0.18"
+tokio      = { version = "1", features = ["rt-multi-thread", "macros"] }
+# Sérialisation des blobs de signaling (types mediasoup → JSON opaque pour le
+# métier). Le CodecAdapter vit ici, jamais dans l'abstraction.
+serde      = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
@@ -5,15 +5,25 @@
 //! Nodyx ici : uniquement la traduction du port vers l'API mediasoup
 //! (Worker / Router / Transport / Producer / Consumer).
 //!
-//! Portée SPIKE (§15) : transports **Direct** (pas de navigateur), audio Opus
-//! avec `RtpParameters` fabriqués en interne. La vraie négociation
-//! codecs/capabilities client viendra avec le `CodecAdapter` (P1) : c'est LA
-//! fuite d'abstraction identifiée au CDC, on la garde isolée ici.
+//! Deux modes de transport :
+//! - **Direct** (défaut) : pas de navigateur, `RtpParameters` fabriqués en
+//!   interne. Sert aux scénarios automatisés (spike, futurs tests d'intégration).
+//! - **WebRTC** (`new_webrtc`) : vrais `WebRtcTransport` (ICE/DTLS/SRTP), les
+//!   paramètres transitent en blobs de signaling opaques (P1).
 //!
-//! Les objets mediasoup se ferment au `Drop` : les registres ci-dessous les
-//! gardent vivants tant que le port n'a pas demandé leur fermeture.
+//! La négociation codecs/capabilities vit ICI (sérialisation serde des types
+//! mediasoup) : c'est LA fuite d'abstraction identifiée au CDC (CodecAdapter),
+//! confinée dans l'adaptateur.
+//!
+//! Enseignements du spike (payés en heures de debug, ne pas re-perdre) :
+//! - les objets mediasoup se ferment au `Drop` → registres de rétention ;
+//! - le pipe relie des routers de workers DIFFÉRENTS (intra-worker : collision
+//!   d'ID de handler) ;
+//! - le producer pipé conserve l'UUID de l'original → clé de registre
+//!   distincte obligatoire, sinon l'insert droppe l'original (cascade).
 
 use std::collections::HashMap;
+use std::net::IpAddr;
 use std::num::{NonZeroU32, NonZeroU8};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -23,7 +33,8 @@ use mediasoup::rtp_parameters::RtpCodecCapabilityFinalized;
 
 use nodyx_sfu::{
     ConsumerId, EngineStats, Layer, MediaEngine, MediaError, NodeId, ParticipantId, PipeHandle,
-    ProducerId, Result, RoomId, RouterHandle, StatsScope, TrackKind, TransportHandle,
+    ProducerId, Result, RoomId, RouterHandle, SignalingBlob, StatsScope, TrackKind,
+    TransportHandle,
 };
 
 // ── Codec du spike : Opus, aligné sur le vocal actuel (48 kHz, FEC) ─────────
@@ -60,10 +71,8 @@ fn opus_rtp_parameters(ssrc: u32) -> RtpParameters {
 }
 
 /// Les capabilities "finalized" du router (payload types assignés) → les
-/// capabilities d'un consommateur. Dans la vraie vie (P1), ces caps viennent
-/// du CLIENT (navigateur) via le CodecAdapter ; pour le spike (transports
-/// Direct, pas de navigateur), consommer avec les caps du router est le
-/// comportement de référence des exemples mediasoup.
+/// capabilities d'un consommateur. Utilisé quand le client n'a pas fourni les
+/// siennes (mode Direct) ; en WebRTC le client envoie les siennes via le blob.
 fn consumer_caps(finalized: &RtpCapabilitiesFinalized) -> RtpCapabilities {
     let codecs = finalized
         .codecs
@@ -107,11 +116,21 @@ fn consumer_caps(finalized: &RtpCapabilitiesFinalized) -> RtpCapabilities {
     }
 }
 
+// ── Transports : Direct (scénarios auto) ou WebRTC (vrais clients) ──────────
+
+enum AnyTransport {
+    Direct(DirectTransport),
+    WebRtc(WebRtcTransport),
+}
+
 // ── L'adaptateur ─────────────────────────────────────────────────────────────
 
 struct Inner {
     manager: WorkerManager,
     worker: Worker,
+    /// Mode WebRTC : IP d'écoute (+ adresse annoncée aux clients, ex: IP
+    /// publique du VPS). `None` = transports Direct.
+    webrtc_listen: Option<(IpAddr, Option<String>)>,
     /// Workers supplémentaires (spike : le "nœud distant" a SON worker, car le
     /// pipe mediasoup relie des routers de workers DIFFÉRENTS ; en prod P1 :
     /// un worker par cœur CPU, même mécanique).
@@ -119,9 +138,9 @@ struct Inner {
     /// RouterHandle.0 → Router (un par salon).
     routers: Mutex<HashMap<String, Router>>,
     /// TransportHandle.0 → (transport, clé du router parent).
-    transports: Mutex<HashMap<String, (DirectTransport, String)>>,
+    transports: Mutex<HashMap<String, (Arc<AnyTransport>, String)>>,
     /// ProducerId.0 → (Producer, clé du router qui l'héberge). Inclut les
-    /// producers "pipés" (consommables côté nœud distant).
+    /// producers "pipés" (consommables côté nœud distant, clé `piped-<uuid>`).
     producers: Mutex<HashMap<String, (Producer, String)>>,
     /// ConsumerId.0 → Consumer.
     consumers: Mutex<HashMap<String, Consumer>>,
@@ -139,7 +158,18 @@ pub struct MediasoupEngine {
 }
 
 impl MediasoupEngine {
+    /// Mode Direct (scénarios automatisés, pas de navigateur).
     pub async fn new() -> Result<Self> {
+        Self::build(None).await
+    }
+
+    /// Mode WebRTC : vrais transports ICE/DTLS. `listen_ip` = IP d'écoute
+    /// locale, `announced` = adresse annoncée aux clients (IP publique).
+    pub async fn new_webrtc(listen_ip: IpAddr, announced: Option<String>) -> Result<Self> {
+        Self::build(Some((listen_ip, announced))).await
+    }
+
+    async fn build(webrtc_listen: Option<(IpAddr, Option<String>)>) -> Result<Self> {
         let manager = WorkerManager::new();
         let worker = manager
             .create_worker(WorkerSettings::default())
@@ -149,6 +179,7 @@ impl MediasoupEngine {
             inner: Arc::new(Inner {
                 manager,
                 worker,
+                webrtc_listen,
                 extra_workers: Mutex::new(Vec::new()),
                 routers: Mutex::new(HashMap::new()),
                 transports: Mutex::new(HashMap::new()),
@@ -175,8 +206,18 @@ impl MediasoupEngine {
             .ok_or_else(|| MediaError::NotFound(format!("router {key}")))
     }
 
-    /// Enregistre un nœud SFU "distant" (spike : un Router d'un autre salon /
-    /// worker local qui joue le rôle de l'SFU d'une autre instance).
+    fn transport_of(&self, key: &str) -> Result<(Arc<AnyTransport>, String)> {
+        self.inner
+            .transports
+            .lock()
+            .unwrap()
+            .get(key)
+            .map(|(t, rk)| (Arc::clone(t), rk.clone()))
+            .ok_or_else(|| MediaError::NotFound(format!("transport {key}")))
+    }
+
+    /// Enregistre un nœud SFU "distant" (spike : un Router d'un autre worker
+    /// local qui joue le rôle de l'SFU d'une autre instance).
     pub fn register_remote_node(&self, node: &NodeId, router: Router) {
         self.inner
             .remote_nodes
@@ -223,44 +264,120 @@ impl MediaEngine for MediasoupEngine {
         Ok(RouterHandle(key))
     }
 
+    async fn room_capabilities(&self, router: &RouterHandle) -> Result<SignalingBlob> {
+        let r = self.router_of(&router.0)?;
+        let json = serde_json::to_string(r.rtp_capabilities())
+            .map_err(|e| MediaError::Engine(format!("caps serde: {e}")))?;
+        Ok(SignalingBlob(json))
+    }
+
     async fn create_transport(
         &self,
         router: &RouterHandle,
         _participant: ParticipantId,
     ) -> Result<TransportHandle> {
         let r = self.router_of(&router.0)?;
-        let transport = r
-            .create_direct_transport(DirectTransportOptions::default())
-            .await
-            .map_err(|e| MediaError::Engine(format!("create_transport: {e}")))?;
+        let transport = match &self.inner.webrtc_listen {
+            None => AnyTransport::Direct(
+                r.create_direct_transport(DirectTransportOptions::default())
+                    .await
+                    .map_err(|e| MediaError::Engine(format!("create_transport(direct): {e}")))?,
+            ),
+            Some((ip, announced)) => {
+                let listen = ListenInfo {
+                    protocol: Protocol::Udp,
+                    ip: *ip,
+                    announced_address: announced.clone(),
+                    port: None,
+                    port_range: None,
+                    flags: None,
+                    send_buffer_size: None,
+                    recv_buffer_size: None,
+                };
+                AnyTransport::WebRtc(
+                    r.create_webrtc_transport(WebRtcTransportOptions::new(
+                        WebRtcTransportListenInfos::new(listen),
+                    ))
+                    .await
+                    .map_err(|e| MediaError::Engine(format!("create_transport(webrtc): {e}")))?,
+                )
+            }
+        };
         let key = self.next("transport");
         self.inner
             .transports
             .lock()
             .unwrap()
-            .insert(key.clone(), (transport, router.0.clone()));
+            .insert(key.clone(), (Arc::new(transport), router.0.clone()));
         Ok(TransportHandle(key))
     }
 
-    async fn produce(&self, transport: &TransportHandle, kind: TrackKind) -> Result<ProducerId> {
-        if kind != TrackKind::Audio {
-            // Spike audio-only (P1) : la vidéo/simulcast arrive en P2/P3.
-            return Err(MediaError::Unsupported("produce non-audio (spike P1)"));
+    async fn transport_params(&self, transport: &TransportHandle) -> Result<SignalingBlob> {
+        let (t, _) = self.transport_of(&transport.0)?;
+        match t.as_ref() {
+            AnyTransport::Direct(_) => Ok(SignalingBlob("{\"kind\":\"direct\"}".into())),
+            AnyTransport::WebRtc(w) => {
+                let json = serde_json::json!({
+                    "id": transport.0,
+                    "iceParameters": w.ice_parameters(),
+                    "iceCandidates": w.ice_candidates(),
+                    "dtlsParameters": w.dtls_parameters(),
+                });
+                Ok(SignalingBlob(json.to_string()))
+            }
         }
-        let (t, router_key) = {
-            let map = self.inner.transports.lock().unwrap();
-            map.get(&transport.0)
-                .map(|(t, rk)| (t.clone(), rk.clone()))
-                .ok_or_else(|| MediaError::NotFound(format!("transport {}", transport.0)))?
+    }
+
+    async fn connect_transport(
+        &self,
+        transport: &TransportHandle,
+        client: &SignalingBlob,
+    ) -> Result<()> {
+        let (t, _) = self.transport_of(&transport.0)?;
+        match t.as_ref() {
+            AnyTransport::Direct(_) => Ok(()), // rien à connecter en Direct
+            AnyTransport::WebRtc(w) => {
+                #[derive(serde::Deserialize)]
+                #[serde(rename_all = "camelCase")]
+                struct ConnectPayload {
+                    dtls_parameters: DtlsParameters,
+                }
+                let payload: ConnectPayload = serde_json::from_str(&client.0)
+                    .map_err(|e| MediaError::Engine(format!("connect payload: {e}")))?;
+                w.connect(WebRtcTransportRemoteParameters {
+                    dtls_parameters: payload.dtls_parameters,
+                })
+                .await
+                .map_err(|e| MediaError::Engine(format!("connect: {e}")))
+            }
+        }
+    }
+
+    async fn produce(
+        &self,
+        transport: &TransportHandle,
+        kind: TrackKind,
+        client: &SignalingBlob,
+    ) -> Result<ProducerId> {
+        if kind != TrackKind::Audio {
+            // P1 = audio. La vidéo/simulcast arrive en P2/P3.
+            return Err(MediaError::Unsupported("produce non-audio (P1 audio)"));
+        }
+        let (t, router_key) = self.transport_of(&transport.0)?;
+        // Paramètres RTP du client si fournis (WebRTC), sinon fabriqués (Direct).
+        let rtp: RtpParameters = match serde_json::from_str(&client.0) {
+            Ok(p) => p,
+            Err(_) => {
+                let ssrc = 1000 + self.inner.seq.fetch_add(1, Ordering::Relaxed) as u32;
+                opus_rtp_parameters(ssrc)
+            }
         };
-        let ssrc = 1000 + self.inner.seq.fetch_add(1, Ordering::Relaxed) as u32;
-        let producer = t
-            .produce(ProducerOptions::new(
-                MediaKind::Audio,
-                opus_rtp_parameters(ssrc),
-            ))
-            .await
-            .map_err(|e| MediaError::Engine(format!("produce: {e}")))?;
+        let options = ProducerOptions::new(MediaKind::Audio, rtp);
+        let producer = match t.as_ref() {
+            AnyTransport::Direct(d) => d.produce(options).await,
+            AnyTransport::WebRtc(w) => w.produce(options).await,
+        }
+        .map_err(|e| MediaError::Engine(format!("produce: {e}")))?;
         let key = producer.id().to_string();
         self.inner
             .producers
@@ -274,29 +391,37 @@ impl MediaEngine for MediasoupEngine {
         &self,
         transport: &TransportHandle,
         producer: &ProducerId,
-    ) -> Result<ConsumerId> {
-        let (t, router_key) = {
-            let map = self.inner.transports.lock().unwrap();
-            map.get(&transport.0)
-                .map(|(t, rk)| (t.clone(), rk.clone()))
-                .ok_or_else(|| MediaError::NotFound(format!("transport {}", transport.0)))?
-        };
+        client_caps: &SignalingBlob,
+    ) -> Result<(ConsumerId, SignalingBlob)> {
+        let (t, router_key) = self.transport_of(&transport.0)?;
         let ms_producer_id = {
             let map = self.inner.producers.lock().unwrap();
             map.get(&producer.0)
                 .map(|(p, _)| p.id())
                 .ok_or_else(|| MediaError::NotFound(format!("producer {}", producer.0)))?
         };
-        // Spike : on consomme avec les capabilities du router (transports Direct).
-        // La vraie négociation avec les capabilities du CLIENT = CodecAdapter (P1).
-        let caps = consumer_caps(self.router_of(&router_key)?.rtp_capabilities());
-        let consumer = t
-            .consume(ConsumerOptions::new(ms_producer_id, caps))
-            .await
-            .map_err(|e| MediaError::Engine(format!("consume: {e}")))?;
+        // Capabilities du client si fournies (WebRTC), sinon celles du router
+        // (Direct). C'est le cœur du futur CodecAdapter.
+        let caps: RtpCapabilities = match serde_json::from_str(&client_caps.0) {
+            Ok(c) => c,
+            Err(_) => consumer_caps(self.router_of(&router_key)?.rtp_capabilities()),
+        };
+        let options = ConsumerOptions::new(ms_producer_id, caps);
+        let consumer = match t.as_ref() {
+            AnyTransport::Direct(d) => d.consume(options).await,
+            AnyTransport::WebRtc(w) => w.consume(options).await,
+        }
+        .map_err(|e| MediaError::Engine(format!("consume: {e}")))?;
+        // Ce que le client doit appliquer pour recevoir le flux.
+        let params = serde_json::json!({
+            "id": consumer.id(),
+            "producerId": ms_producer_id,
+            "kind": consumer.kind(),
+            "rtpParameters": consumer.rtp_parameters(),
+        });
         let key = consumer.id().to_string();
         self.inner.consumers.lock().unwrap().insert(key.clone(), consumer);
-        Ok(ConsumerId(key))
+        Ok((ConsumerId(key), SignalingBlob(params.to_string())))
     }
 
     async fn set_preferred_layer(&self, _consumer: &ConsumerId, _layer: Layer) -> Result<()> {
@@ -325,12 +450,10 @@ impl MediaEngine for MediasoupEngine {
             .map_err(|e| MediaError::Engine(format!("pipe_to_remote: {e}")))?;
 
         // Le producer "pipé" vit sur le router DISTANT : on l'enregistre pour
-        // que consume() le trouve côté nœud distant. Le consumer de pipe (côté
-        // source) est gardé en vie, sinon Drop = pipe fermé.
+        // que consume() le trouve côté nœud distant. Sémantique mediasoup : il
+        // garde le MÊME uuid que l'original → clé distincte obligatoire, sinon
+        // insert() écrase (et droppe = ferme) l'original, cascade fatale.
         let piped = pair.pipe_producer.into_inner();
-        // Sémantique mediasoup : le producer pipé garde le MÊME uuid que
-        // l'original. Clé distincte obligatoire, sinon insert() écrase (et
-        // droppe = ferme) l'original, et tout le pipe s'effondre en cascade.
         let piped_key = format!("piped-{}", piped.id());
         self.inner
             .producers

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/main.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/main.rs
@@ -17,8 +17,12 @@ mod engine;
 
 use engine::MediasoupEngine;
 use nodyx_sfu::{
-    MediaEngine, Mode, NodeId, ParticipantId, RoomId, TrackKind, VoiceService,
+    MediaEngine, Mode, NodeId, ParticipantId, RoomId, SignalingBlob, TrackKind, VoiceService,
 };
+
+fn blob() -> SignalingBlob {
+    SignalingBlob("{}".into())
+}
 
 fn p(n: u32) -> ParticipantId {
     ParticipantId(format!("user-{n}"))
@@ -66,15 +70,26 @@ async fn main() {
     assert_eq!(out.migrated.len(), 4, "les 4 présents ont été migrés");
     println!("     → mode={:?}, transports provisionnés: 5", svc.mode(&room).unwrap());
 
+    let caps = step!(
+        "room_capabilities (blob pour device.load côté client)",
+        svc.room_capabilities(&room).await
+    );
+    println!("     → caps: {} octets de JSON (opaque pour le métier)", caps.0.len());
+    let tparams = step!(
+        "transport_params de user-1 (mode Direct : blob minimal)",
+        svc.transport_params(&room, &p(1)).await
+    );
+    println!("     → params: {tparams}");
     let producer = step!(
         "publish audio Opus de user-1 (Producer mediasoup réel)",
-        svc.publish(room.clone(), p(1), TrackKind::Audio).await
+        svc.publish(room.clone(), p(1), TrackKind::Audio, &blob()).await
     );
-    let consumer = step!(
+    let (consumer, cparams) = step!(
         "subscribe de user-2 au flux de user-1 (Consumer mediasoup réel)",
-        svc.subscribe(room.clone(), p(2), producer.clone()).await
+        svc.subscribe(room.clone(), p(2), producer.clone(), &blob()).await
     );
     println!("     → producer={producer} consumer={consumer}");
+    println!("     → params consumer pour le client: {} octets", cparams.0.len());
     step!(
         "set_preferred_layer (no-op audio, contrat du port respecté)",
         svc.set_preferred_layer(room.clone(), p(2), producer.clone(), nodyx_sfu::Layer::LOWEST)
@@ -111,11 +126,42 @@ async fn main() {
     let piped_producer = nodyx_sfu::ProducerId(
         pipe.0.strip_prefix("pipe-").unwrap_or(&pipe.0).to_string(),
     );
-    let remote_consumer = step!(
+    let (remote_consumer, _) = step!(
         "consume du flux pipé côté nœud distant (LA brique de la cascade P4)",
-        engine.consume(&remote_transport, &piped_producer).await
+        engine.consume(&remote_transport, &piped_producer, &blob()).await
     );
     println!("     → remote_consumer={remote_consumer}");
+
+    // ── Scénario W : vrais WebRtcTransport (P1) ──────────────────────────────
+    println!("\n[W] WebRtcTransport réels (ICE/DTLS, prêts pour un navigateur)");
+    let web = step!(
+        "moteur en mode WebRTC (écoute 127.0.0.1)",
+        engine::MediasoupEngine::new_webrtc("127.0.0.1".parse().unwrap(), None).await
+    );
+    let wroom = step!("salon WebRTC", web.create_room(RoomId("webrtc-room".into())).await);
+    let wtrans = step!(
+        "WebRtcTransport (socket UDP réellement lié)",
+        web.create_transport(&wroom, ParticipantId("browser-user".into())).await
+    );
+    let wparams = step!("transport_params (ICE/DTLS)", web.transport_params(&wtrans).await);
+    assert!(
+        wparams.0.contains("iceParameters") && wparams.0.contains("dtlsParameters"),
+        "le blob doit contenir ICE + DTLS"
+    );
+    println!(
+        "     → blob de {} octets, candidats ICE + fingerprints DTLS présents",
+        wparams.0.len()
+    );
+    // connect avec un payload invalide → erreur PROPRE (pas de panique) :
+    // le vrai connect exige les dtlsParameters d'un navigateur.
+    match web.connect_transport(&wtrans, &blob()).await {
+        Err(e) => println!("  ✔ connect(payload invalide) rejeté proprement : {e}"),
+        Ok(()) => {
+            println!("  ✘ connect aurait dû rejeter un payload sans dtlsParameters");
+            std::process::exit(1);
+        }
+    }
+    step!("close du salon WebRTC", web.close_room(wroom).await);
 
     // ── Fin propre ───────────────────────────────────────────────────────────
     println!("\n[C] fermeture propre");
@@ -125,9 +171,8 @@ async fn main() {
     step!("close du salon distant", engine.close_room(remote_room).await);
 
     println!("\n══════════════════════════════════════════════════════");
-    println!("SPIKE VERT : le cerveau (VoiceService, inchangé) a piloté");
-    println!("le vrai moteur mediasoup derrière le trait, ET la primitive");
-    println!("de cascade fédérée (pipe) fonctionne. Gate P1 : OUVERT.");
-    println!("Reste au gate P4 : pipe vers un HOST distant réel.");
+    println!("P1 LOT 1 VERT : le port sait signaler (blobs opaques), le cerveau");
+    println!("pilote toujours le vrai moteur, les WebRtcTransport se créent");
+    println!("avec ICE/DTLS réels. Reste P1 : signaling nodyx-core + client.");
     println!("══════════════════════════════════════════════════════");
 }

--- a/nodyx-p2p/crates/nodyx-sfu/src/lib.rs
+++ b/nodyx-p2p/crates/nodyx-sfu/src/lib.rs
@@ -74,6 +74,20 @@ impl Layer {
     pub const LOWEST: Layer = Layer { spatial: 0, temporal: 0 };
 }
 
+/// Charge utile de signaling, OPAQUE pour le métier. Contenu propre au moteur
+/// (mediasoup : JSON ICE/DTLS/RtpParameters ; un autre moteur : SDP…). Le
+/// cerveau (`VoiceService`) la TRANSPORTE entre client et moteur sans jamais
+/// la lire : c'est ce qui garde le métier 100 % agnostique du moteur (CDC §18,
+/// la « fuite » codecs confinée dans l'adaptateur/CodecAdapter).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignalingBlob(pub String);
+
+impl fmt::Display for SignalingBlob {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 /// Portée d'une requête de stats.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StatsScope {
@@ -135,12 +149,23 @@ pub type Result<T> = std::result::Result<T, MediaError>;
 pub trait MediaEngine: Send + Sync {
     /// Crée le Router d'un salon (idempotent côté appelant recommandé).
     async fn create_room(&self, room: RoomId) -> Result<RouterHandle>;
+    /// Capabilities du salon à remettre au client au join (mediasoup :
+    /// `router.rtpCapabilities` pour `device.load()`). Blob opaque.
+    async fn room_capabilities(&self, router: &RouterHandle) -> Result<SignalingBlob>;
     /// Crée le Transport WebRTC d'un participant dans un salon.
     async fn create_transport(&self, router: &RouterHandle, participant: ParticipantId) -> Result<TransportHandle>;
-    /// Le participant publie un flux (audio / écran / cam).
-    async fn produce(&self, transport: &TransportHandle, kind: TrackKind) -> Result<ProducerId>;
-    /// Le participant souscrit à un flux publié.
-    async fn consume(&self, transport: &TransportHandle, producer: &ProducerId) -> Result<ConsumerId>;
+    /// Paramètres de connexion du transport à remettre au client
+    /// (mediasoup : id + iceParameters + iceCandidates + dtlsParameters).
+    async fn transport_params(&self, transport: &TransportHandle) -> Result<SignalingBlob>;
+    /// Finalise la connexion du transport avec la réponse du client
+    /// (mediasoup : dtlsParameters du `connect`).
+    async fn connect_transport(&self, transport: &TransportHandle, client: &SignalingBlob) -> Result<()>;
+    /// Le participant publie un flux (audio / écran / cam). `client` porte ses
+    /// paramètres RTP (opaque ; un moteur de test peut l'ignorer).
+    async fn produce(&self, transport: &TransportHandle, kind: TrackKind, client: &SignalingBlob) -> Result<ProducerId>;
+    /// Le participant souscrit à un flux publié. `client_caps` porte ses
+    /// capabilities ; retourne les paramètres que le client doit appliquer.
+    async fn consume(&self, transport: &TransportHandle, producer: &ProducerId, client_caps: &SignalingBlob) -> Result<(ConsumerId, SignalingBlob)>;
     /// Force la couche servie à un abonné (adaptation bande passante).
     async fn set_preferred_layer(&self, consumer: &ConsumerId, layer: Layer) -> Result<()>;
     /// Relaie un flux vers un nœud SFU distant (cascade fédérée, PipeTransport).
@@ -174,14 +199,24 @@ impl MediaEngine for NullEngine {
     async fn create_room(&self, _room: RoomId) -> Result<RouterHandle> {
         Ok(RouterHandle(self.next("router")))
     }
+    async fn room_capabilities(&self, router: &RouterHandle) -> Result<SignalingBlob> {
+        Ok(SignalingBlob(format!("{{\"engine\":\"null\",\"router\":\"{router}\"}}")))
+    }
     async fn create_transport(&self, _router: &RouterHandle, _participant: ParticipantId) -> Result<TransportHandle> {
         Ok(TransportHandle(self.next("transport")))
     }
-    async fn produce(&self, _transport: &TransportHandle, _kind: TrackKind) -> Result<ProducerId> {
+    async fn transport_params(&self, transport: &TransportHandle) -> Result<SignalingBlob> {
+        Ok(SignalingBlob(format!("{{\"engine\":\"null\",\"transport\":\"{transport}\"}}")))
+    }
+    async fn connect_transport(&self, _transport: &TransportHandle, _client: &SignalingBlob) -> Result<()> {
+        Ok(())
+    }
+    async fn produce(&self, _transport: &TransportHandle, _kind: TrackKind, _client: &SignalingBlob) -> Result<ProducerId> {
         Ok(ProducerId(self.next("producer")))
     }
-    async fn consume(&self, _transport: &TransportHandle, _producer: &ProducerId) -> Result<ConsumerId> {
-        Ok(ConsumerId(self.next("consumer")))
+    async fn consume(&self, _transport: &TransportHandle, _producer: &ProducerId, client_caps: &SignalingBlob) -> Result<(ConsumerId, SignalingBlob)> {
+        // Écho des caps client : déterministe, suffisant pour l'orchestration.
+        Ok((ConsumerId(self.next("consumer")), client_caps.clone()))
     }
     async fn set_preferred_layer(&self, _consumer: &ConsumerId, _layer: Layer) -> Result<()> {
         Ok(())

--- a/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
+++ b/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
@@ -24,7 +24,7 @@
 
 use crate::{
     ConsumerId, Layer, MediaEngine, MediaError, ParticipantId, ProducerId, RoomId,
-    RouterHandle, TrackKind, TransportHandle,
+    RouterHandle, SignalingBlob, TrackKind, TransportHandle,
 };
 use std::collections::HashMap;
 use std::fmt;
@@ -390,11 +390,13 @@ impl<E: MediaEngine> VoiceService<E> {
     /// Le participant publie un flux. Un partage d'écran (`Screen`) force d'abord
     /// la bascule SFU de tout le salon. En mesh (pas de transport), publier renvoie
     /// [`VoiceError::NotInSfu`] (rien n'est produit côté serveur en mesh).
+    /// `client` = paramètres RTP du client (blob opaque, transmis au moteur).
     pub async fn publish(
         &self,
         room: RoomId,
         participant: ParticipantId,
         kind: TrackKind,
+        client: &SignalingBlob,
     ) -> Result<ProducerId, VoiceError> {
         if kind == TrackKind::Screen {
             self.ensure_sfu(room.clone()).await?;
@@ -407,7 +409,7 @@ impl<E: MediaEngine> VoiceService<E> {
             p.transport.clone().ok_or(VoiceError::NotInSfu)?
         };
 
-        let producer = self.engine.produce(&transport, kind).await?;
+        let producer = self.engine.produce(&transport, kind, client).await?;
 
         {
             let mut rooms = self.rooms();
@@ -422,12 +424,15 @@ impl<E: MediaEngine> VoiceService<E> {
     }
 
     /// Le participant souscrit à une publication. Requiert le mode SFU (transport).
+    /// `client_caps` = capabilities du client (blob opaque) ; retourne aussi les
+    /// paramètres que le client doit appliquer (blob du moteur).
     pub async fn subscribe(
         &self,
         room: RoomId,
         subscriber: ParticipantId,
         producer: ProducerId,
-    ) -> Result<ConsumerId, VoiceError> {
+        client_caps: &SignalingBlob,
+    ) -> Result<(ConsumerId, SignalingBlob), VoiceError> {
         let transport = {
             let rooms = self.rooms();
             let state = rooms.get(&room).ok_or(VoiceError::NotInRoom)?;
@@ -438,7 +443,7 @@ impl<E: MediaEngine> VoiceService<E> {
             p.transport.clone().ok_or(VoiceError::NotInSfu)?
         };
 
-        let consumer = self.engine.consume(&transport, &producer).await?;
+        let (consumer, params) = self.engine.consume(&transport, &producer, client_caps).await?;
 
         {
             let mut rooms = self.rooms();
@@ -449,7 +454,52 @@ impl<E: MediaEngine> VoiceService<E> {
                 p.subscriptions.insert(producer, consumer.clone());
             }
         }
-        Ok(consumer)
+        Ok((consumer, params))
+    }
+
+    // ── Signaling pass-through (blobs opaques, jamais lus par le métier) ─────
+
+    /// Capabilities du salon, à remettre au client au join SFU (§17-A).
+    pub async fn room_capabilities(&self, room: &RoomId) -> Result<SignalingBlob, VoiceError> {
+        let router = {
+            let rooms = self.rooms();
+            let state = rooms.get(room).ok_or(VoiceError::NotInRoom)?;
+            state.router.clone().ok_or(VoiceError::NotInSfu)?
+        };
+        Ok(self.engine.room_capabilities(&router).await?)
+    }
+
+    /// Paramètres de connexion du transport d'un participant (ICE/DTLS…),
+    /// à remettre au client pour qu'il établisse sa PC vers le SFU.
+    pub async fn transport_params(
+        &self,
+        room: &RoomId,
+        participant: &ParticipantId,
+    ) -> Result<SignalingBlob, VoiceError> {
+        let transport = self.transport_of(room, participant)?;
+        Ok(self.engine.transport_params(&transport).await?)
+    }
+
+    /// Finalise la connexion du transport avec la réponse du client (§17-A).
+    pub async fn connect_transport(
+        &self,
+        room: &RoomId,
+        participant: &ParticipantId,
+        client: &SignalingBlob,
+    ) -> Result<(), VoiceError> {
+        let transport = self.transport_of(room, participant)?;
+        Ok(self.engine.connect_transport(&transport, client).await?)
+    }
+
+    fn transport_of(
+        &self,
+        room: &RoomId,
+        participant: &ParticipantId,
+    ) -> Result<TransportHandle, VoiceError> {
+        let rooms = self.rooms();
+        let state = rooms.get(room).ok_or(VoiceError::NotInRoom)?;
+        let p = state.participants.get(participant).ok_or(VoiceError::NotInRoom)?;
+        p.transport.clone().ok_or(VoiceError::NotInSfu)
     }
 
     /// Force la couche servie à un abonné (adaptation bande passante, §17-C).
@@ -502,6 +552,10 @@ mod tests {
 
     fn p(n: u32) -> ParticipantId {
         ParticipantId(format!("user-{n}"))
+    }
+
+    fn blob() -> SignalingBlob {
+        SignalingBlob("{}".into())
     }
 
     // ── règle pure ──────────────────────────────────────────────────────────
@@ -630,7 +684,7 @@ mod tests {
         block_on(s.join(room(), p(1))).unwrap();
         block_on(s.join(room(), p(2))).unwrap();
         // p1 partage son écran depuis un salon mesh → bascule + producer
-        let prod = block_on(s.publish(room(), p(1), TrackKind::Screen)).unwrap();
+        let prod = block_on(s.publish(room(), p(1), TrackKind::Screen, &blob())).unwrap();
         assert_eq!(s.mode(&room()), Some(Mode::Sfu));
         let pubs = s.publications(&room());
         assert_eq!(pubs.len(), 1);
@@ -646,7 +700,7 @@ mod tests {
         block_on(s.join(room(), p(2))).unwrap();
         // audio ne bascule pas en SFU ; en mesh il n'y a pas de producer serveur
         assert_eq!(
-            block_on(s.publish(room(), p(1), TrackKind::Audio)),
+            block_on(s.publish(room(), p(1), TrackKind::Audio, &blob())),
             Err(VoiceError::NotInSfu)
         );
     }
@@ -656,9 +710,12 @@ mod tests {
         let s = svc();
         block_on(s.join(room(), p(1))).unwrap();
         block_on(s.join(room(), p(2))).unwrap();
-        let prod = block_on(s.publish(room(), p(1), TrackKind::Screen)).unwrap();
+        let prod = block_on(s.publish(room(), p(1), TrackKind::Screen, &blob())).unwrap();
         // p2 (migré par la bascule) s'abonne au flux de p1
-        let consumer = block_on(s.subscribe(room(), p(2), prod.clone())).unwrap();
+        let caps = SignalingBlob("{\"caps\":\"p2\"}".into());
+        let (consumer, params) = block_on(s.subscribe(room(), p(2), prod.clone(), &caps)).unwrap();
+        // NullEngine échoie les caps : le blob transite intact par le métier
+        assert_eq!(params, caps);
         // régler la couche servie à p2 → OK
         block_on(s.set_preferred_layer(room(), p(2), prod, Layer::LOWEST)).unwrap();
         assert_eq!(consumer, consumer.clone());
@@ -672,7 +729,7 @@ mod tests {
         }
         let ghost = ProducerId("does-not-exist".into());
         assert_eq!(
-            block_on(s.subscribe(room(), p(2), ghost)),
+            block_on(s.subscribe(room(), p(2), ghost, &blob())),
             Err(VoiceError::NoSuchPublication)
         );
     }
@@ -682,7 +739,7 @@ mod tests {
         let s = svc();
         block_on(s.join(room(), p(1))).unwrap();
         block_on(s.join(room(), p(2))).unwrap();
-        let prod = block_on(s.publish(room(), p(1), TrackKind::Screen)).unwrap();
+        let prod = block_on(s.publish(room(), p(1), TrackKind::Screen, &blob())).unwrap();
         // p2 n'a pas souscrit → NotSubscribed
         assert_eq!(
             block_on(s.set_preferred_layer(room(), p(2), prod, Layer::LOWEST)),
@@ -691,11 +748,45 @@ mod tests {
     }
 
     #[test]
+    fn signaling_passthrough_in_sfu_mode() {
+        let s = svc();
+        block_on(s.join(room(), p(1))).unwrap();
+        block_on(s.join(room(), p(2))).unwrap();
+        block_on(s.set_screenshare(room(), true)).unwrap(); // force SFU
+        // capabilities du salon dispo
+        let caps = block_on(s.room_capabilities(&room())).unwrap();
+        assert!(caps.0.contains("router"), "blob moteur transmis tel quel");
+        // paramètres de transport du participant + connect
+        let params = block_on(s.transport_params(&room(), &p(1))).unwrap();
+        assert!(params.0.contains("transport"));
+        block_on(s.connect_transport(&room(), &p(1), &blob())).unwrap();
+    }
+
+    #[test]
+    fn signaling_in_mesh_is_rejected() {
+        let s = svc();
+        block_on(s.join(room(), p(1))).unwrap();
+        // en mesh : pas de router, pas de transport
+        assert_eq!(
+            block_on(s.room_capabilities(&room())),
+            Err(VoiceError::NotInSfu)
+        );
+        assert_eq!(
+            block_on(s.transport_params(&room(), &p(1))),
+            Err(VoiceError::NotInSfu)
+        );
+        assert_eq!(
+            block_on(s.room_capabilities(&RoomId("nope".into()))),
+            Err(VoiceError::NotInRoom)
+        );
+    }
+
+    #[test]
     fn leaving_owner_drops_its_publications() {
         let s = svc();
         block_on(s.join(room(), p(1))).unwrap();
         block_on(s.join(room(), p(2))).unwrap();
-        block_on(s.publish(room(), p(1), TrackKind::Screen)).unwrap();
+        block_on(s.publish(room(), p(1), TrackKind::Screen, &blob())).unwrap();
         assert_eq!(s.publications(&room()).len(), 1);
         block_on(s.leave(room(), p(1))).unwrap();
         assert!(s.publications(&room()).is_empty(), "publications du partant retirées");


### PR DESCRIPTION
Évolution **délibérée** du trait `MediaEngine` (CDC §18 synchronisé dans la même PR) : les données de signaling transitent en `SignalingBlob` **opaques**. Le métier les transporte sans jamais les lire : `VoiceService` reste 100% agnostique du moteur, la négociation codecs (le CodecAdapter du CDC) vit dans l'adaptateur et nulle part ailleurs.

- **trait** : + `room_capabilities` (device.load client), + `transport_params` (ICE/DTLS → client), + `connect_transport` ; `produce` reçoit les paramètres RTP du client ; `consume` reçoit ses capabilities et retourne les paramètres à appliquer
- **VoiceService** : pass-through de signaling par salon+participant, **25 tests verts (+2)**, toujours zéro dépendance
- **MediasoupEngine** : mode WebRTC (`new_webrtc`) avec **vrais `WebRtcTransport`** + mode Direct (scénarios auto) ; serde des caps/params ; connect DTLS
- **Spike enrichi** (`cargo run` tout vert) : scénario **[W]** = WebRtcTransport réel, blob ICE+DTLS ~1 Ko, connect(payload invalide) rejeté proprement ; A/B passent avec les nouvelles signatures
- **NOTICE** (obligation CDC §14) : mediasoup ISC + libwebrtc BSD-3 + ed25519-dalek BSD-3

Reste P1 : daemon SFU (API interne) + câblage signaling nodyx-core (**sanctuaire**, validation dédiée) + client frontend + bench.