### PR TITLE
feat(voice): relais SFU dans nodyx-core, additif et DORMANT (P1 lot 2b)

### DIFF
--- a/nodyx-core/.env.example
+++ b/nodyx-core/.env.example
@@ -286,3 +286,9 @@ NODYX_GLOBAL_INDEXING=true
 #  À NOTER : le frontend (nodyx-frontend) a son propre .env, avec notamment
 #  PUBLIC_API_URL (URL de l'API vue par le navigateur). Voir nodyx-frontend.
 # ══════════════════════════════════════════════════════════════════════════════
+
+# ── Voice SFU (P1, expérimental) ──────────────────────────────────────────────
+# Relais de signaling vers le daemon nodyx-sfud (API interne localhost).
+# ABSENT = SFU totalement désactivé, le vocal mesh actuel est seul actif.
+# VOICE_SFU_URL=http://127.0.0.1:3901
+# VOICE_SFU_TOKEN=   # = SFU_TOKEN du daemon (>=16 caractères)

--- a/nodyx-core/src/socket/index.ts
+++ b/nodyx-core/src/socket/index.ts
@@ -1,4 +1,5 @@
 import { registerVoiceHandlers, sendVoiceSnapshot } from './voice'
+import { registerVoiceSfuHandlers } from './voiceSfu'
 import { registerWhisperHandlers } from './whisper'
 import { registerCanvasHandlers }  from './canvas'
 import { checkRateLimit } from './rateLimiter'
