### PR TITLE
fix(sfu): exorcise les fantômes — heartbeat + TTL daemon + réconciliation client

### DIFF
--- a/nodyx-core/src/socket/rateLimiter.ts
+++ b/nodyx-core/src/socket/rateLimiter.ts
@@ -47,6 +47,7 @@ export const RATE_RULES: Record<string, RuleConfig[]> = {
   'voice:sfu_consume':      [{ limit: 40, windowMs: 10_000 }],
   'voice:sfu_publications': [{ limit: 10, windowMs: 10_000 }],
   'voice:sfu_audit':        [{ limit: 20, windowMs: 10_000 }],
+  'voice:sfu_heartbeat':    [{ limit: 6,  windowMs: 10_000 }],
 }
 
 // Clé composite : `${userId}::${eventKey}`

--- a/nodyx-core/src/socket/voiceSfu.ts
+++ b/nodyx-core/src/socket/voiceSfu.ts
@@ -256,6 +256,19 @@ export function registerVoiceSfuHandlers(socket: Socket, server: Server): void {
     cb({ ok: true, publications: res.data.publications ?? [] })
   })
 
+  // ── voice:sfu_heartbeat — garde le participant vivant (anti-fantôme) ────────
+  // Léger et fréquent : pas de requête DB de rôle (le join l'a déjà validé ; le
+  // daemon ne rafraîchit QUE les participants déjà présents). Un heartbeat pour
+  // un salon non rejoint est un no-op côté daemon.
+  socket.on('voice:sfu_heartbeat', async (channelId: unknown, cb: unknown) => {
+    const ack: Ack = isAck(cb) ? cb : () => {}
+    if (!sfuUrl()) { ack({ ok: false, error: 'sfu_disabled' }); return }
+    if (checkRateLimit(userId, 'voice:sfu_heartbeat')) { ack({ ok: false, error: 'rate_limited' }); return }
+    if (!isUuid(channelId)) { ack({ ok: false, error: 'bad_channel' }); return }
+    const res = await sfuFetch('/v1/heartbeat', { room: channelId, participant: userId })
+    ack(res.ok ? { ok: true } : { ok: false, error: res.error })
+  })
+
   // ── voice:sfu_audit — diagnostic réseau du salon (OWNER/ADMIN only) ─────────
   // Expose les IP/ICE/perte des participants : réservé aux admins même si le
   // labo est déjà page-gated. Outil de dev, pas de surveillance persistante.

--- a/nodyx-core/src/tests/voice-sfu.test.ts
+++ b/nodyx-core/src/tests/voice-sfu.test.ts
@@ -244,6 +244,18 @@ describe('flow SFU', () => {
     expect(h.socket.leave).toHaveBeenCalledWith(`voicesfu:${CHANNEL}`)
   })
 
