### PR TITLE
feat(sfu): plage de ports RTC bornée + unité systemd (le verrou avant activation)

### DIFF
--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/nodyx-sfud.service
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/nodyx-sfud.service
@@ -1,0 +1,29 @@
+## nodyx-sfud — daemon SFU de l'instance (CDC SFU, P1)
+##
+## Modèle d'exploitation identique à nexus-turn : un binaire Rust, un service,
+## une instance = son SFU. Modèle de ce fichier : à copier vers
+## /etc/systemd/system/nodyx-sfud.service, avec /etc/nodyx-sfud.env à côté
+## (SFU_TOKEN obligatoire, cf variables documentées dans le binaire).
+##
+## ⚠ Firewall : ouvrir UNIQUEMENT la plage RTC configurée, ex :
+##    ufw allow 40000:40999/udp comment 'SFU media (nodyx-sfud)'
+## L'API interne (SFU_HTTP_ADDR, défaut 127.0.0.1:3901) ne s'ouvre JAMAIS.
+
+[Unit]
+Description=Nodyx SFU daemon (mediasoup) — vocal & partage d'écran scalable
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/nodyx-sfud.env
+ExecStart=/usr/local/bin/nodyx-sfud
+Restart=on-failure
+RestartSec=5s
+User=nodyx
+# Durcissement (le daemon n'écrit rien sur le disque)
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/bin/nodyx-sfud.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/bin/nodyx-sfud.rs
@@ -20,6 +20,10 @@
 //!   SFU_LISTEN_IP      IP d'écoute média WebRTC   (défaut 127.0.0.1)
 //!   SFU_ANNOUNCED_IP   adresse annoncée aux clients (IP publique du VPS)
 //!   SFU_MESH_THRESHOLD seuil mesh→SFU (défaut 4) · SFU_MAX_SEATS (défaut 25)
+//!   SFU_RTC_MIN_PORT / SFU_RTC_MAX_PORT
+//!                      plage UDP RTC des workers (défaut 40000-40999).
+//!                      DOIT correspondre au firewall (ufw allow <min>:<max>/udp),
+//!                      leçon nexus-turn : jamais de ports éphémères OS.
 
 use std::net::IpAddr;
 use std::sync::Arc;
