### PR TITLE
feat(voice): client SFU mediasoup-client + labo /admin/sfu-lab (P1 lot 2c)

### DIFF
--- a/nodyx-frontend/package-lock.json
+++ b/nodyx-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodyx-frontend",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodyx-frontend",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "dependencies": {
         "@iconify/svelte": "^5.2.2",
         "@jitsi/rnnoise-wasm": "0.2.1",
@@ -30,6 +30,7 @@
         "@tiptap/starter-kit": "3.27.1",
         "lowlight": "3.3.0",
         "lucide-svelte": "1.0.1",
+        "mediasoup-client": "3.21.0",
         "qrcode": "1.5.4",
         "satori": "0.26.0",
         "socket.io-client": "4.8.3"
@@ -561,6 +562,27 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@polka/url": {
@@ -2304,6 +2326,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2317,6 +2348,13 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/events-alias": {
+      "name": "@types/events",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
+      "integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
+      "license": "MIT"
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -2325,6 +2363,12 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.5.0",
@@ -2554,6 +2598,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/awaitqueue": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-3.3.1.tgz",
+      "integrity": "sha512-kzMN6Bdfalok/JWZvwDfI704cIyCvHDi6Ez/bApGzNPjGHQhwJ07DzGd3DDzeXH2fjr9P5g8paESFUvYnbs7rA==",
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mediasoup"
       }
     },
     "node_modules/axobject-query": {
@@ -2937,6 +2997,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/events-alias": {
+      "name": "events",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2945,6 +3015,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-mediastreamtrack": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fake-mediastreamtrack/-/fake-mediastreamtrack-2.2.1.tgz",
+      "integrity": "sha512-SITLc7UTDirSdgLGORrlmqjWLJtbtfIz/xO7DwVbJH3f0ds+NQok4ccl/WEzz49NSgiUlXf2wDW0+y5C+TO6EA==",
+      "license": "ISC",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/fdir": {
@@ -3024,6 +3106,22 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/h264-profile-level-id": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-2.3.3.tgz",
+      "integrity": "sha512-rPd5gpyWuIfEbBiHC/f9I4wdeCpAhg0aWdYgjMRdVTqhJT22C6VrWTi4hpAAgJad1Vv8BJDEvrzAQTW7CxzmJw==",
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mediasoup"
+      }
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -3447,6 +3545,30 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mediasoup-client": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/mediasoup-client/-/mediasoup-client-3.21.0.tgz",
+      "integrity": "sha512-KRpq0gqstqkeyjB3ykypM2u+pCdSQueB5Q2y8GDOPCNZYsKSRpYlmVR/GTVErKfe5wYtpnTZ1F+XSQkuAFmYyw==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/debug": "^4.1.13",
+        "@types/events-alias": "npm:@types/events@^3.0.3",
+        "awaitqueue": "^3.3.1",
+        "debug": "^4.4.3",
+        "events-alias": "npm:events@^3.3.0",
+        "fake-mediastreamtrack": "^2.2.1",
+        "h264-profile-level-id": "^2.3.3",
+        "sdp-transform": "^3.0.0",
+        "supports-color": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mediasoup"
       }
     },
     "node_modules/mri": {
@@ -3942,6 +4064,15 @@
         "node": ">=16"
       }
     },
+    "node_modules/sdp-transform": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-3.0.0.tgz",
+      "integrity": "sha512-gfYVRGxjHkGF2NPeUWHw5u6T/KGFtS5/drPms73gaSuMaVHKCY3lpLnGDfswVQO0kddeePoti09AwhYP4zA8dQ==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -4059,6 +4190,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {

--- a/nodyx-frontend/package.json
+++ b/nodyx-frontend/package.json
@@ -50,6 +50,7 @@
     "@tiptap/starter-kit": "3.27.1",
     "lowlight": "3.3.0",
     "lucide-svelte": "1.0.1",
+    "mediasoup-client": "3.21.0",
     "qrcode": "1.5.4",
     "satori": "0.26.0",
     "socket.io-client": "4.8.3"

