### PR TITLE
feat(sfu): audit réseau visible au labo (IP/ICE/débit/perte, live)

### DIFF
--- a/nodyx-core/src/socket/rateLimiter.ts
+++ b/nodyx-core/src/socket/rateLimiter.ts
@@ -46,6 +46,7 @@ export const RATE_RULES: Record<string, RuleConfig[]> = {
   'voice:sfu_produce':      [{ limit: 10, windowMs: 10_000 }],
   'voice:sfu_consume':      [{ limit: 40, windowMs: 10_000 }],
   'voice:sfu_publications': [{ limit: 10, windowMs: 10_000 }],
+  'voice:sfu_audit':        [{ limit: 20, windowMs: 10_000 }],
 }
 
 // Clé composite : `${userId}::${eventKey}`

--- a/nodyx-core/src/socket/voiceSfu.ts
+++ b/nodyx-core/src/socket/voiceSfu.ts
@@ -256,6 +256,18 @@ export function registerVoiceSfuHandlers(socket: Socket, server: Server): void {
     cb({ ok: true, publications: res.data.publications ?? [] })
   })
 
+  // ── voice:sfu_audit — diagnostic réseau du salon (OWNER/ADMIN only) ─────────
+  // Expose les IP/ICE/perte des participants : réservé aux admins même si le
+  // labo est déjà page-gated. Outil de dev, pas de surveillance persistante.
+  socket.on('voice:sfu_audit', async (channelId: unknown, cb: unknown) => {
+    if (!isAck(cb)) return
+    const role = await guard('voice:sfu_audit', channelId, cb)
+    if (!role) return
+    if (role !== 'owner' && role !== 'admin') { cb({ ok: false, error: 'forbidden' }); return }
+    const res = await sfuFetch('/v1/audit', { room: channelId })
+    cb(res.ok ? { ok: true, transports: res.data.transports ?? [] } : { ok: false, error: res.error })
+  })
+
   // ── voice:sfu_leave ─────────────────────────────────────────────────────────
   socket.on('voice:sfu_leave', async (channelId: unknown, cb: unknown) => {
     const ack: Ack = isAck(cb) ? cb : () => {}

--- a/nodyx-core/src/tests/voice-sfu.test.ts
+++ b/nodyx-core/src/tests/voice-sfu.test.ts
@@ -244,6 +244,26 @@ describe('flow SFU', () => {
     expect(h.socket.leave).toHaveBeenCalledWith(`voicesfu:${CHANNEL}`)
   })
 
+  it('audit : owner/admin OK, membre refusé', async () => {
+    // membre → forbidden, aucun appel daemon
+    const member = makeHarness()
+    fetchMock.mockClear()
+    await member.fire('voice:sfu_audit', CHANNEL, (() => { const a = ack(); return a.cb })())
+    // (le rôle par défaut du mock est 'member')
+    const a = ack()
+    await member.fire('voice:sfu_audit', CHANNEL, a.cb)
+    expect(a.last).toEqual({ ok: false, error: 'forbidden' })
+    // admin → relaie /v1/audit
+    dbQueryMock.mockResolvedValue({ rows: [{ role: 'admin' }] })
+    const admin = makeHarness('user-admin-audit')
+    fetchMock.mockResolvedValueOnce(daemonJson({ ok: true, transports: [{ participant: 'x', direction: 'send' }] }))
+    const b = ack()
+    await admin.fire('voice:sfu_audit', CHANNEL, b.cb)
+    expect(b.last.ok).toBe(true)
+    expect((b.last.transports as unknown[]).length).toBe(1)
+    expect(fetchMock.mock.calls.some(c => new URL(c[0]).pathname === '/v1/audit')).toBe(true)
+  })
+
   it('connect : direction obligatoire et transmise au daemon', async () => {
     const h = makeHarness()
     const bad = ack()

--- a/nodyx-frontend/src/lib/voiceSfu.ts
+++ b/nodyx-frontend/src/lib/voiceSfu.ts
@@ -42,6 +42,20 @@ export const sfuLogStore:       Writable<string[]>          = writable([])
 export const sfuConsumersStore: Writable<SfuConsumerInfo[]> = writable([])
 export const sfuMutedStore:     Writable<boolean>           = writable(false)
 
+export interface SfuAuditRow {
+  participant: string
+  direction:   string
+  iceState:    string
+  local:       string   // ip:port local
+  remote:      string   // ip:port distant (l'IP du pair)
+  proto:       string
+  recvKbps:    number
+  sendKbps:    number
+  lossRecv:    number   // 0..1
+  lossSent:    number
+}
+export const sfuAuditStore: Writable<SfuAuditRow[]> = writable([])
+
 function log(msg: string): void {
   const line = `[${new Date().toLocaleTimeString()}] ${msg}`
   sfuLogStore.update(l => [...l.slice(-199), line])
@@ -243,6 +257,35 @@ async function consumeOne(sock: Socket, producerId: string, userId: string, kind
   }
 }
 
+/** Audit réseau du salon (owner/admin) : aplatit les WebRtcTransportStat en
+ *  lignes lisibles (IP:port réelles du pair, état ICE, débit, perte). */
+export async function sfuAudit(channelId: string): Promise<void> {
+  const sock = get(socketStore)
+  if (!sock) return
+  const res = await emitAck(sock, 'voice:sfu_audit', channelId)
+  if (!res.ok) { log(`✘ audit : ${res.error}`); sfuAuditStore.set([]); return }
+  const rows: SfuAuditRow[] = []
+  for (const t of (res.transports as Record<string, unknown>[] ?? [])) {
+    const stat = (((t.stats as Record<string, unknown>)?.stats) as Record<string, unknown>[] ?? [])[0] ?? {}
+    const tuple = (stat.iceSelectedTuple ?? null) as Record<string, unknown> | null
+    const fmt = (ip: unknown, port: unknown) => (ip != null ? `${ip}:${port}` : '—')
+    rows.push({
+      participant: String(t.participant ?? '?'),
+      direction:   String(t.direction ?? '?'),
+      iceState:    String(stat.iceState ?? 'new'),
+      local:       tuple ? fmt(tuple.localAddress, tuple.localPort) : '—',
+      remote:      tuple ? fmt(tuple.remoteIp, tuple.remotePort) : '—',
+      proto:       tuple ? String(tuple.protocol ?? '') : '',
+      recvKbps:    Math.round(Number(stat.recvBitrate ?? 0) / 1000),
+      sendKbps:    Math.round(Number(stat.sendBitrate ?? 0) / 1000),
+      lossRecv:    Number(stat.rtpPacketLossReceived ?? 0),
+      lossSent:    Number(stat.rtpPacketLossSent ?? 0),
+    })
+  }
+  sfuAuditStore.set(rows)
+  log(`audit : ${rows.length} transport(s)`)
+}
+
 export function sfuSetMuted(muted: boolean): void {
   if (_session?.micTrack) {
     _session.micTrack.enabled = !muted
@@ -294,4 +337,5 @@ function cleanup(): void {
   try { s.recvTransport.close() } catch { /* déjà fermé */ }
   sfuConsumersStore.set([])
   sfuMutedStore.set(false)
+  sfuAuditStore.set([])
 }

--- a/nodyx-frontend/src/routes/admin/sfu-lab/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/sfu-lab/+page.svelte
@@ -1,9 +1,35 @@
 <script lang="ts">
   import { browser } from '$app/environment'
+  import { onDestroy } from 'svelte'
   import {
-    sfuJoin, sfuLeave, sfuSetMuted,
+    sfuJoin, sfuLeave, sfuSetMuted, sfuAudit,
     sfuPhaseStore, sfuErrorStore, sfuLogStore, sfuConsumersStore, sfuMutedStore,
+    sfuAuditStore,
   } from '$lib/voiceSfu'
+
+  // Audit réseau : rafraîchi manuellement ou en auto (2 s) pendant une session.
+  let autoAudit = $state(false)
+  let auditTimer: ReturnType<typeof setInterval> | null = null
+  function refreshAudit() { if (channelId.trim()) void sfuAudit(channelId.trim()) }
+  $effect(() => {
+    if (auditTimer) { clearInterval(auditTimer); auditTimer = null }
+    if (autoAudit && phase === 'active') {
+      refreshAudit()
+      auditTimer = setInterval(refreshAudit, 2000)
+    }
+  })
+  onDestroy(() => { if (auditTimer) clearInterval(auditTimer) })
+
+  function lossClass(l: number): string {
+    if (l > 0.05) return 'text-red-400'
+    if (l > 0.01) return 'text-amber-400'
+    return 'text-zinc-400'
+  }
+  function iceClass(s: string): string {
+    if (s === 'connected' || s === 'completed') return 'text-emerald-400'
+    if (s === 'disconnected' || s === 'failed' || s === 'closed') return 'text-red-400'
+    return 'text-amber-400'
+  }
 
   // Laboratoire SFU (P1) : prouve le chemin complet device → transports →
   // produce(micro) → consume, en isolation TOTALE du vocal mesh existant.
@@ -124,6 +150,60 @@
           </li>
         {/each}
       </ul>
+    {/if}
+  </div>
+
+  <div class="rounded-xl border border-zinc-800 bg-zinc-900/50 p-5">
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-xs font-bold uppercase tracking-widest text-zinc-500">Audit réseau (IP · ICE · débit · perte)</h2>
+      <div class="flex items-center gap-3">
+        <label class="flex items-center gap-1.5 text-xs text-zinc-400">
+          <input type="checkbox" bind:checked={autoAudit} class="accent-indigo-500" /> auto 2s
+        </label>
+        <button
+          onclick={refreshAudit}
+          disabled={channelId.trim().length < 36}
+          class="rounded-lg bg-zinc-700 px-3 py-1.5 text-xs font-semibold text-white hover:bg-zinc-600 disabled:opacity-40"
+        >
+          Rafraîchir
+        </button>
+      </div>
+    </div>
+    {#if $sfuAuditStore.length === 0}
+      <p class="text-sm text-zinc-600">Aucun transport. Rejoins un salon en mode SFU, puis rafraîchis (les IP apparaissent une fois ICE connecté).</p>
+    {:else}
+      <div class="overflow-x-auto">
+        <table class="w-full text-xs font-mono">
+          <thead class="text-zinc-500">
+            <tr class="text-left">
+              <th class="py-1 pr-3 font-semibold">Participant</th>
+              <th class="py-1 pr-3 font-semibold">Dir</th>
+              <th class="py-1 pr-3 font-semibold">ICE</th>
+              <th class="py-1 pr-3 font-semibold">Local</th>
+              <th class="py-1 pr-3 font-semibold">Distant (pair)</th>
+              <th class="py-1 pr-3 font-semibold">Proto</th>
+              <th class="py-1 pr-3 font-semibold text-right">↓ kbps</th>
+              <th class="py-1 pr-3 font-semibold text-right">↑ kbps</th>
+              <th class="py-1 pr-3 font-semibold text-right">Perte</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each $sfuAuditStore as r (r.participant + r.direction)}
+              <tr class="border-t border-zinc-800/60">
+                <td class="py-1 pr-3 text-zinc-300">{r.participant.slice(0, 8)}</td>
+                <td class="py-1 pr-3 text-zinc-500">{r.direction}</td>
+                <td class="py-1 pr-3 {iceClass(r.iceState)}">{r.iceState}</td>
+                <td class="py-1 pr-3 text-zinc-400">{r.local}</td>
+                <td class="py-1 pr-3 text-indigo-300">{r.remote}</td>
+                <td class="py-1 pr-3 text-zinc-500">{r.proto}</td>
+                <td class="py-1 pr-3 text-right text-zinc-300">{r.recvKbps}</td>
+                <td class="py-1 pr-3 text-right text-zinc-300">{r.sendKbps}</td>
+                <td class="py-1 pr-3 text-right {lossClass(Math.max(r.lossRecv, r.lossSent))}">{(Math.max(r.lossRecv, r.lossSent) * 100).toFixed(1)}%</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
     {/if}
   </div>
 


### PR DESCRIPTION
On **voit les IP pendant le dev**, en direct.

- **relais** : `voice:sfu_audit` (**owner/admin only** — l'audit expose les IP des participants) → `/v1/audit`. Test admin OK / membre forbidden. **23 tests core**
- **client** : `sfuAudit()` aplatit les `WebRtcTransportStat` en lignes lisibles (paire ICE = IP:port locale ↔ **IP:port du pair**, état ICE, ↓/↑ kbps, perte %)
- **labo** : panneau *Audit réseau* — tableau (ICE coloré, distant/pair en évidence, débits, perte colorée) + Rafraîchir + auto 2 s

svelte-check 0 erreur, front 9 tests.