### PR TITLE
fix(sfu): passe de relecture post-MVP, 4 trouvailles corrigées

### DIFF
--- a/nodyx-core/src/socket/voiceSfu.ts
+++ b/nodyx-core/src/socket/voiceSfu.ts
@@ -157,9 +157,18 @@ export function registerVoiceSfuHandlers(socket: Socket, server: Server): void {
       sfuFetch('/v1/transport_params', { room: channelId, participant: userId, direction: 'send' }),
       sfuFetch('/v1/transport_params', { room: channelId, participant: userId, direction: 'recv' }),
     ])
-    if (!caps.ok) { cb({ ok: false, error: caps.error }); return }
-    if (!sendParams.ok) { cb({ ok: false, error: sendParams.error }); return }
-    if (!recvParams.ok) { cb({ ok: false, error: recvParams.error }); return }
+    // Relecture 2026-07-06 : sans rollback, un échec ICI laissait le
+    // participant inscrit côté daemon → tout retry répondait "déjà présent
+    // dans le salon" jusqu'au disconnect du socket.
+    const rollbackJoin = async (error: string) => {
+      joined.delete(channelId as string)
+      await socket.leave(sfuRoom(channelId as string))
+      void sfuFetch('/v1/leave', { room: channelId, participant: userId })
+      cb({ ok: false, error })
+    }
+    if (!caps.ok) { await rollbackJoin(caps.error); return }
+    if (!sendParams.ok) { await rollbackJoin(sendParams.error); return }
+    if (!recvParams.ok) { await rollbackJoin(recvParams.error); return }
 
     // Si cette arrivée a fait basculer le salon (des participants ont été
     // migrés), on prévient le salon : chacun fera son propre sfu_join pour

--- a/nodyx-core/src/tests/voice-sfu.test.ts
+++ b/nodyx-core/src/tests/voice-sfu.test.ts
@@ -224,6 +224,26 @@ describe('flow SFU', () => {
     expect(h.roomEmit).toHaveBeenCalledWith('voice:sfu_mode', { channelId: CHANNEL, mode: 'sfu' })
   })
 