--- a/nodyx-frontend/src/lib/voiceSfu.test.ts
+++ b/nodyx-frontend/src/lib/voiceSfu.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Tests des parties PURES du client SFU (voiceSfu.ts).
+ * Le flux complet (device/transports/média) se prouve dans le labo
+ * /admin/sfu-lab avec de vrais navigateurs : ici on verrouille les garde-fous.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { looksLikeTransportParams } from './voiceSfu'
+
+describe('looksLikeTransportParams (garde-fou avant mediasoup-client)', () => {
+  const valid = {
+    id: 'transport-1',
+    iceParameters:  { usernameFragment: 'x', password: 'y' },
+    iceCandidates:  [{ ip: '1.2.3.4' }],
+    dtlsParameters: { fingerprints: [] },
+  }
+
+  it('accepte la forme complète', () => {
+    expect(looksLikeTransportParams(valid)).toBe(true)
+  })
+
+  it('rejette null, string, tableau', () => {
+    expect(looksLikeTransportParams(null)).toBe(false)
+    expect(looksLikeTransportParams('{"id":"x"}')).toBe(false)
+    expect(looksLikeTransportParams([])).toBe(false)
+  })
+
+  it('rejette chaque champ manquant', () => {
+    for (const missing of ['id', 'iceParameters', 'iceCandidates', 'dtlsParameters'] as const) {
+      const broken: Record<string, unknown> = { ...valid }
+      delete broken[missing]
+      expect(looksLikeTransportParams(broken), `sans ${missing}`).toBe(false)
+    }
+  })
+
+  it('rejette iceCandidates non-tableau (poison sournois)', () => {
+    expect(looksLikeTransportParams({ ...valid, iceCandidates: {} })).toBe(false)
+  })
+})

