### PR TITLE
feat(benchmark): site 4 pages du banc d'essai vocal

### DIFF
--- a/nodyx-frontend/static/benchmark/bench.js
+++ b/nodyx-frontend/static/benchmark/bench.js
@@ -1,0 +1,174 @@
+/* Nodyx · Benchmark — moteur partagé (graphes, reveal au scroll, thème, nav) */
+(() => {
+  "use strict";
+  const REDUCED = matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const NS = "http://www.w3.org/2000/svg";
+  const css = v => getComputedStyle(document.documentElement).getPropertyValue(v).trim();
+  const el = (t, a = {}) => { const e = document.createElementNS(NS, t); for (const k in a) e.setAttribute(k, a[k]); return e; };
+
+  // ── Navigation (source unique) ─────────────────────────────
+  const PAGES = [
+    { id: "pire-cas",        href: "pire-cas.html",        label: "Le pire cas" },
+    { id: "diffusion-audio", href: "diffusion-audio.html", label: "Diffusion audio" },
+    { id: "partage-ecran",   href: "partage-ecran.html",   label: "Partage d'écran" },
+    { id: "technique",       href: "technique.html",       label: "Technique", tech: true },
+  ];
+  function buildNav(current) {
+    const mount = document.getElementById("nav-mount");
+    if (!mount) return;
+    const links = PAGES.map(p => {
+      const cur = p.id === current ? ' aria-current="page"' : "";
+      const cls = p.tech ? ' class="tech-link"' : "";
+      return `<li${p.tech ? ' class="tech"' : ""}><a href="${p.href}"${cur}${cls}>${p.label}</a></li>`;
+    }).join("");
+    mount.className = "nav";
+    mount.innerHTML =
+      `<div class="nav-in">
+        <a class="brand" href="pire-cas.html"><span class="dot"></span> Nodyx · Benchmark</a>
+        <ul>${links}</ul>
+        <button class="theme-btn" id="theme" type="button" aria-label="Thème clair/sombre"><span id="theme-ico">◐</span></button>
+      </div>`;
+    initTheme();
+  }
+
+  // ── Thème ──────────────────────────────────────────────────
+  function initTheme() {
+    const root = document.documentElement, ico = document.getElementById("theme-ico"), btn = document.getElementById("theme");
+    if (!btn) return;
+    try { const s = localStorage.getItem("nodyx-bench-theme"); if (s) root.setAttribute("data-theme", s); } catch (e) {}
+    const sync = () => { const t = root.getAttribute("data-theme"); if (ico) ico.textContent = t === "dark" ? "●" : t === "light" ? "○" : "◐"; };
+    sync();
+    btn.addEventListener("click", () => {
+      const cur = root.getAttribute("data-theme");
+      const next = cur === "dark" ? "light" : cur === "light" ? "dark" : (matchMedia("(prefers-color-scheme: dark)").matches ? "light" : "dark");
+      root.setAttribute("data-theme", next);
+      try { localStorage.setItem("nodyx-bench-theme", next); } catch (e) {}
+      sync();
+      redrawAll();
+    });
+  }
+
+  // ── Reveal au scroll (une fois) ────────────────────────────
+  function onView(node, fn) {
+    if (!("IntersectionObserver" in window)) { fn(); return; }
+    const io = new IntersectionObserver((ents) => {
+      ents.forEach(e => { if (e.isIntersecting) { io.disconnect(); fn(); } });
+    }, { threshold: 0.25, rootMargin: "0px 0px -8% 0px" });
+    io.observe(node);
+  }
+
+  // ── Compteurs (chiffres qui montent, au scroll) ────────────
+  function animateCount(s) {
+    if (s.dataset.done) return; s.dataset.done = "1";
+    const to = parseFloat(s.dataset.count), dec = +(s.dataset.dec || 0);
+    const fmt = v => v.toFixed(dec).replace(".", ",");
+    if (REDUCED) { s.textContent = fmt(to); return; }
+    const t0 = performance.now(), dur = 1300;
+    const step = t => { const p = Math.min((t - t0) / dur, 1), e = 1 - Math.pow(1 - p, 3); s.textContent = fmt(to * e); if (p < 1) requestAnimationFrame(step); };
+    requestAnimationFrame(step);
+  }
+  function counters(scope) { (scope || document).querySelectorAll("[data-count]").forEach(animateCount); }
+  function autoCounters() { document.querySelectorAll("[data-count]").forEach(s => onView(s, () => animateCount(s))); }
+
+  // ── Barres comparatives (data-bar = largeur %) ─────────────
+  function autoBars() {
+    document.querySelectorAll("[data-bar]").forEach(f => {
+      f.style.width = "0%";
+      onView(f, () => {
+        if (REDUCED) { f.style.width = f.dataset.bar + "%"; return; }
+        f.style.transition = "width 1.5s cubic-bezier(.22,.61,.36,1)";
+        requestAnimationFrame(() => requestAnimationFrame(() => { f.style.width = f.dataset.bar + "%"; }));
+      });
+    });
+  }
+
+  // ── Graphe (aire + ligne, reveal géométrique, hover) ───────
+  const tip = (() => { let t = document.querySelector(".tip"); if (!t) { t = document.createElement("div"); t.className = "tip"; document.body.appendChild(t); } return t; })();
+  const registry = [];
+
+  function chart(svg, opts) {
+    const spec = { svg, opts };
+    registry.push(spec);
+    build(spec);
+    // Démarre vide (hors écran), s'anime en entrant dans la vue.
+    if (!REDUCED) spec.reveal(0);
+    onView(svg, () => play(spec));
+    return { play: () => play(spec) };
+  }
+
+  function play(spec) {
+    if (REDUCED) { spec.reveal(1); return; }
+    const dur = 1500, t0 = performance.now();
+    const step = t => { const p = Math.min((t - t0) / dur, 1), e = 1 - Math.pow(1 - p, 3); spec.reveal(e); if (p < 1) requestAnimationFrame(step); };
+    requestAnimationFrame(step);
+  }
+
+  function build(spec) {
+    const { svg, opts } = spec;
+    const W = +svg.viewBox.baseVal.width, H = +svg.viewBox.baseVal.height;
+    const m = opts.margin || { t: 24, r: 20, b: 34, l: 48 };
+    const rows = opts.rows, xkey = opts.xkey || (d => d.x);
+    const pw = W - m.l - m.r, ph = H - m.t - m.b, N = rows.length, baseY = m.t + ph;
+    const x = i => m.l + (N === 1 ? pw / 2 : (i / (N - 1)) * pw);
+    const y = v => m.t + ph - (v / opts.max) * ph;
+    while (svg.firstChild) svg.removeChild(svg.firstChild);
+    if (opts.ruptureFrom != null) { const xi = x(opts.ruptureFrom); svg.appendChild(el("rect", { x: xi, y: m.t, width: m.l + pw - xi, height: ph, class: "rupture-band" })); }
+    (opts.yticks || []).forEach(t => {
+      const yy = y(t);
+      svg.appendChild(el("line", { x1: m.l, y1: yy, x2: m.l + pw, y2: yy, class: "grid-line" }));
+      const lb = el("text", { x: m.l - 8, y: yy + 4, class: "axis-txt", "text-anchor": "end" }); lb.textContent = opts.yfmt ? opts.yfmt(t) : t; svg.appendChild(lb);
+    });
+    if (opts.ref != null) {
+      const yy = y(opts.ref);
+      svg.appendChild(el("line", { x1: m.l, y1: yy, x2: m.l + pw, y2: yy, class: "refline" }));
+      const rt = el("text", { x: m.l + pw, y: yy - 7, class: "axis-txt", "text-anchor": "end", fill: css("--ink-2") }); rt.textContent = opts.refLabel || ""; svg.appendChild(rt);
+    }
+    rows.forEach((d, i) => { if (opts.xevery && !opts.xevery.includes(xkey(d))) return; const t = el("text", { x: x(i), y: H - 12, class: "axis-txt", "text-anchor": "middle" }); t.textContent = xkey(d); svg.appendChild(t); });
+    const pts = rows.map((d, i) => [x(i), y(opts.val(d))]);
+    const linePath = a => { let s = `M ${a[0][0]} ${a[0][1]} `; for (let i = 1; i < a.length; i++) s += `L ${a[i][0]} ${a[i][1]} `; return s; };
+    const areaPath = a => { let s = `M ${a[0][0]} ${baseY} `; a.forEach(p => s += `L ${p[0]} ${p[1]} `); s += `L ${a[a.length - 1][0]} ${baseY} Z`; return s; };
+    const area = el("path", { d: areaPath(pts), fill: opts.areaFill }); svg.appendChild(area);
+    const line = el("path", { d: linePath(pts), class: "series-line", stroke: opts.stroke }); svg.appendChild(line);
+    const last = pts[pts.length - 1];
+    const endpoint = el("circle", { cx: last[0], cy: last[1], r: 4.5, fill: opts.stroke, class: "endpoint" }); svg.appendChild(endpoint);
+    const labelObjs = [];
+    (opts.labels || []).forEach(L => {
+      const i = rows.findIndex(d => xkey(d) === L.at); if (i < 0) return;
+      const px = x(i), py = y(opts.val(rows[i])), g = el("g", { style: "transition:opacity .35s" });
+      const tw = L.text.length * 7.6 + 12, lx = Math.min(Math.max(px + L.dx, m.l + tw / 2), m.l + pw - tw / 2 - 2);
+      g.appendChild(el("rect", { x: lx - tw / 2, y: py + L.dy - 12, width: tw, height: 18, rx: 5, class: "dlabel-bg" }));
+      const tx = el("text", { x: lx, y: py + L.dy + 1, class: "dlabel", "text-anchor": "middle", fill: L.color || opts.stroke }); tx.textContent = L.text; g.appendChild(tx); svg.appendChild(g);
+      labelObjs.push({ g, px });
+    });
+    spec.reveal = e => {
+      const xMax = m.l + e * pw, inc = [];
+      for (let i = 0; i < pts.length; i++) { if (pts[i][0] <= xMax) inc.push(pts[i]); else { if (i > 0) { const a = pts[i - 1], b = pts[i], tt = (xMax - a[0]) / (b[0] - a[0]); inc.push([xMax, a[1] + (b[1] - a[1]) * tt]); } break; } }
+      if (!inc.length) inc.push([pts[0][0], pts[0][1]]);
+      line.setAttribute("d", linePath(inc)); area.setAttribute("d", areaPath(inc));
+      const tp = inc[inc.length - 1]; endpoint.setAttribute("cx", tp[0]); endpoint.setAttribute("cy", tp[1]);
+      labelObjs.forEach(o => o.g.style.opacity = xMax >= o.px ? 1 : 0);
+    };
+    // hover
+    const cross = el("line", { class: "crosshair", y1: m.t, y2: m.t + ph }); svg.appendChild(cross);
+    const hoverDot = el("circle", { r: 5, fill: opts.stroke, class: "endpoint", opacity: 0 }); svg.appendChild(hoverDot);
+    const overlay = el("rect", { x: m.l, y: m.t, width: pw, height: ph, fill: "transparent", style: "cursor:crosshair" }); svg.appendChild(overlay);
+    const move = ev => {
+      const r = svg.getBoundingClientRect(), sx = (ev.clientX - r.left) / r.width * W;
+      let best = 0, bd = 1e9; pts.forEach((p, i) => { const dd = Math.abs(p[0] - sx); if (dd < bd) { bd = dd; best = i; } });
+      const p = pts[best], d = rows[best];
+      cross.setAttribute("x1", p[0]); cross.setAttribute("x2", p[0]); cross.setAttribute("opacity", 1);
+      hoverDot.setAttribute("cx", p[0]); hoverDot.setAttribute("cy", p[1]); hoverDot.setAttribute("opacity", 1);
+      tip.innerHTML = `<div class="tn">${opts.tipTitle(d)}</div><div class="tv">${opts.tipVal(d)}</div><div class="ts">${opts.tipSub(d)}</div>`;
+      tip.style.opacity = 1; tip.style.left = Math.min(ev.clientX + 14, innerWidth - tip.offsetWidth - 8) + "px"; tip.style.top = (ev.clientY - tip.offsetHeight - 10) + "px";
+    };
+    overlay.addEventListener("pointermove", move);
+    overlay.addEventListener("pointerleave", () => { cross.setAttribute("opacity", 0); hoverDot.setAttribute("opacity", 0); tip.style.opacity = 0; });
+  }
+
+  function redrawAll() { registry.forEach(spec => { build(spec); spec.reveal(1); }); }
+
+  window.Bench = {
+    boot(page) { buildNav(page); autoCounters(); autoBars(); },
+    chart, counters, onView, css,
+  };
+})();

