### PR TITLE
feat(sfu): bascule mesh↔SFU, client frontend (étape 2, dormante)

### DIFF
--- a/nodyx-core/src/socket/voice.ts
+++ b/nodyx-core/src/socket/voice.ts
@@ -184,21 +184,20 @@ export function registerVoiceHandlers(socket: Socket, server: Server): void {
     const chMode = bascule.channelMode(channelId)
     socket.emit('voice:init', { channelId, peers, mySeatIndex: mySeat, iceServers: buildIceServers(userId), mode: chMode })
 
-    // Notify existing peers about the newcomer — SAUF si le canal est déjà en SFU
-    // (topologie étoile : le nouveau producer est relayé via voice:sfu_new_producer,
-    // pas de PC mesh à créer). En 'mesh' et 'switching' (overlap), on prévient bien.
-    if (chMode !== 'sfu') {
-      socket.to(room).emit('voice:peer_joined', {
-        channelId,
-        peer: {
-          socketId:  socket.id,
-          userId,
-          username,
-          avatar:    socket.data.avatar ?? null,
-          seatIndex: mySeat,
-        },
-      })
-    }
+    // Roster : on prévient TOUJOURS les pairs. voice:peer_joined peuple la liste des
+    // participants (voiceStore.peers), indépendamment du média. C'est le CLIENT qui
+    // décide de créer un PC mesh ou non selon le mode (en SFU : roster seul, le média
+    // passe par l'SFU via voice:sfu_new_producer). Cf SPECS/NODYX_SFU_BASCULE.md.
+    socket.to(room).emit('voice:peer_joined', {
+      channelId,
+      peer: {
+        socketId:  socket.id,
+        userId,
+        username,
+        avatar:    socket.data.avatar ?? null,
+        seatIndex: mySeat,
+      },
+    })
 
     // Le seuil est-il franchi ? (no-op si le flag est off)
     bascule.onSeatCount(server, channelId, getChannelSeats(channelId).size)

--- a/nodyx-frontend/src/lib/voice.ts
+++ b/nodyx-frontend/src/lib/voice.ts
@@ -8,8 +8,16 @@ import { writable, derived, get } from 'svelte/store'
 import type { Socket } from 'socket.io-client'
 import { voiceSettingsStore, getPeerVolume, type VoiceSettings } from './voiceSettings'
 import { p2pManager } from './p2p'
+import * as bascule from './voiceBascule'
 export { voiceSettingsStore } from './voiceSettings'
 export type { VoiceSettings } from './voiceSettings'
+
+// ── Bascule mesh↔SFU (§17-B) : mode du canal côté client ──────────────────────
+// 'mesh' par défaut. Passe à 'switching'/'sfu' UNIQUEMENT sur événement serveur
+// (qui n'arrive que si VOICE_SFU_AUTO est actif). Tant que c'est 'mesh', tous les
+// chemins mesh ci-dessous sont strictement ceux d'avant.
+type ChannelMode = 'mesh' | 'switching' | 'sfu'
+let _channelMode: ChannelMode = 'mesh'
 
 // ── ICE Configuration ─────────────────────────────────────────────
 // Priority: dynamic servers from voice:init (nodyx-turn) > static env vars (legacy coturn).
@@ -953,6 +961,9 @@ export async function joinVoice(channelId: string, socket: Socket): Promise<void
   socket.on('voice:stats',       onPeerStats)
   socket.on('voice:full',        onVoiceFull)
   socket.on('voice:kicked',      onKicked)
+  socket.on('voice:mode',        onVoiceModeEvent)   // bascule §17-B (dormant si flag off)
+  socket.on('voice:sfu_commit',  onSfuCommitEvent)
+  _channelMode = 'mesh'                               // repart toujours de mesh
 
   _onSocketReconnect = () => {
     console.debug('[voice] Socket reconnected — rejoining voice room')
@@ -976,6 +987,10 @@ export function leaveVoice(): void {
   if (channelId && _socket) {
     _socket.emit('voice:leave', channelId)
   }
+  // Si on était passé sur l'SFU (bascule), quitter aussi la session SFU. Idempotent
+  // en mesh pur (aucune session SFU ⇒ no-op). Puis on repart de mesh.
+  void bascule.basculeLeaveSfu()
+  _channelMode = 'mesh'
 
   if (_socket) {
     _socket.off('voice:init',        onVoiceInit)
@@ -988,6 +1003,8 @@ export function leaveVoice(): void {
     _socket.off('voice:stats',       onPeerStats)
     _socket.off('voice:full',        onVoiceFull)
     _socket.off('voice:kicked',      onKicked)
+    _socket.off('voice:mode',        onVoiceModeEvent)
+    _socket.off('voice:sfu_commit',  onSfuCommitEvent)
     if (_onSocketReconnect) {
       _socket.off('connect', _onSocketReconnect)
       _onSocketReconnect = null
@@ -1205,11 +1222,12 @@ export function stopScreenShare(): void {
 
 // ── Socket event handlers ─────────────────────────────────────────
 
-function onVoiceInit({ channelId, peers, mySeatIndex, iceServers }: {
+function onVoiceInit({ channelId, peers, mySeatIndex, iceServers, mode }: {
   channelId:   string
   peers:       { socketId: string; userId: string; username: string; avatar: string | null; seatIndex: number }[]
   mySeatIndex: number
   iceServers?: RTCIceServer[]
+  mode?:       ChannelMode
 }): void {
   if (iceServers && iceServers.length > 0) {
     _dynamicIceServers = iceServers
@@ -1227,8 +1245,20 @@ function onVoiceInit({ channelId, peers, mySeatIndex, iceServers }: {
   const peerList: VoicePeer[] = peers.map(p => ({ ...p, stream: null, speaking: false, iceState: null }))
   voiceStore.update(s => ({ ...s, peers: peerList, mySeatIndex }))
 
-  for (const peer of peers) {
-    createPeerConn(peer.socketId, channelId, true)
+  _channelMode = mode ?? 'mesh'
+  if (_channelMode === 'sfu') {
+    // Arrivant tardif sur un canal DÉJÀ en SFU (§5) : aucun PC mesh, on rejoint
+    // l'SFU directement (lecture immédiate). Le roster ci-dessus reste affiché.
+    void bascule.basculeJoinDirectSfu(channelId)
+  } else {
+    for (const peer of peers) {
+      createPeerConn(peer.socketId, channelId, true)
+    }
+    if (_channelMode === 'switching' && _socket) {
+      // J'arrive pendant une bascule : mesh (ci-dessus) + établir l'SFU en
+      // parallèle sans jouer, puis confirmer. Le commit viendra du serveur.
+      void bascule.basculeBeginSwitch(_socket, channelId)
+    }
   }
 }
 
@@ -1247,7 +1277,9 @@ function onPeerJoined({ channelId, peer }: {
     if (s.peers.some(p => p.socketId === peer.socketId)) return s
     return { ...s, peers: [...s.peers, { ...peer, stream: null, speaking: false, iceState: null }] }
   })
-  if (!_peerConns.has(peer.socketId)) {
+  // Roster mis à jour ci-dessus dans TOUS les modes. On ne crée un PC mesh que
+  // hors SFU : en SFU, le nouveau flux est relayé via l'SFU (voice:sfu_new_producer).
+  if (_channelMode !== 'sfu' && !_peerConns.has(peer.socketId)) {
     createPeerConn(peer.socketId, channelId, false)
   }
 }
@@ -1262,6 +1294,49 @@ function onPeerLeft({ socketId }: { channelId: string; socketId: string }): void
   _offerLocks.delete(socketId)
   remoteScreenStore.update(map => { map.delete(socketId); return new Map(map) })
   voiceStore.update(s => ({ ...s, peers: s.peers.filter(p => p.socketId !== socketId) }))
+}
+
+// ── Bascule mesh↔SFU (§17-B) : handlers serveur + opérations mesh ──
+// Invoqués UNIQUEMENT si le serveur émet voice:mode / voice:sfu_commit (⇒
+// VOICE_SFU_AUTO actif). En mesh pur, ces fonctions ne tournent jamais.
+
+function _meshMutePlayback(muted: boolean): void {
+  for (const node of _peerAudio.values()) node.audioEl.muted = muted
+}
+
+function _meshTeardownConnections(): void {
+  // Ferme le MÉDIA mesh (PC + audio), garde la SESSION (roster, micro local,
+  // socket, seat). Le média passe désormais par l'SFU. Même geste que le teardown
+  // de leaveVoice, mais sans toucher au reste. Le micro mesh, désormais inutilisé,
+  // reste ouvert : inoffensif, et on évite de risquer l'état de session.
+  for (const [sid, pc] of _peerConns) {
+    destroyPeerAudio(sid)
+    pc.close()
+  }
+  _peerConns.clear()
+  _iceQueues.clear()
+  _initiatorMap.clear()
+  _offerLocks.clear()
+}
+
+function onVoiceModeEvent({ channelId, mode }: { channelId: string; mode: 'sfu' | 'mesh' }): void {
+  if (mode === 'sfu') {
+    if (_channelMode !== 'mesh') return            // déjà en switching/sfu
+    _channelMode = 'switching'
+    // Garder le mesh + établir l'SFU en parallèle (hold), puis confirmer.
+    if (_socket) void bascule.basculeBeginSwitch(_socket, channelId)
+  } else if (mode === 'mesh') {                    // abandon décidé par le serveur
+    if (_channelMode === 'switching') {
+      _channelMode = 'mesh'
+      void bascule.basculeLeaveSfu()               // on lâche l'SFU, le mesh (jamais lâché) reste
+    }
+  }
+}
+
+function onSfuCommitEvent(_payload: { channelId: string }): void {
+  _channelMode = 'sfu'
+  // Instant zéro-coupure : joue l'SFU, coupe puis démonte le mesh.
+  bascule.basculeCommit(_meshMutePlayback, _meshTeardownConnections)
 }
 
 async function onOffer({ from, sdp, channelId }: { from: string; sdp: RTCSessionDescriptionInit; channelId: string }): Promise<void> {

--- a/nodyx-frontend/src/lib/voiceBascule.test.ts
+++ b/nodyx-frontend/src/lib/voiceBascule.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests de l'orchestrateur client de la bascule mesh↔SFU (voiceBascule.ts).
+ * On mocke voiceSfu : on teste la COORDINATION (hold, confirmation, ordre du
+ * commit zéro-coupure), pas la couche mediasoup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { sfuJoin, sfuLeave, sfuActivatePlayback, sfuIsActive } = vi.hoisted(() => ({
+  sfuJoin:             vi.fn(async () => {}),
+  sfuLeave:            vi.fn(async () => {}),
+  sfuActivatePlayback: vi.fn(),
+  sfuIsActive:         vi.fn(() => true),
+}))
+vi.mock('./voiceSfu', () => ({ sfuJoin, sfuLeave, sfuActivatePlayback, sfuIsActive }))
+
+import { basculeBeginSwitch, basculeJoinDirectSfu, basculeLeaveSfu, basculeCommit } from './voiceBascule'
+
+beforeEach(() => { vi.clearAllMocks() })
+
+describe('basculeBeginSwitch (cas A/C : bascule ou arrivée en switching)', () => {
+  it('établit l\'SFU en HOLD, puis confirme voice:sfu_ready si actif', async () => {
+    const emit = vi.fn()
+    await basculeBeginSwitch({ emit }, 'chan-1')
+    expect(sfuJoin).toHaveBeenCalledWith('chan-1', { holdPlayback: true })
+    expect(emit).toHaveBeenCalledWith('voice:sfu_ready', { channelId: 'chan-1' })
+  })
+
+  it('ne confirme PAS si l\'établissement a échoué (le serveur abandonnera)', async () => {
+    sfuIsActive.mockReturnValueOnce(false)
+    const emit = vi.fn()
+    await basculeBeginSwitch({ emit }, 'chan-1')
+    expect(sfuJoin).toHaveBeenCalledWith('chan-1', { holdPlayback: true })
+    expect(emit).not.toHaveBeenCalled()
+  })
+})
+
+describe('basculeJoinDirectSfu (cas B : arrivée sur un canal déjà SFU)', () => {
+  it('rejoint l\'SFU en lecture immédiate (pas de hold)', async () => {
+    await basculeJoinDirectSfu('chan-1')
+    expect(sfuJoin).toHaveBeenCalledWith('chan-1')
+  })
+})
+
+describe('basculeLeaveSfu (abandon / départ)', () => {
+  it('quitte l\'SFU', async () => {
+    await basculeLeaveSfu()
+    expect(sfuLeave).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('basculeCommit (l\'instant zéro-coupure)', () => {
+  it('joue l\'SFU AVANT de couper puis démonter le mesh', () => {
+    const order: string[] = []
+    sfuActivatePlayback.mockImplementationOnce(() => order.push('sfu'))
+    const meshMute = vi.fn((m: boolean) => order.push(`mute:${m}`))
+    const meshTeardown = vi.fn(() => order.push('teardown'))
+
+    basculeCommit(meshMute, meshTeardown)
+
+    expect(meshMute).toHaveBeenCalledWith(true)
+    expect(meshTeardown).toHaveBeenCalledTimes(1)
+    // Ordre critique : SFU joue d'abord (relais pris), PUIS le mesh se tait et se démonte.
+    expect(order).toEqual(['sfu', 'mute:true', 'teardown'])
+  })
+})

--- a/nodyx-frontend/src/lib/voiceBascule.ts
+++ b/nodyx-frontend/src/lib/voiceBascule.ts
@@ -1,0 +1,47 @@
+// ── Bascule mesh ↔ SFU — orchestrateur CLIENT (§17-B) ─────────────────────────
+//
+// N'agit QUE sur événement serveur (voice:mode / voice:sfu_commit), lesquels ne
+// sont émis que si le flag backend VOICE_SFU_AUTO est actif. Sans bascule, ces
+// fonctions ne sont jamais appelées ⇒ le mesh (voice.ts) est strictement inchangé.
+//
+// Zéro import de voice.ts : le commit reçoit les opérations mesh en paramètres
+// (pas d'import circulaire). N'importe que voiceSfu (la couche SFU).
+
+import { sfuJoin, sfuLeave, sfuActivatePlayback, sfuIsActive } from './voiceSfu'
+
+// Type minimal : on n'a besoin que d'emit pour confirmer au serveur.
+type Emitter = { emit: (event: string, payload: unknown) => void }
+
+// Cas A/C : le canal bascule (ou j'arrive pendant switching) → établir l'SFU EN
+// PARALLÈLE du mesh, SANS jouer (holdPlayback), puis confirmer au serveur. Le mesh
+// n'est PAS touché : on entend toujours via lui jusqu'au commit.
+export async function basculeBeginSwitch(socket: Emitter, channelId: string): Promise<void> {
+  await sfuJoin(channelId, { holdPlayback: true })
+  if (sfuIsActive()) {
+    socket.emit('voice:sfu_ready', { channelId })
+  }
+  // sinon : établissement échoué → le serveur abandonnera au timeout (voice:mode mesh)
+}
+
+// Cas B : j'arrive sur un canal DÉJÀ en SFU → rejoindre l'SFU directement, en
+// jouant (pas de mesh, donc pas d'overlap à gérer).
+export async function basculeJoinDirectSfu(channelId: string): Promise<void> {
+  await sfuJoin(channelId) // holdPlayback false ⇒ lecture immédiate
+}
+
+// Abandon / départ : on lâche l'SFU. Le mesh (jamais lâché) reste seul. Idempotent
+// (sfuLeave gère l'absence de session).
+export async function basculeLeaveSfu(): Promise<void> {
+  await sfuLeave()
+}
+
+// Commit : l'instant zéro-coupure. On joue l'SFU (bref overlap : les deux jouent),
+// puis on coupe et démonte le mesh. Les opérations mesh sont fournies par voice.ts.
+export function basculeCommit(
+  meshMutePlayback: (muted: boolean) => void,
+  meshTeardownConnections: () => void,
+): void {
+  sfuActivatePlayback()        // l'SFU prend le relais
+  meshMutePlayback(true)       // le mesh se tait
+  meshTeardownConnections()    // puis on démonte les PC mesh (roster/session conservés)
+}

--- a/nodyx-frontend/src/lib/voiceSfu.ts
+++ b/nodyx-frontend/src/lib/voiceSfu.ts
@@ -154,8 +154,9 @@ function setMediaSession(active: boolean): void {
   } catch { /* pas supporté */ }
 }
 
-export async function sfuJoin(channelId: string): Promise<void> {
+export async function sfuJoin(channelId: string, opts: { holdPlayback?: boolean } = {}): Promise<void> {
   if (_session) { log('⚠ session déjà active, join ignoré (leave d\'abord)'); return }
+  _holdPlayback = !!opts.holdPlayback // overlap bascule : établir sans jouer
   const sock = get(socketStore)
   if (!sock) { fail('socket non connecté'); return }
 
@@ -283,6 +284,11 @@ export async function sfuJoin(channelId: string): Promise<void> {
 
 const _consuming = new Set<string>()
 
+// Overlap bascule (§17-B) : quand vrai, les consumers sont créés MUETS (établis
+// mais non joués) jusqu'à sfuActivatePlayback() — évite le double son pendant que
+// le mesh joue encore. Défaut false = comportement normal (labo : lecture immédiate).
+let _holdPlayback = false
+
 async function consumeOne(sock: Socket, producerId: string, userId: string, kind: string): Promise<void> {
   const s = _session
   if (!s) return
@@ -305,6 +311,7 @@ async function consumeOne(sock: Socket, producerId: string, userId: string, kind
     const el = new Audio()
     el.srcObject = new MediaStream([consumer.track])
     el.autoplay = true
+    el.muted = _holdPlayback // overlap : établi mais silencieux jusqu'au commit
     s.audioEls.set(producerId, el)
     void el.play().catch(err => log(`⚠ autoplay : ${err.message}`))
 
@@ -413,6 +420,24 @@ export function sfuSetMuted(muted: boolean): void {
     sfuMutedStore.set(muted)
     log(muted ? 'micro coupé' : 'micro ouvert')
   }
+}
+
+/** Bascule (commit) : on lève l'overlap → on joue enfin les flux SFU (dé-mute les
+ *  <audio> établis en hold, et les futurs consumers joueront normalement). Idempotent. */
+export function sfuActivatePlayback(): void {
+  _holdPlayback = false
+  const s = _session
+  if (!s) return
+  for (const el of s.audioEls.values()) {
+    el.muted = false
+    void el.play().catch(() => { /* autoplay pointilleux : ignoré */ })
+  }
+  log('▶ lecture SFU activée (commit)')
+}
+
+/** État établi (produce + consume faits) : le bascule attend ça pour voice:sfu_ready. */
+export function sfuIsActive(): boolean {
+  return _session !== null && get(sfuPhaseStore) === 'active'
 }
 
 export async function sfuLeave(): Promise<void> {


### PR DESCRIPTION
Étape 2 (frontend) de la bascule mesh↔SFU (§17-B). L'overlap **zéro-coupure** côté client.

- `voiceSfu.ts` : `holdPlayback` (consumers créés muets) + `sfuActivatePlayback` + `sfuIsActive`.
- `voiceBascule.ts` (nouveau) : orchestrateur client, **aucun import circulaire** (le commit reçoit les ops mesh en paramètres). 5 tests dont l'**ordre du commit** (SFU d'abord → mesh coupé après).
- `voice.ts` (mesh) : mode du canal côté client, PC mesh gardé par le mode (SFU = roster seul), handlers `voice:mode`/`voice:sfu_commit`, mute+teardown mesh (garde session+roster), register/off/reset.
- **Backend** : garde `peer_joined` retirée (le roster doit TOUJOURS passer ; le client gate le PC mesh). Le fix qui garde la liste des participants en SFU.

**ADDITIF & DORMANT** : sans event serveur (`VOICE_SFU_AUTO` off), `_channelMode` reste 'mesh' partout ⇒ mesh **strictement inchangé**. svelte-check 0 err, builds clean, **397 back + 14 front** tests verts.

Reste : déploiement dormant + activation sur un canal (étape 3).