+  it('rollback : si caps/params échouent après le join, le daemon reçoit un leave', async () => {
+    const h = makeHarness()
+    const calls: string[] = []
+    fetchMock.mockImplementation(async (url: string, init: { body: string }) => {
+      const path = new URL(url).pathname
+      calls.push(path)
+      if (path === '/v1/join') return daemonJson({ ok: true, mode: 'sfu', migrated: [] })
+      if (path === '/v1/caps') return daemonJson({ ok: false, error: 'caps_kaput' }, 500)
+      if (path === '/v1/transport_params') return daemonJson({ ok: true, params: '{"id":"t"}' })
+      if (path === '/v1/leave') return daemonJson({ ok: true })
+      return daemonJson({ ok: false, error: 'unexpected' }, 404)
+    })
+    const a = ack()
+    await h.fire('voice:sfu_join', CHANNEL, a.cb)
+    expect(a.last).toEqual({ ok: false, error: 'caps_kaput' })
+    // Le rollback a bien envoyé le leave (sinon : "déjà présent" à tout retry).
+    expect(calls).toContain('/v1/leave')
+    expect(h.socket.leave).toHaveBeenCalledWith(`voicesfu:${CHANNEL}`)
+  })
+
   it('connect : direction obligatoire et transmise au daemon', async () => {
     const h = makeHarness()
     const bad = ack()

--- a/nodyx-frontend/src/lib/voiceSfu.ts
+++ b/nodyx-frontend/src/lib/voiceSfu.ts
@@ -63,6 +63,10 @@ interface Session {
 
 let _session: Session | null = null
 
+/** Salon inscrit côté daemon (survit à l'échec de session : le leave doit
+ *  TOUJOURS pouvoir partir, sinon fantôme jusqu'au disconnect du socket). */
+let _joinedChannel: string | null = null
+
 // ── Ack avec timeout : l'UI ne reste JAMAIS suspendue ─────────────────────────
 
 const ACK_TIMEOUT_MS = 8_000
@@ -110,6 +114,7 @@ export async function sfuJoin(channelId: string): Promise<void> {
 
   const join = await emitAck(sock, 'voice:sfu_join', channelId)
   if (!join.ok) { fail(`join refusé : ${join.error}`); return }
+  _joinedChannel = channelId
 
   if (join.mode !== 'sfu') {
     sfuPhaseStore.set('mesh')
@@ -202,10 +207,15 @@ export async function sfuJoin(channelId: string): Promise<void> {
   }
 }
 
+const _consuming = new Set<string>()
+
 async function consumeOne(sock: Socket, producerId: string, userId: string, kind: string): Promise<void> {
   const s = _session
   if (!s) return
-  if (s.consumers.has(producerId)) return // déjà consommé (annonce + liste peuvent se croiser)
+  // Relecture 2026-07-06 : la liste publications et l'annonce new_producer
+  // peuvent se croiser → sans garde EN VOL, double consume = double audio.
+  if (s.consumers.has(producerId) || _consuming.has(producerId)) return
+  _consuming.add(producerId)
   try {
     const r = await emitAck(sock, 'voice:sfu_consume', {
       channelId: s.channelId, producerId, rtpCapabilities: s.device.rtpCapabilities,
@@ -228,6 +238,8 @@ async function consumeOne(sock: Socket, producerId: string, userId: string, kind
     log(`✓ flux de ${userId} en lecture`)
   } catch (e) {
     log(`✘ consume : ${(e as Error).message}`)
+  } finally {
+    _consuming.delete(producerId)
   }
 }
 
@@ -240,12 +252,12 @@ export function sfuSetMuted(muted: boolean): void {
 }
 
 export async function sfuLeave(): Promise<void> {
-  const s = _session
-  if (!s) { sfuPhaseStore.set('idle'); return }
+  const channel = _session?.channelId ?? _joinedChannel
   log('→ leave + nettoyage complet')
   const sock = get(socketStore)
   cleanup()
-  if (sock) await emitAck(sock, 'voice:sfu_leave', s.channelId)
+  _joinedChannel = null
+  if (sock && channel) await emitAck(sock, 'voice:sfu_leave', channel)
   sfuPhaseStore.set('idle')
   log('✓ session fermée')
 }
@@ -254,6 +266,13 @@ function fail(reason: string): void {
   log(`✘ ${reason}`)
   sfuErrorStore.set(reason)
   cleanup()
+  // Relecture 2026-07-06 : sans ce leave, un échec en cours de session
+  // laissait le participant inscrit côté daemon tant que l'onglet vivait.
+  const sock = get(socketStore)
+  if (sock && _joinedChannel) {
+    void emitAck(sock, 'voice:sfu_leave', _joinedChannel)
+    _joinedChannel = null
+  }
   sfuPhaseStore.set('error')
 }
 

--- a/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
+++ b/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
@@ -333,55 +333,113 @@ impl<E: MediaEngine> VoiceService<E> {
     /// CHAQUE participant incomplet. Idempotent. Primitive unique de migration
     /// (utilisée par `join`, `set_screenshare`, `publish` d'un écran).
     pub async fn ensure_sfu(&self, room: RoomId) -> Result<SfuMigration, VoiceError> {
-        // ── plan : router manquant ? qui n'a pas sa paire complète ? ──
-        let (need_router, existing_router, missing): (bool, Option<RouterHandle>, Vec<ParticipantId>) = {
-            let rooms = self.rooms();
-            let Some(state) = rooms.get(&room) else {
-                return Err(VoiceError::NotInRoom);
+        // Boucle de convergence (relecture 2026-07-06) : deux ensure_sfu
+        // concurrents sur un salon vierge créaient DEUX routers ; le perdant
+        // n'était jamais fermé et ses transports pouvaient être commités →
+        // participants à cheval sur deux routers, consume inter-routers en
+        // échec. Ici : si on perd la course au commit, on FERME notre router
+        // (l'adaptateur libère ses transports avec lui) et on recommence sur
+        // celui du gagnant. Converge en ≤2 tours réels ; borne dure à 4 par
+        // paranoïa. NB : sur un router PARTAGÉ, une double-provision du même
+        // participant laisse des transports orphelins côté moteur (inutilisés,
+        // libérés au close_room) : bénin, la vraie sérialisation par salon
+        // arrive avec le durcissement P1.
+        let mut switched = false;
+        let mut migrated_all: Vec<ParticipantId> = Vec::new();
+        for _tour in 0..4 {
+            // ── plan : router manquant ? qui n'a pas sa paire complète ? ──
+            let (need_router, existing_router, missing): (bool, Option<RouterHandle>, Vec<ParticipantId>) = {
+                let rooms = self.rooms();
+                let Some(state) = rooms.get(&room) else {
+                    return Err(VoiceError::NotInRoom);
+                };
+                let missing = state
+                    .participants
+                    .iter()
+                    .filter(|(_, p)| !p.in_sfu())
+                    .map(|(id, _)| id.clone())
+                    .collect();
+                (state.router.is_none(), state.router.clone(), missing)
             };
-            let missing = state
-                .participants
-                .iter()
-                .filter(|(_, p)| !p.in_sfu())
-                .map(|(id, _)| id.clone())
-                .collect();
-            (state.router.is_none(), state.router.clone(), missing)
-        };
+            if !need_router && missing.is_empty() {
+                break; // rien à faire : idempotence
+            }
 
-        // ── apply (hors verrou) : router puis paires de transports ──
-        let router = if need_router {
-            self.engine.create_room(room.clone()).await?
-        } else {
-            existing_router.expect("router SFU présent quand need_router=false")
-        };
-        let mut provisioned: Vec<(ParticipantId, TransportHandle, TransportHandle)> =
-            Vec::with_capacity(missing.len());
-        for pid in missing {
-            let send = self.engine.create_transport(&router, pid.clone()).await?;
-            let recv = self.engine.create_transport(&router, pid.clone()).await?;
-            provisioned.push((pid, send, recv));
-        }
+            // ── apply (hors verrou) : router puis paires de transports ──
+            let router = if need_router {
+                self.engine.create_room(room.clone()).await?
+            } else {
+                existing_router.expect("router SFU présent quand need_router=false")
+            };
+            let mut provisioned: Vec<(ParticipantId, TransportHandle, TransportHandle)> =
+                Vec::with_capacity(missing.len());
+            for pid in missing {
+                let send = self.engine.create_transport(&router, pid.clone()).await?;
+                let recv = self.engine.create_transport(&router, pid.clone()).await?;
+                provisioned.push((pid, send, recv));
+            }
 
-        // ── commit : figer router + paires ──
-        {
-            let mut rooms = self.rooms();
-            if let Some(state) = rooms.get_mut(&room) {
-                if state.router.is_none() {
-                    state.router = Some(router);
-                }
-                for (pid, send, recv) in &provisioned {
-                    if let Some(p) = state.participants.get_mut(pid) {
-                        if p.send_transport.is_none() { p.send_transport = Some(send.clone()); }
-                        if p.recv_transport.is_none() { p.recv_transport = Some(recv.clone()); }
+            // ── commit : figer router + paires, OU détecter la course perdue ──
+            enum Outcome { Won(Vec<ParticipantId>), LostRace, RoomGone }
+            let outcome = {
+                let mut rooms = self.rooms();
+                match rooms.get_mut(&room) {
+                    None => Outcome::RoomGone,
+                    Some(state) => {
+                        let lost = need_router
+                            && state.router.as_ref().is_some_and(|r| r != &router);
+                        if lost {
+                            Outcome::LostRace
+                        } else {
+                            if state.router.is_none() {
+                                state.router = Some(router.clone());
+                            }
+                            let mut committed = Vec::new();
+                            for (pid, send, recv) in &provisioned {
+                                if let Some(p) = state.participants.get_mut(pid) {
+                                    let mut used = false;
+                                    if p.send_transport.is_none() {
+                                        p.send_transport = Some(send.clone());
+                                        used = true;
+                                    }
+                                    if p.recv_transport.is_none() {
+                                        p.recv_transport = Some(recv.clone());
+                                        used = true;
+                                    }
+                                    if used {
+                                        committed.push(pid.clone());
+                                    }
+                                }
+                            }
+                            Outcome::Won(committed)
+                        }
                     }
+                }
+            };
+
+            match outcome {
+                Outcome::Won(committed) => {
+                    switched |= need_router;
+                    migrated_all.extend(committed);
+                    break;
+                }
+                Outcome::LostRace => {
+                    // Nos transports vivent sur NOTRE router : sa fermeture les
+                    // libère côté adaptateur. Puis on retente sur le gagnant.
+                    let _ = self.engine.close_room(router).await;
+                }
+                Outcome::RoomGone => {
+                    // Salon fermé pendant le travail moteur (dernier leave) :
+                    // on libère ce qu'on venait de créer et on le signale.
+                    if need_router {
+                        let _ = self.engine.close_room(router).await;
+                    }
+                    return Err(VoiceError::NotInRoom);
                 }
             }
         }
 
-        Ok(SfuMigration {
-            switched_to_sfu: need_router,
-            migrated: provisioned.into_iter().map(|(pid, _, _)| pid).collect(),
-        })
+        Ok(SfuMigration { switched_to_sfu: switched, migrated: migrated_all })
     }
 
     /// Un partage d'écran démarre/s'arrête. Le démarrage force le mode SFU (quel


### PR DESCRIPTION
Relecture à froid demandée par le owner après la preuve du MVP audio. **Quatre défauts réels**, invisibles des 410+ tests parce qu'aucun ne casse un chemin nominal :

| | Où | Défaut | Fix |
|---|---|---|---|
| **R1** | `voice.rs` | 2 `ensure_sfu` concurrents sur salon vierge → 2 routers, le perdant jamais fermé, participants à cheval | boucle de convergence : course perdue = fermer NOTRE router + retenter sur le gagnant (borne 4 tours) |
| **C1** | relais core | join daemon OK puis échec caps/params → participant fantôme, "déjà présent" à tout retry | `rollbackJoin` (leave + sortie room + joined.delete) sur les 3 branches, **testé** |
| **F1** | client | `fail()` ne prévenait jamais le daemon ; leave impossible sans session | `_joinedChannel` tracé hors session, leave best-effort partout |
| **F2** | client | publications × new_producer croisés → double consume, double audio | garde d'unicité **en vol** (`_consuming`) |

Rust 25 + clippy clean · core **22 tests (+1)** suite complète verte · frontend 9, svelte-check 0 erreur.