--- a/nodyx-frontend/static/benchmark/diffusion-audio.html
+++ b/nodyx-frontend/static/benchmark/diffusion-audio.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Diffusion audio — Nodyx · Banc d'essai vocal</title>
+<meta name="description" content="Une personne parle, tout le monde écoute : un seul cœur diffuse à ~8000 personnes, son parfait. Le cas réel. Mesures réelles, auto-hébergé.">
+<meta name="color-scheme" content="light dark">
+<meta property="og:title" content="Diffusion audio : ~8000 personnes écoutent, sur un seul cœur">
+<meta property="og:description" content="Le cas réel du vocal Nodyx : une personne parle, des milliers écoutent. Mesuré sans filtre.">
+<link rel="stylesheet" href="style.css?v=2">
+</head>
+<body data-page="diffusion-audio">
+<div id="nav-mount"></div>
+<div class="wrap">
+
+  <header class="hero">
+    <div class="tapehead">
+      <span class="live">Banc d'essai vocal</span>
+      <span><b>Scénario 02 / 03</b> — le cas réel</span>
+      <span>Forme · <b>1 parle, N écoutent</b></span>
+      <span>Flux · <b>audio</b> (~32 kbit/s)</span>
+    </div>
+    <h1>Une personne parle, des milliers écoutent.</h1>
+    <p class="lede">Le cas le plus courant : une conférence, une annonce, un town-hall. Une voix, beaucoup
+      d'oreilles. Là, le serveur n'a qu'à relayer un flux : la capacité change complètement d'échelle.</p>
+
+    <div class="readout">
+      <div class="ro"><span class="ro-v sig">~<span data-count="8000">0</span></span><span class="ro-k">personnes écoutent · par cœur</span></div>
+      <div class="ro"><span class="ro-v"><span data-count="100">0</span><span class="u">%</span></span><span class="ro-k">son parfait · jusqu'à 8000</span></div>
+      <div class="ro"><span class="ro-v">&lt; <span data-count="1">0</span></span><span class="ro-k">cœur utilisé · pour 8000 personnes</span></div>
+    </div>
+
+    <nav class="scene-nav" aria-label="Scénarios">
+      <a href="pire-cas.html">01 · Le pire cas</a>
+      <a href="diffusion-audio.html" aria-current="page">02 · Diffusion audio</a>
+      <a href="partage-ecran.html">03 · Partage d'écran</a>
+    </nav>
+  </header>
+
+  <div class="callout">
+    <span class="cl-badge">80× le pire cas</span>
+    <p>Quand tout le monde parle en même temps (scénario 01), un cœur tient ~100 personnes. Quand
+      <b>une seule parle</b> et que les autres écoutent, ce même cœur en tient <b>~8000</b> : le serveur ne
+      relaie plus qu'un flux au lieu de tous les croiser. C'est ça, la vraie vie d'un salon d'écoute.</p>
+  </div>
+
+  <section>
+    <div class="sec-head">
+      <span class="sec-n">Mesure 01 · un cœur</span>
+      <h2>Un cœur, jusqu'à ~8000 auditeurs</h2>
+      <p>On empile les auditeurs sur une seule diffusion. Le cœur reste tranquille très longtemps : il ne
+        sature que vers 9000. En dessous, aucun mot perdu.</p>
+    </div>
+    <figure>
+      <div class="fig-title"><span class="swatch"></span> Charge d'un cœur selon le nombre d'auditeurs</div>
+      <svg class="chart" id="c-audio" viewBox="0 0 900 320" role="img" aria-label="Charge d'un cœur : 0,03 pour 250 auditeurs, 0,16 pour 1000, 0,57 pour 5000, 0,92 pour 8000 (son parfait), puis saturation vers 10000 (son à 86 %)."></svg>
+    </figure>
+  </section>
+
+  <section>
+    <div class="sec-head">
+      <span class="sec-n">Mesure 02 · la qualité</span>
+      <h2>La qualité ne change pas la capacité</h2>
+      <p>Surprise : que le son soit économe ou studio, un cœur tient toujours ~8000 auditeurs. La cadence
+        des paquets est la même ; seule la bande passante par auditeur monte. Discord tourne à ~64 kbps.</p>
+    </div>
+    <div class="table-scroll">
+      <table class="data">
+        <thead><tr><th>Qualité</th><th>Débit / auditeur</th><th>Auditeurs / cœur</th><th>Bande passante à 8000</th></tr></thead>
+        <tbody>
+          <tr><td>Économe</td><td>32 kbps</td><td>~8 000</td><td>256 Mbit/s</td></tr>
+          <tr><td>Standard <span class="tag ok">≈ Discord</span></td><td>64 kbps</td><td>~8 000</td><td>512 Mbit/s</td></tr>
+          <tr><td>Haute</td><td>96 kbps</td><td>~8 000</td><td>768 Mbit/s</td></tr>
+          <tr><td>Studio</td><td>128 kbps</td><td>~8 000</td><td>~1 Gbit/s</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="sec-head" style="margin-top:16px;color:var(--ink-3);font-family:var(--mono);font-size:.8rem;">
+      Mesuré : à 8000 auditeurs, le son reste parfait de 32 à 128 kbps. En studio (128 kbps), 8000 auditeurs
+      représentent ~1 Gbit/s : c'est là que la connexion du serveur commence à compter.</p>
+  </section>
+
+  <section>
+    <div class="sec-head">
+      <span class="sec-n">03 · en clair</span>
+      <h2>Concrètement</h2>
+      <p>Ce que ça veut dire pour une annonce ou une conférence.</p>
+    </div>
+    <div class="grid2">
+      <div class="card">
+        <h3>Une voix, beaucoup d'oreilles</h3>
+        <p>Conférence, town-hall, annonce à la communauté : une personne parle, des milliers suivent en
+          direct, sur ton propre serveur. Un seul cœur suffit largement.</p>
+      </div>
+      <div class="card">
+        <h3>Et le réseau, à très grande échelle ?</h3>
+        <p>L'audio est léger (~32 kbit/s par auditeur). À l'échelle de dizaines de milliers, c'est alors
+          ta connexion internet qui borne le total, pas le processeur. Le détail est sur la page technique.</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head"><h2>La suite</h2></div>
+    <div class="next">
+      <a href="partage-ecran.html">
+        <div class="nx-k">Scénario 03 / 03</div>
+        <div class="nx-t">Partage d'écran : là, c'est le réseau qui décide <span class="arr">→</span></div>
+      </a>
+      <a href="technique.html">
+        <div class="nx-k">Pour les techniciens</div>
+        <div class="nx-t">Chiffres bruts, méthode, par machine <span class="arr">→</span></div>
+      </a>
+    </div>
+  </section>
+
+</div>
+<footer class="site"><div class="wrap">Mesures réelles issues de <a href="https://github.com/Pokled/nodyx">sfu-bench</a> · <a href="https://nodyx.org">Nodyx</a>, vocal souverain auto-hébergé · AGPL-3.0 · <a href="technique.html">reproduire →</a></div></footer>
+
+<script src="bench.js?v=2"></script>
+<script>
+  const AUDIO = [
+    { spec: 250,   cpu: 0.03, health: 100 },
+    { spec: 500,   cpu: 0.07, health: 100 },
+    { spec: 1000,  cpu: 0.16, health: 100 },
+    { spec: 2000,  cpu: 0.30, health: 100 },
+    { spec: 5000,  cpu: 0.57, health: 100 },
+    { spec: 8000,  cpu: 0.92, health: 100 },
+    { spec: 10000, cpu: 1.01, health: 85.8 },
+  ];
+  Bench.chart(document.getElementById("c-audio"), {
+    rows: AUDIO, xkey: d => d.spec, val: d => d.cpu,
+    max: 1.15, ref: 1.0, refLabel: "limite d'un cœur", ruptureFrom: 6,
+    yticks: [0, 0.5, 1.0], yfmt: t => t.toFixed(1),
+    xevery: [250, 1000, 2000, 5000, 8000, 10000],
+    stroke: Bench.css("--signal"), areaFill: Bench.css("--signal-soft"),
+    labels: [
+      { at: 8000, text: "8000 · son parfait", dx: -30, dy: 22, color: Bench.css("--signal") },
+      { at: 10000, text: "ça sature", dx: -20, dy: -12, color: Bench.css("--danger") },
+    ],
+    tipTitle: d => d.spec.toLocaleString("fr") + " auditeurs",
+    tipVal: d => d.cpu.toFixed(2).replace(".", ",") + " cœur",
+    tipSub: d => (d.health % 1 ? d.health.toFixed(1).replace(".", ",") : d.health) + " % du son",
+  });
+  Bench.boot("diffusion-audio");
+</script>
+</body>
+</html>