+  it('heartbeat : relaie /v1/heartbeat sans requête DB de rôle', async () => {
+    const h = makeHarness()
+    dbQueryMock.mockClear()
+    fetchMock.mockResolvedValueOnce(daemonJson({ ok: true }))
+    const a = ack()
+    await h.fire('voice:sfu_heartbeat', CHANNEL, a.cb)
+    expect(a.last).toEqual({ ok: true })
+    expect(fetchMock.mock.calls[0][0]).toContain('/v1/heartbeat')
+    // léger : pas de check rôle en base à chaque battement
+    expect(dbQueryMock).not.toHaveBeenCalled()
+  })
+
   it('audit : owner/admin OK, membre refusé', async () => {
     // membre → forbidden, aucun appel daemon
     const member = makeHarness()

--- a/nodyx-frontend/src/lib/voiceSfu.ts
+++ b/nodyx-frontend/src/lib/voiceSfu.ts
@@ -73,6 +73,7 @@ interface Session {
   consumers:     Map<string, import('mediasoup-client').types.Consumer>
   audioEls:      Map<string, HTMLAudioElement>
   offNewProducer: (() => void) | null
+  maintain:      ReturnType<typeof setInterval> | null
 }
 
 let _session: Session | null = null
@@ -184,6 +185,7 @@ export async function sfuJoin(channelId: string): Promise<void> {
       channelId, device, sendTransport, recvTransport,
       micTrack: null, producer: null,
       consumers: new Map(), audioEls: new Map(), offNewProducer: null,
+      maintain: null,
     }
 
     // Micro (le clic "Rejoindre" du labo = geste utilisateur → autoplay OK).
@@ -213,6 +215,16 @@ export async function sfuJoin(channelId: string): Promise<void> {
     }
     sock.on('voice:sfu_new_producer', onNewProducer)
     _session.offNewProducer = () => { sock.off('voice:sfu_new_producer', onNewProducer) }
+
+    // Maintenance périodique (5 s) : heartbeat (anti-éviction) + réconciliation
+    // des flux (ferme les consumers dont le producer a disparu = fantômes ;
+    // rattrape aussi une annonce new_producer manquée). Auto-guérison.
+    _session.maintain = setInterval(() => {
+      const sk = get(socketStore)
+      if (!sk || !_session) return
+      void emitAck(sk, 'voice:sfu_heartbeat', _session.channelId)
+      void reconcile(sk)
+    }, 5000)
 
     sfuPhaseStore.set('active')
     log('══ SESSION SFU ACTIVE ══')
@@ -286,6 +298,35 @@ export async function sfuAudit(channelId: string): Promise<void> {
   log(`audit : ${rows.length} transport(s)`)
 }
 
+/** Réconcilie les consumers locaux avec les publications réelles du salon :
+ *  ferme ceux dont le producer a disparu (fantôme), consomme les nouveaux. */
+async function reconcile(sock: Socket): Promise<void> {
+  const s = _session
+  if (!s) return
+  const pubs = await emitAck(sock, 'voice:sfu_publications', s.channelId)
+  if (!pubs.ok || !Array.isArray(pubs.publications)) return
+  const list = pubs.publications as { producer: string; owner: string; kind: string }[]
+  const live = new Set(list.map(p => p.producer))
+  // fermer les fantômes (producer disparu des publications)
+  for (const [producerId, consumer] of [...s.consumers]) {
+    if (!live.has(producerId)) {
+      try { consumer.close() } catch { /* déjà fermé */ }
+      s.consumers.delete(producerId)
+      const el = s.audioEls.get(producerId)
+      if (el) { try { el.pause(); el.srcObject = null } catch { /* mort */ } s.audioEls.delete(producerId) }
+      sfuConsumersStore.update(l => l.filter(c => c.producerId !== producerId))
+      log(`flux ${producerId.slice(0, 8)}… disparu → consumer fermé`)
+    }
+  }
+  // consommer les nouveaux (rattrapage d'une annonce manquée)
+  for (const pub of list) {
+    if (s.producer && pub.producer === s.producer.id) continue
+    if (!s.consumers.has(pub.producer) && !_consuming.has(pub.producer)) {
+      await consumeOne(sock, pub.producer, pub.owner, pub.kind)
+    }
+  }
+}
+
 export function sfuSetMuted(muted: boolean): void {
   if (_session?.micTrack) {
     _session.micTrack.enabled = !muted
@@ -324,6 +365,7 @@ function cleanup(): void {
   const s = _session
   _session = null
   if (!s) return
+  if (s.maintain) { clearInterval(s.maintain); s.maintain = null }
   try { s.offNewProducer?.() } catch { /* déjà off */ }
   for (const el of s.audioEls.values()) {
     try { el.pause(); el.srcObject = null } catch { /* déjà mort */ }

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/bin/nodyx-sfud.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/bin/nodyx-sfud.rs
@@ -20,6 +20,8 @@
 //!   SFU_LISTEN_IP      IP d'écoute média WebRTC   (défaut 127.0.0.1)
 //!   SFU_ANNOUNCED_IP   adresse annoncée aux clients (IP publique du VPS)
 //!   SFU_MESH_THRESHOLD seuil mesh→SFU (défaut 4) · SFU_MAX_SEATS (défaut 25)
+//!   SFU_PARTICIPANT_TTL secs avant éviction d'un participant sans heartbeat
+//!                      (défaut 30 ; le client bat toutes les ~10 s)
 //!   (route /v1/audit : audit réseau d'un salon — IP:port réelles, état ICE,
 //!    bitrate/perte par transport ; outil de diagnostic dev)
 //!   SFU_RTC_MIN_PORT / SFU_RTC_MAX_PORT
@@ -58,6 +60,13 @@ fn token_eq(a: &[u8], b: &[u8]) -> bool {
         diff |= x ^ y;
     }
     diff == 0
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 fn mode_str(m: Mode) -> &'static str {
@@ -111,12 +120,31 @@ async fn route(app: &App, path: &str, body: &serde_json::Value) -> (u16, serde_j
             let (Some(r), Some(p)) = (room(), participant()) else {
                 return err_json(400, "room et participant requis");
             };
-            match app.svc.join(r, p).await {
+            let r2 = r.clone();
+            let p2 = p.clone();
+            let res = app.svc.join(r, p).await;
+            if res.is_ok() {
+                // Marque vivant dès l'arrivée (sinon la tâche d'éviction pourrait
+                // le cueillir avant le premier heartbeat client).
+                app.svc.touch(&r2, &p2, now_secs());
+            }
+            match res {
                 Ok(out) => ok_json(serde_json::json!({
                     "mode": mode_str(out.mode),
                     "migrated": out.migrated.iter().map(|p| p.0.clone()).collect::<Vec<_>>(),
                 })),
                 Err(e) => err_json(409, e.to_string()),
+            }
+        }
+
+        "/v1/heartbeat" => {
+            let (Some(r), Some(p)) = (room(), participant()) else {
+                return err_json(400, "room et participant requis");
+            };
+            if app.svc.touch(&r, &p, now_secs()) {
+                ok_json(serde_json::json!({}))
+            } else {
+                err_json(409, "absent du salon")
             }
         }
 
@@ -393,6 +421,7 @@ async fn main() {
     let announced = std::env::var("SFU_ANNOUNCED_IP").ok();
     let threshold: usize = std::env::var("SFU_MESH_THRESHOLD").ok().and_then(|v| v.parse().ok()).unwrap_or(4);
     let seats: usize = std::env::var("SFU_MAX_SEATS").ok().and_then(|v| v.parse().ok()).unwrap_or(25);
+    let ttl: u64 = std::env::var("SFU_PARTICIPANT_TTL").ok().and_then(|v| v.parse().ok()).unwrap_or(30);
     let rtc_min: u16 = std::env::var("SFU_RTC_MIN_PORT").ok().and_then(|v| v.parse().ok()).unwrap_or(40000);
     let rtc_max: u16 = std::env::var("SFU_RTC_MAX_PORT").ok().and_then(|v| v.parse().ok()).unwrap_or(40999);
     if rtc_min > rtc_max {
@@ -406,9 +435,28 @@ async fn main() {
     let svc = VoiceService::new(engine, VoiceConfig { max_seats: seats, mesh_threshold: threshold });
     let app = Arc::new(App { svc, token });
 
+    // Tâche d'éviction : purge les participants sans heartbeat depuis > TTL
+    // (déconnexion sale : VPN qui saute, onglet fermé, core redémarré).
+    // C'est l'exorciste des fantômes (leur producer disparaît des publications,
+    // le client réconcilie et ferme son consumer mort).
+    {
+        let app = Arc::clone(&app);
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(Duration::from_secs(5));
+            loop {
+                tick.tick().await;
+                let cutoff = now_secs().saturating_sub(ttl);
+                for (room, participant) in app.svc.stale(cutoff) {
+                    let _ = app.svc.leave(room.clone(), participant.clone()).await;
+                    eprintln!("nodyx-sfud: évincé {} de {} (heartbeat expiré)", participant.0, room.0);
+                }
+            }
+        });
+    }
+
     let listener = TcpListener::bind(&http_addr).await.expect("bind API interne");
     println!(
-        "nodyx-sfud — API interne http://{http_addr} | média listen={listen_ip} announced={} | RTC udp {rtc_min}-{rtc_max} | seuil mesh→SFU={threshold} sièges={seats}",
+        "nodyx-sfud — API interne http://{http_addr} | média listen={listen_ip} announced={} | RTC udp {rtc_min}-{rtc_max} | seuil mesh→SFU={threshold} sièges={seats} | TTL {ttl}s",
         announced.as_deref().unwrap_or("(aucune)")
     );
 

--- a/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
+++ b/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
@@ -164,7 +164,6 @@ pub struct PublicationInfo {
 
 // ── État interne ────────────────────────────────────────────────────────────
 
-#[derive(Default)]
 struct Participant {
     /// Transport d'ÉMISSION (publish) — absent tant qu'on est en mesh.
     send_transport: Option<TransportHandle>,
@@ -172,6 +171,20 @@ struct Participant {
     recv_transport: Option<TransportHandle>,
     /// Ce que ce participant consomme : publication → consumer.
     subscriptions: HashMap<ProducerId, ConsumerId>,
+    /// Dernier heartbeat (secs). u64::MAX = frais (jamais vu) → jamais évincé
+    /// tant que l'appelant n'a pas `touch()`é au moins une fois.
+    last_seen: u64,
+}
+
+impl Default for Participant {
+    fn default() -> Self {
+        Self {
+            send_transport: None,
+            recv_transport: None,
+            subscriptions: HashMap::new(),
+            last_seen: u64::MAX,
+        }
+    }
 }
 
 impl Participant {
@@ -236,6 +249,33 @@ impl<E: MediaEngine> VoiceService<E> {
     /// Nombre de participants d'un salon.
     pub fn participant_count(&self, room: &RoomId) -> usize {
         self.rooms().get(room).map_or(0, |s| s.participants.len())
+    }
+
+    /// Rafraîchit le heartbeat d'un participant (secs). Retourne false s'il est
+    /// absent. Le clock est INJECTÉ (le métier reste sans horloge) : c'est le
+    /// daemon qui fournit `now`, appelé au join et à chaque heartbeat client.
+    pub fn touch(&self, room: &RoomId, participant: &ParticipantId, now_secs: u64) -> bool {
+        let mut rooms = self.rooms();
+        match rooms.get_mut(room).and_then(|s| s.participants.get_mut(participant)) {
+            Some(p) => { p.last_seen = now_secs; true }
+            None => false,
+        }
+    }
+
+    /// Participants dont le dernier heartbeat est antérieur à `cutoff_secs`
+    /// (= à évincer). Les frais (jamais `touch`és, last_seen = MAX) ne sont
+    /// jamais renvoyés. Pur/sync : le daemon appelle ensuite `leave` sur chacun.
+    pub fn stale(&self, cutoff_secs: u64) -> Vec<(RoomId, ParticipantId)> {
+        let rooms = self.rooms();
+        let mut out = Vec::new();
+        for (room, state) in rooms.iter() {
+            for (pid, p) in &state.participants {
+                if p.last_seen < cutoff_secs {
+                    out.push((room.clone(), pid.clone()));
+                }
+            }
+        }
+        out
     }
 
     /// Publications en cours dans un salon (pour `voice:publications`).
@@ -917,6 +957,28 @@ mod tests {
         assert_eq!(recvs, 5);
         // le blob du moteur transite tel quel (NullEngine renvoie un stub identifiable)
         assert!(audit[0].stats.0.contains("transport"));
+    }
+
+    #[test]
+    fn heartbeat_and_stale_eviction() {
+        let s = svc();
+        block_on(s.join(room(), p(1))).unwrap();
+        block_on(s.join(room(), p(2))).unwrap();
+        // frais (jamais touché) → jamais stale, même avec un grand cutoff
+        assert!(s.stale(1_000_000).is_empty());
+        // touch : p1 à t=100, p2 à t=500
+        assert!(s.touch(&room(), &p(1), 100));
+        assert!(s.touch(&room(), &p(2), 500));
+        // cutoff 300 : p1 (100<300) évincible, p2 (500) non
+        let stale = s.stale(300);
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].0, room());
+        assert_eq!(stale[0].1, p(1));
+        // touch d'un inconnu → false
+        assert!(!s.touch(&room(), &p(9), 100));
+        // évincer p1 via leave : il disparaît du stale
+        block_on(s.leave(room(), p(1))).unwrap();
+        assert!(s.stale(300).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Bug surgi **au labo** (expérience VPN de Jonathan, vu dans le panneau d'audit qu'on venait de livrer) : une déconnexion sale laisse un producer orphelin, le client garde son consumer mort → **double flux du même user**. Fix respectueux de l'archi (core→daemon uniquement) :

- **nodyx-sfu** (CI) : `last_seen` (Default MAX = frais), `touch(now)` (clock injecté) + `stale(cutoff)`. **28 tests**
- **daemon** : `/v1/heartbeat`, touch au join, tâche d'éviction 5 s (leave si pas de heartbeat depuis > `SFU_PARTICIPANT_TTL`, défaut 30 s). Vérifié au curl : évincé après 9 s sans heartbeat, gardé vivant avec
- **relais** : `voice:sfu_heartbeat` (léger, sans requête DB de rôle). **24 tests core**
- **client** : maintenance 5 s = heartbeat + `reconcile()` (ferme les consumers fantômes, consomme les nouveaux). **Auto-guérison**

Rust 28 + clippy · core 24 · front 9 · svelte-check 0 erreur.