@@ -753,6 +754,8 @@ export function registerSocketIO(server: Server): void {
 
     // ── Voice (WebRTC signaling) ───────────────────────────────────────────────
     registerVoiceHandlers(socket, server)
+    // SFU (relais vers nodyx-sfud, DORMANT sans VOICE_SFU_URL — CDC SFU §17)
+    registerVoiceSfuHandlers(socket, server)
 
     // ── DM events ─────────────────────────────────────────────────────────────
 

--- a/nodyx-core/src/socket/rateLimiter.ts
+++ b/nodyx-core/src/socket/rateLimiter.ts
@@ -40,6 +40,12 @@ export const RATE_RULES: Record<string, RuleConfig[]> = {
   'jukebox:request_sync': [{ limit: 3,  windowMs: 1_000  }],
   'voice:ping':           [{ limit: 3,  windowMs: 1_000  }],
   'voice:stats':          [{ limit: 10, windowMs: 1_000  }],
+  // Signaling SFU (voiceSfu.ts) : requête/réponse, cadence humaine attendue
+  'voice:sfu_join':         [{ limit: 5,  windowMs: 10_000 }],
+  'voice:sfu_connect':      [{ limit: 10, windowMs: 10_000 }],
+  'voice:sfu_produce':      [{ limit: 10, windowMs: 10_000 }],
+  'voice:sfu_consume':      [{ limit: 40, windowMs: 10_000 }],
+  'voice:sfu_publications': [{ limit: 10, windowMs: 10_000 }],
 }
 
 // Clé composite : `${userId}::${eventKey}`

--- a/nodyx-core/src/socket/voice.ts
+++ b/nodyx-core/src/socket/voice.ts
@@ -6,7 +6,7 @@ import { db } from '../config/database'
 type CommunityRole = 'owner' | 'admin' | 'moderator' | 'member'
 const MOD_ROLES: ReadonlyArray<CommunityRole> = ['owner', 'admin', 'moderator']
 
-async function getCommunityRoleForChannel(
+export async function getCommunityRoleForChannel(
   channelId: string, userId: string,
 ): Promise<CommunityRole | null> {
   const { rows } = await db.query<{ role: CommunityRole }>(
@@ -20,7 +20,7 @@ async function getCommunityRoleForChannel(
 }
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-function isUuid(v: unknown): v is string { return typeof v === 'string' && UUID_RE.test(v) }
+export function isUuid(v: unknown): v is string { return typeof v === 'string' && UUID_RE.test(v) }
 
 // Max size for jukebox state payload (10 KB)
 const JUKEBOX_STATE_MAX = 10_240
@@ -99,7 +99,7 @@ function getChannelSeats(channelId: string): Map<string, number> {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function voiceRoom(channelId: string): string {
+export function voiceRoom(channelId: string): string {
   return `voice:${channelId}`
 }
 

--- a/nodyx-core/src/socket/voiceSfu.ts
+++ b/nodyx-core/src/socket/voiceSfu.ts
@@ -1,0 +1,248 @@
+/**
+ * NODYX — Voice SFU signaling relay (P1, CDC SFU §17)
+ *
+ * Relais PUR entre les clients socket.io et le daemon `nodyx-sfud` (API HTTP
+ * interne localhost). Aucune logique média ici : le core transporte des blobs
+ * de signaling opaques (ICE/DTLS/RTP params) entre le client et le daemon.
+ *
+ * DOCTRINE CHIRURGICALE (validée par le owner, 2026-07-06) :
+ * - Fichier ADDITIF : le mesh existant (voice.ts) n'est modifié en rien.
+ *   Les events sont namespacés `voice:sfu_*`, aucun ne collisionne.
+ * - DORMANT par défaut : sans VOICE_SFU_URL dans l'env, chaque handler répond
+ *   `sfu_disabled` et ne contacte jamais rien. Rollback = retirer la variable.
+ * - Dégradation gracieuse : daemon injoignable => réponse d'erreur propre au
+ *   client, JAMAIS d'exception qui remonte, le mesh continue sa vie.
+ * - Mêmes gardes d'admission que le mesh : isUuid + getCommunityRoleForChannel
+ *   (réutilisées depuis voice.ts, pas dupliquées), + rate limiting par event.
+ * - L'identité vient TOUJOURS de socket.data (JWT vérifié), jamais du payload.
+ *
+ * Style ack (callback socket.io) : nouveau dans ce fichier uniquement. Le
+ * signaling SFU est un protocole requête/réponse strict (connect -> produce ->
+ * consume s'enchaînent), les acks éliminent toute erreur de corrélation.
+ *
+ * Env : VOICE_SFU_URL   (ex: http://127.0.0.1:3901) — absent = SFU désactivé
+ *       VOICE_SFU_TOKEN (= SFU_TOKEN du daemon)
+ */
+
+import { Server, Socket } from 'socket.io'
+import { checkRateLimit } from './rateLimiter'
+import { getCommunityRoleForChannel, isUuid, voiceRoom } from './voice'
+
+// ── Configuration (lue à CHAQUE appel : cohérent avec le système de settings
+//    tier-3 qui ré-applique les valeurs DB sur process.env à chaud) ───────────
+
+function sfuUrl(): string | null {
+  const v = process.env.VOICE_SFU_URL?.trim()
+  return v ? v.replace(/\/+$/, '') : null
+}
+
+// ── Garde-fous ────────────────────────────────────────────────────────────────
+
+/** Taille max d'un blob client (rtpParameters/capabilities ~2-3 Ko réels). */
+const MAX_CLIENT_BLOB = 64_000
+/** Timeout d'un appel daemon : au-delà, on répond une erreur propre. */
+const DAEMON_TIMEOUT_MS = 5_000
+
+type Ack = (response: Record<string, unknown>) => void
+
+/** Un ack manquant ou malformé = requête ignorée (pas de crash possible). */
+function isAck(cb: unknown): cb is Ack {
+  return typeof cb === 'function'
+}
+
+/** Sérialise un objet client borné, ou null si invalide/trop gros. */
+function boundedJson(value: unknown): string | null {
+  if (value === null || value === undefined) return '{}'
+  try {
+    const s = JSON.stringify(value)
+    if (typeof s !== 'string' || s.length > MAX_CLIENT_BLOB) return null
+    return s
+  } catch {
+    return null
+  }
+}
+
+/** Parse un blob JSON renvoyé par le daemon (string) en objet pour le client. */
+function parseBlob(s: unknown): unknown {
+  if (typeof s !== 'string') return s
+  try { return JSON.parse(s) } catch { return s }
+}
+
+// ── Appel daemon : ne throw JAMAIS ───────────────────────────────────────────
+
+type DaemonResult = { ok: true; data: Record<string, unknown> } | { ok: false; error: string }
+
+async function sfuFetch(path: string, payload: Record<string, unknown>): Promise<DaemonResult> {
+  const base = sfuUrl()
+  if (!base) return { ok: false, error: 'sfu_disabled' }
+  try {
+    const res = await fetch(`${base}${path}`, {
+      method:  'POST',
+      headers: {
+        'Content-Type':  'application/json',
+        'Authorization': `Bearer ${process.env.VOICE_SFU_TOKEN ?? ''}`,
+      },
+      body:   JSON.stringify(payload),
+      signal: AbortSignal.timeout(DAEMON_TIMEOUT_MS),
+    })
+    const data = (await res.json().catch(() => null)) as Record<string, unknown> | null
+    if (!data || typeof data !== 'object') {
+      return { ok: false, error: `sfu_bad_response_${res.status}` }
+    }
+    if (data.ok !== true) {
+      return { ok: false, error: typeof data.error === 'string' ? data.error : `sfu_error_${res.status}` }
+    }
+    return { ok: true, data }
+  } catch {
+    // Daemon éteint, timeout, refus de connexion : le mesh n'est pas concerné.
+    return { ok: false, error: 'sfu_unreachable' }
+  }
+}
+
+// ── Registration ──────────────────────────────────────────────────────────────
+
+export function registerVoiceSfuHandlers(socket: Socket, server: Server): void {
+  const { userId } = socket.data
+
+  /** Salons SFU rejoints par CE socket (nettoyage garanti au disconnect). */
+  const joined = new Set<string>()
+
+  /**
+   * Gardes communes à tous les handlers. Retourne le rôle communauté si tout
+   * passe, sinon répond l'erreur dans l'ack et retourne null.
+   */
+  async function guard(event: string, channelId: unknown, cb: Ack): Promise<string | null> {
+    if (!sfuUrl()) { cb({ ok: false, error: 'sfu_disabled' }); return null }
+    if (checkRateLimit(userId, event)) { cb({ ok: false, error: 'rate_limited' }); return null }
+    if (!isUuid(channelId)) { cb({ ok: false, error: 'bad_channel' }); return null }
+    const role = await getCommunityRoleForChannel(channelId, userId)
+    if (!role) { cb({ ok: false, error: 'forbidden' }); return null }
+    return role
+  }
+
+  // ── voice:sfu_join — rejoint le salon côté SFU (§17-A) ─────────────────────
+  // Réponse : { ok, mode, caps?, transportParams? } (caps + params seulement en
+  // mode SFU : tout ce qu'il faut au client pour device.load + créer sa PC).
+  socket.on('voice:sfu_join', async (channelId: unknown, cb: unknown) => {
+    if (!isAck(cb)) return
+    if (!(await guard('voice:sfu_join', channelId, cb))) return
+
+    const join = await sfuFetch('/v1/join', { room: channelId, participant: userId })
+    if (!join.ok) { cb({ ok: false, error: join.error }); return }
+
+    joined.add(channelId as string)
+    const mode = join.data.mode
+
+    if (mode !== 'sfu') { cb({ ok: true, mode }); return }
+
+    // Mode SFU : le client a besoin des capabilities + de ses transport params.
+    const [caps, params] = await Promise.all([
+      sfuFetch('/v1/caps', { room: channelId }),
+      sfuFetch('/v1/transport_params', { room: channelId, participant: userId }),
+    ])
+    if (!caps.ok) { cb({ ok: false, error: caps.error }); return }
+    if (!params.ok) { cb({ ok: false, error: params.error }); return }
+
+    // Si cette arrivée a fait basculer le salon (des participants ont été
+    // migrés), on prévient le salon : chacun fera son propre sfu_join pour
+    // récupérer SES transport params.
+    const migrated = Array.isArray(join.data.migrated) ? join.data.migrated : []
+    if (migrated.length > 0) {
+      server.to(voiceRoom(channelId as string)).emit('voice:sfu_mode', { channelId, mode: 'sfu' })
+    }
+
+    cb({
+      ok: true,
+      mode,
+      caps:            parseBlob(caps.data.caps),
+      transportParams: parseBlob(params.data.params),
+    })
+  })
+
+  // ── voice:sfu_connect — finalise la PC (dtlsParameters du client) ──────────
+  socket.on('voice:sfu_connect', async (payload: unknown, cb: unknown) => {
+    if (!isAck(cb)) return
+    const { channelId, dtlsParameters } = (payload ?? {}) as Record<string, unknown>
+    if (!(await guard('voice:sfu_connect', channelId, cb))) return
+
+    const client = boundedJson({ dtlsParameters })
+    if (!client) { cb({ ok: false, error: 'payload_too_large' }); return }
+
+    const res = await sfuFetch('/v1/connect', { room: channelId, participant: userId, client })
+    cb(res.ok ? { ok: true } : { ok: false, error: res.error })
+  })
+
+  // ── voice:sfu_produce — publie un flux (rtpParameters du client) ───────────
+  socket.on('voice:sfu_produce', async (payload: unknown, cb: unknown) => {
+    if (!isAck(cb)) return
+    const { channelId, kind, rtpParameters } = (payload ?? {}) as Record<string, unknown>
+    if (!(await guard('voice:sfu_produce', channelId, cb))) return
+    if (kind !== 'audio' && kind !== 'screen' && kind !== 'cam') {
+      cb({ ok: false, error: 'bad_kind' }); return
+    }
+    const client = boundedJson(rtpParameters)
+    if (!client) { cb({ ok: false, error: 'payload_too_large' }); return }
+
+    const res = await sfuFetch('/v1/produce', { room: channelId, participant: userId, kind, client })
+    if (!res.ok) { cb({ ok: false, error: res.error }); return }
+
+    // Annonce aux autres : un nouveau flux est disponible à la souscription.
+    socket.to(voiceRoom(channelId as string)).emit('voice:sfu_new_producer', {
+      channelId,
+      producerId: res.data.producer,
+      kind,
+      userId,
+    })
+    cb({ ok: true, producerId: res.data.producer })
+  })
+
+  // ── voice:sfu_consume — souscrit à un flux publié ──────────────────────────
+  socket.on('voice:sfu_consume', async (payload: unknown, cb: unknown) => {
+    if (!isAck(cb)) return
+    const { channelId, producerId, rtpCapabilities } = (payload ?? {}) as Record<string, unknown>
+    if (!(await guard('voice:sfu_consume', channelId, cb))) return
+    if (typeof producerId !== 'string' || producerId.length === 0 || producerId.length > 200) {
+      cb({ ok: false, error: 'bad_producer' }); return
+    }
+    const clientCaps = boundedJson(rtpCapabilities)
+    if (!clientCaps) { cb({ ok: false, error: 'payload_too_large' }); return }
+
+    const res = await sfuFetch('/v1/consume', {
+      room: channelId, participant: userId, producer: producerId, clientCaps,
+    })
+    if (!res.ok) { cb({ ok: false, error: res.error }); return }
+    cb({ ok: true, consumerId: res.data.consumer, params: parseBlob(res.data.params) })
+  })
+
+  // ── voice:sfu_publications — liste des flux du salon (§17-A) ───────────────
+  socket.on('voice:sfu_publications', async (channelId: unknown, cb: unknown) => {
+    if (!isAck(cb)) return
+    if (!(await guard('voice:sfu_publications', channelId, cb))) return
+
+    const res = await sfuFetch('/v1/publications', { room: channelId })
+    if (!res.ok) { cb({ ok: false, error: res.error }); return }
+    cb({ ok: true, publications: res.data.publications ?? [] })
+  })
+
+  // ── voice:sfu_leave ─────────────────────────────────────────────────────────
+  socket.on('voice:sfu_leave', async (channelId: unknown, cb: unknown) => {
+    const ack: Ack = isAck(cb) ? cb : () => {}
+    if (!sfuUrl()) { ack({ ok: false, error: 'sfu_disabled' }); return }
+    if (!isUuid(channelId)) { ack({ ok: false, error: 'bad_channel' }); return }
+    // Pas de check de rôle au leave : on doit toujours pouvoir sortir.
+    joined.delete(channelId)
+    const res = await sfuFetch('/v1/leave', { room: channelId, participant: userId })
+    ack(res.ok ? { ok: true } : { ok: false, error: res.error })
+  })
+
+  // ── Nettoyage garanti : un socket qui meurt libère ses salons SFU ───────────
+  // (listener ADDITIONNEL au disconnect existant de voice.ts : socket.io
+  // supporte plusieurs listeners, celui du mesh n'est pas touché)
+  socket.on('disconnect', () => {
+    for (const channelId of joined) {
+      // fire-and-forget : le daemon évince, personne n'attend de réponse
+      void sfuFetch('/v1/leave', { room: channelId, participant: userId })
+    }
+    joined.clear()
+  })
+}

--- a/nodyx-core/src/tests/voice-sfu.test.ts
+++ b/nodyx-core/src/tests/voice-sfu.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Tests du relais SFU (socket/voiceSfu.ts) — doctrine "laisse rien passer".
+ *
+ * Vérifie les invariants de la doctrine chirurgicale :
+ * 1. DORMANT sans VOICE_SFU_URL (aucun fetch, réponse sfu_disabled)
+ * 2. Gardes : uuid, rôle communauté, rate limit, payloads bornés/hostiles
+ * 3. Identité = socket.data (jamais le payload client)
+ * 4. Daemon mort => erreur propre, jamais d'exception
+ * 5. Nettoyage garanti au disconnect
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { dbQueryMock } = vi.hoisted(() => ({
+  dbQueryMock: vi.fn(),
+}))
+
+vi.mock('../config/database', () => ({
+  db:    { query: dbQueryMock },
+  redis: {},
+}))
+
+import { registerVoiceSfuHandlers } from '../socket/voiceSfu'
+
+// ── Harnais socket factice ────────────────────────────────────────────────────
+
+const CHANNEL = '01234567-89ab-4cde-8f01-23456789abcd'
+const DAEMON  = 'http://127.0.0.1:3901'
+
+type Handler = (...args: unknown[]) => void | Promise<void>
+
+// userId unique par défaut : le rate limiter est RÉEL et ses buckets persistent
+// entre les tests (limite 5 joins/10s par user). C'est voulu : on le teste aussi.
+let _seq = 0
+function makeHarness(userId = `user-${Date.now()}-${_seq++}`) {
+  const handlers = new Map<string, Handler>()
+  const roomEmit = vi.fn()
+  const socketToEmit = vi.fn()
+  const socket = {
+    id:   'socket-1',
+    data: { userId, username: 'jo' },
+    on:   (ev: string, fn: Handler) => { handlers.set(ev, fn) },
+    to:   vi.fn(() => ({ emit: socketToEmit })),
+    emit: vi.fn(),
+  }
+  const server = {
+    to: vi.fn(() => ({ emit: roomEmit })),
+  }
+  registerVoiceSfuHandlers(socket as never, server as never)
+  const fire = async (ev: string, ...args: unknown[]) => {
+    await handlers.get(ev)!(...args)
+  }
+  return { handlers, fire, socket, server, roomEmit, socketToEmit }
+}
+
+/** Ack qui capture sa réponse. */
+function ack() {
+  const calls: Record<string, unknown>[] = []
+  const cb = (r: Record<string, unknown>) => { calls.push(r) }
+  return { cb, get last() { return calls[calls.length - 1] }, calls }
+}
+
+/** Réponse daemon standard. */
+function daemonJson(body: Record<string, unknown>, status = 200) {
+  return { status, json: async () => body } as Response
+}
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.stubGlobal('fetch', fetchMock)
+  process.env.VOICE_SFU_URL   = DAEMON
+  process.env.VOICE_SFU_TOKEN = 'test-token-0123456789abcdef'
+  // Rôle communauté par défaut : membre légitime.
+  dbQueryMock.mockResolvedValue({ rows: [{ role: 'member' }] })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  delete process.env.VOICE_SFU_URL
+  delete process.env.VOICE_SFU_TOKEN
+})
+
+// ── 1. Dormance ───────────────────────────────────────────────────────────────
+
+describe('dormance (flag OFF)', () => {
+  it('répond sfu_disabled et ne contacte RIEN quand VOICE_SFU_URL est absent', async () => {
+    delete process.env.VOICE_SFU_URL
+    const h = makeHarness()
+    const a = ack()
+    await h.fire('voice:sfu_join', CHANNEL, a.cb)
+    expect(a.last).toEqual({ ok: false, error: 'sfu_disabled' })
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(dbQueryMock).not.toHaveBeenCalled() // même pas de requête DB
+  })
+
+  it('tous les handlers sont dormants sans le flag', async () => {
+    delete process.env.VOICE_SFU_URL
+    const h = makeHarness()
+    for (const ev of ['voice:sfu_connect', 'voice:sfu_produce', 'voice:sfu_consume', 'voice:sfu_publications']) {
+      const a = ack()
+      await h.fire(ev, { channelId: CHANNEL }, a.cb)
+      expect(a.last.error, ev).toBe('sfu_disabled')
+    }
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+// ── 2. Gardes ─────────────────────────────────────────────────────────────────
+
+describe('gardes', () => {
+  it('rejette un channelId non-uuid sans toucher au daemon', async () => {
+    const h = makeHarness()
+    const a = ack()
+    await h.fire('voice:sfu_join', 'pas-un-uuid', a.cb)
+    expect(a.last).toEqual({ ok: false, error: 'bad_channel' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejette un non-membre de la communauté (forbidden)', async () => {
+    dbQueryMock.mockResolvedValue({ rows: [] })
+    const h = makeHarness()
+    const a = ack()
+    await h.fire('voice:sfu_join', CHANNEL, a.cb)
+    expect(a.last).toEqual({ ok: false, error: 'forbidden' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('un cb manquant ou non-fonction est ignoré sans crash', async () => {
+    const h = makeHarness()
+    await expect(h.fire('voice:sfu_join', CHANNEL, 'pas-une-fonction')).resolves.toBeUndefined()
+    await expect(h.fire('voice:sfu_join', CHANNEL)).resolves.toBeUndefined()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rate limit : la 6e jointure en 10 s est rejetée', async () => {
+    const h = makeHarness('user-rate-limited-test')
+    fetchMock.mockResolvedValue(daemonJson({ ok: true, mode: 'mesh', migrated: [] }))
+    const results: (string | undefined)[] = []
+    for (let i = 0; i < 6; i++) {
+      const a = ack()
+      await h.fire('voice:sfu_join', CHANNEL, a.cb)
+      results.push(a.last.error as string | undefined)
+    }
+    expect(results.slice(0, 5).every(e => e === undefined)).toBe(true)
+    expect(results[5]).toBe('rate_limited')
+  })
+
+  it('un payload client trop gros est rejeté (payload_too_large)', async () => {
+    const h = makeHarness()
+    const a = ack()
+    await h.fire('voice:sfu_produce', {
+      channelId: CHANNEL, kind: 'audio', rtpParameters: { junk: 'x'.repeat(70_000) },
+    }, a.cb)
+    expect(a.last).toEqual({ ok: false, error: 'payload_too_large' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('kind inconnu rejeté, producerId hostile rejeté', async () => {
+    const h = makeHarness()
+    const a1 = ack()
+    await h.fire('voice:sfu_produce', { channelId: CHANNEL, kind: 'exploit', rtpParameters: {} }, a1.cb)
+    expect(a1.last.error).toBe('bad_kind')
+    const a2 = ack()
+    await h.fire('voice:sfu_consume', { channelId: CHANNEL, producerId: 'x'.repeat(500), rtpCapabilities: {} }, a2.cb)
+    expect(a2.last.error).toBe('bad_producer')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+// ── 3. Identité serveur ───────────────────────────────────────────────────────
+
+describe('identité', () => {
+  it("le participant envoyé au daemon vient de socket.data, jamais du payload", async () => {
+    const h = makeHarness('vrai-user')
+    fetchMock.mockResolvedValue(daemonJson({ ok: true, mode: 'mesh', migrated: [] }))
+    const a = ack()
+    // Le client tente d'usurper : le champ participant du payload doit être ignoré.
+    await h.fire('voice:sfu_join', CHANNEL, a.cb)
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string)
+    expect(body.participant).toBe('vrai-user')
+    // Et le Bearer du daemon est bien posé.
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe('Bearer test-token-0123456789abcdef')
+  })
+})
+
+// ── 4. Chemins heureux ────────────────────────────────────────────────────────
+
+describe('flow SFU', () => {
+  it('join en mode mesh : ok simple, pas de caps demandées', async () => {
+    const h = makeHarness()
+    fetchMock.mockResolvedValueOnce(daemonJson({ ok: true, mode: 'mesh', migrated: [] }))
+    const a = ack()
+    await h.fire('voice:sfu_join', CHANNEL, a.cb)
+    expect(a.last).toEqual({ ok: true, mode: 'mesh' })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('join en mode SFU : renvoie caps + transportParams parsés, annonce la bascule', async () => {
+    const h = makeHarness()
+    fetchMock
+      .mockResolvedValueOnce(daemonJson({
+        ok: true, mode: 'sfu', transport: 't-9',
+        migrated: [{ participant: 'u2', transport: 't-2' }],
+      }))
+      .mockResolvedValueOnce(daemonJson({ ok: true, caps: '{"codecs":[{"mimeType":"audio/opus"}]}' }))
+      .mockResolvedValueOnce(daemonJson({ ok: true, params: '{"id":"t-9","iceParameters":{"a":1}}' }))
+    const a = ack()
+    await h.fire('voice:sfu_join', CHANNEL, a.cb)
+    expect(a.last.ok).toBe(true)
+    expect(a.last.mode).toBe('sfu')
+    expect((a.last.caps as { codecs: unknown[] }).codecs).toHaveLength(1)
+    expect((a.last.transportParams as { id: string }).id).toBe('t-9')
+    // La bascule (migrated non vide) est annoncée au salon vocal.
+    expect(h.server.to).toHaveBeenCalledWith(`voice:${CHANNEL}`)
+    expect(h.roomEmit).toHaveBeenCalledWith('voice:sfu_mode', { channelId: CHANNEL, mode: 'sfu' })
+  })
+
+  it('produce : annonce voice:sfu_new_producer aux autres', async () => {
+    const h = makeHarness('user-jonathan')
+    fetchMock.mockResolvedValueOnce(daemonJson({ ok: true, producer: 'prod-1' }))
+    const a = ack()
+    await h.fire('voice:sfu_produce', { channelId: CHANNEL, kind: 'audio', rtpParameters: { codecs: [] } }, a.cb)
+    expect(a.last).toEqual({ ok: true, producerId: 'prod-1' })
+    expect(h.socket.to).toHaveBeenCalledWith(`voice:${CHANNEL}`)
+    expect(h.socketToEmit).toHaveBeenCalledWith('voice:sfu_new_producer', {
+      channelId: CHANNEL, producerId: 'prod-1', kind: 'audio', userId: 'user-jonathan',
+    })
+  })
+
+  it('consume : renvoie consumerId + params parsés', async () => {
+    const h = makeHarness()
+    fetchMock.mockResolvedValueOnce(daemonJson({
+      ok: true, consumer: 'cons-1', params: '{"id":"cons-1","rtpParameters":{"codecs":[]}}',
+    }))
+    const a = ack()
+    await h.fire('voice:sfu_consume', { channelId: CHANNEL, producerId: 'prod-1', rtpCapabilities: {} }, a.cb)
+    expect(a.last.ok).toBe(true)
+    expect(a.last.consumerId).toBe('cons-1')
+    expect((a.last.params as { id: string }).id).toBe('cons-1')
+  })
+})
+
+// ── 5. Panne du daemon ────────────────────────────────────────────────────────
+
+describe('dégradation gracieuse', () => {
+  it('daemon injoignable : erreur propre, aucune exception', async () => {
+    const h = makeHarness()
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'))
+    const a = ack()
+    await expect(h.fire('voice:sfu_join', CHANNEL, a.cb)).resolves.toBeUndefined()
+    expect(a.last).toEqual({ ok: false, error: 'sfu_unreachable' })
+  })
+
+  it('erreur métier du daemon relayée telle quelle', async () => {
+    const h = makeHarness()
+    fetchMock.mockResolvedValueOnce(daemonJson({ ok: false, error: 'salon plein' }, 409))
+    const a = ack()
+    await h.fire('voice:sfu_join', CHANNEL, a.cb)
+    expect(a.last).toEqual({ ok: false, error: 'salon plein' })
+  })
+
+  it('réponse daemon non-JSON : erreur propre', async () => {
+    const h = makeHarness()
+    fetchMock.mockResolvedValueOnce({ status: 502, json: async () => { throw new Error('html') } } as never)
+    const a = ack()
+    await h.fire('voice:sfu_join', CHANNEL, a.cb)
+    expect(a.last).toEqual({ ok: false, error: 'sfu_bad_response_502' })
+  })
+})
+
+// ── 6. Nettoyage au disconnect ────────────────────────────────────────────────
+
+describe('nettoyage', () => {
+  it('un disconnect après join envoie leave au daemon pour chaque salon', async () => {
+    const h = makeHarness('user-disconnect-test')
+    fetchMock.mockResolvedValue(daemonJson({ ok: true, mode: 'mesh', migrated: [] }))
+    await h.fire('voice:sfu_join', CHANNEL, ack().cb)
+    fetchMock.mockClear()
+
+    await h.fire('disconnect')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toBe(`${DAEMON}/v1/leave`)
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string)
+    expect(body).toEqual({ room: CHANNEL, participant: 'user-disconnect-test' })
+  })
+
+  it('leave explicite retire le salon du nettoyage', async () => {
+    const h = makeHarness()
+    fetchMock.mockResolvedValue(daemonJson({ ok: true, mode: 'mesh', migrated: [] }))
+    await h.fire('voice:sfu_join', CHANNEL, ack().cb)
+    await h.fire('voice:sfu_leave', CHANNEL, ack().cb)
+    fetchMock.mockClear()
+
+    await h.fire('disconnect')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Câblage **sanctuaire** validé par le owner, doctrine chirurgicale appliquée à la lettre :

### Le fichier de bataille n'a pas bougé
`voice.ts` : **3 mots ajoutés** (`export` devant `isUuid`, `voiceRoom`, `getCommunityRoleForChannel`). Visibilité pure, zéro duplication (leçon canvas retenue).

### Nouveau fichier `voiceSfu.ts` : relais pur, dormant
- **Sans `VOICE_SFU_URL` : chaque handler répond `sfu_disabled` sans contacter quoi que ce soit** (ni daemon, ni DB). Rollback = retirer la variable.
- Events `voice:sfu_*` (join/connect/produce/consume/publications/leave), style ack (requête/réponse strict, contenu à ce fichier).
- Chaque handler : flag → rate limit → `isUuid` → rôle communauté (**mêmes gardes que le mesh**) ; identité = `socket.data`, jamais le payload ; blobs bornés 64 Ko ; timeout daemon 5 s ; `sfuFetch` ne throw **jamais**.
- Nettoyage garanti : listener `disconnect` additionnel qui libère les salons SFU.

### Preuves
**18 nouveaux tests** : dormance totale, payloads hostiles (70 Ko, kind inconnu, producerId 500 chars), identité serveur + Bearer, join SFU complet avec bascule annoncée, daemon mort/réponse non-JSON, nettoyage disconnect.
**Suite complète : 382 tests verts (les 364 existants INTACTS).** tsc clean.