### PR TITLE
feat(sfu): stats réseau du panneau vocal en mode SFU

### DIFF
--- a/nodyx-frontend/src/lib/voice.ts
+++ b/nodyx-frontend/src/lib/voice.ts
@@ -990,6 +990,7 @@ export function leaveVoice(): void {
   // Si on était passé sur l'SFU (bascule), quitter aussi la session SFU. Idempotent
   // en mesh pur (aucune session SFU ⇒ no-op). Puis on repart de mesh.
   void bascule.basculeLeaveSfu()
+  _stopSfuStatsPolling()
   _channelMode = 'mesh'
 
   if (_socket) {
@@ -1249,7 +1250,7 @@ function onVoiceInit({ channelId, peers, mySeatIndex, iceServers, mode }: {
   if (_channelMode === 'sfu') {
     // Arrivant tardif sur un canal DÉJÀ en SFU (§5) : aucun PC mesh, on rejoint
     // l'SFU directement (lecture immédiate). Le roster ci-dessus reste affiché.
-    void bascule.basculeJoinDirectSfu(channelId)
+    void bascule.basculeJoinDirectSfu(channelId).then(() => _startSfuStatsPolling())
   } else {
     for (const peer of peers) {
       createPeerConn(peer.socketId, channelId, true)
@@ -1329,6 +1330,36 @@ function _meshTeardownConnections(): void {
   _offerLocks.clear()
 }
 
+// Stats SFU : un seul poller (pas de PC mesh à interroger). Il relève les stats de
+// la session SFU et les mappe sur le roster (userId → socketId) pour alimenter le
+// MÊME panneau réseau que le mesh (ping vers le SFU, perte/gigue par personne, type).
+let _sfuStatsInterval: ReturnType<typeof setInterval> | null = null
+function _startSfuStatsPolling(): void {
+  if (_sfuStatsInterval) return
+  void _pollSfuStats() // premier relevé immédiat
+  _sfuStatsInterval = setInterval(() => void _pollSfuStats(), 2000)
+}
+function _stopSfuStatsPolling(): void {
+  if (_sfuStatsInterval) { clearInterval(_sfuStatsInterval); _sfuStatsInterval = null }
+}
+async function _pollSfuStats(): Promise<void> {
+  const st = await bascule.basculeCollectStats()
+  const peers = get(voiceStore).peers
+  peerStatsStore.update(map => {
+    for (const p of peers) {
+      const u = st.perUser.get(p.userId)
+      map.set(p.socketId, {
+        rtt:            st.rtt,          // mon ping vers le SFU
+        theirRtt:       null,            // leur leg vers le SFU : non exposé en v1
+        packetLoss:     u?.packetLoss ?? null,
+        jitter:         u?.jitter ?? null,
+        connectionType: st.connType,
+      })
+    }
+    return new Map(map)
+  })
+}
+
 function onVoiceModeEvent({ channelId, mode }: { channelId: string; mode: 'sfu' | 'mesh' }): void {
   if (mode === 'sfu') {
     if (_channelMode !== 'mesh') return            // déjà en switching/sfu
@@ -1340,6 +1371,7 @@ function onVoiceModeEvent({ channelId, mode }: { channelId: string; mode: 'sfu' 
     if (_channelMode === 'switching') {
       _channelMode = 'mesh'
       void bascule.basculeLeaveSfu()               // on lâche l'SFU, le mesh (jamais lâché) reste
+      _stopSfuStatsPolling()
     }
   }
 }
@@ -1348,6 +1380,7 @@ function onSfuCommitEvent(_payload: { channelId: string }): void {
   _channelMode = 'sfu'
   // Instant zéro-coupure : joue l'SFU, coupe puis démonte le mesh.
   bascule.basculeCommit(_meshMutePlayback, _meshTeardownConnections)
+  _startSfuStatsPolling() // le panneau réseau se remplit depuis l'SFU
 }
 
 async function onOffer({ from, sdp, channelId }: { from: string; sdp: RTCSessionDescriptionInit; channelId: string }): Promise<void> {

--- a/nodyx-frontend/src/lib/voiceBascule.test.ts
+++ b/nodyx-frontend/src/lib/voiceBascule.test.ts
@@ -6,13 +6,14 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const { sfuJoin, sfuLeave, sfuIsActive, sfuSetConsumerPlayingCallback } = vi.hoisted(() => ({
+const { sfuJoin, sfuLeave, sfuIsActive, sfuSetConsumerPlayingCallback, sfuCollectStats } = vi.hoisted(() => ({
   sfuJoin:                       vi.fn(async () => {}),
   sfuLeave:                      vi.fn(async () => {}),
   sfuIsActive:                   vi.fn(() => true),
   sfuSetConsumerPlayingCallback: vi.fn(),
+  sfuCollectStats:               vi.fn(async () => ({ rtt: null, connType: 'unknown', perUser: new Map() })),
 }))
-vi.mock('./voiceSfu', () => ({ sfuJoin, sfuLeave, sfuIsActive, sfuSetConsumerPlayingCallback }))
+vi.mock('./voiceSfu', () => ({ sfuJoin, sfuLeave, sfuIsActive, sfuSetConsumerPlayingCallback, sfuCollectStats }))
 
 import { basculeBeginSwitch, basculeJoinDirectSfu, basculeLeaveSfu, basculeCommit } from './voiceBascule'
 

--- a/nodyx-frontend/src/lib/voiceBascule.ts
+++ b/nodyx-frontend/src/lib/voiceBascule.ts
@@ -10,9 +10,13 @@
 // jouer (crossfade par personne). Donc pour chacun : mesh OU SFU, jamais les deux,
 // jamais le vide. voice.ts fournit les opérations mesh (pas d'import circulaire).
 
-import { sfuJoin, sfuLeave, sfuIsActive, sfuSetConsumerPlayingCallback } from './voiceSfu'
+import { sfuJoin, sfuLeave, sfuIsActive, sfuSetConsumerPlayingCallback, sfuCollectStats } from './voiceSfu'
 
 type Emitter = { emit: (event: string, payload: unknown) => void }
+
+// Stats de la session SFU (RTT/type + perte/gigue par userId), pour alimenter le
+// même panneau réseau que le mesh. voice.ts fait le mapping userId → socketId.
+export const basculeCollectStats = sfuCollectStats
 
 // Cas A/C : le canal bascule (ou j'arrive pendant switching). On établit l'SFU en
 // PARALLÈLE du mesh, en JOUANT tout de suite ; `onSfuPeerPlaying(userId)` coupe le

--- a/nodyx-frontend/src/lib/voiceSfu.ts
+++ b/nodyx-frontend/src/lib/voiceSfu.ts
@@ -292,6 +292,10 @@ export function sfuSetConsumerPlayingCallback(cb: ((userId: string) => void) | n
   _onConsumerPlaying = cb
 }
 
+// Stats SFU : compteurs de paquets précédents par flux (producerId), pour calculer
+// la perte en delta entre deux relevés (même méthode que le mesh).
+const _sfuPrevPackets = new Map<string, { received: number; lost: number }>()
+
 async function consumeOne(sock: Socket, producerId: string, userId: string, kind: string): Promise<void> {
   const s = _session
   if (!s) return
@@ -430,6 +434,61 @@ export function sfuSetMuted(muted: boolean): void {
 /** État établi (produce + consume faits) : le bascule attend ça pour voice:sfu_ready. */
 export function sfuIsActive(): boolean {
   return _session !== null && get(sfuPhaseStore) === 'active'
+}
+
+/** Stats de MA session SFU, pour alimenter le même panneau réseau que le mesh :
+ *  - lien vers le SFU (RTT + relais/direct) depuis mon recvTransport ;
+ *  - perte + gigue PAR flux (donc par userId) depuis chaque consumer.
+ *  Le mapping userId → socketId (roster) se fait côté voice.ts. */
+export async function sfuCollectStats(): Promise<{
+  rtt: number | null
+  connType: 'relay' | 'direct' | 'unknown'
+  perUser: Map<string, { packetLoss: number | null; jitter: number | null }>
+}> {
+  const out = { rtt: null as number | null, connType: 'unknown' as 'relay' | 'direct' | 'unknown', perUser: new Map<string, { packetLoss: number | null; jitter: number | null }>() }
+  const s = _session
+  if (!s) return out
+  // Lien vers le SFU (RTT + type de connexion) depuis la paire ICE active.
+  try {
+    const rs = await s.recvTransport.getStats()
+    for (const r of rs.values()) {
+      if (r.type === 'candidate-pair' && r.nominated) {
+        if (r.currentRoundTripTime != null) out.rtt = Math.round(r.currentRoundTripTime * 1000)
+        const local = rs.get(r.localCandidateId)
+        if (local?.candidateType === 'relay') out.connType = 'relay'
+        else if (local?.candidateType)        out.connType = 'direct'
+      }
+    }
+  } catch { /* transport en cours de fermeture : on renvoie ce qu'on a */ }
+  // Perte + gigue par flux (par userId) depuis chaque consumer.
+  const userOf = new Map<string, string>() // producerId → userId
+  for (const c of get(sfuConsumersStore)) userOf.set(c.producerId, c.userId)
+  for (const [producerId, consumer] of s.consumers) {
+    const userId = userOf.get(producerId)
+    if (!userId) continue
+    try {
+      const cs = await consumer.getStats()
+      let packetLoss: number | null = null
+      let jitter: number | null = null
+      for (const r of cs.values()) {
+        if (r.type === 'inbound-rtp' && r.kind === 'audio') {
+          if (r.jitter != null) jitter = Math.round(r.jitter * 1000)
+          const prev = _sfuPrevPackets.get(producerId)
+          const received = r.packetsReceived ?? 0
+          const lost = r.packetsLost ?? 0
+          if (prev) {
+            const dRec = received - prev.received
+            const dLost = Math.max(0, lost - prev.lost)
+            const total = dRec + dLost
+            if (total > 0) packetLoss = Math.round((dLost / total) * 1000) / 10
+          }
+          _sfuPrevPackets.set(producerId, { received, lost })
+        }
+      }
+      out.perUser.set(userId, { packetLoss, jitter })
+    } catch { /* consumer fermé entre-temps : on l'ignore */ }
+  }
+  return out
 }
 
 export async function sfuLeave(): Promise<void> {


### PR DESCRIPTION
En SFU, le panneau réseau affichait « Inconnu » (stats câblées sur le mesh, vides sans PC mesh). On les branche sans toucher un seul composant UI (même `peerStatsStore`).

- `voiceSfu.ts` : `sfuCollectStats()` — RTT + relais/direct (recvTransport), perte + gigue par flux (chaque consumer), par userId.
- `voiceBascule.ts` : re-export `basculeCollectStats`.
- `voice.ts` : poller SFU (2s) actif en mode SFU (commit + arrivée directe), arrêté au départ/abandon ; mappe userId→socketId via le roster → remplit `peerStatsStore`.

« Leur ping » reste vide en v1 (leur leg vers le SFU non exposé). svelte-check 0 err, 14 tests front, build clean. À voir sur Réunion après déploiement.