@@ -364,8 +368,14 @@ async fn main() {
     let announced = std::env::var("SFU_ANNOUNCED_IP").ok();
     let threshold: usize = std::env::var("SFU_MESH_THRESHOLD").ok().and_then(|v| v.parse().ok()).unwrap_or(4);
     let seats: usize = std::env::var("SFU_MAX_SEATS").ok().and_then(|v| v.parse().ok()).unwrap_or(25);
+    let rtc_min: u16 = std::env::var("SFU_RTC_MIN_PORT").ok().and_then(|v| v.parse().ok()).unwrap_or(40000);
+    let rtc_max: u16 = std::env::var("SFU_RTC_MAX_PORT").ok().and_then(|v| v.parse().ok()).unwrap_or(40999);
+    if rtc_min > rtc_max {
+        eprintln!("Plage RTC invalide : SFU_RTC_MIN_PORT ({rtc_min}) > SFU_RTC_MAX_PORT ({rtc_max}). Refus de démarrer.");
+        std::process::exit(1);
+    }
 
-    let engine = MediasoupEngine::new_webrtc(listen_ip, announced.clone())
+    let engine = MediasoupEngine::new_webrtc(listen_ip, announced.clone(), rtc_min..=rtc_max)
         .await
         .expect("boot moteur mediasoup");
     let svc = VoiceService::new(engine, VoiceConfig { max_seats: seats, mesh_threshold: threshold });
@@ -373,7 +383,7 @@ async fn main() {
 
     let listener = TcpListener::bind(&http_addr).await.expect("bind API interne");
     println!(
-        "nodyx-sfud — API interne http://{http_addr} | média listen={listen_ip} announced={} | seuil mesh→SFU={threshold} sièges={seats}",
+        "nodyx-sfud — API interne http://{http_addr} | média listen={listen_ip} announced={} | RTC udp {rtc_min}-{rtc_max} | seuil mesh→SFU={threshold} sièges={seats}",
         announced.as_deref().unwrap_or("(aucune)")
     );
 

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/bin/spike.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/bin/spike.rs
@@ -133,8 +133,8 @@ async fn main() {
     // ── Scénario W : vrais WebRtcTransport (P1) ──────────────────────────────
     println!("\n[W] WebRtcTransport réels (ICE/DTLS, prêts pour un navigateur)");
     let web = step!(
-        "moteur en mode WebRTC (écoute 127.0.0.1)",
-        MediasoupEngine::new_webrtc("127.0.0.1".parse().unwrap(), None).await
+        "moteur en mode WebRTC (écoute 127.0.0.1, plage RTC bornée 40100-40199)",
+        MediasoupEngine::new_webrtc("127.0.0.1".parse().unwrap(), None, 40100..=40199).await
     );
     let wroom = step!("salon WebRTC", web.create_room(RoomId("webrtc-room".into())).await);
     let wtrans = step!(
@@ -146,6 +146,19 @@ async fn main() {
         wparams.0.contains("iceParameters") && wparams.0.contains("dtlsParameters"),
         "le blob doit contenir ICE + DTLS"
     );
+    // Le port du candidat ICE doit tomber DANS la plage bornée (leçon
+    // nexus-turn : un port hors plage firewall = média silencieusement mort).
+    let port: u16 = wparams.0
+        .split("\"port\":")
+        .nth(1)
+        .and_then(|s| s.split(&[',', '}'][..]).next())
+        .and_then(|s| s.trim().parse().ok())
+        .expect("port du candidat ICE introuvable dans le blob");
+    assert!(
+        (40100..=40199).contains(&port),
+        "port ICE {port} HORS de la plage bornée 40100-40199"
+    );
+    println!("  ✔ port ICE {port} dans la plage bornée 40100-40199");
     println!(
         "     → blob de {} octets, candidats ICE + fingerprints DTLS présents",
         wparams.0.len()

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
@@ -25,6 +25,7 @@
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::num::{NonZeroU32, NonZeroU8};
+use std::ops::RangeInclusive;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -128,6 +129,10 @@ enum AnyTransport {
 struct Inner {
     manager: WorkerManager,
     worker: Worker,
+    /// Plage de ports UDP RTC des workers. Le défaut mediasoup (10000..=59999)
+    /// est un piège firewall (leçon nexus-turn) : on borne TOUJOURS, et la
+    /// même plage vaut pour tous les workers (mediasoup saute les ports pris).
+    rtc_ports: RangeInclusive<u16>,
     /// Mode WebRTC : IP d'écoute (+ adresse annoncée aux clients, ex: IP
     /// publique du VPS). `None` = transports Direct.
     webrtc_listen: Option<(IpAddr, Option<String>)>,
@@ -157,28 +162,50 @@ pub struct MediasoupEngine {
     inner: Arc<Inner>,
 }
 
+/// Plage RTC par défaut : 1000 ports = ~500 participants (paire send+recv),
+/// large pour une instance, étroite pour un firewall.
+pub const DEFAULT_RTC_PORTS: RangeInclusive<u16> = 40000..=40999;
+
+fn worker_settings(rtc_ports: &RangeInclusive<u16>) -> WorkerSettings {
+    let mut s = WorkerSettings::default();
+    s.rtc_port_range = rtc_ports.clone();
+    s
+}
+
 impl MediasoupEngine {
     /// Mode Direct (scénarios automatisés, pas de navigateur).
     pub async fn new() -> Result<Self> {
-        Self::build(None).await
+        Self::build(None, DEFAULT_RTC_PORTS).await
     }
 
     /// Mode WebRTC : vrais transports ICE/DTLS. `listen_ip` = IP d'écoute
-    /// locale, `announced` = adresse annoncée aux clients (IP publique).
-    pub async fn new_webrtc(listen_ip: IpAddr, announced: Option<String>) -> Result<Self> {
-        Self::build(Some((listen_ip, announced))).await
+    /// locale, `announced` = adresse annoncée aux clients (IP publique),
+    /// `rtc_ports` = plage UDP à ouvrir au firewall (et RIEN d'autre).
+    pub async fn new_webrtc(
+        listen_ip: IpAddr,
+        announced: Option<String>,
+        rtc_ports: RangeInclusive<u16>,
+    ) -> Result<Self> {
+        Self::build(Some((listen_ip, announced)), rtc_ports).await
     }
 
-    async fn build(webrtc_listen: Option<(IpAddr, Option<String>)>) -> Result<Self> {
+    async fn build(
+        webrtc_listen: Option<(IpAddr, Option<String>)>,
+        rtc_ports: RangeInclusive<u16>,
+    ) -> Result<Self> {
+        if rtc_ports.is_empty() {
+            return Err(MediaError::Engine("plage RTC vide (min > max)".into()));
+        }
         let manager = WorkerManager::new();
         let worker = manager
-            .create_worker(WorkerSettings::default())
+            .create_worker(worker_settings(&rtc_ports))
             .await
             .map_err(|e| MediaError::Engine(format!("create_worker: {e}")))?;
         Ok(Self {
             inner: Arc::new(Inner {
                 manager,
                 worker,
+                rtc_ports,
                 webrtc_listen,
                 extra_workers: Mutex::new(Vec::new()),
                 routers: Mutex::new(HashMap::new()),
@@ -237,7 +264,7 @@ impl MediasoupEngine {
         let worker = self
             .inner
             .manager
-            .create_worker(WorkerSettings::default())
+            .create_worker(worker_settings(&self.inner.rtc_ports))
             .await
             .map_err(|e| MediaError::Engine(format!("create_worker(remote): {e}")))?;
         let router = worker


### PR DESCRIPTION
La leçon nexus-turn appliquée **avant** le bug cette fois : le défaut mediasoup (`rtc_port_range` **10000..=59999**) est un piège firewall, 50 000 ports éphémères jamais documentés.

- **engine** : `worker_settings(rtc_ports)` injecté dans **tous** les workers (principal + nœuds distants), défaut `40000..=40999`, plage vide refusée
- **daemon** : `SFU_RTC_MIN_PORT`/`SFU_RTC_MAX_PORT`, refus de démarrer si min > max, plage affichée au boot
- **spike** : preuve exécutable, port du candidat ICE vérifié **dans** la plage (spike borné 40100-40199 → port obtenu **40124**, assertion verte)
- **`nodyx-sfud.service`** : modèle systemd durci (User=nodyx, NoNewPrivileges, ProtectSystem=strict, ProtectHome, PrivateTmp) + consigne firewall

Sur le VPS (hors repo) : binaire release installé, `/etc/nodyx-sfud.env` (token généré, root:nodyx 640), unité **disabled/inactive**, `ufw allow 40000:40999/udp`. **Rien n'est activé** : l'essai labo se fait avec le owner.