--- a/nodyx-frontend/static/benchmark/index.html
+++ b/nodyx-frontend/static/benchmark/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="0; url=pire-cas.html">
+<link rel="canonical" href="pire-cas.html">
+<title>Nodyx · Banc d'essai vocal</title>
+</head>
+<body>
+<p><a href="pire-cas.html">Banc d'essai vocal Nodyx →</a></p>
+</body>
+</html>

--- a/nodyx-frontend/static/benchmark/partage-ecran.html
+++ b/nodyx-frontend/static/benchmark/partage-ecran.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Partage d'écran — Nodyx · Banc d'essai vocal</title>
+<meta name="description" content="Une personne partage son écran, les autres regardent. Le processeur tient des milliers ; c'est la connexion du serveur qui décide. Capacité par résolution (480p à 4K). Mesures réelles.">
+<meta name="color-scheme" content="light dark">
+<meta property="og:title" content="Partage d'écran : c'est le réseau qui décide, par résolution">
+<meta property="og:description" content="Capacité vidéo du moteur Nodyx, mesurée, du 480p au 4K. Le CPU tient des milliers ; la limite, c'est le débit.">
+<link rel="stylesheet" href="style.css?v=2">
+</head>
+<body data-page="partage-ecran">
+<div id="nav-mount"></div>
+<div class="wrap">
+
+  <header class="hero">
+    <div class="tapehead">
+      <span class="live">Banc d'essai vocal</span>
+      <span><b>Scénario 03 / 03</b> — la vidéo</span>
+      <span>Forme · <b>1 partage, N regardent</b></span>
+      <span>Flux · <b>vidéo</b> (480p → 4K)</span>
+    </div>
+    <h1>Une personne partage, les autres regardent.</h1>
+    <p class="lede">Le partage d'écran, c'est de la vidéo : bien plus lourd que la voix. Et là, une surprise
+      utile : ce n'est pas le processeur qui limite, c'est la <b>connexion internet</b> du serveur. Donc
+      tout dépend de la <b>résolution</b>.</p>
+
+    <div class="readout">
+      <div class="ro"><span class="ro-v sig">~<span data-count="400">0</span></span><span class="ro-k">spectateurs en 720p · serveur 1 Gbit/s</span></div>
+      <div class="ro"><span class="ro-v">~<span data-count="220">0</span></span><span class="ro-k">spectateurs en 1080p · serveur 1 Gbit/s</span></div>
+      <div class="ro"><span class="ro-v">× <span data-count="10">0</span></span><span class="ro-k">sur un serveur à 10 Gbit/s</span></div>
+    </div>
+
+    <nav class="scene-nav" aria-label="Scénarios">
+      <a href="pire-cas.html">01 · Le pire cas</a>
+      <a href="diffusion-audio.html">02 · Diffusion audio</a>
+      <a href="partage-ecran.html" aria-current="page">03 · Partage d'écran</a>
+    </nav>
+  </header>
+
+  <div class="callout warn">
+    <span class="cl-badge">Le réseau décide</span>
+    <p>En vidéo, le processeur forwarde à des milliers de spectateurs sans transpirer. Le vrai frein, c'est
+      le <b>débit</b> : chaque spectateur reçoit le flux en entier. Plus la résolution est haute, plus le
+      flux est gros, moins il y a de place. À qualité <b>720p</b> (celle de Discord par défaut), une
+      connexion à 1 Gbit/s porte ~400 spectateurs ; à 10 Gbit/s, ~4000. <b>Gros watch-party ? Le tuyau
+      compte plus que les cœurs.</b></p>
+  </div>
+
+  <section>
+    <div class="sec-head">
+      <span class="sec-n">Mesure 01 · le processeur</span>
+      <h2>Le CPU tient, largement</h2>
+      <p>Côté calcul, un seul cœur relaie la vidéo à des milliers de personnes sans forcer (mesuré jusqu'en
+        1080p). Le processeur n'est pas le mur.</p>
+    </div>
+    <figure>
+      <div class="fig-title"><span class="swatch"></span> Charge d'un cœur en 720p (~2,5 Mbit/s), selon le nombre de spectateurs</div>
+      <svg class="chart" id="c-video" viewBox="0 0 900 300" role="img" aria-label="Charge d'un cœur en vidéo 720p : 0,11 pour 200 spectateurs, 0,22 pour 400, 0,47 pour 800, 0,74 pour 2400. Le cœur reste loin de sa limite."></svg>
+    </figure>
+  </section>
+
+  <section>
+    <div class="sec-head">
+      <span class="sec-n">Mesure 02 · le réseau</span>
+      <h2>Ce qui décide vraiment : la résolution</h2>
+      <p>Le nombre de spectateurs dépend directement du débit de chaque flux (donc de la résolution) et de
+        la connexion du serveur. Voici le calcul, pour un débit typique par résolution.</p>
+    </div>
+    <div class="table-scroll">
+      <table class="data">
+        <thead><tr><th>Résolution</th><th>Débit typique</th><th>Serveur 1 Gbit/s</th><th>Serveur 2,5 Gbit/s</th><th>Serveur 10 Gbit/s</th></tr></thead>
+        <tbody>
+          <tr><td>480p</td><td>~1 Mbit/s</td><td>~1 000</td><td>~2 500</td><td>~10 000</td></tr>
+          <tr><td>720p <span class="tag ok">≈ Discord</span></td><td>~2,5 Mbit/s</td><td>~400</td><td>~1 000</td><td>~4 000</td></tr>
+          <tr><td>1080p</td><td>~4,5 Mbit/s</td><td>~220</td><td>~555</td><td>~2 200</td></tr>
+          <tr><td>4K</td><td>~16 Mbit/s</td><td>~62</td><td>~156</td><td>~625</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="sec-head" style="margin-top:16px;color:var(--ink-3);font-family:var(--mono);font-size:.8rem;">
+      Spectateurs = débit du serveur / débit du flux. Débits typiques d'un partage d'écran ; le réel varie
+      selon le contenu (une image fixe consomme bien moins qu'une vidéo qui bouge).</p>
+  </section>
+
+  <div class="callout">
+    <span class="cl-badge">Transparence</span>
+    <p>Soyons clairs : le partage d'écran <b>sur ce moteur n'est pas encore en production</b> (il arrive).
+      Ces chiffres mesurent ce que le <b>moteur vidéo encaisse en relais</b> : c'est une capacité réelle,
+      pas une promesse que « le partage d'écran est parfait » aujourd'hui. La fluidité à l'écran (côté
+      navigateur) est un autre chantier, qu'on teste en vrai, pas au banc d'essai.</p>
+  </div>
+
+  <section>
+    <div class="sec-head"><h2>La suite</h2></div>
+    <div class="next">
+      <a href="technique.html">
+        <div class="nx-k">Pour les techniciens</div>
+        <div class="nx-t">Tous les chiffres bruts, la méthode, par machine <span class="arr">→</span></div>
+      </a>
+      <a href="pire-cas.html">
+        <div class="nx-k">Revenir au début</div>
+        <div class="nx-t">Scénario 01 · le pire cas <span class="arr">→</span></div>
+      </a>
+    </div>
+  </section>
+
+</div>
+<footer class="site"><div class="wrap">Mesures réelles issues de <a href="https://github.com/Pokled/nodyx">sfu-bench</a> · <a href="https://nodyx.org">Nodyx</a>, vocal souverain auto-hébergé · AGPL-3.0 · <a href="technique.html">reproduire →</a></div></footer>
+
+<script src="bench.js?v=2"></script>
+<script>
+  const VIDEO = [
+    { spec: 200,  cpu: 0.11 },
+    { spec: 400,  cpu: 0.22 },
+    { spec: 800,  cpu: 0.47 },
+    { spec: 1600, cpu: 0.55 },
+    { spec: 2400, cpu: 0.74 },
+  ];
+  Bench.chart(document.getElementById("c-video"), {
+    rows: VIDEO, xkey: d => d.spec, val: d => d.cpu,
+    max: 1.05, ref: 1.0, refLabel: "limite d'un cœur",
+    yticks: [0, 0.5, 1.0], yfmt: t => t.toFixed(1),
+    xevery: [200, 400, 800, 1600, 2400],
+    stroke: Bench.css("--signal"), areaFill: Bench.css("--signal-soft"),
+    labels: [{ at: 2400, text: "2400 · à peine 0,74 cœur", dx: -50, dy: -14, color: Bench.css("--signal") }],
+    tipTitle: d => d.spec.toLocaleString("fr") + " spectateurs",
+    tipVal: d => d.cpu.toFixed(2).replace(".", ",") + " cœur",
+    tipSub: d => "720p ~2,5 Mbit/s",
+  });
+  Bench.boot("partage-ecran");
+</script>
+</body>
+</html>

