### PR TITLE
fix(sfu): bascule mesh↔SFU, lecture SFU immédiate + crossfade par personne

### DIFF
--- a/nodyx-frontend/src/lib/voice.ts
+++ b/nodyx-frontend/src/lib/voice.ts
@@ -1256,8 +1256,8 @@ function onVoiceInit({ channelId, peers, mySeatIndex, iceServers, mode }: {
     }
     if (_channelMode === 'switching' && _socket) {
       // J'arrive pendant une bascule : mesh (ci-dessus) + établir l'SFU en
-      // parallèle sans jouer, puis confirmer. Le commit viendra du serveur.
-      void bascule.basculeBeginSwitch(_socket, channelId)
+      // parallèle ; chaque flux SFU qui démarre coupe le mesh de la personne.
+      void bascule.basculeBeginSwitch(_socket, channelId, _meshMutePeerByUserId)
     }
   }
 }
@@ -1304,6 +1304,16 @@ function _meshMutePlayback(muted: boolean): void {
   for (const node of _peerAudio.values()) node.audioEl.muted = muted
 }
 
+// Crossfade par personne : coupe le mesh de l'utilisateur dont le flux SFU vient
+// de commencer à jouer (appelé par voiceSfu via le callback). Le roster fait le
+// lien userId → socketId mesh.
+function _meshMutePeerByUserId(userId: string): void {
+  const peer = get(voiceStore).peers.find(p => p.userId === userId)
+  if (!peer) return
+  const node = _peerAudio.get(peer.socketId)
+  if (node) node.audioEl.muted = true
+}
+
 function _meshTeardownConnections(): void {
   // Ferme le MÉDIA mesh (PC + audio), garde la SESSION (roster, micro local,
   // socket, seat). Le média passe désormais par l'SFU. Même geste que le teardown
@@ -1323,8 +1333,9 @@ function onVoiceModeEvent({ channelId, mode }: { channelId: string; mode: 'sfu' 
   if (mode === 'sfu') {
     if (_channelMode !== 'mesh') return            // déjà en switching/sfu
     _channelMode = 'switching'
-    // Garder le mesh + établir l'SFU en parallèle (hold), puis confirmer.
-    if (_socket) void bascule.basculeBeginSwitch(_socket, channelId)
+    // Garder le mesh + établir l'SFU (lecture immédiate) ; chaque flux SFU coupe
+    // le mesh de la personne concernée. Puis confirmer au serveur.
+    if (_socket) void bascule.basculeBeginSwitch(_socket, channelId, _meshMutePeerByUserId)
   } else if (mode === 'mesh') {                    // abandon décidé par le serveur
     if (_channelMode === 'switching') {
       _channelMode = 'mesh'

--- a/nodyx-frontend/src/lib/voiceBascule.test.ts
+++ b/nodyx-frontend/src/lib/voiceBascule.test.ts
@@ -1,66 +1,66 @@
 /**
  * Tests de l'orchestrateur client de la bascule mesh↔SFU (voiceBascule.ts).
- * On mocke voiceSfu : on teste la COORDINATION (hold, confirmation, ordre du
- * commit zéro-coupure), pas la couche mediasoup.
+ * On mocke voiceSfu : on teste la COORDINATION (lecture immédiate + crossfade par
+ * personne, confirmation, teardown au commit), pas la couche mediasoup.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const { sfuJoin, sfuLeave, sfuActivatePlayback, sfuIsActive } = vi.hoisted(() => ({
-  sfuJoin:             vi.fn(async () => {}),
-  sfuLeave:            vi.fn(async () => {}),
-  sfuActivatePlayback: vi.fn(),
-  sfuIsActive:         vi.fn(() => true),
+const { sfuJoin, sfuLeave, sfuIsActive, sfuSetConsumerPlayingCallback } = vi.hoisted(() => ({
+  sfuJoin:                       vi.fn(async () => {}),
+  sfuLeave:                      vi.fn(async () => {}),
+  sfuIsActive:                   vi.fn(() => true),
+  sfuSetConsumerPlayingCallback: vi.fn(),
 }))
-vi.mock('./voiceSfu', () => ({ sfuJoin, sfuLeave, sfuActivatePlayback, sfuIsActive }))
+vi.mock('./voiceSfu', () => ({ sfuJoin, sfuLeave, sfuIsActive, sfuSetConsumerPlayingCallback }))
 
 import { basculeBeginSwitch, basculeJoinDirectSfu, basculeLeaveSfu, basculeCommit } from './voiceBascule'
 
 beforeEach(() => { vi.clearAllMocks() })
 
 describe('basculeBeginSwitch (cas A/C : bascule ou arrivée en switching)', () => {
-  it('établit l\'SFU en HOLD, puis confirme voice:sfu_ready si actif', async () => {
+  it('enregistre le callback crossfade, joue tout de suite, puis confirme si actif', async () => {
     const emit = vi.fn()
-    await basculeBeginSwitch({ emit }, 'chan-1')
-    expect(sfuJoin).toHaveBeenCalledWith('chan-1', { holdPlayback: true })
+    const cross = vi.fn()
+    await basculeBeginSwitch({ emit }, 'chan-1', cross)
+    expect(sfuSetConsumerPlayingCallback).toHaveBeenCalledWith(cross)  // coupe le mesh par personne
+    expect(sfuJoin).toHaveBeenCalledWith('chan-1')                     // lecture immédiate (pas de hold)
     expect(emit).toHaveBeenCalledWith('voice:sfu_ready', { channelId: 'chan-1' })
   })
 
   it('ne confirme PAS si l\'établissement a échoué (le serveur abandonnera)', async () => {
     sfuIsActive.mockReturnValueOnce(false)
     const emit = vi.fn()
-    await basculeBeginSwitch({ emit }, 'chan-1')
-    expect(sfuJoin).toHaveBeenCalledWith('chan-1', { holdPlayback: true })
+    await basculeBeginSwitch({ emit }, 'chan-1', vi.fn())
+    expect(sfuJoin).toHaveBeenCalledWith('chan-1')
     expect(emit).not.toHaveBeenCalled()
   })
 })
 
 describe('basculeJoinDirectSfu (cas B : arrivée sur un canal déjà SFU)', () => {
-  it('rejoint l\'SFU en lecture immédiate (pas de hold)', async () => {
+  it('rejoint l\'SFU directement', async () => {
     await basculeJoinDirectSfu('chan-1')
     expect(sfuJoin).toHaveBeenCalledWith('chan-1')
   })
 })
 
 describe('basculeLeaveSfu (abandon / départ)', () => {
-  it('quitte l\'SFU', async () => {
+  it('oublie le callback puis quitte l\'SFU', async () => {
     await basculeLeaveSfu()
+    expect(sfuSetConsumerPlayingCallback).toHaveBeenCalledWith(null)
     expect(sfuLeave).toHaveBeenCalledTimes(1)
   })
 })
 
-describe('basculeCommit (l\'instant zéro-coupure)', () => {
-  it('joue l\'SFU AVANT de couper puis démonter le mesh', () => {
+describe('basculeCommit (finalisation)', () => {
+  it('oublie le callback, coupe un résidu mesh, puis démonte les PC', () => {
     const order: string[] = []
-    sfuActivatePlayback.mockImplementationOnce(() => order.push('sfu'))
     const meshMute = vi.fn((m: boolean) => order.push(`mute:${m}`))
     const meshTeardown = vi.fn(() => order.push('teardown'))
 
     basculeCommit(meshMute, meshTeardown)
 
-    expect(meshMute).toHaveBeenCalledWith(true)
-    expect(meshTeardown).toHaveBeenCalledTimes(1)
-    // Ordre critique : SFU joue d'abord (relais pris), PUIS le mesh se tait et se démonte.
-    expect(order).toEqual(['sfu', 'mute:true', 'teardown'])
+    expect(sfuSetConsumerPlayingCallback).toHaveBeenCalledWith(null)
+    expect(order).toEqual(['mute:true', 'teardown'])  // coupe le résidu avant de démonter
   })
 })

--- a/nodyx-frontend/src/lib/voiceBascule.ts
+++ b/nodyx-frontend/src/lib/voiceBascule.ts
@@ -4,44 +4,52 @@
 // sont émis que si le flag backend VOICE_SFU_AUTO est actif. Sans bascule, ces
 // fonctions ne sont jamais appelées ⇒ le mesh (voice.ts) est strictement inchangé.
 //
-// Zéro import de voice.ts : le commit reçoit les opérations mesh en paramètres
-// (pas d'import circulaire). N'importe que voiceSfu (la couche SFU).
+// Zéro-coupure SANS son différé (qui se faisait bloquer par la politique autoplay,
+// surtout mobile) : on JOUE le flux SFU immédiatement (comme le labo, prouvé), et
+// on coupe le mesh de chaque personne au moment EXACT où son flux SFU se met à
+// jouer (crossfade par personne). Donc pour chacun : mesh OU SFU, jamais les deux,
+// jamais le vide. voice.ts fournit les opérations mesh (pas d'import circulaire).
 
-import { sfuJoin, sfuLeave, sfuActivatePlayback, sfuIsActive } from './voiceSfu'
+import { sfuJoin, sfuLeave, sfuIsActive, sfuSetConsumerPlayingCallback } from './voiceSfu'
 
-// Type minimal : on n'a besoin que d'emit pour confirmer au serveur.
 type Emitter = { emit: (event: string, payload: unknown) => void }
 
-// Cas A/C : le canal bascule (ou j'arrive pendant switching) → établir l'SFU EN
-// PARALLÈLE du mesh, SANS jouer (holdPlayback), puis confirmer au serveur. Le mesh
-// n'est PAS touché : on entend toujours via lui jusqu'au commit.
-export async function basculeBeginSwitch(socket: Emitter, channelId: string): Promise<void> {
-  await sfuJoin(channelId, { holdPlayback: true })
+// Cas A/C : le canal bascule (ou j'arrive pendant switching). On établit l'SFU en
+// PARALLÈLE du mesh, en JOUANT tout de suite ; `onSfuPeerPlaying(userId)` coupe le
+// mesh de cette personne à l'instant où son flux SFU démarre. Puis on confirme.
+export async function basculeBeginSwitch(
+  socket: Emitter,
+  channelId: string,
+  onSfuPeerPlaying: (userId: string) => void,
+): Promise<void> {
+  sfuSetConsumerPlayingCallback(onSfuPeerPlaying)
+  await sfuJoin(channelId)
   if (sfuIsActive()) {
     socket.emit('voice:sfu_ready', { channelId })
   }
   // sinon : établissement échoué → le serveur abandonnera au timeout (voice:mode mesh)
 }
 
-// Cas B : j'arrive sur un canal DÉJÀ en SFU → rejoindre l'SFU directement, en
-// jouant (pas de mesh, donc pas d'overlap à gérer).
+// Cas B : j'arrive sur un canal DÉJÀ en SFU → rejoindre l'SFU directement (pas de
+// mesh, donc pas de crossfade à gérer).
 export async function basculeJoinDirectSfu(channelId: string): Promise<void> {
-  await sfuJoin(channelId) // holdPlayback false ⇒ lecture immédiate
+  await sfuJoin(channelId)
 }
 
-// Abandon / départ : on lâche l'SFU. Le mesh (jamais lâché) reste seul. Idempotent
-// (sfuLeave gère l'absence de session).
+// Abandon / départ : on lâche l'SFU et on oublie le callback. Le mesh (jamais
+// lâché) reste seul. Idempotent.
 export async function basculeLeaveSfu(): Promise<void> {
+  sfuSetConsumerPlayingCallback(null)
   await sfuLeave()
 }
 
-// Commit : l'instant zéro-coupure. On joue l'SFU (bref overlap : les deux jouent),
-// puis on coupe et démonte le mesh. Les opérations mesh sont fournies par voice.ts.
+// Commit : tout le monde est sur l'SFU (chaque flux joue déjà, le mesh de chacun a
+// été coupé au passage). On coupe un éventuel résidu mesh et on démonte les PC.
 export function basculeCommit(
   meshMutePlayback: (muted: boolean) => void,
   meshTeardownConnections: () => void,
 ): void {
-  sfuActivatePlayback()        // l'SFU prend le relais
-  meshMutePlayback(true)       // le mesh se tait
-  meshTeardownConnections()    // puis on démonte les PC mesh (roster/session conservés)
+  sfuSetConsumerPlayingCallback(null)
+  meshMutePlayback(true)      // filet de sécurité (résidu éventuel)
+  meshTeardownConnections()   // démonte les PC mesh (roster/session conservés)
 }

--- a/nodyx-frontend/src/lib/voiceSfu.ts
+++ b/nodyx-frontend/src/lib/voiceSfu.ts
@@ -154,9 +154,8 @@ function setMediaSession(active: boolean): void {
   } catch { /* pas supporté */ }
 }
 
-export async function sfuJoin(channelId: string, opts: { holdPlayback?: boolean } = {}): Promise<void> {
+export async function sfuJoin(channelId: string): Promise<void> {
   if (_session) { log('⚠ session déjà active, join ignoré (leave d\'abord)'); return }
-  _holdPlayback = !!opts.holdPlayback // overlap bascule : établir sans jouer
   const sock = get(socketStore)
   if (!sock) { fail('socket non connecté'); return }
 
@@ -284,10 +283,14 @@ export async function sfuJoin(channelId: string, opts: { holdPlayback?: boolean 
 
 const _consuming = new Set<string>()
 
-// Overlap bascule (§17-B) : quand vrai, les consumers sont créés MUETS (établis
-// mais non joués) jusqu'à sfuActivatePlayback() — évite le double son pendant que
-// le mesh joue encore. Défaut false = comportement normal (labo : lecture immédiate).
-let _holdPlayback = false
+// Overlap bascule (§17-B) : callback appelé quand un flux SFU COMMENCE À JOUER
+// (par userId). La bascule s'en sert pour couper le mesh de cette personne au
+// même instant (crossfade par personne = zéro coupure, sans son différé qui se
+// ferait bloquer par la politique autoplay des navigateurs, surtout mobile).
+let _onConsumerPlaying: ((userId: string) => void) | null = null
+export function sfuSetConsumerPlayingCallback(cb: ((userId: string) => void) | null): void {
+  _onConsumerPlaying = cb
+}
 
 async function consumeOne(sock: Socket, producerId: string, userId: string, kind: string): Promise<void> {
   const s = _session
@@ -311,12 +314,14 @@ async function consumeOne(sock: Socket, producerId: string, userId: string, kind
     const el = new Audio()
     el.srcObject = new MediaStream([consumer.track])
     el.autoplay = true
-    el.muted = _holdPlayback // overlap : établi mais silencieux jusqu'au commit
     s.audioEls.set(producerId, el)
     void el.play().catch(err => log(`⚠ autoplay : ${err.message}`))
 
     sfuConsumersStore.update(list => [...list, { consumerId: consumer.id, producerId, userId, kind }])
     log(`✓ flux de ${userId} en lecture`)
+    // Overlap bascule : ce flux SFU joue maintenant → la bascule coupe le mesh de
+    // cette personne au même instant (crossfade par personne, zéro coupure).
+    _onConsumerPlaying?.(userId)
   } catch (e) {
     log(`✘ consume : ${(e as Error).message}`)
   } finally {
@@ -420,19 +425,6 @@ export function sfuSetMuted(muted: boolean): void {
     sfuMutedStore.set(muted)
     log(muted ? 'micro coupé' : 'micro ouvert')
   }
-}
-
-/** Bascule (commit) : on lève l'overlap → on joue enfin les flux SFU (dé-mute les
- *  <audio> établis en hold, et les futurs consumers joueront normalement). Idempotent. */
-export function sfuActivatePlayback(): void {
-  _holdPlayback = false
-  const s = _session
-  if (!s) return
-  for (const el of s.audioEls.values()) {
-    el.muted = false
-    void el.play().catch(() => { /* autoplay pointilleux : ignoré */ })
-  }
-  log('▶ lecture SFU activée (commit)')
 }
 
 /** État établi (produce + consume faits) : le bascule attend ça pour voice:sfu_ready. */


### PR DESCRIPTION
**Le test réel a trouvé le bug** : après la bascule, aucun son distant (surtout mobile). Cause : on établissait l'SFU en sourdine puis on dé-coupait le son au commit, or les navigateurs (mobile en tête) **bloquent le fait de dé-couper un son non déclenché par un geste utilisateur**.

**Fix** : on JOUE le flux SFU **immédiatement** (comme le labo, prouvé sur mobile), et on coupe le mesh de chaque personne à l'instant EXACT où son flux SFU se met à jouer (**crossfade par personne**). Pour chacun : mesh OU SFU, jamais les deux, jamais le vide. Plus de son différé.

- `voiceSfu.ts` : retrait de holdPlayback ; callback `sfuSetConsumerPlayingCallback(userId)`.
- `voiceBascule.ts` : enregistre le callback avant `sfuJoin` ; le commit démonte juste le mesh.
- `voice.ts` : `_meshMutePeerByUserId` (roster userId→socketId).

svelte-check 0 err, build clean, **14 tests front**. Additif & dormant. À re-tester à 2 sur Réunion.