### PR TITLE
feat(sfu): audit réseau — les vraies IP/ICE/perte par transport (fondation bench)

### DIFF
--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/bin/nodyx-sfud.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/bin/nodyx-sfud.rs
@@ -20,6 +20,8 @@
 //!   SFU_LISTEN_IP      IP d'écoute média WebRTC   (défaut 127.0.0.1)
 //!   SFU_ANNOUNCED_IP   adresse annoncée aux clients (IP publique du VPS)
 //!   SFU_MESH_THRESHOLD seuil mesh→SFU (défaut 4) · SFU_MAX_SEATS (défaut 25)
+//!   (route /v1/audit : audit réseau d'un salon — IP:port réelles, état ICE,
+//!    bitrate/perte par transport ; outil de diagnostic dev)
 //!   SFU_RTC_MIN_PORT / SFU_RTC_MAX_PORT
 //!                      plage UDP RTC des workers (défaut 40000-40999).
 //!                      DOIT correspondre au firewall (ufw allow <min>:<max>/udp),
@@ -193,6 +195,29 @@ async fn route(app: &App, path: &str, body: &serde_json::Value) -> (u16, serde_j
                 })),
                 Err(e) => err_json(409, e.to_string()),
             }
+        }
+
+        "/v1/audit" => {
+            let Some(r) = room() else { return err_json(400, "room requis") };
+            let audit = app.svc.audit(&r).await;
+            let lines = audit
+                .iter()
+                .map(|a| {
+                    // Le blob stats du moteur est du JSON : on le ré-injecte
+                    // comme objet (pas comme string) pour un audit lisible.
+                    let stats: serde_json::Value =
+                        serde_json::from_str(&a.stats.0).unwrap_or(serde_json::Value::Null);
+                    serde_json::json!({
+                        "participant": a.participant.0,
+                        "direction": match a.direction {
+                            Direction::Send => "send",
+                            Direction::Recv => "recv",
+                        },
+                        "stats": stats,
+                    })
+                })
+                .collect::<Vec<_>>();
+            ok_json(serde_json::json!({ "room": r.0, "transports": lines }))
         }
 
         "/v1/publications" => {

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
@@ -355,6 +355,25 @@ impl MediaEngine for MediasoupEngine {
         }
     }
 
+    async fn transport_stats(&self, transport: &TransportHandle) -> Result<SignalingBlob> {
+        let (t, _) = self.transport_of(&transport.0)?;
+        match t.as_ref() {
+            AnyTransport::Direct(_) => Ok(SignalingBlob("{\"kind\":\"direct\"}".into())),
+            AnyTransport::WebRtc(w) => {
+                // get_stats() → WebRtcTransportStat : contient la paire ICE
+                // sélectionnée (IP:port locale ↔ distante), ice_state, bitrate,
+                // perte. C'EST l'audit réseau réel. Sérialisé tel quel (le champ
+                // ice_selected_tuple.remoteIp est l'IP du pair).
+                let stats = w
+                    .get_stats()
+                    .await
+                    .map_err(|e| MediaError::Engine(format!("get_stats: {e}")))?;
+                let json = serde_json::json!({ "id": transport.0, "stats": stats });
+                Ok(SignalingBlob(json.to_string()))
+            }
+        }
+    }
+
     async fn connect_transport(
         &self,
         transport: &TransportHandle,

--- a/nodyx-p2p/crates/nodyx-sfu/src/lib.rs
+++ b/nodyx-p2p/crates/nodyx-sfu/src/lib.rs
@@ -17,8 +17,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 mod voice;
 pub use voice::{
-    desired_mode, Direction, JoinOutcome, Mode, PublicationInfo, SfuMigration, VoiceConfig,
-    VoiceError, VoiceService,
+    desired_mode, Direction, JoinOutcome, Mode, PublicationInfo, SfuMigration, TransportAudit,
+    VoiceConfig, VoiceError, VoiceService,
 };
 
 // ── Identifiants du domaine ─────────────────────────────────────────────────
@@ -160,6 +160,11 @@ pub trait MediaEngine: Send + Sync {
     /// Finalise la connexion du transport avec la réponse du client
     /// (mediasoup : dtlsParameters du `connect`).
     async fn connect_transport(&self, transport: &TransportHandle, client: &SignalingBlob) -> Result<()>;
+    /// Audit réseau d'un transport : blob opaque contenant la réalité du lien
+    /// (mediasoup : paire ICE sélectionnée = IP:port locale ↔ distante, ice_state,
+    /// bitrate/perte live). Outil de DIAGNOSTIC : le métier le transporte sans
+    /// jamais le lire. Un moteur de test renvoie un stub.
+    async fn transport_stats(&self, transport: &TransportHandle) -> Result<SignalingBlob>;
     /// Le participant publie un flux (audio / écran / cam). `client` porte ses
     /// paramètres RTP (opaque ; un moteur de test peut l'ignorer).
     async fn produce(&self, transport: &TransportHandle, kind: TrackKind, client: &SignalingBlob) -> Result<ProducerId>;
@@ -210,6 +215,9 @@ impl MediaEngine for NullEngine {
     }
     async fn connect_transport(&self, _transport: &TransportHandle, _client: &SignalingBlob) -> Result<()> {
         Ok(())
+    }
+    async fn transport_stats(&self, transport: &TransportHandle) -> Result<SignalingBlob> {
+        Ok(SignalingBlob(format!("{{\"engine\":\"null\",\"transport\":\"{transport}\"}}")))
     }
     async fn produce(&self, _transport: &TransportHandle, _kind: TrackKind, _client: &SignalingBlob) -> Result<ProducerId> {
         Ok(ProducerId(self.next("producer")))

--- a/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
+++ b/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
@@ -145,6 +145,15 @@ pub struct SfuMigration {
     pub migrated: Vec<ParticipantId>,
 }
 
+/// Ligne d'audit réseau d'un transport (diagnostic dev : IP/ICE/perte).
+/// `stats` est un blob opaque du moteur (le métier ne le lit pas).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransportAudit {
+    pub participant: ParticipantId,
+    pub direction: Direction,
+    pub stats: SignalingBlob,
+}
+
 /// Vue d'une publication (pour l'event `voice:publications`, §17-A).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PublicationInfo {
@@ -244,6 +253,37 @@ impl<E: MediaEngine> VoiceService<E> {
                 owner: pubb.owner.clone(),
             })
             .collect()
+    }
+
+    /// Audit réseau du salon : pour chaque transport de chaque participant,
+    /// le blob de stats du moteur (mediasoup : IP:port réelles, état ICE,
+    /// bitrate, perte). Outil de diagnostic dev. Salon absent → vecteur vide.
+    pub async fn audit(&self, room: &RoomId) -> Vec<TransportAudit> {
+        // Snapshot des handles sous verrou (pas d'await pendant qu'on tient le lock).
+        let handles: Vec<(ParticipantId, Direction, TransportHandle)> = {
+            let rooms = self.rooms();
+            let Some(state) = rooms.get(room) else { return Vec::new() };
+            let mut v = Vec::new();
+            for (pid, p) in &state.participants {
+                if let Some(t) = p.send_transport.clone() {
+                    v.push((pid.clone(), Direction::Send, t));
+                }
+                if let Some(t) = p.recv_transport.clone() {
+                    v.push((pid.clone(), Direction::Recv, t));
+                }
+            }
+            v
+        };
+        // Appels moteur hors verrou.
+        let mut out = Vec::with_capacity(handles.len());
+        for (participant, direction, handle) in handles {
+            let stats = match self.engine.transport_stats(&handle).await {
+                Ok(b) => b,
+                Err(e) => SignalingBlob(format!("{{\"error\":\"{e}\"}}")),
+            };
+            out.push(TransportAudit { participant, direction, stats });
+        }
+        out
     }
 
     // ── cycle de vie participant ─────────────────────────────────────────────