--- a/nodyx-frontend/static/benchmark/pire-cas.html
+++ b/nodyx-frontend/static/benchmark/pire-cas.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Le pire cas — Nodyx · Banc d'essai vocal</title>
+<meta name="description" content="Le scénario le plus dur : tout le monde parle en même temps. Un serveur Nodyx tient ~600 personnes en vocal. Mesures réelles, auto-hébergé.">
+<meta name="color-scheme" content="light dark">
+<meta property="og:title" content="Le pire cas : ~600 personnes en vocal, tous parlent en même temps">
+<meta property="og:description" content="Le scénario extrême du vocal Nodyx, mesuré sans filtre. Auto-hébergé, AGPL-3.0.">
+<link rel="stylesheet" href="style.css?v=2">
+</head>
+<body data-page="pire-cas">
+<div id="nav-mount"></div>
+<div class="wrap">
+
+  <header class="hero">
+    <div class="tapehead">
+      <span class="live">Banc d'essai vocal</span>
+      <span><b>Scénario 01 / 03</b> — le cas extrême</span>
+      <span>Machine · <b>1 serveur, 8 cœurs</b></span>
+      <span>Méthode · <b>full-mesh</b> (tous parlent)</span>
+    </div>
+    <h1>Tout le monde parle en même temps.</h1>
+    <p class="lede">On a pris le scénario le plus dur imaginable pour un serveur vocal, et on a mesuré combien
+      de monde il tient sans perdre un mot. C'est le plancher : la vraie vie est bien plus légère.</p>
+
+    <div class="readout">
+      <div class="ro"><span class="ro-v sig">~<span data-count="600">0</span></span><span class="ro-k">personnes en vocal · tout le serveur</span></div>
+      <div class="ro"><span class="ro-v"><span data-count="100">0</span></span><span class="ro-k">par pièce · sans perdre un mot</span></div>
+      <div class="ro"><span class="ro-v"><span data-count="6">0</span><span class="u">/ 8</span></span><span class="ro-k">cœurs utilisés · 2 gardés pour le reste</span></div>
+    </div>
+
+    <nav class="scene-nav" aria-label="Scénarios">
+      <a href="pire-cas.html" aria-current="page">01 · Le pire cas</a>
+      <a href="diffusion-audio.html">02 · Diffusion audio</a>
+      <a href="partage-ecran.html">03 · Partage d'écran</a>
+    </nav>
+  </header>
+
+  <div class="callout warn">
+    <span class="cl-badge">Le pire cas imaginable</span>
+    <p>Ici, les 600 personnes <b>parlent ET écoutent tout le monde en même temps</b>, en continu : comme si
+      chacune diffusait sa voix à toutes les autres sans jamais s'arrêter. Dans la vraie vie, ça
+      <b>n'arrive jamais</b> (dans une conversation, une ou deux personnes parlent à la fois). On a choisi
+      exprès le scénario <b>le plus dur qui soit</b> : les cas réels (scénarios suivants) tiennent
+      <b>bien, bien plus</b> de monde.</p>
+  </div>
+
+  <section>
+    <div class="sec-head">
+      <span class="sec-n">Mesure 01 · une pièce</span>
+      <h2>Jusqu'où tient une seule pièce</h2>
+      <p>Dans une pièce, tout est parfait jusqu'à ~100 personnes. Au-delà, une pièce seule sature : c'est
+        là qu'on en ouvre d'autres.</p>
+    </div>
+    <figure>
+      <div class="fig-title"><span class="swatch"></span> Qualité du son selon le monde dans une pièce</div>
+      <svg class="chart" id="c-cliff" viewBox="0 0 900 320" role="img" aria-label="Qualité du son : parfaite à 100 % jusqu'à 100 personnes dans une pièce, puis chute (68 % à 125, 46 % à 150, 24 % à 200, 9 % à 300)."></svg>
+    </figure>
+  </section>
+
+  <section>
+    <div class="sec-head">
+      <span class="sec-n">Mesure 02 · le serveur</span>
+      <h2>Et sur tout le serveur : ~600</h2>
+      <p>On ouvre plusieurs pièces ; le serveur les répartit sur ses cœurs, une par cœur. La charge monte
+        droit : chaque centaine de personnes prend un cœur.</p>
+    </div>
+    <figure>
+      <div class="fig-title"><span class="swatch"></span> Charge du serveur selon le nombre de pièces (100 personnes chacune)</div>
+      <svg class="chart" id="c-pool" viewBox="0 0 900 320" role="img" aria-label="Charge du serveur : 1 cœur pour 100 personnes, 2 pour 200, 4 pour 400, 6 cœurs pour 600 personnes. Montée parfaitement linéaire."></svg>
+    </figure>
+  </section>
+
+  <section>
+    <div class="sec-head">
+      <span class="sec-n">03 · en clair</span>
+      <h2>Concrètement</h2>
+      <p>Sans le jargon, ce que ça change pour ta communauté.</p>
+    </div>
+    <div class="grid2">
+      <div class="card">
+        <h3>Une pièce = une communauté active</h3>
+        <p>Jusqu'à ~100 personnes qui se parlent dans la même pièce vocale, en même temps, sans qu'un mot
+          se perde. C'est déjà plus qu'un gros vocal bien rempli.</p>
+      </div>
+      <div class="card">
+        <h3>Le serveur en fait tourner plein</h3>
+        <p>Le serveur répartit les pièces sur ses cœurs : ~600 personnes au total dans ce test extrême,
+          tout en gardant 2 cœurs pour le forum, le chat et le reste de la plateforme.</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head"><h2>La suite</h2></div>
+    <div class="next">
+      <a href="diffusion-audio.html">
+        <div class="nx-k">Scénario 02 / 03</div>
+        <div class="nx-t">Diffusion audio : une personne parle, des milliers écoutent <span class="arr">→</span></div>
+      </a>
+      <a href="technique.html">
+        <div class="nx-k">Pour les techniciens</div>
+        <div class="nx-t">Chiffres bruts, méthode, par machine <span class="arr">→</span></div>
+      </a>
+    </div>
+  </section>
+
+</div>
+<footer class="site"><div class="wrap">Mesures réelles issues de <a href="https://github.com/Pokled/nodyx">sfu-bench</a> · <a href="https://nodyx.org">Nodyx</a>, vocal souverain auto-hébergé · AGPL-3.0 · <a href="technique.html">reproduire →</a></div></footer>
+
+<script src="bench.js?v=2"></script>
+<script>
+  const CLIFF = [
+    { n: 2,   health: 100,  paths: 2 },
+    { n: 5,   health: 100,  paths: 20 },
+    { n: 10,  health: 100,  paths: 90 },
+    { n: 20,  health: 100,  paths: 380 },
+    { n: 50,  health: 100,  paths: 2450 },
+    { n: 75,  health: 100,  paths: 5550 },
+    { n: 100, health: 100,  paths: 9900 },
+    { n: 125, health: 67.9, paths: 15500 },
+    { n: 150, health: 45.9, paths: 22350 },
+    { n: 200, health: 24.0, paths: 39800 },
+    { n: 300, health: 9.2,  paths: 89700 },
+  ];
+  const POOL = [
+    { rooms: 1, cpu: 0.99, total: 100 },
+    { rooms: 2, cpu: 2.03, total: 200 },
+    { rooms: 4, cpu: 4.08, total: 400 },
+    { rooms: 6, cpu: 6.03, total: 600 },
+  ];
+
+  Bench.chart(document.getElementById("c-cliff"), {
+    rows: CLIFF, xkey: d => d.n, val: d => d.health,
+    max: 108, ruptureFrom: 6, yticks: [0, 25, 50, 75, 100], yfmt: t => t + " %",
+    xevery: [2, 20, 50, 100, 125, 150, 200, 300],
+    stroke: Bench.css("--signal"), areaFill: Bench.css("--signal-soft"),
+    labels: [
+      { at: 100, text: "parfait jusqu'à 100", dx: -10, dy: -14, color: Bench.css("--signal") },
+      { at: 150, text: "ça décroche", dx: 6, dy: 24, color: Bench.css("--danger") },
+    ],
+    tipTitle: d => d.n + " personnes",
+    tipVal: d => (d.health % 1 ? d.health.toFixed(1).replace(".", ",") : d.health) + " % du son",
+    tipSub: d => "une seule pièce",
+  });
+
+  Bench.chart(document.getElementById("c-pool"), {
+    rows: POOL, xkey: d => d.rooms, val: d => d.cpu,
+    max: 7, yticks: [0, 2, 4, 6], yfmt: t => t,
+    xevery: [1, 2, 4, 6],
+    stroke: Bench.css("--signal"), areaFill: Bench.css("--signal-soft"),
+    labels: [{ at: 6, text: "600 personnes · 6 cœurs", dx: -40, dy: -14, color: Bench.css("--signal") }],
+    tipTitle: d => d.total + " personnes",
+    tipVal: d => d.cpu.toFixed(2).replace(".", ",") + " cœurs",
+    tipSub: d => d.rooms + " pièces de 100",
+  });
+
+  Bench.boot("pire-cas");
+</script>
+</body>
+</html>

