### PR TITLE
fix(sfu): libellé de connexion « SFU » (au lieu de « Direct P2P »)

### DIFF
--- a/nodyx-frontend/src/lib/components/VoicePanel.svelte
+++ b/nodyx-frontend/src/lib/components/VoicePanel.svelte
@@ -335,6 +335,8 @@
                             <span class='text-[8px] px-1.5 py-0.5 rounded-full bg-green-900/60 text-green-400 border border-green-700/50'>P2P</span>
                         {:else if stats?.connectionType === 'relay'}
                             <span class='text-[8px] px-1.5 py-0.5 rounded-full bg-blue-900/60 text-blue-400 border border-blue-700/50'>TURN</span>
+                        {:else if stats?.connectionType === 'sfu'}
+                            <span class='text-[8px] px-1.5 py-0.5 rounded-full bg-indigo-900/60 text-indigo-300 border border-indigo-700/50'>SFU</span>
                         {/if}
                     </p>
                     
@@ -400,6 +402,11 @@
                         <span class='text-[10px] px-2 py-0.5 rounded-full bg-green-900/60 text-green-300 font-medium border border-green-700/50 flex items-center gap-1'>
                             <span class="w-1 h-1 rounded-full bg-green-400 animate-pulse"></span>
                             {tFn('voice.direct_p2p')}
+                        </span>
+                    {:else if stats?.connectionType === 'sfu'}
+                        <span class='text-[10px] px-2 py-0.5 rounded-full bg-indigo-900/60 text-indigo-300 font-medium border border-indigo-700/50 flex items-center gap-1'>
+                            <span class="w-1 h-1 rounded-full bg-indigo-400 animate-pulse"></span>
+                            SFU
                         </span>
                     {:else}
                         <span class='text-[10px] px-2 py-0.5 rounded-full bg-gray-800 text-gray-500 font-medium border border-gray-700'>

--- a/nodyx-frontend/src/lib/voice.ts
+++ b/nodyx-frontend/src/lib/voice.ts
@@ -101,7 +101,7 @@ export interface PeerStats {
   theirRtt:       number | null  // ms — leur RTT (ils le broadcastent)
   packetLoss:     number | null  // %
   jitter:         number | null  // ms
-  connectionType: 'relay' | 'direct' | 'unknown'
+  connectionType: 'relay' | 'direct' | 'sfu' | 'unknown'  // 'sfu' = via le serveur SFU (pas du P2P)
 }
 
 export type NetQuality = 'excellent' | 'good' | 'fair' | 'poor' | 'unknown'

--- a/nodyx-frontend/src/lib/voiceSfu.ts
+++ b/nodyx-frontend/src/lib/voiceSfu.ts
@@ -442,21 +442,19 @@ export function sfuIsActive(): boolean {
  *  Le mapping userId → socketId (roster) se fait côté voice.ts. */
 export async function sfuCollectStats(): Promise<{
   rtt: number | null
-  connType: 'relay' | 'direct' | 'unknown'
+  connType: 'relay' | 'direct' | 'sfu' | 'unknown'
   perUser: Map<string, { packetLoss: number | null; jitter: number | null }>
 }> {
-  const out = { rtt: null as number | null, connType: 'unknown' as 'relay' | 'direct' | 'unknown', perUser: new Map<string, { packetLoss: number | null; jitter: number | null }>() }
+  const out = { rtt: null as number | null, connType: 'unknown' as 'relay' | 'direct' | 'sfu' | 'unknown', perUser: new Map<string, { packetLoss: number | null; jitter: number | null }>() }
   const s = _session
   if (!s) return out
-  // Lien vers le SFU (RTT + type de connexion) depuis la paire ICE active.
+  out.connType = 'sfu' // en SFU le média passe par le serveur : ce n'est PAS du P2P
+  // RTT vers le SFU depuis la paire ICE active.
   try {
     const rs = await s.recvTransport.getStats()
     for (const r of rs.values()) {
-      if (r.type === 'candidate-pair' && r.nominated) {
-        if (r.currentRoundTripTime != null) out.rtt = Math.round(r.currentRoundTripTime * 1000)
-        const local = rs.get(r.localCandidateId)
-        if (local?.candidateType === 'relay') out.connType = 'relay'
-        else if (local?.candidateType)        out.connType = 'direct'
+      if (r.type === 'candidate-pair' && r.nominated && r.currentRoundTripTime != null) {
+        out.rtt = Math.round(r.currentRoundTripTime * 1000)
       }
     }
   } catch { /* transport en cours de fermeture : on renvoie ce qu'on a */ }


### PR DESCRIPTION
En SFU, le panneau réseau affichait « P2P / Direct P2P » — faux : la connexion est directe **vers le serveur SFU**, pas du pair-à-pair. Nouveau type `'sfu'` : `sfuCollectStats` le renvoie, `PeerStats.connectionType` l'accepte, VoicePanel affiche un badge « SFU » + ligne « SFU » (indigo). svelte-check 0 err, 14 tests, build clean.