### PR TITLE
feat(sfu): bascule mesh↔SFU, orchestration serveur (étape 1, dormante)

### DIFF
--- a/SPECS/NODYX_SFU_BASCULE.md
+++ b/SPECS/NODYX_SFU_BASCULE.md
@@ -1,0 +1,118 @@
+# CDC — Bascule mesh ↔ SFU (§17-B concret)
+
+> Design de l'orchestration qui fait passer un **vrai** canal vocal du mesh (P2P) à
+> l'SFU **sans couper l'audio**. Complète le CDC principal (`NODYX_SFU_CDC.md` §4, §17).
+> Le §17 du CDC principal décrit des offer/answer bruts : **obsolète**, l'implémentation
+> réelle utilise mediasoup-client (transports + `voice:sfu_*` en style ack, cf `voiceSfu.ts`).
+> Ce document fait foi pour la bascule.
+>
+> **Statut : DESIGN, en attente de validation Jonathan. Zéro ligne de code avant OK
+> (voice.ts = sanctuaire).**
+
+## 1. But & doctrine
+
+- **Zéro coupure** : à aucun instant un participant ne perd l'audio d'un autre pendant la transition.
+- **Additif & dormant** : quand le flag est OFF, `voice.ts` (mesh) se comporte **exactement** comme aujourd'hui, à la ligne près. Rollback = éteindre le flag.
+- **Le mesh reste le défaut** pour les petits salons. L'SFU ne s'active qu'au-delà d'un seuil, là où le mesh peine.
+- **Sanctuaire** : les modifs de `voice.ts` (back + front) sont chirurgicales, gardées par le flag, et testées. On ne touche au sanctuaire qu'avec cette validation.
+
+## 2. Déclencheur
+
+Un canal bascule mesh → SFU quand **toutes** ces conditions sont vraies :
+- `VOICE_SFU_URL` défini (le daemon existe) **et** `VOICE_SFU_AUTO=true` (nouveau flag, OFF par défaut) ;
+- **liste blanche** `VOICE_SFU_AUTO_CHANNELS` (IDs de canaux, séparés par des virgules) : le canal y figure — **ou** la liste est vide = tous les canaux. Permet d'activer sur **UN seul vrai canal** de test (décision rollout) sans toucher aux autres ;
+- le nombre de participants (seats) du canal **atteint le seuil** `VOICE_SFU_MESH_THRESHOLD` = **6** (décidé : le mesh audio tient ~8-10, on bascule à 6 avec de la marge) ;
+- (P2, plus tard) **ou** un partage d'écran démarre (le mesh plafonne à ~4 en vidéo).
+
+**v1 : on reste en SFU une fois basculé** (pas de re-bascule SFU→mesh sous le seuil ; cf CDC §13). Simple et sûr.
+
+## 3. Machine à états (par canal, côté serveur)
+
+```
+mesh  ──(seuil franchi)──►  switching  ──(tous prêts)──►  sfu
+  ▲                             │
+  └──────(échec / abandon)──────┘
+```
+
+Le serveur tient une map `channelMode: channelId → 'mesh' | 'switching' | 'sfu'` (défaut `mesh`).
+Pendant `switching`, le mesh **reste entièrement debout**.
+
+## 4. Le protocole overlap — le cœur (zéro coupure)
+
+Le principe : **tout le monde s'entend via le mesh jusqu'à ce que tout le monde soit sur l'SFU, puis on bascule ensemble.** Le mesh n'est fermé qu'au tout dernier instant, coordonné par le serveur.
+
+```
+1. Serveur (seuil franchi) : channelMode = switching
+   Serveur → room : voice:mode {sfu}          # "établissez l'SFU, MAIS gardez le mesh"
+
+2. Chaque client, à voice:mode {sfu} :
+   - GARDE son mesh actif (voice.ts inchangé : entend/émet toujours via P2P)
+   - EN PARALLÈLE : établit l'SFU (voiceSfu.ts) : device.load, send+recv transports,
+     produce(micro), consume(toutes les publications du salon)
+   - NE JOUE PAS ENCORE l'audio SFU (sinon double son / écho)
+   - quand son SFU produit ET consomme les autres → client → serveur : voice:sfu_ready
+
+3. Serveur : collecte les voice:sfu_ready de TOUS les sockets du salon.
+   Quand tous prêts (dans le délai T) :
+   channelMode = sfu
+   Serveur → room : voice:sfu_commit
+
+4. Chaque client, à voice:sfu_commit :
+   - bascule la lecture mesh → SFU (coupe/retire les <audio> mesh, active les <audio> SFU)
+   - ferme ses PC mesh
+   => le mesh jouait jusqu'à cet instant précis : AUCUN trou.
+```
+
+**Pourquoi la porte "tous prêts" est indispensable** : le mesh est N↔N. Si un client fermait son mesh dès que SON SFU est prêt, un pair encore en mesh (pas encore basculé) cesserait de l'entendre (le producer SFU du premier n'étant consommé par le retardataire qu'une fois basculé). En fermant le mesh **seulement quand tous sont sur l'SFU**, personne ne tombe dans un trou.
+
+**Anti-double-son** : pendant `switching`, le client reçoit potentiellement l'audio d'un pair par le mesh **et** par l'SFU. Règle simple : **on ne joue que le mesh** jusqu'au `commit`, **puis** on joue l'SFU. Pas de lecture simultanée des deux → pas d'écho.
+
+## 5. Arrivée tardive (salon déjà en SFU)
+
+Trivial : à `voice:join`, si `channelMode == sfu`, le serveur renvoie `voice:mode {sfu}` dans le `voice:init` ; le client rejoint directement l'SFU (pas de mesh du tout). C'est déjà le chemin du labo actuel.
+
+## 6. Échecs & départs pendant la transition
+
+- **Un client se déconnecte pendant `switching`** : le serveur le retire du set attendu ; si les restants sont tous prêts → `commit`. Pas de blocage.
+- **Un client n'atteint pas l'SFU dans le délai T** (pas d'UDP, firewall) : **DÉCIDÉ = abandon**. Le serveur repasse `channelMode = mesh` et → room : `voice:mode {mesh}` ; tout le monde reste/revient au mesh, le client garde son mesh (il ne l'a jamais lâché) → aucune dégradation. L'SFU utilise le même chemin réseau que le TURN (déjà validé pour la plupart), donc l'échec est rare. Coût nul au seuil : à 6-8 personnes le mesh audio marche parfaitement.
+- **Anti-flapping** : après un abandon, le canal reste `mesh` et **ne re-tente pas** la bascule tant que la composition du salon n'a pas changé (join/leave). Évite la boucle abandon→retry.
+- **Arrivée tardive qui n'atteint pas l'SFU** (salon déjà `sfu`) : cas résiduel rare (topologie étoile, pas de pont mesh) → message clair « impossible de rejoindre le vocal » à cet user. Assumé v1.
+- **Timeout T** : **~8-10 s** (le temps d'établir device+transports+produce+consume, cf voiceSfu.ts).
+
+## 7. Points de contact sanctuaire (chirurgical, additif, flag-gardé)
+
+Quand `VOICE_SFU_AUTO` est OFF : **aucun** de ces chemins ne s'exécute → mesh strictement identique à aujourd'hui.
+
+- **`nodyx-core/src/socket/voice.ts`** (backend mesh) :
+  - map `channelMode` + set des `sfu_ready` par canal ;
+  - dans `voice:join`/`voice:leave` : recompter les seats, franchir le seuil → passer `switching` + `voice:mode {sfu}` ; en `sfu`, envoyer le mode au tardif ;
+  - nouveaux handlers `voice:sfu_ready` (compter, gater le commit) ;
+  - émettre `voice:sfu_commit` / abandon `voice:mode {mesh}` ;
+  - au départ/déco : nettoyer le set, ré-évaluer.
+  - **Additif** : les handlers mesh existants (`offer/answer/ice/leave/kick`) ne changent pas.
+- **`nodyx-core/src/socket/voiceSfu.ts`** (relais SFU, déjà là) : réutilisé tel quel (join/produce/consume/publications). Éventuellement la coordination ready/commit vit ici plutôt que dans voice.ts pour garder voice.ts au minimum.
+- **`nodyx-frontend/src/lib/voice.ts`** (client mesh) : à `voice:mode {sfu}` → **ne pas fermer le mesh**, déclencher l'établissement SFU (appel dans voiceSfu.ts) ; à `voice:sfu_commit` → basculer la lecture + fermer les PC mesh ; à `voice:mode {mesh}` (abandon) → annuler l'SFU, rester mesh. **Le point le plus délicat** : garder tout ça derrière un mode, mesh inchangé si flag off.
+- **`nodyx-frontend/src/lib/voiceSfu.ts`** (client SFU) : exposer un mode "établir sans jouer, puis activer au commit" (produce+consume mais lecture retenue jusqu'au commit).
+
+## 8. Déploiement & test
+
+- Flag `VOICE_SFU_AUTO` **OFF** partout au départ. Le labo `/admin/sfu-lab` reste pour le test manuel.
+- Activation progressive : un seul canal / **sleemstudio d'abord**, puis élargir.
+- Rollback instantané = flag OFF (retour mesh pur).
+- Tests Vitest : la logique de seuil + porte "tous prêts" + abandon, côté serveur (mockable) ; le client testé en labo à plusieurs.
+
+## 9. Décisions — TRANCHÉES (Jonathan, 2026-07-08)
+
+- **(a) Échec d'un client à joindre l'SFU → ABANDON → mesh.** Zéro dégradation, coût nul au seuil, échec rare. (+ anti-flapping, cf §6.)
+- **(b) Porte "tous prêts" serveur → OUI** (garantit le zéro-coupure ; la bascule par-client indépendante rouvrirait le trou mesh N↔N du §4).
+- **(c) Seuil = 6.** (Mesh audio confortable jusqu'à ~8-10 ; marge.)
+- **(d) Re-bascule SFU→mesh sous le seuil → NON en v1** (on reste SFU).
+- **(e) Rollout → UN canal réel de nodyx.org**, via la liste blanche `VOICE_SFU_AUTO_CHANNELS` (§2). Les autres canaux restent mesh pur.
+- **(f) Timeout T = ~8-10 s.**
+
+## 10. Ce que ça N'EST PAS (portée v1)
+
+- Pas de re-bascule descendante (§9-d).
+- Pas de topologie mixte mesh+SFU simultanée (§9-a : on est tout-mesh ou tout-SFU).
+- Pas de partage d'écran SFU (P2, séparé).
+- Pas de fédération inter-instances (P4).

--- a/nodyx-core/src/socket/voice.ts
+++ b/nodyx-core/src/socket/voice.ts
@@ -2,6 +2,9 @@ import { Server, Socket } from 'socket.io'
 import * as crypto from 'crypto'
 import { checkRateLimit } from './rateLimiter'
 import { db } from '../config/database'
+// Bascule mesh↔SFU (§17-B) : additif & dormant. Flag OFF ⇒ channelMode()==='mesh'
+// partout ⇒ les lignes ci-dessous se comportent EXACTEMENT comme avant.
+import * as bascule from './voiceBascule'
 
 type CommunityRole = 'owner' | 'admin' | 'moderator' | 'member'
 const MOD_ROLES: ReadonlyArray<CommunityRole> = ['owner', 'admin', 'moderator']
@@ -175,20 +178,30 @@ export function registerVoiceHandlers(socket: Socket, server: Server): void {
     // Broadcast updated member list to presence room
     await broadcastVoiceChannelUpdate(server, channelId)
 
-    // Send current peer list to the joiner (with their seat index + dynamic TURN creds)
-    socket.emit('voice:init', { channelId, peers, mySeatIndex: mySeat, iceServers: buildIceServers(userId) })
+    // Send current peer list to the joiner (with their seat index + dynamic TURN creds).
+    // `mode` : 'mesh' par défaut (flag off) ; 'switching'/'sfu' si la bascule est active
+    // (un arrivant sur un canal déjà SFU rejoint directement l'SFU, cf §5 du CDC bascule).
+    const chMode = bascule.channelMode(channelId)
+    socket.emit('voice:init', { channelId, peers, mySeatIndex: mySeat, iceServers: buildIceServers(userId), mode: chMode })
 
-    // Notify existing peers about the newcomer
-    socket.to(room).emit('voice:peer_joined', {
-      channelId,
-      peer: {
-        socketId:  socket.id,
-        userId,
-        username,
-        avatar:    socket.data.avatar ?? null,
-        seatIndex: mySeat,
-      },
-    })
+    // Notify existing peers about the newcomer — SAUF si le canal est déjà en SFU
+    // (topologie étoile : le nouveau producer est relayé via voice:sfu_new_producer,
+    // pas de PC mesh à créer). En 'mesh' et 'switching' (overlap), on prévient bien.
+    if (chMode !== 'sfu') {
+      socket.to(room).emit('voice:peer_joined', {
+        channelId,
+        peer: {
+          socketId:  socket.id,
+          userId,
+          username,
+          avatar:    socket.data.avatar ?? null,
+          seatIndex: mySeat,
+        },
+      })
+    }
+
+    // Le seuil est-il franchi ? (no-op si le flag est off)
+    bascule.onSeatCount(server, channelId, getChannelSeats(channelId).size)
   })
 
   // ── voice:leave ───────────────────────────────────────────────────────────
@@ -199,6 +212,16 @@ export function registerVoiceHandlers(socket: Socket, server: Server): void {
     freeSeat(channelId, socket.id)
     server.to(room).emit('voice:peer_left', { channelId, socketId: socket.id })
     await broadcastVoiceChannelUpdate(server, channelId)
+    bascule.onLeave(server, channelId, socket.id, getChannelSeats(channelId).size)
+  })
+
+  // ── voice:sfu_ready — bascule (§17-B) ─────────────────────────────────────
+  // Un client confirme que son SFU produit + consomme (audio prêt, pas encore joué).
+  // no-op si le canal n'est pas en 'switching'. Le client émettra cet event à
+  // l'étape 2 (frontend) ; inoffensif d'ici là (flag off).
+  socket.on('voice:sfu_ready', ({ channelId }: { channelId: string }) => {
+    if (!isUuid(channelId)) return
+    bascule.onSfuReady(server, channelId, socket.id)
   })
 
   // ── voice:kick — moderator action ─────────────────────────────────────────
@@ -235,6 +258,7 @@ export function registerVoiceHandlers(socket: Socket, server: Server): void {
     target.leave(room)
     server.to(room).emit('voice:peer_left', { channelId, socketId: target.id })
     await broadcastVoiceChannelUpdate(server, channelId)
+    bascule.onLeave(server, channelId, target.id, getChannelSeats(channelId).size)
 
     try {
       await db.query(
@@ -377,6 +401,7 @@ export function registerVoiceHandlers(socket: Socket, server: Server): void {
         server.to(room).emit('voice:peer_left', { channelId, socketId: socket.id })
         // Exclude this socket manually — socket.rooms not yet cleared at disconnect
         await broadcastVoiceChannelUpdate(server, channelId, socket.id)
+        bascule.onLeave(server, channelId, socket.id, getChannelSeats(channelId).size)
       }
     }
     // Clean up P2P registry

--- a/nodyx-core/src/socket/voiceBascule.ts
+++ b/nodyx-core/src/socket/voiceBascule.ts
@@ -1,0 +1,118 @@
+// ── Bascule mesh ↔ SFU (§17-B, cf SPECS/NODYX_SFU_BASCULE.md) ──────────────────
+//
+// Orchestration côté serveur du passage d'un canal vocal du mesh (P2P) à l'SFU
+// SANS coupure : on garde le mesh debout, chaque client établit l'SFU en
+// parallèle, et on ne ferme le mesh QUE quand TOUT LE MONDE est prêt (porte
+// "tous prêts") — sinon un pair encore en mesh tomberait dans un trou (mesh N↔N).
+//
+// ADDITIF & DORMANT : si `VOICE_SFU_AUTO` ≠ 'true' (ou pas de `VOICE_SFU_URL`, ou
+// canal hors liste blanche), `enabled()` est faux, aucune transition ne démarre,
+// `channelMode()` reste 'mesh', et le mesh est STRICTEMENT inchangé.
+
+import type { Server } from 'socket.io'
+
+// Config lue paresseusement (testable : les tests règlent l'env puis appellent).
+function auto(): boolean { return process.env.VOICE_SFU_AUTO === 'true' }
+function hasSfu(): boolean { return !!process.env.VOICE_SFU_URL }
+function allowList(): string[] {
+  return (process.env.VOICE_SFU_AUTO_CHANNELS ?? '').split(',').map(s => s.trim()).filter(Boolean)
+}
+function threshold(): number {
+  const n = parseInt(process.env.VOICE_SFU_MESH_THRESHOLD ?? '6', 10)
+  return Number.isFinite(n) && n > 0 ? n : 6
+}
+const SWITCH_TIMEOUT_MS = 9000 // délai d'overlap avant abandon
+
+function enabled(channelId: string): boolean {
+  const allow = allowList()
+  return auto() && hasSfu() && (allow.length === 0 || allow.includes(channelId))
+}
+
+type Mode = 'mesh' | 'switching' | 'sfu'
+
+const _mode = new Map<string, Mode>()
+const _ready = new Map<string, Set<string>>()   // socketIds ayant confirmé leur SFU
+const _timer = new Map<string, ReturnType<typeof setTimeout>>()
+const _cooldown = new Set<string>()             // canaux ayant abandonné : pas de retry avant changement de composition
+
+function room(channelId: string): string { return `voice:${channelId}` }
+
+export function channelMode(channelId: string): Mode {
+  return _mode.get(channelId) ?? 'mesh'
+}
+export function channelIsSfu(channelId: string): boolean {
+  return channelMode(channelId) === 'sfu'
+}
+
+// Appelé après un join, avec le nombre de participants du canal (seats).
+export function onSeatCount(server: Server, channelId: string, count: number): void {
+  if (!enabled(channelId)) return
+  if (channelMode(channelId) !== 'mesh') return
+  if (_cooldown.has(channelId)) return
+  if (count < threshold()) return
+  startSwitch(server, channelId)
+}
+
+function startSwitch(server: Server, channelId: string): void {
+  _mode.set(channelId, 'switching')
+  _ready.set(channelId, new Set())
+  server.to(room(channelId)).emit('voice:mode', { channelId, mode: 'sfu' })
+  clearTimer(channelId)
+  _timer.set(channelId, setTimeout(() => abort(server, channelId), SWITCH_TIMEOUT_MS))
+}
+
+// Un client confirme que son SFU produit ET consomme (audio prêt, non joué).
+export function onSfuReady(server: Server, channelId: string, socketId: string): void {
+  if (channelMode(channelId) !== 'switching') return
+  _ready.get(channelId)?.add(socketId)
+  void checkAllReady(server, channelId)
+}
+
+async function checkAllReady(server: Server, channelId: string): Promise<void> {
+  if (channelMode(channelId) !== 'switching') return
+  const sockets = await server.in(room(channelId)).fetchSockets()
+  if (sockets.length === 0) { reset(channelId); return }
+  const ready = _ready.get(channelId) ?? new Set<string>()
+  if (sockets.every(s => ready.has(s.id))) commit(server, channelId)
+}
+
+function commit(server: Server, channelId: string): void {
+  clearTimer(channelId)
+  _mode.set(channelId, 'sfu')
+  _ready.delete(channelId)
+  server.to(room(channelId)).emit('voice:sfu_commit', { channelId })
+}
+
+function abort(server: Server, channelId: string): void {
+  if (channelMode(channelId) !== 'switching') return
+  clearTimer(channelId)
+  _mode.set(channelId, 'mesh')
+  _ready.delete(channelId)
+  _cooldown.add(channelId) // anti-flapping
+  server.to(room(channelId)).emit('voice:mode', { channelId, mode: 'mesh' })
+}
+
+// Appelé au départ / à la déconnexion, avec le nombre de participants RESTANTS.
+export function onLeave(server: Server, channelId: string, socketId: string, remaining: number): void {
+  _ready.get(channelId)?.delete(socketId)
+  if (remaining < threshold()) _cooldown.delete(channelId) // dip sous le seuil → on pourra re-tenter
+  if (remaining === 0) { reset(channelId); return }
+  if (channelMode(channelId) === 'switching') void checkAllReady(server, channelId)
+}
+
+function reset(channelId: string): void {
+  clearTimer(channelId)
+  _mode.delete(channelId)
+  _ready.delete(channelId)
+  _cooldown.delete(channelId)
+}
+function clearTimer(channelId: string): void {
+  const t = _timer.get(channelId)
+  if (t) { clearTimeout(t); _timer.delete(channelId) }
+}
+
+// ── Tests uniquement ──────────────────────────────────────────────────────────
+export function _resetAllForTest(): void {
+  for (const t of _timer.values()) clearTimeout(t)
+  _mode.clear(); _ready.clear(); _timer.clear(); _cooldown.clear()
+}

--- a/nodyx-core/src/tests/voice-bascule.test.ts
+++ b/nodyx-core/src/tests/voice-bascule.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests de la bascule mesh↔SFU (socket/voiceBascule.ts) — machine à états serveur.
+ *
+ * Couvre : déclencheur au seuil, porte "tous prêts" (zéro coupure), abandon au
+ * timeout, anti-flapping, remise à zéro, et surtout la DORMANCE (flag off ⇒ rien).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as bascule from '../socket/voiceBascule'
+
+const CH = 'chan-1'
+
+type Sock = { id: string }
+function makeServer(initial: Sock[] = []) {
+  const emits: { room: string; ev: string; payload: Record<string, unknown> }[] = []
+  let current = initial
+  const server = {
+    to: (room: string) => ({
+      emit: (ev: string, payload: Record<string, unknown>) => { emits.push({ room, ev, payload }) },
+    }),
+    in: (_room: string) => ({ fetchSockets: async () => current }),
+  }
+  return { server: server as never, emits, setSockets: (s: Sock[]) => { current = s } }
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+const evs = (emits: { ev: string }[]) => emits.map((e) => e.ev)
+
+beforeEach(() => {
+  process.env.VOICE_SFU_AUTO = 'true'
+  process.env.VOICE_SFU_URL = 'http://127.0.0.1:3901'
+  process.env.VOICE_SFU_AUTO_CHANNELS = ''
+  process.env.VOICE_SFU_MESH_THRESHOLD = '3'
+  bascule._resetAllForTest()
+})
+afterEach(() => { vi.useRealTimers() })
+
+describe('déclencheur', () => {
+  it('sous le seuil : reste mesh, aucune annonce', () => {
+    const { server, emits } = makeServer()
+    bascule.onSeatCount(server, CH, 2)
+    expect(bascule.channelMode(CH)).toBe('mesh')
+    expect(emits).toHaveLength(0)
+  })
+
+  it('au seuil : passe en switching et annonce voice:mode sfu', () => {
+    const { server, emits } = makeServer()
+    bascule.onSeatCount(server, CH, 3)
+    expect(bascule.channelMode(CH)).toBe('switching')
+    expect(emits).toHaveLength(1)
+    expect(emits[0].ev).toBe('voice:mode')
+    expect(emits[0].payload).toMatchObject({ channelId: CH, mode: 'sfu' })
+  })
+})
+
+describe('porte "tous prêts" (zéro coupure)', () => {
+  it('commit seulement quand TOUS les sockets sont prêts', async () => {
+    const { server, emits } = makeServer([{ id: 's1' }, { id: 's2' }, { id: 's3' }])
+    bascule.onSeatCount(server, CH, 3)
+
+    bascule.onSfuReady(server, CH, 's1')
+    bascule.onSfuReady(server, CH, 's2')
+    await flush()
+    expect(bascule.channelMode(CH)).toBe('switching')  // pas encore tous prêts
+    expect(evs(emits)).not.toContain('voice:sfu_commit')
+
+    bascule.onSfuReady(server, CH, 's3')
+    await flush()
+    expect(bascule.channelMode(CH)).toBe('sfu')
+    expect(bascule.channelIsSfu(CH)).toBe(true)
+    expect(evs(emits)).toContain('voice:sfu_commit')
+  })
+
+  it("un départ pendant switching débloque le commit s'il ne restait que lui", async () => {
+    const srv = makeServer([{ id: 's1' }, { id: 's2' }, { id: 's3' }])
+    bascule.onSeatCount(srv.server, CH, 3)
+    bascule.onSfuReady(srv.server, CH, 's1')
+    bascule.onSfuReady(srv.server, CH, 's2')
+    await flush()
+    expect(bascule.channelMode(CH)).toBe('switching')
+
+    // s3 part : il ne reste que s1+s2, tous deux prêts → commit
+    srv.setSockets([{ id: 's1' }, { id: 's2' }])
+    bascule.onLeave(srv.server, CH, 's3', 2)
+    await flush()
+    expect(bascule.channelMode(CH)).toBe('sfu')
+  })
+})
+
+describe('abandon (échec) + anti-flapping', () => {
+  it('timeout ⇒ abandon vers mesh, puis pas de retry avant baisse sous le seuil', async () => {
+    vi.useFakeTimers()
+    const { server, emits } = makeServer([{ id: 's1' }, { id: 's2' }, { id: 's3' }])
+    bascule.onSeatCount(server, CH, 3)
+    expect(bascule.channelMode(CH)).toBe('switching')
+
+    vi.advanceTimersByTime(9001) // personne n'a confirmé → abandon
+    expect(bascule.channelMode(CH)).toBe('mesh')
+    const abortEmit = emits.find((e) => e.ev === 'voice:mode' && e.payload.mode === 'mesh')
+    expect(abortEmit).toBeDefined()
+
+    // Anti-flapping : re-franchir le seuil ne relance PAS tant que la compo n'a pas changé
+    const before = emits.length
+    bascule.onSeatCount(server, CH, 3)
+    expect(bascule.channelMode(CH)).toBe('mesh')
+    expect(emits.length).toBe(before)
+
+    // La compo baisse sous le seuil → le cooldown se lève
+    bascule.onLeave(server, CH, 's3', 2)
+    // Re-franchir : on retente
+    bascule.onSeatCount(server, CH, 3)
+    expect(bascule.channelMode(CH)).toBe('switching')
+  })
+})
+
+describe('remise à zéro', () => {
+  it('canal vidé (remaining 0) ⇒ retour à mesh', async () => {
+    const { server } = makeServer([{ id: 's1' }, { id: 's2' }, { id: 's3' }])
+    bascule.onSeatCount(server, CH, 3)
+    bascule.onSfuReady(server, CH, 's1')
+    bascule.onSfuReady(server, CH, 's2')
+    bascule.onSfuReady(server, CH, 's3')
+    await flush()
+    expect(bascule.channelMode(CH)).toBe('sfu')
+
+    bascule.onLeave(server, CH, 's1', 0)
+    expect(bascule.channelMode(CH)).toBe('mesh')
+  })
+})
+
+describe('dormance (doctrine additive)', () => {
+  it('flag off ⇒ jamais de bascule, aucune annonce', () => {
+    process.env.VOICE_SFU_AUTO = 'false'
+    const { server, emits } = makeServer()
+    bascule.onSeatCount(server, CH, 50)
+    expect(bascule.channelMode(CH)).toBe('mesh')
+    expect(emits).toHaveLength(0)
+  })
+
+  it('sans VOICE_SFU_URL ⇒ dormant', () => {
+    delete process.env.VOICE_SFU_URL
+    const { server, emits } = makeServer()
+    bascule.onSeatCount(server, CH, 50)
+    expect(bascule.channelMode(CH)).toBe('mesh')
+    expect(emits).toHaveLength(0)
+  })
+
+  it('canal hors liste blanche ⇒ dormant, canal listé ⇒ actif', () => {
+    process.env.VOICE_SFU_AUTO_CHANNELS = 'autre-canal'
+    const a = makeServer()
+    bascule.onSeatCount(a.server, CH, 5)
+    expect(bascule.channelMode(CH)).toBe('mesh')  // CH pas dans la liste
+
+    process.env.VOICE_SFU_AUTO_CHANNELS = `autre-canal,${CH}`
+    const b = makeServer()
+    bascule.onSeatCount(b.server, CH, 5)
+    expect(bascule.channelMode(CH)).toBe('switching')  // CH listé → actif
+  })
+})


### PR DESCRIPTION
Étape 1 (backend) de la bascule mesh↔SFU (§17-B, cf `SPECS/NODYX_SFU_BASCULE.md`).

**Mécanisme zéro-coupure** : overlap (le mesh reste debout) + porte "tous prêts" (on ne ferme le mesh que quand TOUT LE MONDE est sur l'SFU, sinon un pair mesh N↔N tomberait dans un trou).

- Nouveau `socket/voiceBascule.ts` : machine à états par canal (mesh→switching→sfu), déclencheur au seuil (6), `voice:mode` / `voice:sfu_ready` / `voice:sfu_commit`, abandon au timeout + anti-flapping, liste blanche par canal.
- `voice.ts` : ~6 lignes de hooks **additifs**.
- **DORMANT** : `VOICE_SFU_AUTO` off (défaut) ⇒ `channelMode`==='mesh' partout ⇒ mesh **strictement inchangé**. Rollback = flag off.
- **9 tests** (seuil, porte tous-prêts, abandon, anti-flap, dormance) + suite **397 verte**, tsc clean.

Sanctuaire respecté : additif, flag-gardé, testé. Étape 2 = frontend.