--- a/nodyx-frontend/static/benchmark/style.css
+++ b/nodyx-frontend/static/benchmark/style.css
@@ -1,0 +1,160 @@
+/* Nodyx · Banc d'essai — identité "instrument de mesure" (datasheet / oscilloscope) */
+:root{
+  color-scheme: light dark;
+  --paper:#f6f5f0; --surface:#fbfaf6; --ink:#16171b; --ink-2:#54555b; --ink-3:#8b8b8f;
+  --line:#cfcec5; --line-2:#e2e1d8; --grid:#e7e6dd;
+  --signal:#b4530f; --signal-2:#8f4109; --signal-soft:#b4530f12; --danger:#9c2b2b; --danger-soft:#9c2b2b12;
+  --mono:ui-monospace,"SF Mono","SFMono-Regular",Menlo,Consolas,"Liberation Mono",monospace;
+  --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,Roboto,Helvetica,Arial,sans-serif;
+}
+@media (prefers-color-scheme:dark){:root{
+  --paper:#0c0d0a; --surface:#121311; --ink:#e9e8df; --ink-2:#9a9a8f; --ink-3:#63645b;
+  --line:#26261f; --line-2:#1b1c16; --grid:#191a14;
+  --signal:#e6a13c; --signal-2:#f0b45e; --signal-soft:#e6a13c14; --danger:#d9603f; --danger-soft:#d9603f18;
+}}
+:root[data-theme="light"]{
+  --paper:#f6f5f0; --surface:#fbfaf6; --ink:#16171b; --ink-2:#54555b; --ink-3:#8b8b8f;
+  --line:#cfcec5; --line-2:#e2e1d8; --grid:#e7e6dd;
+  --signal:#b4530f; --signal-2:#8f4109; --signal-soft:#b4530f12; --danger:#9c2b2b; --danger-soft:#9c2b2b12;
+}
+:root[data-theme="dark"]{
+  --paper:#0c0d0a; --surface:#121311; --ink:#e9e8df; --ink-2:#9a9a8f; --ink-3:#63645b;
+  --line:#26261f; --line-2:#1b1c16; --grid:#191a14;
+  --signal:#e6a13c; --signal-2:#f0b45e; --signal-soft:#e6a13c14; --danger:#d9603f; --danger-soft:#d9603f18;
+}
+*{box-sizing:border-box;}
+html,body{margin:0;padding:0;}
+body{
+  background:var(--paper);color:var(--ink);font-family:var(--sans);line-height:1.6;
+  -webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;
+  background-image:linear-gradient(var(--grid) 1px,transparent 1px),linear-gradient(90deg,var(--grid) 1px,transparent 1px);
+  background-size:30px 30px;background-position:-1px -1px;
+}
+.wrap{max-width:1080px;margin:0 auto;padding:0 28px;}
+.mono{font-family:var(--mono);font-variant-numeric:tabular-nums;}
+a{color:var(--ink);text-decoration:none;}
+::selection{background:var(--signal);color:var(--paper);}
+
+/* ── Nav : barre d'appareil ──────────────────────────── */
+.nav{position:sticky;top:0;z-index:30;background:var(--paper);border-bottom:1px solid var(--ink);}
+.nav-in{max-width:1080px;margin:0 auto;padding:0 28px;display:flex;align-items:stretch;gap:0;flex-wrap:wrap;min-height:46px;}
+.nav .brand{font-family:var(--mono);font-size:.8rem;letter-spacing:.04em;color:var(--ink);display:flex;align-items:center;gap:9px;font-weight:600;padding:0 20px 0 0;text-transform:uppercase;}
+.nav .brand .dot{width:7px;height:7px;background:var(--signal);}
+.nav ul{list-style:none;display:flex;gap:0;margin:0;padding:0;flex-wrap:wrap;}
+.nav li{display:flex;}
+.nav a{font-family:var(--mono);font-size:.74rem;color:var(--ink-2);padding:14px 16px;display:flex;align-items:center;border-left:1px solid var(--line);white-space:nowrap;letter-spacing:.02em;}
+.nav a:hover{background:var(--surface);color:var(--ink);}
+.nav a[aria-current="page"]{color:var(--ink);box-shadow:inset 0 -2px 0 var(--signal);font-weight:600;}
+.nav .tech{margin-left:auto;}
+.nav .tech a{border-left:1px solid var(--ink);}
+.theme-btn{font-family:var(--mono);font-size:.72rem;background:transparent;color:var(--ink-2);border:0;border-left:1px solid var(--line);padding:0 15px;cursor:pointer;}
+.theme-btn:hover{color:var(--ink);background:var(--surface);}
+.theme-btn:focus-visible{outline:2px solid var(--signal);outline-offset:-2px;}
+
+/* ── Bandeau technique (tape head) ───────────────────── */
+.tapehead{font-family:var(--mono);font-size:.72rem;letter-spacing:.16em;text-transform:uppercase;color:var(--ink-3);
+  padding:16px 0;border-bottom:1px solid var(--line);display:flex;gap:14px;flex-wrap:wrap;}
+.tapehead b{color:var(--ink-2);font-weight:500;}
+.tapehead .live{color:var(--signal);display:flex;align-items:center;gap:7px;}
+.tapehead .live::before{content:"";width:6px;height:6px;background:var(--signal);}
+
+/* ── Hero ────────────────────────────────────────────── */
+header.hero{padding:38px 0 0;}
+h1{font-family:var(--mono);font-size:clamp(1.8rem,4.4vw,2.9rem);line-height:1.08;margin:22px 0 0;letter-spacing:-.02em;font-weight:640;text-wrap:balance;max-width:20ch;}
+.lede{margin:20px 0 0;font-size:1.14rem;color:var(--ink-2);max-width:60ch;}
+
+/* Afficheur de mesure : cellules séparées par des hairlines */
+.readout{display:grid;grid-template-columns:repeat(3,1fr);border:1px solid var(--ink);margin:34px 0 0;background:var(--surface);}
+.readout .ro{padding:20px 22px;border-left:1px solid var(--line);}
+.readout .ro:first-child{border-left:0;}
+.readout .ro-v{font-family:var(--mono);font-variant-numeric:tabular-nums;font-size:clamp(2.2rem,6vw,3.4rem);line-height:1;letter-spacing:-.04em;color:var(--ink);display:block;}
+.readout .ro-v .u{font-size:.4em;color:var(--ink-3);margin-left:2px;letter-spacing:0;}
+.readout .ro-v.sig{color:var(--signal);}
+.readout .ro-k{font-family:var(--mono);font-size:.72rem;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-3);margin-top:12px;display:block;line-height:1.4;}
+
+.scene-nav{display:flex;gap:0;margin:28px 0 0;border:1px solid var(--line);width:max-content;max-width:100%;flex-wrap:wrap;}
+.scene-nav a{font-family:var(--mono);font-size:.75rem;color:var(--ink-2);padding:9px 15px;border-left:1px solid var(--line);letter-spacing:.02em;}
+.scene-nav a:first-child{border-left:0;}
+.scene-nav a:hover{background:var(--surface);color:var(--ink);}
+.scene-nav a[aria-current="page"]{background:var(--ink);color:var(--paper);}
+
+/* ── Callout ─────────────────────────────────────────── */
+.callout{border:1px solid var(--ink);border-left-width:3px;margin:40px 0 0;padding:22px 24px;background:var(--surface);}
+.callout.warn{border-left-color:var(--signal);}
+.callout .cl-badge{display:inline-block;font-family:var(--mono);font-size:.68rem;letter-spacing:.14em;text-transform:uppercase;color:var(--signal);margin-bottom:12px;}
+.callout p{margin:0;color:var(--ink);font-size:1.02rem;line-height:1.68;}
+.callout b{color:var(--ink);font-weight:640;}
+
+/* ── Sections & figures ──────────────────────────────── */
+section{padding:52px 0;border-top:1px solid var(--line);}
+.sec-head{margin-bottom:26px;}
+.sec-n{font-family:var(--mono);font-size:.72rem;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-3);display:block;margin-bottom:10px;}
+h2{font-family:var(--mono);font-size:1.4rem;letter-spacing:-.01em;margin:0;font-weight:620;}
+.sec-head p{margin:12px 0 0;color:var(--ink-2);font-size:1rem;max-width:56ch;}
+figure{margin:0;border:1px solid var(--line);background:var(--surface);padding:18px 18px 6px;}
+.fig-title{font-family:var(--mono);font-size:.72rem;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-3);display:flex;align-items:center;gap:10px;}
+.fig-title .swatch{width:14px;height:3px;background:var(--signal);}
+.chart{width:100%;height:auto;display:block;margin-top:10px;overflow:visible;touch-action:none;}
+.grid-line{stroke:var(--grid);stroke-width:1;}
+.axis-txt{font-family:var(--mono);font-size:11px;fill:var(--ink-3);}
+.series-line{fill:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;}
+.endpoint{stroke:var(--surface);stroke-width:2.5;}
+.dlabel{font-family:var(--mono);font-size:12px;font-weight:600;}
+.dlabel-bg{fill:var(--surface);}
+.crosshair{stroke:var(--ink-3);stroke-width:1;stroke-dasharray:2 3;opacity:0;}
+.rupture-band{fill:var(--danger-soft);}
+.refline{stroke:var(--ink-3);stroke-width:1;stroke-dasharray:4 3;opacity:.8;}
+
+/* ── Cartes (rectangles à filet) ─────────────────────── */
+.grid2{display:grid;grid-template-columns:1fr 1fr;gap:0;border:1px solid var(--line);}
+.grid2 .card{border-left:1px solid var(--line);}
+.grid2 .card:first-child{border-left:0;}
+.card{background:var(--surface);padding:26px;}
+.card h3{font-family:var(--mono);margin:0 0 12px;font-size:1rem;letter-spacing:-.01em;font-weight:620;}
+.card p{margin:0 0 12px;color:var(--ink-2);font-size:.97rem;}
+.card p:last-child{margin-bottom:0;}
+.card code{font-family:var(--mono);font-size:.86em;background:var(--paper);padding:1px 6px;color:var(--ink);}
+.card b{color:var(--ink);}
+
+/* ── Table ───────────────────────────────────────────── */
+.table-scroll{overflow-x:auto;border:1px solid var(--line);background:var(--surface);}
+table.data{border-collapse:collapse;width:100%;font-family:var(--mono);font-variant-numeric:tabular-nums;font-size:.85rem;min-width:520px;}
+table.data th,table.data td{padding:10px 16px;text-align:right;border-bottom:1px solid var(--line-2);white-space:nowrap;}
+table.data th:first-child,table.data td:first-child{text-align:left;}
+table.data thead th{font-size:.68rem;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-3);font-weight:500;position:sticky;top:0;background:var(--surface);border-bottom:1px solid var(--ink);}
+table.data tbody tr:last-child td{border-bottom:none;}
+table.data tbody tr.break td{background:var(--danger-soft);}
+.tag{font-family:var(--mono);font-size:.7rem;padding:2px 9px;display:inline-block;min-width:64px;text-align:center;border:1px solid currentColor;}
+.tag.ok{color:var(--ink-2);}
+.tag.crit{color:var(--danger);}
+.tag.warn{color:var(--signal);}
+
+/* ── Suite / footer ──────────────────────────────────── */
+.next{display:flex;gap:0;flex-wrap:wrap;border:1px solid var(--line);}
+.next a{flex:1;min-width:250px;padding:22px 24px;border-left:1px solid var(--line);background:var(--surface);}
+.next a:first-child{border-left:0;}
+.next a:hover{background:var(--paper);}
+.next .nx-k{font-family:var(--mono);font-size:.68rem;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-3);}
+.next .nx-t{font-family:var(--mono);color:var(--ink);font-size:1rem;margin-top:8px;font-weight:600;line-height:1.4;}
+.next .nx-t .arr{color:var(--signal);}
+footer.site{border-top:1px solid var(--ink);padding:30px 0 72px;color:var(--ink-3);font-family:var(--mono);font-size:.76rem;}
+footer.site b{color:var(--ink-2);font-weight:500;}
+footer.site a{color:var(--signal);}
+
+.tip{position:fixed;pointer-events:none;z-index:40;background:var(--surface);border:1px solid var(--ink);padding:9px 12px;font-family:var(--mono);font-size:.78rem;opacity:0;transition:opacity .1s;min-width:130px;}
+.tip .tn{color:var(--ink-3);font-size:.68rem;letter-spacing:.06em;text-transform:uppercase;}
+.tip .tv{color:var(--ink);font-size:1.05rem;margin-top:4px;}
+.tip .ts{color:var(--ink-2);margin-top:2px;font-size:.74rem;}
+
+@media (max-width:720px){
+  .readout{grid-template-columns:1fr;}
+  .readout .ro{border-left:0;border-top:1px solid var(--line);}
+  .readout .ro:first-child{border-top:0;}
+  .grid2{grid-template-columns:1fr;}
+  .grid2 .card{border-left:0;border-top:1px solid var(--line);}
+  .grid2 .card:first-child{border-top:0;}
+  .nav .tech{margin-left:0;}
+}
+@media (prefers-reduced-motion:reduce){
+  .series-line{stroke-dasharray:none!important;stroke-dashoffset:0!important;}
+}