--- a/nodyx-frontend/src/lib/voiceSfu.ts
+++ b/nodyx-frontend/src/lib/voiceSfu.ts
@@ -1,0 +1,278 @@
+/**
+ * NODYX — Client SFU expérimental (P1 lot 2c, CDC SFU §17)
+ *
+ * Pilote une session vocale via le SFU (mediasoup) : Device → transports
+ * send/recv → produce(micro) → consume des flux publiés.
+ *
+ * DOCTRINE (parano assumée) :
+ * - Ce module N'IMPORTE RIEN de voice.ts (mesh) et ne touche à aucun de ses
+ *   stores : les deux mondes sont étanches. Utilisé UNIQUEMENT par la page
+ *   labo /admin/sfu-lab tant que le chemin n'est pas prouvé de bout en bout.
+ * - SSR-safe : mediasoup-client est importé dynamiquement, jamais au top-level.
+ * - Chaque ack a un TIMEOUT (l'UI ne peut pas rester suspendue), chaque étape
+ *   est journalisée (store sfuLogStore, la console du labo), chaque échec mène
+ *   à l'état 'error' avec nettoyage complet.
+ * - Double join impossible, leave/cleanup idempotents.
+ */
+
+import { get, writable, type Writable } from 'svelte/store'
+import { socket as socketStore } from '$lib/socket'
+import type { Socket } from 'socket.io-client'
+
+// ── Types & état observable ───────────────────────────────────────────────────
+
+export type SfuPhase =
+  | 'idle'        // rien en cours
+  | 'joining'     // voice:sfu_join envoyé
+  | 'mesh'        // le salon est en mesh : SFU pas (encore) actif côté daemon
+  | 'connecting'  // device + transports en cours d'établissement
+  | 'active'      // micro publié, consommation en cours
+  | 'error'       // échec (raison dans sfuErrorStore), tout est nettoyé
+
+export interface SfuConsumerInfo {
+  consumerId: string
+  producerId: string
+  userId:     string
+  kind:       string
+}
+
+export const sfuPhaseStore:     Writable<SfuPhase>          = writable('idle')
+export const sfuErrorStore:     Writable<string | null>     = writable(null)
+export const sfuLogStore:       Writable<string[]>          = writable([])
+export const sfuConsumersStore: Writable<SfuConsumerInfo[]> = writable([])
+export const sfuMutedStore:     Writable<boolean>           = writable(false)
+
+function log(msg: string): void {
+  const line = `[${new Date().toLocaleTimeString()}] ${msg}`
+  sfuLogStore.update(l => [...l.slice(-199), line])
+}
+
+// ── Session (une seule à la fois, par construction) ───────────────────────────
+
+interface Session {
+  channelId:     string
+  device:        import('mediasoup-client').types.Device
+  sendTransport: import('mediasoup-client').types.Transport
+  recvTransport: import('mediasoup-client').types.Transport
+  micTrack:      MediaStreamTrack | null
+  producer:      import('mediasoup-client').types.Producer | null
+  consumers:     Map<string, import('mediasoup-client').types.Consumer>
+  audioEls:      Map<string, HTMLAudioElement>
+  offNewProducer: (() => void) | null
+}
+
+let _session: Session | null = null
+
+// ── Ack avec timeout : l'UI ne reste JAMAIS suspendue ─────────────────────────
+
+const ACK_TIMEOUT_MS = 8_000
+
+type AckResponse = { ok: boolean; error?: string; [k: string]: unknown }
+
+function emitAck(sock: Socket, event: string, payload: unknown): Promise<AckResponse> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(
+      () => resolve({ ok: false, error: `${event}: timeout (${ACK_TIMEOUT_MS} ms)` }),
+      ACK_TIMEOUT_MS,
+    )
+    try {
+      sock.emit(event, payload, (resp: AckResponse) => {
+        clearTimeout(timer)
+        resolve(resp && typeof resp === 'object' ? resp : { ok: false, error: `${event}: réponse invalide` })
+      })
+    } catch (e) {
+      clearTimeout(timer)
+      resolve({ ok: false, error: `${event}: ${(e as Error).message}` })
+    }
+  })
+}
+
+/** Garde-fou : la forme minimale des params transport avant de les donner à
+ *  mediasoup-client (échec précoce et lisible plutôt qu'exception interne). */
+export function looksLikeTransportParams(p: unknown): boolean {
+  if (!p || typeof p !== 'object') return false
+  const o = p as Record<string, unknown>
+  return typeof o.id === 'string'
+    && !!o.iceParameters && !!o.dtlsParameters && Array.isArray(o.iceCandidates)
+}
+
+// ── Cycle de vie ──────────────────────────────────────────────────────────────
+
+export async function sfuJoin(channelId: string): Promise<void> {
+  if (_session) { log('⚠ session déjà active, join ignoré (leave d\'abord)'); return }
+  const sock = get(socketStore)
+  if (!sock) { fail('socket non connecté'); return }
+
+  sfuErrorStore.set(null)
+  sfuConsumersStore.set([])
+  sfuPhaseStore.set('joining')
+  log(`→ voice:sfu_join ${channelId.slice(0, 8)}…`)
+
+  const join = await emitAck(sock, 'voice:sfu_join', channelId)
+  if (!join.ok) { fail(`join refusé : ${join.error}`); return }
+
+  if (join.mode !== 'sfu') {
+    sfuPhaseStore.set('mesh')
+    log(`salon en mode ${String(join.mode)} : le SFU n'est pas actif pour ce salon`)
+    log('(labo : mettre SFU_MESH_THRESHOLD=0 sur le daemon pour forcer le SFU)')
+    return
+  }
+  log('✓ join accepté, mode SFU')
+
+  if (!looksLikeTransportParams(join.sendTransportParams) || !looksLikeTransportParams(join.recvTransportParams)) {
+    fail('paramètres de transport invalides (send/recv)')
+    return
+  }
+
+  sfuPhaseStore.set('connecting')
+  try {
+    // SSR-safe + pas de coût tant que le labo n'est pas utilisé.
+    const { Device } = await import('mediasoup-client')
+    const device = new Device()
+    await device.load({ routerRtpCapabilities: join.caps as never })
+    log(`✓ device chargé (${device.rtpCapabilities.codecs?.length ?? 0} codecs)`)
+
+    const wireTransport = (
+      transport: import('mediasoup-client').types.Transport,
+      direction: 'send' | 'recv',
+    ) => {
+      transport.on('connect', ({ dtlsParameters }, callback, errback) => {
+        log(`→ connect ${direction} (DTLS)`)
+        emitAck(sock, 'voice:sfu_connect', { channelId, direction, dtlsParameters })
+          .then(r => r.ok ? (log(`✓ ${direction} connecté`), callback()) : errback(new Error(String(r.error))))
+      })
+      transport.on('connectionstatechange', (state) => {
+        log(`transport ${direction} : ${state}`)
+        if (state === 'failed') fail(`transport ${direction} en échec ICE/DTLS`)
+      })
+    }
+
+    const sendTransport = device.createSendTransport(join.sendTransportParams as never)
+    wireTransport(sendTransport, 'send')
+    sendTransport.on('produce', ({ kind, rtpParameters }, callback, errback) => {
+      if (kind !== 'audio') { errback(new Error('labo : audio uniquement')); return }
+      log('→ produce audio (rtpParameters au SFU)')
+      emitAck(sock, 'voice:sfu_produce', { channelId, kind: 'audio', rtpParameters })
+        .then(r => r.ok
+          ? (log(`✓ producer ${String(r.producerId).slice(0, 8)}…`), callback({ id: String(r.producerId) }))
+          : errback(new Error(String(r.error))))
+    })
+
+    const recvTransport = device.createRecvTransport(join.recvTransportParams as never)
+    wireTransport(recvTransport, 'recv')
+
+    _session = {
+      channelId, device, sendTransport, recvTransport,
+      micTrack: null, producer: null,
+      consumers: new Map(), audioEls: new Map(), offNewProducer: null,
+    }
+
+    // Micro (le clic "Rejoindre" du labo = geste utilisateur → autoplay OK).
+    log('→ getUserMedia (micro)')
+    const mic = await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+    })
+    const micTrack = mic.getAudioTracks()[0]
+    if (!micTrack) { fail('aucune piste micro'); return }
+    _session.micTrack = micTrack
+    _session.producer = await sendTransport.produce({ track: micTrack })
+    log('✓ micro publié')
+
+    // Flux déjà présents + flux futurs.
+    const pubs = await emitAck(sock, 'voice:sfu_publications', channelId)
+    if (pubs.ok && Array.isArray(pubs.publications)) {
+      log(`${pubs.publications.length} publication(s) existante(s)`)
+      for (const pub of pubs.publications as { producer: string; owner: string; kind: string }[]) {
+        if (_session.producer && pub.producer === _session.producer.id) continue // pas soi-même
+        await consumeOne(sock, pub.producer, pub.owner, pub.kind)
+      }
+    }
+    const onNewProducer = (data: { channelId: string; producerId: string; kind: string; userId: string }) => {
+      if (!_session || data.channelId !== _session.channelId) return
+      log(`nouveau flux annoncé par ${data.userId}`)
+      void consumeOne(sock, data.producerId, data.userId, data.kind)
+    }
+    sock.on('voice:sfu_new_producer', onNewProducer)
+    _session.offNewProducer = () => { sock.off('voice:sfu_new_producer', onNewProducer) }
+
+    sfuPhaseStore.set('active')
+    log('══ SESSION SFU ACTIVE ══')
+  } catch (e) {
+    fail(`établissement : ${(e as Error).message}`)
+  }
+}
+
+async function consumeOne(sock: Socket, producerId: string, userId: string, kind: string): Promise<void> {
+  const s = _session
+  if (!s) return
+  if (s.consumers.has(producerId)) return // déjà consommé (annonce + liste peuvent se croiser)
+  try {
+    const r = await emitAck(sock, 'voice:sfu_consume', {
+      channelId: s.channelId, producerId, rtpCapabilities: s.device.rtpCapabilities,
+    })
+    if (!r.ok) { log(`✘ consume ${producerId.slice(0, 8)}… : ${r.error}`); return }
+    const params = r.params as { id: string; producerId: string; kind: 'audio' | 'video'; rtpParameters: never }
+    const consumer = await s.recvTransport.consume({
+      id: params.id, producerId: params.producerId, kind: params.kind, rtpParameters: params.rtpParameters,
+    })
+    s.consumers.set(producerId, consumer)
+
+    // Lecture : un <audio> par flux, détaché du DOM (labo audio-only).
+    const el = new Audio()
+    el.srcObject = new MediaStream([consumer.track])
+    el.autoplay = true
+    s.audioEls.set(producerId, el)
+    void el.play().catch(err => log(`⚠ autoplay : ${err.message}`))
+
+    sfuConsumersStore.update(list => [...list, { consumerId: consumer.id, producerId, userId, kind }])
+    log(`✓ flux de ${userId} en lecture`)
+  } catch (e) {
+    log(`✘ consume : ${(e as Error).message}`)
+  }
+}
+
+export function sfuSetMuted(muted: boolean): void {
+  if (_session?.micTrack) {
+    _session.micTrack.enabled = !muted
+    sfuMutedStore.set(muted)
+    log(muted ? 'micro coupé' : 'micro ouvert')
+  }
+}
+
+export async function sfuLeave(): Promise<void> {
+  const s = _session
+  if (!s) { sfuPhaseStore.set('idle'); return }
+  log('→ leave + nettoyage complet')
+  const sock = get(socketStore)
+  cleanup()
+  if (sock) await emitAck(sock, 'voice:sfu_leave', s.channelId)
+  sfuPhaseStore.set('idle')
+  log('✓ session fermée')
+}
+
+function fail(reason: string): void {
+  log(`✘ ${reason}`)
+  sfuErrorStore.set(reason)
+  cleanup()
+  sfuPhaseStore.set('error')
+}
+
+/** Idempotent : détruit TOUT ce que la session a créé, dans l'ordre inverse. */
+function cleanup(): void {
+  const s = _session
+  _session = null
+  if (!s) return
+  try { s.offNewProducer?.() } catch { /* déjà off */ }
+  for (const el of s.audioEls.values()) {
+    try { el.pause(); el.srcObject = null } catch { /* déjà mort */ }
+  }
+  for (const c of s.consumers.values()) {
+    try { c.close() } catch { /* déjà fermé */ }
+  }
+  try { s.producer?.close() } catch { /* déjà fermé */ }
+  try { s.micTrack?.stop() } catch { /* déjà stoppé */ }
+  try { s.sendTransport.close() } catch { /* déjà fermé */ }
+  try { s.recvTransport.close() } catch { /* déjà fermé */ }
+  sfuConsumersStore.set([])
+  sfuMutedStore.set(false)
+}

