### PR TITLE
fix(voice): room d'annonces SFU dédiée, le 1er arrivé entend enfin les suivants

### DIFF
--- a/nodyx-core/src/socket/voiceSfu.ts
+++ b/nodyx-core/src/socket/voiceSfu.ts
@@ -28,6 +28,18 @@ import { Server, Socket } from 'socket.io'
 import { checkRateLimit } from './rateLimiter'
 import { getCommunityRoleForChannel, isUuid, voiceRoom } from './voice'
 
+/**
+ * Room socket.io DÉDIÉE aux clients SFU d'un salon. SURTOUT PAS voiceRoom()
+ * du mesh : la liste des membres vocaux de la sidebar est reconstruite depuis
+ * cette room-là (broadcastVoiceChannelUpdate fetchSockets) — y mettre les
+ * clients SFU les ferait apparaître en fantômes. Les annonces SFU
+ * (new_producer…) circulent ici ; voice:sfu_mode reste émis vers la room mesh
+ * (ce sont les clients MESH qu'une bascule doit prévenir, §17-B).
+ */
+function sfuRoom(channelId: string): string {
+  return `voicesfu:${channelId}`
+}
+
 // ── Configuration (lue à CHAQUE appel : cohérent avec le système de settings
 //    tier-3 qui ré-applique les valeurs DB sur process.env à chaud) ───────────
 
@@ -131,6 +143,9 @@ export function registerVoiceSfuHandlers(socket: Socket, server: Server): void {
     if (!join.ok) { cb({ ok: false, error: join.error }); return }
 
     joined.add(channelId as string)
+    // Rejoint la room d'annonces SFU : sans elle, le premier arrivé n'apprend
+    // JAMAIS les flux publiés après lui (bug du labo : PC silencieux).
+    await socket.join(sfuRoom(channelId as string))
     const mode = join.data.mode
 
     if (mode !== 'sfu') { cb({ ok: true, mode }); return }
@@ -194,8 +209,8 @@ export function registerVoiceSfuHandlers(socket: Socket, server: Server): void {
     const res = await sfuFetch('/v1/produce', { room: channelId, participant: userId, kind, client })
     if (!res.ok) { cb({ ok: false, error: res.error }); return }
 
-    // Annonce aux autres : un nouveau flux est disponible à la souscription.
-    socket.to(voiceRoom(channelId as string)).emit('voice:sfu_new_producer', {
+    // Annonce aux autres clients SFU : un nouveau flux est à souscrire.
+    socket.to(sfuRoom(channelId as string)).emit('voice:sfu_new_producer', {
       channelId,
       producerId: res.data.producer,
       kind,
@@ -239,6 +254,7 @@ export function registerVoiceSfuHandlers(socket: Socket, server: Server): void {
     if (!isUuid(channelId)) { ack({ ok: false, error: 'bad_channel' }); return }
     // Pas de check de rôle au leave : on doit toujours pouvoir sortir.
     joined.delete(channelId)
+    await socket.leave(sfuRoom(channelId))
     const res = await sfuFetch('/v1/leave', { room: channelId, participant: userId })
     ack(res.ok ? { ok: true } : { ok: false, error: res.error })
   })

--- a/nodyx-core/src/tests/voice-sfu.test.ts
+++ b/nodyx-core/src/tests/voice-sfu.test.ts
@@ -37,11 +37,13 @@ function makeHarness(userId = `user-${Date.now()}-${_seq++}`) {
   const roomEmit = vi.fn()
   const socketToEmit = vi.fn()
   const socket = {
-    id:   'socket-1',
-    data: { userId, username: 'jo' },
-    on:   (ev: string, fn: Handler) => { handlers.set(ev, fn) },
-    to:   vi.fn(() => ({ emit: socketToEmit })),
-    emit: vi.fn(),
+    id:    'socket-1',
+    data:  { userId, username: 'jo' },
+    on:    (ev: string, fn: Handler) => { handlers.set(ev, fn) },
+    to:    vi.fn(() => ({ emit: socketToEmit })),
+    emit:  vi.fn(),
+    join:  vi.fn(async () => {}),
+    leave: vi.fn(async () => {}),
   }
   const server = {
     to: vi.fn(() => ({ emit: roomEmit })),
@@ -235,16 +237,33 @@ describe('flow SFU', () => {
     expect(body.direction).toBe('recv')
   })
 
-  it('produce : annonce voice:sfu_new_producer aux autres', async () => {
+  it('produce : annonce voice:sfu_new_producer dans la room SFU DÉDIÉE (pas celle du mesh)', async () => {
     const h = makeHarness('user-jonathan')
     fetchMock.mockResolvedValueOnce(daemonJson({ ok: true, producer: 'prod-1' }))
     const a = ack()
     await h.fire('voice:sfu_produce', { channelId: CHANNEL, kind: 'audio', rtpParameters: { codecs: [] } }, a.cb)
     expect(a.last).toEqual({ ok: true, producerId: 'prod-1' })
-    expect(h.socket.to).toHaveBeenCalledWith(`voice:${CHANNEL}`)
+    // Room dédiée voicesfu: — JAMAIS la room mesh (fantômes dans la sidebar).
+    expect(h.socket.to).toHaveBeenCalledWith(`voicesfu:${CHANNEL}`)
+    expect(h.socket.to).not.toHaveBeenCalledWith(`voice:${CHANNEL}`)
     expect(h.socketToEmit).toHaveBeenCalledWith('voice:sfu_new_producer', {
       channelId: CHANNEL, producerId: 'prod-1', kind: 'audio', userId: 'user-jonathan',
     })
+  })
+
+  it('join : rejoint la room d\'annonces SFU (le 1er arrivé doit entendre les suivants)', async () => {
+    const h = makeHarness()
+    fetchMock.mockResolvedValueOnce(daemonJson({ ok: true, mode: 'mesh', migrated: [] }))
+    await h.fire('voice:sfu_join', CHANNEL, ack().cb)
+    expect(h.socket.join).toHaveBeenCalledWith(`voicesfu:${CHANNEL}`)
+  })
+
+  it('leave : quitte la room d\'annonces SFU', async () => {
+    const h = makeHarness()
+    fetchMock.mockResolvedValue(daemonJson({ ok: true, mode: 'mesh', migrated: [] }))
+    await h.fire('voice:sfu_join', CHANNEL, ack().cb)
+    await h.fire('voice:sfu_leave', CHANNEL, ack().cb)
+    expect(h.socket.leave).toHaveBeenCalledWith(`voicesfu:${CHANNEL}`)
   })
 
   it('consume : renvoie consumerId + params parsés', async () => {


### PR DESCRIPTION
Bug trouvé **au labo réel** (PC + téléphone 4G) : zéro erreur au journal, mais le PC n'entendait pas le téléphone.

**Cause** : `voice:sfu_new_producer` était émis vers la room mesh `voice:<id>`, que les clients SFU ne rejoignent jamais. Le 2e arrivant trouve le flux du 1er via `/v1/publications` (le téléphone entendait le PC), mais le 1er n'apprend jamais le flux du 2e : annonce dans une salle vide, silence parfait sans échec.

**Fix** : room dédiée `voicesfu:<id>` (join au sfu_join, leave au sfu_leave, sortie auto au disconnect). **Surtout pas la room mesh** : la sidebar reconstruit la liste des membres vocaux par `fetchSockets()` dessus, les clients SFU y apparaîtraient en fantômes. `voice:sfu_mode` reste vers la room mesh (c'est les clients mesh qu'une bascule prévient, §17-B).

**Tests : 21** (+2 room join/leave, +1 anti-régression : l'annonce ne part jamais vers la room mesh).