@@ -862,6 +902,29 @@ mod tests {
             block_on(s.room_capabilities(&RoomId("nope".into()))),
             Err(VoiceError::NotInRoom)
         );
+    }
+
+    #[test]
+    fn audit_lists_both_transports_per_participant() {
+        let s = svc();
+        for i in 1..=5 { block_on(s.join(room(), p(i))).unwrap(); } // franchit le seuil → SFU
+        let audit = block_on(s.audit(&room()));
+        // 5 participants × 2 transports (send + recv) = 10 lignes
+        assert_eq!(audit.len(), 10);
+        let sends = audit.iter().filter(|a| a.direction == Direction::Send).count();
+        let recvs = audit.iter().filter(|a| a.direction == Direction::Recv).count();
+        assert_eq!(sends, 5);
+        assert_eq!(recvs, 5);
+        // le blob du moteur transite tel quel (NullEngine renvoie un stub identifiable)
+        assert!(audit[0].stats.0.contains("transport"));
+    }
+
+    #[test]
+    fn audit_empty_room_is_empty() {
+        let s = svc();
+        assert!(block_on(s.audit(&RoomId("nope".into()))).is_empty());
+        block_on(s.join(room(), p(1))).unwrap(); // mesh : pas de transport
+        assert!(block_on(s.audit(&room())).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Premier module de l'arsenal d'analyse. Expose la réalité réseau d'une session : **qui, quelle IP, quel chemin, combien de perte**. Outil de diagnostic dev (les IP d'une session live = ingénierie, pas tracking ; la seule ligne éthique — ne jamais persister les IP de vrais users dans un analytics — reste tenue).

- **trait** : `transport_stats` en blob **opaque** (même patron que `transport_params`), NullEngine stubbé
- **VoiceService::audit(room)** : par participant × direction, le blob moteur ; verrou relâché avant les appels moteur. **27 tests** nodyx-sfu, clippy clean
- **MediasoupEngine** : `get_stats()` → `WebRtcTransportStat` réel = `ice_selected_tuple` (**localAddr:port ↔ remoteIp:port**), `ice_state`, bitrate, perte
- **daemon `/v1/audit`** : vérifié au curl (port isolé) — 5 participants → 10 transports, stats moteur réelles remontées ; avec un navigateur, la paire ICE porte l'**IP réelle du pair**

Prochain : la surface (relais admin + panneau labo) pour voir l'audit **live** pendant un test PC+téléphone, puis le canon de charge + le rapport visuel.