--- a/nodyx-frontend/src/routes/admin/sfu-lab/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/sfu-lab/+page.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  import { browser } from '$app/environment'
+  import {
+    sfuJoin, sfuLeave, sfuSetMuted,
+    sfuPhaseStore, sfuErrorStore, sfuLogStore, sfuConsumersStore, sfuMutedStore,
+  } from '$lib/voiceSfu'
+
+  // Laboratoire SFU (P1) : prouve le chemin complet device → transports →
+  // produce(micro) → consume, en isolation TOTALE du vocal mesh existant.
+  // Prérequis côté serveur : nodyx-sfud lancé + VOICE_SFU_URL/VOICE_SFU_TOKEN
+  // dans le .env du core (sinon toute action répond sfu_disabled).
+
+  let channelId = $state(browser ? (localStorage.getItem('nodyx:sfu-lab:channel') ?? '') : '')
+  let logEl: HTMLElement | null = $state(null)
+
+  const phase = $derived($sfuPhaseStore)
+  const busy  = $derived(phase === 'joining' || phase === 'connecting')
+
+  function join() {
+    if (browser) localStorage.setItem('nodyx:sfu-lab:channel', channelId.trim())
+    void sfuJoin(channelId.trim())
+  }
+
+  // Console : suit le bas automatiquement.
+  $effect(() => {
+    $sfuLogStore
+    if (logEl) logEl.scrollTop = logEl.scrollHeight
+  })
+
+  const PHASE_LABEL: Record<string, string> = {
+    idle: 'Inactif', joining: 'Connexion…', mesh: 'Salon en mesh',
+    connecting: 'Établissement…', active: 'SESSION ACTIVE', error: 'Erreur',
+  }
+  const PHASE_CLASS: Record<string, string> = {
+    idle: 'bg-zinc-800 text-zinc-400',
+    joining: 'bg-amber-500/15 text-amber-400',
+    mesh: 'bg-sky-500/15 text-sky-400',
+    connecting: 'bg-amber-500/15 text-amber-400',
+    active: 'bg-emerald-500/15 text-emerald-400',
+    error: 'bg-red-500/15 text-red-400',
+  }
+</script>
+
+<svelte:head><title>Labo SFU — Admin Nodyx</title></svelte:head>
+
+<div class="space-y-6 max-w-3xl">
+  <div class="flex items-center justify-between">
+    <div>
+      <h1 class="text-2xl font-bold text-white">Labo SFU</h1>
+      <p class="text-sm text-zinc-500 mt-1">
+        Session vocale via le SFU (mediasoup), isolée du vocal mesh. Expérimental.
+      </p>
+    </div>
+    <span class="rounded-full px-3 py-1 text-xs font-semibold tracking-wide {PHASE_CLASS[phase]}">
+      {PHASE_LABEL[phase]}
+    </span>
+  </div>
+
+  {#if $sfuErrorStore}
+    <div class="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+      {$sfuErrorStore}
+    </div>
+  {/if}
+
+  <div class="rounded-xl border border-zinc-800 bg-zinc-900/50 p-5 space-y-4">
+    <label class="block">
+      <span class="text-xs font-semibold uppercase tracking-widest text-zinc-500">Channel vocal (UUID)</span>
+      <input
+        type="text"
+        bind:value={channelId}
+        placeholder="00000000-0000-0000-0000-000000000000"
+        disabled={phase === 'active' || busy}
+        class="mt-2 w-full rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-2 font-mono text-sm text-zinc-200 focus:border-indigo-500 focus:outline-none disabled:opacity-50"
+      />
+    </label>
+
+    <div class="flex gap-3">
+      {#if phase === 'active'}
+        <button
+          onclick={() => sfuSetMuted(!$sfuMutedStore)}
+          class="rounded-lg px-4 py-2 text-sm font-semibold {$sfuMutedStore ? 'bg-amber-600 hover:bg-amber-500' : 'bg-zinc-700 hover:bg-zinc-600'} text-white"
+        >
+          {$sfuMutedStore ? 'Micro coupé' : 'Couper le micro'}
+        </button>
+        <button
+          onclick={() => void sfuLeave()}
+          class="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-500"
+        >
+          Quitter
+        </button>
+      {:else}
+        <button
+          onclick={join}
+          disabled={busy || channelId.trim().length < 36}
+          class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 disabled:bg-zinc-800 disabled:text-zinc-500"
+        >
+          {busy ? 'Connexion…' : 'Rejoindre via SFU'}
+        </button>
+        {#if phase === 'error' || phase === 'mesh'}
+          <button
+            onclick={() => void sfuLeave()}
+            class="rounded-lg bg-zinc-700 px-4 py-2 text-sm font-semibold text-white hover:bg-zinc-600"
+          >
+            Réinitialiser
+          </button>
+        {/if}
+      {/if}
+    </div>
+  </div>
+
+  <div class="rounded-xl border border-zinc-800 bg-zinc-900/50 p-5">
+    <h2 class="text-xs font-bold uppercase tracking-widest text-zinc-500 mb-3">
+      Flux reçus ({$sfuConsumersStore.length})
+    </h2>
+    {#if $sfuConsumersStore.length === 0}
+      <p class="text-sm text-zinc-600">Aucun flux consommé. Ouvre ce labo sur un second compte pour vous entendre.</p>
+    {:else}
+      <ul class="space-y-2">
+        {#each $sfuConsumersStore as c (c.consumerId)}
+          <li class="flex items-center gap-3 rounded-lg bg-zinc-950 px-3 py-2 text-sm">
+            <span class="h-2 w-2 rounded-full bg-emerald-400 animate-pulse"></span>
+            <span class="text-zinc-200 font-medium">{c.userId}</span>
+            <span class="text-zinc-600 font-mono text-xs">{c.kind} · {c.producerId.slice(0, 8)}…</span>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </div>
+
+  <div class="rounded-xl border border-zinc-800 bg-zinc-950 p-4">
+    <h2 class="text-xs font-bold uppercase tracking-widest text-zinc-500 mb-2">Journal</h2>
+    <div bind:this={logEl} class="h-64 overflow-y-auto font-mono text-xs leading-relaxed text-zinc-400">
+      {#if $sfuLogStore.length === 0}
+        <p class="text-zinc-700">En attente d'une session…</p>
+      {/if}
+      {#each $sfuLogStore as line}
+        <div class:text-red-400={line.includes('✘')} class:text-emerald-400={line.includes('✓')}>{line}</div>
+      {/each}
+    </div>
+  </div>
+
+  <p class="text-xs text-zinc-600">
+    Prérequis serveur : daemon <code class="text-zinc-500">nodyx-sfud</code> actif,
+    <code class="text-zinc-500">VOICE_SFU_URL</code> + <code class="text-zinc-500">VOICE_SFU_TOKEN</code>
+    dans le .env du core. Pour forcer le mode SFU à 2 participants :
+    <code class="text-zinc-500">SFU_MESH_THRESHOLD=0</code> côté daemon.
+  </p>
+</div>

--- a/nodyx-frontend/src/tests/stub-app-environment.ts
+++ b/nodyx-frontend/src/tests/stub-app-environment.ts
@@ -1,0 +1,5 @@
+// Stub vitest du module virtuel SvelteKit $app/environment (env node).
+export const browser = false
+export const dev = false
+export const building = false
+export const version = 'test'

--- a/nodyx-frontend/vitest.config.ts
+++ b/nodyx-frontend/vitest.config.ts
@@ -1,8 +1,18 @@
 import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
 
 // Config Vitest dédiée (séparée de vite.config.ts pour ne pas toucher au build
 // SvelteKit). Environnement node : suffisant pour les modules purs (WebCrypto).
 export default defineConfig({
+	resolve: {
+		alias: {
+			// Résout $lib comme SvelteKit (nécessaire aux modules testés qui
+			// importent d'autres modules $lib, ex: voiceSfu → $lib/socket).
+			$lib: fileURLToPath(new URL('./src/lib', import.meta.url)),
+			// Module virtuel SvelteKit indisponible hors runtime Kit : stubbé.
+			'$app/environment': fileURLToPath(new URL('./src/tests/stub-app-environment.ts', import.meta.url)),
+		},
+	},
 	test: {
 		environment: 'node',
 		include: ['src/**/*.test.ts'],


### PR DESCRIPTION
Le chemin client complet, en **isolation totale** du vocal mesh (**zéro ligne modifiée dans `lib/voice.ts`**) :

- **mediasoup-client 3.21.0** épinglé exact (pas de script post-install depuis le registry, 0 vulnérabilité)
- **`lib/voiceSfu.ts`** : Device → paire send/recv (params par direction) → acks `voice:sfu_*` → produce(micro) → consume (publications existantes + annonces live). Machine à états observable, import dynamique SSR-safe, **timeout sur chaque ack**, journal horodaté, double-join impossible, **cleanup idempotent en ordre inverse**
- **`/admin/sfu-lab`** (gardée server-side) : join par channelId, mute, flux reçus, console live. **Dormant** : sans `VOICE_SFU_URL`, toute action répond `sfu_disabled`
- Tests des garde-fous purs + stub `$app/environment` pour vitest node. **9 tests frontend verts**

svelte-check 0 erreur, build Vite OK.