--- a/nodyx-frontend/static/benchmark/technique.html
+++ b/nodyx-frontend/static/benchmark/technique.html
@@ -1,0 +1,265 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Détail technique — Nodyx · Banc d'essai vocal</title>
+<meta name="description" content="Tous les chiffres bruts du banc d'essai vocal Nodyx : full-mesh, diffusion audio, partage d'écran, limites réseau, méthode et machines testées. Sans filtre.">
+<meta name="color-scheme" content="light dark">
+<link rel="stylesheet" href="style.css?v=2">
+</head>
+<body data-page="technique">
+<div id="nav-mount"></div>
+<div class="wrap">
+
+  <header class="hero">
+    <div class="tapehead">
+      <span class="live">Banc d'essai vocal</span>
+      <span><b>Détail technique</b> — chiffres bruts</span>
+      <span>Outil · <b>sfu-bench</b> (open source)</span>
+    </div>
+    <h1>Le détail technique, sans filtre.</h1>
+    <p class="lede">Toutes les mesures brutes, la méthode, et ce qu'on ne cache pas. C'est la partie pour
+      les techniciens : rien n'est arrangé, tout est reproductible.</p>
+    <nav class="scene-nav" aria-label="Scénarios">
+      <a href="pire-cas.html">01 · Le pire cas</a>
+      <a href="diffusion-audio.html">02 · Diffusion audio</a>
+      <a href="partage-ecran.html">03 · Partage d'écran</a>
+    </nav>
+  </header>
+
+  <section>
+    <div class="sec-head">
+      <span class="sec-n">Synthèse</span>
+      <h2>Les trois scénarios d'un coup</h2>
+      <p>La même histoire, résumée : combien de monde selon la forme d'usage, sur un seul serveur 8 cœurs.</p>
+    </div>
+    <div class="table-scroll">
+      <table class="data">
+        <thead><tr><th>Scénario</th><th>Forme</th><th>Capacité (1 serveur, 8 cœurs)</th><th>Limité par</th></tr></thead>
+        <tbody>
+          <tr><td>Pire cas</td><td>tous parlent</td><td>~600 personnes</td><td>processeur</td></tr>
+          <tr><td>Diffusion audio</td><td>1 parle, N écoutent</td><td>~8 000 / cœur</td><td>processeur, puis réseau à grande échelle</td></tr>
+          <tr><td>Partage d'écran</td><td>1 partage, N regardent</td><td>~450 (1 Gbit/s) → ~4 500 (10 Gbit/s)</td><td>réseau</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head">
+      <span class="sec-n">Test 01</span>
+      <h2>Pire cas — full-mesh (tous parlent)</h2>
+      <p>Une pièce, N participants, chacun consomme tous les autres (N×(N-1) chemins). Le son est parfait
+        jusqu'à ~100, puis décroche.</p>
+    </div>
+    <div class="table-scroll">
+      <table class="data" id="t-mesh">
+        <thead><tr><th>Participants</th><th>Chemins</th><th>CPU (cœurs)</th><th>% machine</th><th>RSS (Mo)</th><th>Son</th><th>État</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head">
+      <span class="sec-n">Test 02</span>
+      <h2>Plusieurs pièces réparties sur les cœurs</h2>
+      <p>Des pièces de 100 personnes (full-mesh) réparties une par cœur : la charge monte linéairement,
+        ~600 personnes sur 6 cœurs.</p>
+    </div>
+    <div class="table-scroll">
+      <table class="data" id="t-pool">
+        <thead><tr><th>Pièces</th><th>Total personnes</th><th>CPU (cœurs)</th><th>Son</th><th>État</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head">
+      <span class="sec-n">Test 03</span>
+      <h2>Diffusion audio (1 parle, N écoutent)</h2>
+      <p>Une seule voix relayée à N auditeurs, sur un cœur. En étoile : N chemins, pas N×(N-1).</p>
+    </div>
+    <div class="table-scroll">
+      <table class="data" id="t-audio">
+        <thead><tr><th>Auditeurs</th><th>CPU (cœurs)</th><th>Son</th><th>État</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <div class="table-scroll" style="margin-top:16px">
+      <table class="data">
+        <thead><tr><th>Qualité audio</th><th>Débit / auditeur</th><th>Auditeurs / cœur</th><th>Bande passante à 8000</th></tr></thead>
+        <tbody>
+          <tr><td>Économe</td><td>32 kbps</td><td>~8 000</td><td>256 Mbit/s</td></tr>
+          <tr><td>Standard (≈ Discord)</td><td>64 kbps</td><td>~8 000</td><td>512 Mbit/s</td></tr>
+          <tr><td>Haute</td><td>96 kbps</td><td>~8 000</td><td>768 Mbit/s</td></tr>
+          <tr><td>Studio</td><td>128 kbps</td><td>~8 000</td><td>~1 Gbit/s</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head">
+      <span class="sec-n">Test 04</span>
+      <h2>Partage d'écran — vidéo</h2>
+      <p>Une diffusion vidéo relayée à N spectateurs. Côté CPU, très léger (mesuré 720p et 1080p) ; c'est le
+        <b>réseau</b> qui borne, selon la résolution.</p>
+    </div>
+    <div class="table-scroll">
+      <table class="data" id="t-video">
+        <thead><tr><th>Spectateurs (720p)</th><th>CPU (cœurs)</th><th>Son</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <div class="table-scroll" style="margin-top:16px">
+      <table class="data">
+        <thead><tr><th>Résolution</th><th>Débit typique</th><th>1 Gbit/s</th><th>2,5 Gbit/s</th><th>10 Gbit/s</th></tr></thead>
+        <tbody>
+          <tr><td>480p</td><td>~1 Mbit/s</td><td>~1 000</td><td>~2 500</td><td>~10 000</td></tr>
+          <tr><td>720p (≈ Discord)</td><td>~2,5 Mbit/s</td><td>~400</td><td>~1 000</td><td>~4 000</td></tr>
+          <tr><td>1080p</td><td>~4,5 Mbit/s</td><td>~220</td><td>~555</td><td>~2 200</td></tr>
+          <tr><td>4K</td><td>~16 Mbit/s</td><td>~62</td><td>~156</td><td>~625</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head">
+      <span class="sec-n">Machines</span>
+      <h2>Testé sur du vrai matériel</h2>
+      <p>On ne publie que des machines réellement mesurées. Le tableau s'étoffera au fil des tests sur
+        d'autres configurations.</p>
+    </div>
+    <div class="table-scroll">
+      <table class="data">
+        <thead><tr><th>Machine</th><th>Cœurs</th><th>Pire cas (serveur)</th><th>Audio / cœur</th><th>Vidéo (réseau)</th></tr></thead>
+        <tbody>
+          <tr><td>VPS Hetzner CPX42</td><td>8</td><td>~600</td><td>~8 000</td><td>débit-dépendant</td></tr>
+          <tr><td colspan="5" style="color:var(--ink-3)">Raspberry, mini-PC, autres VPS — à venir (mesurés, jamais inventés)</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head">
+      <span class="sec-n">Méthode & honnêteté</span>
+      <h2>Comment c'est mesuré, et ce qu'on ne cache pas</h2>
+    </div>
+    <div class="grid2">
+      <div class="card">
+        <h3>La méthode</h3>
+        <p><b>Outil :</b> <code>sfu-bench</code>, dans le dépôt Nodyx. Participants synthétiques injectant du
+          vrai RTP au rythme réel (audio Opus, ou profil vidéo).</p>
+        <p><b>In-process :</b> le média est injecté directement dans le moteur (sans passer par le réseau)
+          pour isoler le coût de <b>relais</b>. La limite réseau est donc <b>calculée</b> à part (débit ×
+          spectateurs), pas mesurée au banc.</p>
+        <p><b>Son :</b> paquets reçus / attendus sur une fenêtre de 2 s par palier. <b>Machine :</b> VPS
+          Hetzner CPX42, 8 cœurs (6 dédiés au média, 2 gardés pour le reste). Lancé en basse priorité.</p>
+      </div>
+      <div class="card">
+        <h3>Ce qu'on ne cache pas</h3>
+        <p><b>Le partage d'écran sur ce moteur n'est pas encore en production</b> (il arrive). Les chiffres
+          vidéo mesurent ce que le moteur <b>encaisse en relais</b>, pas « le partage d'écran est parfait ».
+          La fluidité à l'écran (côté navigateur) se teste en vrai, pas au banc.</p>
+        <p><b>Le vocal en production aujourd'hui, c'est l'audio.</b></p>
+        <p><b>Pire cas assumé :</b> le full-mesh (tous parlent en même temps) n'arrive jamais en vrai. Les
+          cas réels tiennent bien plus de monde. Rien n'est arrangé : les mesures brutes sont ci-dessus.</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head">
+      <span class="sec-n">Reproductible</span>
+      <h2>Vérifiez vous-même</h2>
+      <p>Rien n'est une boîte noire. L'outil de mesure est <b>open source</b> (AGPL-3.0). Compilez-le,
+        lancez-le, comparez : ce sont exactement ces commandes qui alimentent ces pages.</p>
+    </div>
+    <div class="card">
+      <p><b>Le code</b> — <a href="https://github.com/Pokled/nodyx" style="color:var(--signal)">github.com/Pokled/nodyx</a>,
+        binaire <code>sfu-bench</code> dans <code>nodyx-p2p/crates/nodyx-sfu-mediasoup</code>.</p>
+      <pre style="font-family:var(--mono);font-size:.82rem;line-height:1.7;background:var(--paper);border:1px solid var(--line);padding:16px 18px;overflow-x:auto;color:var(--ink);margin:6px 0 0;"># compiler
+cd nodyx-p2p/crates/nodyx-sfu-mediasoup
+cargo build --release --bin sfu-bench
+
+# pire cas — full-mesh (tous parlent)
+./target/release/sfu-bench 2,5,10,20,50,100,150,300
+
+# plusieurs pièces réparties sur les cœurs
+SFU_BENCH_WORKERS=6 ./target/release/sfu-bench rooms 100 1,2,4,6
+
+# diffusion audio — 1 parle, N écoutent
+./target/release/sfu-bench watch 1 250,1000,5000,8000
+
+# partage d'écran 720p (~2,5 Mbit/s) — 1 partage, N regardent
+SFU_BENCH_PAYLOAD=1250 SFU_BENCH_PACKET_MS=4 ./target/release/sfu-bench watch 1 800,1600</pre>
+      <p style="margin-top:14px">Chaque test imprime un tableau lisible <b>et</b> un JSON pour l'archivage.
+        Les chiffres de ce site sortent tels quels de cet outil.</p>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head"><h2>Les scénarios</h2></div>
+    <div class="next">
+      <a href="pire-cas.html"><div class="nx-k">Scénario 01</div><div class="nx-t">Le pire cas <span class="arr">→</span></div></a>
+      <a href="diffusion-audio.html"><div class="nx-k">Scénario 02</div><div class="nx-t">Diffusion audio <span class="arr">→</span></div></a>
+      <a href="partage-ecran.html"><div class="nx-k">Scénario 03</div><div class="nx-t">Partage d'écran <span class="arr">→</span></div></a>
+    </div>
+  </section>
+
+</div>
+<footer class="site"><div class="wrap">Mesures réelles issues de <a href="https://github.com/Pokled/nodyx">sfu-bench</a> · <a href="https://nodyx.org">Nodyx</a>, vocal souverain auto-hébergé · AGPL-3.0</div></footer>
+
+<script src="bench.js?v=2"></script>
+<script>
+  const MESH = [
+    { n: 2,   paths: 2,     cpu: 0.010, box: 0.1,  rss: 24,  health: 100 },
+    { n: 5,   paths: 20,    cpu: 0.015, box: 0.2,  rss: 25,  health: 100 },
+    { n: 10,  paths: 90,    cpu: 0.027, box: 0.3,  rss: 26,  health: 100 },
+    { n: 20,  paths: 380,   cpu: 0.057, box: 0.7,  rss: 28,  health: 100 },
+    { n: 50,  paths: 2450,  cpu: 0.312, box: 3.9,  rss: 46,  health: 100 },
+    { n: 75,  paths: 5550,  cpu: 0.580, box: 7.2,  rss: 73,  health: 100 },
+    { n: 100, paths: 9900,  cpu: 0.970, box: 12.1, rss: 110, health: 100 },
+    { n: 125, paths: 15500, cpu: 1.045, box: 13.1, rss: 162, health: 67.9 },
+    { n: 150, paths: 22350, cpu: 1.050, box: 13.1, rss: 305, health: 45.9 },
+    { n: 200, paths: 39800, cpu: 1.072, box: 13.4, rss: 484, health: 24.0 },
+    { n: 300, paths: 89700, cpu: 1.097, box: 13.7, rss: 985, health: 9.2 },
+  ];
+  const POOL = [
+    { rooms: 1, total: 100, cpu: 0.99, health: 99.6 },
+    { rooms: 2, total: 200, cpu: 2.03, health: 98.7 },
+    { rooms: 4, total: 400, cpu: 4.08, health: 98.9 },
+    { rooms: 6, total: 600, cpu: 6.03, health: 96.4 },
+  ];
+  const AUDIO = [
+    { spec: 250, cpu: 0.03, health: 100 }, { spec: 500, cpu: 0.07, health: 100 },
+    { spec: 1000, cpu: 0.16, health: 100 }, { spec: 2000, cpu: 0.30, health: 100 },
+    { spec: 5000, cpu: 0.57, health: 100 }, { spec: 8000, cpu: 0.92, health: 100 },
+    { spec: 10000, cpu: 1.01, health: 85.8 },
+  ];
+  const VIDEO = [
+    { spec: 200, cpu: 0.11 }, { spec: 400, cpu: 0.22 }, { spec: 800, cpu: 0.47 },
+    { spec: 1600, cpu: 0.55 }, { spec: 2400, cpu: 0.74 },
+  ];
+  const fr = n => n.toLocaleString("fr");
+  const c2 = v => v.toFixed(2).replace(".", ",");
+  const hp = h => (h % 1 ? h.toFixed(1).replace(".", ",") : h) + " %";
+  const state = h => h >= 99 ? '<span class="tag ok">OK</span>' : h >= 90 ? '<span class="tag warn">tendu</span>' : '<span class="tag crit">rupture</span>';
+  const fill = (id, rows, cells) => {
+    const tb = document.querySelector("#" + id + " tbody");
+    tb.innerHTML = rows.map(d => "<tr" + (d.health != null && d.health < 99 ? ' class="break"' : "") + ">" + cells(d).map(c => "<td>" + c + "</td>").join("") + "</tr>").join("");
+  };
+  fill("t-mesh", MESH, d => [d.n, fr(d.paths), c2(d.cpu), c2(d.box) + " %", fr(d.rss), hp(d.health), state(d.health)]);
+  fill("t-pool", POOL, d => [d.rooms, fr(d.total), c2(d.cpu), hp(d.health), state(d.health)]);
+  fill("t-audio", AUDIO, d => [fr(d.spec), c2(d.cpu), hp(d.health), state(d.health)]);
+  fill("t-video", VIDEO, d => [fr(d.spec), c2(d.cpu), '<span class="tag ok">OK</span>']);
+
+  Bench.boot("technique");
+</script>
+</body>
+</html>


### PR DESCRIPTION
Site public auto-hébergé sous `nodyx.org/benchmark/` : 3 scénarios (pire cas, diffusion audio, partage d'écran) + page technique. Design "instrument de mesure" partagé (style.css + bench.js), chiffres réels (audio 32-128k, vidéo par résolution + limite réseau), Discord en repère, reproductibilité (commandes + source). Honnêteté assumée : vidéo = capacité moteur (partage d'écran SFU pas encore en prod), machines réellement testées uniquement.