### PR TITLE
feat(sfu): partage d'écran sur SFU (P2-A/B)

### DIFF
--- a/SPECS/NODYX_SFU_SCREENSHARE.md
+++ b/SPECS/NODYX_SFU_SCREENSHARE.md
@@ -1,0 +1,140 @@
+# CDC — Partage d'écran sur SFU (P2)
+
+> Statut : **conception, en attente validation Jonathan**
+> Prérequis : bascule audio mesh↔SFU en prod (PRs #240→#249, canal « Réunion »).
+> Réf. : `NODYX_SFU_CDC.md` §6 (le cas critique) + §17-B (bascule).
+
+---
+
+## 1. Pourquoi ce chantier
+
+Le mesh WebRTC meurt en partage d'écran à ~4 personnes : chaque partageur
+uploade son flux vidéo N-1 fois (une copie par spectateur). Une vidéo 720p à
+2,5 Mbps × 5 spectateurs = 12,5 Mbps d'upload sur la machine du partageur. Un
+particulier en fibre plafonne, un mobile s'effondre.
+
+Le SFU renverse ça : le partageur uploade **une seule fois** vers le serveur, qui
+recopie vers chaque spectateur. Upload partageur constant quel que soit le nombre
+de spectateurs. C'est LE livrable « on tient tête à Discord » (studio Lapersonne).
+
+**Objectif de tenue (CDC §6)** : 1 partageur + 15+ spectateurs fluide sur un VPS
+standard, chaque spectateur servi selon SA bande passante.
+
+---
+
+## 2. Doctrine (non négociable)
+
+1. **Additif.** Le screenshare mesh (`voice.ts` `startScreenShare`/`stopScreenShare`,
+   `remoteScreenStore`) n'est PAS modifié dans son chemin mesh. On ajoute un chemin
+   SFU à côté, choisi par le mode du canal.
+2. **Gated.** Le screenshare SFU ne s'active QUE si le canal est en mode SFU
+   (bascule active). En mode mesh, on garde le screenshare mesh actuel tel quel.
+   Aucun flag global nouveau : on réutilise l'état de mode déjà porté par la bascule.
+3. **Sanctuaire.** `voice.ts` (mesh) et le moteur Rust ne bougent qu'avec ton OK
+   explicite, diff minimal, chaque ajout isolé du chemin mesh.
+4. **UI inchangée.** L'UI lit déjà `remoteScreenStore` (Map socketId→stream) et
+   `localScreenStore`. Le chemin SFU alimente ces MÊMES stores → zéro refonte UI.
+
+---
+
+## 3. Ce qui est DÉJÀ prêt (moitié du travail est faite)
+
+| Couche | État |
+|---|---|
+| Trait `MediaEngine` | `TrackKind::{Audio,Screen,Cam}` existe déjà. `produce(kind)` typé. |
+| Moteur `consumer_caps` | Convertit déjà les caps **vidéo** finalisées (anticipé). |
+| Client `consumeOne` | Lit déjà `kind:'audio'|'video'` renvoyé par le serveur. |
+| UI | Lit déjà `remoteScreenStore` / `localScreenStore`. |
+
+Ce qui MANQUE, c'est le milieu du tuyau (détaillé §5).
+
+---
+
+## 4. Décisions de conception (tranchées, à valider)
+
+### D1 — Codec : **VP8**
+- VP8 : supporté partout (tous navigateurs), libre de droits, défaut mediasoup.
+- H264 : meilleur sur certains encodeurs matériels mais licences + complexité.
+- **Tranché : VP8 pour v1.** H264 possible plus tard sans casser l'archi.
+
+### D2 — Simulcast : **v1 = 1 couche, simulcast en v1.1**
+- Le CDC §6 veut le simulcast (servir à chacun la couche adaptée). C'est la
+  finalité, mais ça ajoute une vraie complexité (3 encodages, sélection de couche
+  par consumer selon la bande passante).
+- **Tranché : v1 = une seule couche haute qualité** (le screenshare est souvent
+  statique = compresse très bien), pour prouver le chemin de bout en bout et livrer
+  vite un partage d'écran visible via SFU. **Simulcast = v1.1**, chantier suivant.
+
+### D3 — Déclenchement : **v1 = SFU screenshare uniquement si canal DÉJÀ en SFU**
+- Option couplée : démarrer un partage d'écran DÉCLENCHE la bascule mesh→SFU (c'est
+  le scénario où le mesh meurt). Séduisant mais couple deux features.
+- **Tranché : v1 découplé.** Screenshare SFU seulement quand le canal est déjà en
+  mode SFU (bascule audio active). En mode mesh → screenshare mesh actuel intact.
+  Le « screenshare déclenche la bascule » = v1.1 (une fois v1 prouvée).
+
+### D4 — Plusieurs partageurs simultanés : **autorisé** (gratuit dans le modèle SFU)
+- Chaque partage = un producer vidéo de plus. `remoteScreenStore` est déjà une Map.
+  Pas de limite artificielle. L'UI affiche chaque écran distant.
+
+---
+
+## 5. Ce qu'il faut construire (le milieu du tuyau)
+
+### 5-A · Moteur Rust (`nodyx-sfu-mediasoup/engine.rs`) — sanctuaire
+1. Ajouter une capability **VP8** (`vp8_capability()`) au router, à côté d'Opus :
+   `create_router(RouterOptions::new(vec![opus_capability(), vp8_capability()]))`.
+2. `produce` : lever le refus non-audio (ligne 501). Pour `Screen`/`Cam`, construire
+   `ProducerOptions::new(MediaKind::Video, rtp)` à partir des `rtpParameters` client.
+   (En WebRTC les rtpParameters viennent du navigateur, comme pour l'audio.)
+3. `consume` : déjà générique (sert le producer par id). Vérifier qu'il n'a pas de
+   supposition audio. `consumer_caps` gère déjà la vidéo.
+4. Tests Rust : produce/consume vidéo sur un router VP8 (labo, zéro prod).
+
+### 5-B · Relais core (`socket/…`) — passe-plat
+- Les events `voice:sfu_produce`/`voice:sfu_consume`/`voice:sfu_new_producer`
+  portent déjà `kind`. Vérifier que le relais vers `/v1/produce` du daemon passe
+  `kind` sans le forcer à `audio`. Probablement déjà opaque : à confirmer.
+
+### 5-C · Client SFU (`voiceSfu.ts`)
+1. `sfuStartScreenShare()` : `getDisplayMedia` → `sendTransport.produce({track})` en
+   `kind:'video'`. Lever le refus ligne 213 (`kind !== 'audio'`). Émettre
+   `voice:sfu_produce {kind:'video', rtpParameters}`. `localScreenStore.set(stream)`.
+2. `sfuStopScreenShare()` : `producer.close()`, stop tracks, vider `localScreenStore`.
+3. `consumeOne` : si `kind==='video'`, router `consumer.track` vers
+   `remoteScreenStore` (Map keyée par socketId via userId→socketId, comme la bascule
+   audio) au lieu d'un `<audio>`. À la fermeture du consumer → retirer du store.
+
+### 5-D · Orchestration (`voiceBascule.ts` + `voice.ts` borné)
+- Un bouton « partager l'écran » qui, si `_channelMode==='sfu'`, appelle
+  `sfuStartScreenShare` ; sinon garde le mesh. Le mapping userId→socketId pour
+  `remoteScreenStore` réutilise le roster déjà présent (comme `peerStatsStore`).
+
+### 5-E · Stats / labels (mineur)
+- Étendre le panneau : afficher le partageur, éventuellement le bitrate servi.
+
+---
+
+## 6. Phasage (livrable par livrable)
+
+| Phase | Contenu | Testable |
+|---|---|---|
+| **P2-A** | Moteur : VP8 router + produce/consume vidéo + tests Rust | Labo isolé, zéro risque prod |
+| **P2-B** | Client : produce screenshare + consume vidéo → `remoteScreenStore` | /admin/sfu-lab |
+| **P2-C** | Orchestration bouton + mapping roster + UI branchée | Canal « Réunion » en SFU |
+| **P2-D** | Simulcast 3 couches + `preferredLayers` par bande passante | 1 partageur + N spectateurs |
+| **P2-E** | Screenshare déclenche la bascule mesh→SFU (v1.1) | Prod élargie |
+
+**Cette session** : valider ce CDC, puis démarrer **P2-A** (moteur vidéo, isolable
+au labo, aucun risque pour la prod audio qui tourne).
+
+---
+
+## 7. Risques / garde-fous
+
+- **NE JAMAIS** `pkill -f mediasoup-worker` (tue le worker prod). Redéploiement
+  binaire = `mv` (ETXTBSY), jamais `cp`.
+- Le chemin audio SFU en prod (canal Réunion) ne doit pas régresser : VP8 s'AJOUTE
+  aux caps, ne remplace pas Opus. Tests audio à re-passer après P2-A.
+- Screenshare mesh intact tant que P2-E n'est pas là : filet si le SFU vidéo déçoit.
+- CPU : la vidéo coûte plus que l'audio. Le pool de workers (PR #240, 6 workers +
+  réserve) absorbe ; mesurer avant d'élargir.

--- a/nodyx-core/src/socket/voiceSfu.ts
+++ b/nodyx-core/src/socket/voiceSfu.ts
@@ -228,6 +228,32 @@ export function registerVoiceSfuHandlers(socket: Socket, server: Server): void {
     cb({ ok: true, producerId: res.data.producer })
   })
 
+  // ── voice:sfu_unpublish : arrête un flux qu'on a publié (stop partage écran) ─
+  // Le daemon vérifie la PROPRIÉTÉ (on ne ferme que SON flux) : le broadcast qui
+  // suit ne part donc que pour un flux qu'on possédait réellement.
+  socket.on('voice:sfu_unpublish', async (payload: unknown, cb: unknown) => {
+    if (!isAck(cb)) return
+    const { channelId, producerId } = (payload ?? {}) as Record<string, unknown>
+    if (!(await guard('voice:sfu_unpublish', channelId, cb))) return
+    if (typeof producerId !== 'string' || producerId.length === 0 || producerId.length > 200) {
+      cb({ ok: false, error: 'bad_producer' }); return
+    }
+
+    const res = await sfuFetch('/v1/close_producer', {
+      room: channelId, participant: userId, producer: producerId,
+    })
+    if (!res.ok) { cb({ ok: false, error: res.error }); return }
+
+    // Prévenir les autres clients SFU : ce flux disparaît → fermer le consumer et
+    // retirer l'écran (sans attendre la réconciliation périodique = arrêt net).
+    socket.to(sfuRoom(channelId as string)).emit('voice:sfu_producer_closed', {
+      channelId,
+      producerId,
+      userId,
+    })
+    cb({ ok: true })
+  })
+
   // ── voice:sfu_consume — souscrit à un flux publié ──────────────────────────
   socket.on('voice:sfu_consume', async (payload: unknown, cb: unknown) => {
     if (!isAck(cb)) return

--- a/nodyx-frontend/src/lib/voiceSfu.ts
+++ b/nodyx-frontend/src/lib/voiceSfu.ts
@@ -43,6 +43,14 @@ export const sfuLogStore:       Writable<string[]>          = writable([])
 export const sfuConsumersStore: Writable<SfuConsumerInfo[]> = writable([])
 export const sfuMutedStore:     Writable<boolean>           = writable(false)
 
+/** Un écran/cam distant reçu via le SFU (rendu par un <video> côté UI). */
+export interface SfuScreen { producerId: string; userId: string; stream: MediaStream }
+/** Écrans distants reçus (screenshare P2). Le mapping userId → socketId (roster)
+ *  pour l'UI mesh se fait côté voice.ts, comme pour les stats de la bascule. */
+export const sfuScreensStore:     Writable<SfuScreen[]>        = writable([])
+/** MON écran en cours de partage (aperçu local), null si je ne partage pas. */
+export const sfuLocalScreenStore: Writable<MediaStream | null> = writable(null)
+
 export interface SfuAuditRow {
   participant: string
   direction:   string
@@ -71,6 +79,8 @@ interface Session {
   recvTransport: import('mediasoup-client').types.Transport
   micTrack:      MediaStreamTrack | null
   producer:      import('mediasoup-client').types.Producer | null
+  screenProducer: import('mediasoup-client').types.Producer | null
+  screenStream:  MediaStream | null
   consumers:     Map<string, import('mediasoup-client').types.Consumer>
   audioEls:      Map<string, HTMLAudioElement>
   offNewProducer: (() => void) | null
@@ -209,10 +219,13 @@ export async function sfuJoin(channelId: string): Promise<void> {
 
     const sendTransport = device.createSendTransport(join.sendTransportParams as never)
     wireTransport(sendTransport, 'send')
-    sendTransport.on('produce', ({ kind, rtpParameters }, callback, errback) => {
-      if (kind !== 'audio') { errback(new Error('labo : audio uniquement')); return }
-      log('→ produce audio (rtpParameters au SFU)')
-      emitAck(sock, 'voice:sfu_produce', { channelId, kind: 'audio', rtpParameters })
+    sendTransport.on('produce', ({ kind, rtpParameters, appData }, callback, errback) => {
+      // `kind` = nature média ('audio'|'video'). Le "kind SFU" distingue en plus
+      // l'écran de la cam via appData (transmis tel quel par mediasoup-client).
+      const source = (appData as { source?: string } | undefined)?.source
+      const sfuKind = kind === 'audio' ? 'audio' : source === 'cam' ? 'cam' : 'screen'
+      log(`→ produce ${sfuKind} (rtpParameters au SFU)`)
+      emitAck(sock, 'voice:sfu_produce', { channelId, kind: sfuKind, rtpParameters })
         .then(r => r.ok
           ? (log(`✓ producer ${String(r.producerId).slice(0, 8)}…`), callback({ id: String(r.producerId) }))
           : errback(new Error(String(r.error))))
@@ -224,6 +237,7 @@ export async function sfuJoin(channelId: string): Promise<void> {
     _session = {
       channelId, device, sendTransport, recvTransport,
       micTrack: null, producer: null,
+      screenProducer: null, screenStream: null,
       consumers: new Map(), audioEls: new Map(), offNewProducer: null,
       maintain: null, onVisibility: null,
     }
@@ -244,7 +258,7 @@ export async function sfuJoin(channelId: string): Promise<void> {
     if (pubs.ok && Array.isArray(pubs.publications)) {
       log(`${pubs.publications.length} publication(s) existante(s)`)
       for (const pub of pubs.publications as { producer: string; owner: string; kind: string }[]) {
-        if (_session.producer && pub.producer === _session.producer.id) continue // pas soi-même
+        if (isOwnProducer(_session, pub.producer)) continue // ni mon micro, ni mon écran
         await consumeOne(sock, pub.producer, pub.owner, pub.kind)
       }
     }
@@ -254,7 +268,18 @@ export async function sfuJoin(channelId: string): Promise<void> {
       void consumeOne(sock, data.producerId, data.userId, data.kind)
     }
     sock.on('voice:sfu_new_producer', onNewProducer)
-    _session.offNewProducer = () => { sock.off('voice:sfu_new_producer', onNewProducer) }
+    // Arrêt net d'un flux (ex. le partageur stoppe son écran) : on ferme le
+    // consumer et on retire l'écran tout de suite, sans attendre la réconciliation.
+    const onProducerClosed = (data: { channelId: string; producerId: string; userId: string }) => {
+      if (!_session || data.channelId !== _session.channelId) return
+      log(`flux de ${data.userId} fermé → retrait`)
+      closeConsumerFor(_session, data.producerId)
+    }
+    sock.on('voice:sfu_producer_closed', onProducerClosed)
+    _session.offNewProducer = () => {
+      sock.off('voice:sfu_new_producer', onNewProducer)
+      sock.off('voice:sfu_producer_closed', onProducerClosed)
+    }
 
     // Maintenance périodique (5 s) : heartbeat (anti-éviction) + réconciliation
     // des flux (ferme les consumers dont le producer a disparu = fantômes ;
@@ -296,6 +321,24 @@ export function sfuSetConsumerPlayingCallback(cb: ((userId: string) => void) | n
 // la perte en delta entre deux relevés (même méthode que le mesh).
 const _sfuPrevPackets = new Map<string, { received: number; lost: number }>()
 
+/** Un de MES producers (micro ou écran) ? Sert à ne jamais consommer ses propres
+ *  flux (les publications listent TOUT le salon, moi compris). Le broadcast
+ *  new_producer exclut déjà l'émetteur, mais pas la liste des publications. */
+function isOwnProducer(s: Session, producerId: string): boolean {
+  return producerId === s.producer?.id || producerId === s.screenProducer?.id
+}
+
+/** Ferme et oublie le consumer d'un flux (audio OU écran) : par réconciliation
+ *  (producer disparu) ou par arrêt net (voice:sfu_producer_closed). Idempotent. */
+function closeConsumerFor(s: Session, producerId: string): void {
+  const consumer = s.consumers.get(producerId)
+  if (consumer) { try { consumer.close() } catch { /* déjà fermé */ } s.consumers.delete(producerId) }
+  const el = s.audioEls.get(producerId)
+  if (el) { try { el.pause(); el.srcObject = null } catch { /* mort */ } s.audioEls.delete(producerId) }
+  sfuConsumersStore.update(l => l.filter(c => c.producerId !== producerId))
+  sfuScreensStore.update(l => l.filter(x => x.producerId !== producerId))
+}
+
 async function consumeOne(sock: Socket, producerId: string, userId: string, kind: string): Promise<void> {
   const s = _session
   if (!s) return
@@ -314,18 +357,25 @@ async function consumeOne(sock: Socket, producerId: string, userId: string, kind
     })
     s.consumers.set(producerId, consumer)
 
-    // Lecture : un <audio> par flux, détaché du DOM (labo audio-only).
-    const el = new Audio()
-    el.srcObject = new MediaStream([consumer.track])
-    el.autoplay = true
-    s.audioEls.set(producerId, el)
-    void el.play().catch(err => log(`⚠ autoplay : ${err.message}`))
-
     sfuConsumersStore.update(list => [...list, { consumerId: consumer.id, producerId, userId, kind }])
-    log(`✓ flux de ${userId} en lecture`)
-    // Overlap bascule : ce flux SFU joue maintenant → la bascule coupe le mesh de
-    // cette personne au même instant (crossfade par personne, zéro coupure).
-    _onConsumerPlaying?.(userId)
+
+    if (params.kind === 'video') {
+      // Écran/cam : pas de <audio>. On expose le flux (rendu par un <video> UI).
+      const stream = new MediaStream([consumer.track])
+      sfuScreensStore.update(l => [...l.filter(x => x.producerId !== producerId), { producerId, userId, stream }])
+      log(`✓ écran de ${userId} reçu`)
+    } else {
+      // Audio : un <audio> par flux, détaché du DOM.
+      const el = new Audio()
+      el.srcObject = new MediaStream([consumer.track])
+      el.autoplay = true
+      s.audioEls.set(producerId, el)
+      void el.play().catch(err => log(`⚠ autoplay : ${err.message}`))
+      log(`✓ flux de ${userId} en lecture`)
+      // Overlap bascule : ce flux AUDIO joue → couper le mesh audio de la personne
+      // au même instant (crossfade par personne, zéro coupure). Vidéo = hors-sujet.
+      _onConsumerPlaying?.(userId)
+    }
   } catch (e) {
     log(`✘ consume : ${(e as Error).message}`)
   } finally {
@@ -404,19 +454,15 @@ async function reconcile(sock: Socket): Promise<void> {
   const list = pubs.publications as { producer: string; owner: string; kind: string }[]
   const live = new Set(list.map(p => p.producer))
   // fermer les fantômes (producer disparu des publications)
-  for (const [producerId, consumer] of [...s.consumers]) {
+  for (const [producerId] of [...s.consumers]) {
     if (!live.has(producerId)) {
-      try { consumer.close() } catch { /* déjà fermé */ }
-      s.consumers.delete(producerId)
-      const el = s.audioEls.get(producerId)
-      if (el) { try { el.pause(); el.srcObject = null } catch { /* mort */ } s.audioEls.delete(producerId) }
-      sfuConsumersStore.update(l => l.filter(c => c.producerId !== producerId))
+      closeConsumerFor(s, producerId)
       log(`flux ${producerId.slice(0, 8)}… disparu → consumer fermé`)
     }
   }
   // consommer les nouveaux (rattrapage d'une annonce manquée)
   for (const pub of list) {
-    if (s.producer && pub.producer === s.producer.id) continue
+    if (isOwnProducer(s, pub.producer)) continue
     if (!s.consumers.has(pub.producer) && !_consuming.has(pub.producer)) {
       await consumeOne(sock, pub.producer, pub.owner, pub.kind)
     }
@@ -429,6 +475,75 @@ export function sfuSetMuted(muted: boolean): void {
     sfuMutedStore.set(muted)
     log(muted ? 'micro coupé' : 'micro ouvert')
   }
+}
+
+/** Partager son écran via le SFU (P2). getDisplayMedia → produce vidéo (VP8) sur
+ *  le sendTransport existant (à côté du micro). Une seule couche en v1 (le
+ *  simulcast arrive après). Retourne le flux local (aperçu) ou null si annulé.
+ *  Le partage passe par le SFU : un seul upload, le serveur recopie à chacun. */
+export async function sfuStartScreenShare(opts?: { maxBitrate?: number }): Promise<MediaStream | null> {
+  const s = _session
+  if (!s) { log('⚠ pas de session SFU active'); return null }
+  if (s.screenProducer) { log('⚠ partage déjà en cours'); return get(sfuLocalScreenStore) }
+
+  let display: MediaStream
+  try {
+    display = await navigator.mediaDevices.getDisplayMedia({
+      video: { frameRate: { ideal: 30, max: 60 } },
+      audio: false, // le son d'onglet arrivera en P3 ; v1 = vidéo seule
+    })
+  } catch (e) {
+    log(`partage annulé : ${(e as Error).message}`) // l'utilisateur a fermé le sélecteur
+    return null
+  }
+
+  const track = display.getVideoTracks()[0]
+  if (!track) { display.getTracks().forEach(t => t.stop()); log('✘ aucune piste vidéo'); return null }
+
+  try {
+    s.screenStream = display
+    s.screenProducer = await s.sendTransport.produce({
+      track,
+      appData: { source: 'screen' },
+      encodings: [{ maxBitrate: opts?.maxBitrate ?? 2_500_000 }], // v1 : 1 couche
+    })
+    // Le bouton « Arrêter le partage » natif du navigateur termine la piste.
+    track.onended = () => { void sfuStopScreenShare() }
+    sfuLocalScreenStore.set(display)
+    log('✓ écran publié au SFU')
+    return display
+  } catch (e) {
+    display.getTracks().forEach(t => t.stop())
+    s.screenStream = null
+    s.screenProducer = null
+    log(`✘ publication écran : ${(e as Error).message}`)
+    return null
+  }
+}
+
+/** Arrêter mon partage d'écran : ferme le producer LOCAL puis prévient le serveur
+ *  (voice:sfu_unpublish) pour qu'il ferme le producer SERVEUR → les spectateurs
+ *  voient l'écran disparaître immédiatement. Idempotent. */
+export async function sfuStopScreenShare(): Promise<void> {
+  const s = _session
+  if (!s) return
+  const producerId = s.screenProducer?.id ?? null
+  try { s.screenProducer?.close() } catch { /* déjà fermé */ }
+  s.screenProducer = null
+  try { s.screenStream?.getTracks().forEach(t => t.stop()) } catch { /* déjà stoppé */ }
+  s.screenStream = null
+  sfuLocalScreenStore.set(null)
+
+  const sock = get(socketStore)
+  if (sock && producerId) {
+    await emitAck(sock, 'voice:sfu_unpublish', { channelId: s.channelId, producerId })
+  }
+  log('partage d\'écran arrêté')
+}
+
+/** Suis-je en train de partager mon écran via le SFU ? */
+export function sfuIsScreenSharing(): boolean {
+  return _session?.screenProducer != null
 }
 
 /** État établi (produce + consume faits) : le bascule attend ça pour voice:sfu_ready. */
@@ -568,10 +683,14 @@ function cleanup(): void {
     try { c.close() } catch { /* déjà fermé */ }
   }
   try { s.producer?.close() } catch { /* déjà fermé */ }
+  try { s.screenProducer?.close() } catch { /* déjà fermé */ }
   try { s.micTrack?.stop() } catch { /* déjà stoppé */ }
+  try { s.screenStream?.getTracks().forEach(t => t.stop()) } catch { /* déjà stoppé */ }
   try { s.sendTransport.close() } catch { /* déjà fermé */ }
   try { s.recvTransport.close() } catch { /* déjà fermé */ }
   sfuConsumersStore.set([])
+  sfuScreensStore.set([])
+  sfuLocalScreenStore.set(null)
   sfuMutedStore.set(false)
   sfuAuditStore.set([])
 }

--- a/nodyx-frontend/src/routes/admin/sfu-lab/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/sfu-lab/+page.svelte
@@ -3,8 +3,9 @@
   import { onDestroy } from 'svelte'
   import {
     sfuJoin, sfuLeave, sfuSetMuted, sfuAudit,
+    sfuStartScreenShare, sfuStopScreenShare,
     sfuPhaseStore, sfuErrorStore, sfuLogStore, sfuConsumersStore, sfuMutedStore,
-    sfuAuditStore,
+    sfuAuditStore, sfuScreensStore, sfuLocalScreenStore,
   } from '$lib/voiceSfu'
 
   // Audit réseau : rafraîchi manuellement ou en auto (2 s) pendant une session.
@@ -41,6 +42,19 @@
 
   const phase = $derived($sfuPhaseStore)
   const busy  = $derived(phase === 'joining' || phase === 'connecting' || phase === 'recovering')
+
+  // Partage d'écran SFU (P2) : mon aperçu local + les écrans distants reçus.
+  const localScreen   = $derived($sfuLocalScreenStore)
+  const remoteScreens = $derived($sfuScreensStore)
+
+  // Action Svelte : branche un MediaStream sur le srcObject d'un <video>.
+  function bindStream(node: HTMLVideoElement, stream: MediaStream) {
+    node.srcObject = stream
+    return {
+      update(s: MediaStream) { node.srcObject = s },
+      destroy()             { node.srcObject = null },
+    }
+  }
 
   function join() {
     if (browser) localStorage.setItem('nodyx:sfu-lab:channel', channelId.trim())
@@ -111,6 +125,12 @@
           {$sfuMutedStore ? 'Micro coupé' : 'Couper le micro'}
         </button>
         <button
+          onclick={() => (localScreen ? void sfuStopScreenShare() : void sfuStartScreenShare())}
+          class="rounded-lg px-4 py-2 text-sm font-semibold {localScreen ? 'bg-fuchsia-600 hover:bg-fuchsia-500' : 'bg-zinc-700 hover:bg-zinc-600'} text-white"
+        >
+          {localScreen ? 'Arrêter le partage' : "Partager l'écran"}
+        </button>
+        <button
           onclick={() => void sfuLeave()}
           class="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-500"
         >
@@ -154,6 +174,30 @@
       </ul>
     {/if}
   </div>
+
+  {#if localScreen || remoteScreens.length > 0}
+    <div class="rounded-xl border border-zinc-800 bg-zinc-900/50 p-5">
+      <h2 class="text-xs font-bold uppercase tracking-widest text-zinc-500 mb-3">
+        Écrans partagés ({remoteScreens.length + (localScreen ? 1 : 0)})
+      </h2>
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {#if localScreen}
+          <div class="relative aspect-video overflow-hidden rounded-lg border border-fuchsia-500/40 bg-black">
+            <!-- svelte-ignore a11y_media_has_caption -->
+            <video use:bindStream={localScreen} autoplay playsinline muted class="h-full w-full object-contain"></video>
+            <span class="absolute left-2 top-2 rounded-full bg-fuchsia-600/80 px-2 py-0.5 text-[10px] font-bold text-white">MON ÉCRAN</span>
+          </div>
+        {/if}
+        {#each remoteScreens as sc (sc.producerId)}
+          <div class="relative aspect-video overflow-hidden rounded-lg border border-zinc-700 bg-black">
+            <!-- svelte-ignore a11y_media_has_caption -->
+            <video use:bindStream={sc.stream} autoplay playsinline muted class="h-full w-full object-contain"></video>
+            <span class="absolute bottom-2 left-2 rounded-full bg-black/70 px-2 py-0.5 text-[10px] font-semibold text-white">{sc.userId}</span>
+          </div>
+        {/each}
+      </div>
+    </div>
+  {/if}
 
   <div class="rounded-xl border border-zinc-800 bg-zinc-900/50 p-5">
     <div class="flex items-center justify-between mb-3">

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/bin/nodyx-sfud.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/bin/nodyx-sfud.rs
@@ -212,6 +212,17 @@ async fn route(app: &App, path: &str, body: &serde_json::Value) -> (u16, serde_j
             }
         }
 
+        "/v1/close_producer" => {
+            let (Some(r), Some(p), Some(prod)) = (room(), participant(), field(body, "producer"))
+            else {
+                return err_json(400, "room, participant et producer requis");
+            };
+            match app.svc.unpublish(r, p, ProducerId(prod.to_string())).await {
+                Ok(()) => ok_json(serde_json::json!({ "closed": true })),
+                Err(e) => err_json(409, e.to_string()),
+            }
+        }
+
         "/v1/consume" => {
             let (Some(r), Some(p), Some(prod)) = (room(), participant(), field(body, "producer"))
             else {

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
@@ -30,7 +30,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use mediasoup::prelude::*;
-use mediasoup::rtp_parameters::RtpCodecCapabilityFinalized;
+use mediasoup::rtp_parameters::{RtcpFeedback, RtpCodecCapabilityFinalized};
 
 use nodyx_sfu::{
     ConsumerId, EngineStats, Layer, MediaEngine, MediaError, NodeId, ParticipantId, PipeHandle,
@@ -69,6 +69,35 @@ fn opus_rtp_parameters(ssrc: u32) -> RtpParameters {
         }],
         rtcp: RtcpParameters::default(),
     }
+}
+
+// ── Codec vidéo P2 : VP8, universel navigateur, libre de droits (screenshare) ─
+// S'AJOUTE à Opus dans le router (ne le remplace pas) → l'audio ne régresse pas.
+// Le rtcp_feedback est CE qui fait tenir la vidéo : NACK (retransmission), PLI/FIR
+// (demande de keyframe), REMB/transport-cc (contrôle de congestion). Sans lui, le
+// flux vidéo se fige/casse. clock_rate vidéo = 90 kHz (invariant WebRTC).
+
+fn vp8_capability() -> RtpCodecCapability {
+    RtpCodecCapability::Video {
+        mime_type: MimeTypeVideo::Vp8,
+        preferred_payload_type: None,
+        clock_rate: NonZeroU32::new(90000).unwrap(),
+        parameters: RtpCodecParametersParameters::default(),
+        rtcp_feedback: vec![
+            RtcpFeedback::Nack,
+            RtcpFeedback::NackPli,
+            RtcpFeedback::CcmFir,
+            RtcpFeedback::GoogRemb,
+            RtcpFeedback::TransportCc,
+        ],
+    }
+}
+
+/// Codecs du router : Opus (audio, P1) + VP8 (vidéo/screenshare, P2). Les DEUX
+/// routers (local et « remote worker » du pipe de fédération) DOIVENT partager
+/// exactement cette liste, sinon le pipe mismatch. Source unique = cette fonction.
+fn router_codecs() -> Vec<RtpCodecCapability> {
+    vec![opus_capability(), vp8_capability()]
 }
 
 /// Les capabilities "finalized" du router (payload types assignés) → les
@@ -336,7 +365,7 @@ impl MediasoupEngine {
             .await
             .map_err(|e| MediaError::Engine(format!("create_worker(remote): {e}")))?;
         let router = worker
-            .create_router(RouterOptions::new(vec![opus_capability()]))
+            .create_router(RouterOptions::new(router_codecs()))
             .await
             .map_err(|e| MediaError::Engine(format!("create_router({room}): {e}")))?;
         self.inner.extra_workers.lock().unwrap().push(worker);
@@ -363,7 +392,7 @@ impl MediaEngine for MediasoupEngine {
             idx
         };
         let router = match self.inner.workers[idx]
-            .create_router(RouterOptions::new(vec![opus_capability()]))
+            .create_router(RouterOptions::new(router_codecs()))
             .await
         {
             Ok(r) => r,
@@ -498,20 +527,28 @@ impl MediaEngine for MediasoupEngine {
         kind: TrackKind,
         client: &SignalingBlob,
     ) -> Result<ProducerId> {
-        if kind != TrackKind::Audio {
-            // P1 = audio. La vidéo/simulcast arrive en P2/P3.
-            return Err(MediaError::Unsupported("produce non-audio (P1 audio)"));
-        }
+        // P1 = audio (Opus). P2 = vidéo (Screen/Cam → VP8). La vidéo passe
+        // TOUJOURS par WebRTC : le navigateur fournit ses rtpParameters. Le mode
+        // Direct (sans navigateur) ne sait fabriquer que de l'audio Opus.
+        let media_kind = match kind {
+            TrackKind::Audio => MediaKind::Audio,
+            TrackKind::Screen | TrackKind::Cam => MediaKind::Video,
+        };
         let (t, router_key) = self.transport_of(&transport.0)?;
-        // Paramètres RTP du client si fournis (WebRTC), sinon fabriqués (Direct).
+        // Paramètres RTP du client si fournis (WebRTC), sinon fabriqués (Direct audio).
         let rtp: RtpParameters = match serde_json::from_str(&client.0) {
             Ok(p) => p,
             Err(_) => {
+                if media_kind == MediaKind::Video {
+                    return Err(MediaError::Unsupported(
+                        "produce vidéo sans rtpParameters : la vidéo exige WebRTC (v1)",
+                    ));
+                }
                 let ssrc = 1000 + self.inner.seq.fetch_add(1, Ordering::Relaxed) as u32;
                 opus_rtp_parameters(ssrc)
             }
         };
-        let options = ProducerOptions::new(MediaKind::Audio, rtp);
+        let options = ProducerOptions::new(media_kind, rtp);
         let producer = match t.as_ref() {
             AnyTransport::Direct(d) => d.produce(options).await,
             AnyTransport::WebRtc(w) => w.produce(options).await,
@@ -561,6 +598,15 @@ impl MediaEngine for MediasoupEngine {
         let key = consumer.id().to_string();
         self.inner.consumers.lock().unwrap().insert(key.clone(), consumer);
         Ok((ConsumerId(key), SignalingBlob(params.to_string())))
+    }
+
+    async fn close_producer(&self, producer: &ProducerId) -> Result<()> {
+        // Retirer du registre = Drop du Producer mediasoup = fermeture réelle du
+        // flux serveur (les abonnés le verront disparaître des publications, cf.
+        // réconciliation client). Idempotent : absent = déjà fermé, on ne se
+        // plaint pas (un stop de partage doit toujours pouvoir aboutir).
+        self.inner.producers.lock().unwrap().remove(&producer.0);
+        Ok(())
     }
 
     async fn set_preferred_layer(&self, _consumer: &ConsumerId, _layer: Layer) -> Result<()> {
@@ -701,5 +747,55 @@ mod tests {
             .await
             .is_err());
         assert_eq!(engine.worker_loads(), vec![1, 1]);
+    }
+
+    // ── P2 vidéo : le router expose VP8 en plus d'Opus (screenshare), sans faire
+    //    régresser l'audio. C'est LE contrat de P2-A.
+    #[tokio::test]
+    async fn router_exposes_opus_and_vp8() {
+        let engine = MediasoupEngine::build_with(None, DEFAULT_RTC_PORTS, 1)
+            .await
+            .expect("build pool 1");
+        let room = engine
+            .create_room(RoomId("room-caps".into()))
+            .await
+            .expect("create_room");
+        let caps = engine.room_capabilities(&room).await.expect("caps");
+        let lc = caps.0.to_lowercase();
+        assert!(lc.contains("opus"), "Opus doit rester (audio P1) : {}", caps.0);
+        assert!(lc.contains("vp8"), "VP8 doit être exposé (vidéo P2) : {}", caps.0);
+    }
+
+    // ── P2 vidéo : en mode Direct (sans navigateur) on ne fabrique que de l'audio.
+    //    Une demande de produce vidéo est refusée PROPREMENT (pas de panic), tandis
+    //    que l'audio continue de passer (non-régression P1).
+    #[tokio::test]
+    async fn direct_produce_audio_ok_video_rejected() {
+        let engine = MediasoupEngine::build_with(None, DEFAULT_RTC_PORTS, 1)
+            .await
+            .expect("build pool 1");
+        let room = engine
+            .create_room(RoomId("room-prod".into()))
+            .await
+            .expect("create_room");
+        let transport = engine
+            .create_transport(&room, ParticipantId("tester".into()))
+            .await
+            .expect("create_transport");
+
+        // Audio : blob vide → Opus fabriqué → producer créé (P1 intact).
+        engine
+            .produce(&transport, TrackKind::Audio, &SignalingBlob(String::new()))
+            .await
+            .expect("produce audio Direct");
+
+        // Vidéo : blob vide → pas de rtpParameters → refus explicite (WebRTC only).
+        let err = engine
+            .produce(&transport, TrackKind::Screen, &SignalingBlob(String::new()))
+            .await;
+        assert!(
+            matches!(err, Err(MediaError::Unsupported(_))),
+            "produce vidéo Direct doit être refusé, obtenu : {err:?}"
+        );
     }
 }

--- a/nodyx-p2p/crates/nodyx-sfu/src/lib.rs
+++ b/nodyx-p2p/crates/nodyx-sfu/src/lib.rs
@@ -171,6 +171,10 @@ pub trait MediaEngine: Send + Sync {
     /// Le participant souscrit à un flux publié. `client_caps` porte ses
     /// capabilities ; retourne les paramètres que le client doit appliquer.
     async fn consume(&self, transport: &TransportHandle, producer: &ProducerId, client_caps: &SignalingBlob) -> Result<(ConsumerId, SignalingBlob)>;
+    /// Ferme un producer (le participant arrête un flux, ex. stop partage
+    /// d'écran). Idempotent : un producer déjà fermé/inconnu n'est PAS une erreur
+    /// (un nettoyage doit toujours pouvoir aboutir).
+    async fn close_producer(&self, producer: &ProducerId) -> Result<()>;
     /// Force la couche servie à un abonné (adaptation bande passante).
     async fn set_preferred_layer(&self, consumer: &ConsumerId, layer: Layer) -> Result<()>;
     /// Relaie un flux vers un nœud SFU distant (cascade fédérée, PipeTransport).
@@ -225,6 +229,9 @@ impl MediaEngine for NullEngine {
     async fn consume(&self, _transport: &TransportHandle, _producer: &ProducerId, client_caps: &SignalingBlob) -> Result<(ConsumerId, SignalingBlob)> {
         // Écho des caps client : déterministe, suffisant pour l'orchestration.
         Ok((ConsumerId(self.next("consumer")), client_caps.clone()))
+    }
+    async fn close_producer(&self, _producer: &ProducerId) -> Result<()> {
+        Ok(())
     }
     async fn set_preferred_layer(&self, _consumer: &ConsumerId, _layer: Layer) -> Result<()> {
         Ok(())

--- a/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
+++ b/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
@@ -95,6 +95,9 @@ pub enum VoiceError {
     NotInSfu,
     /// Souscription à une publication inexistante.
     NoSuchPublication,
+    /// Tentative de fermer une publication qu'on ne possède pas (arrêt d'un flux
+    /// appartenant à autrui : refusé).
+    NotOwner,
     /// Réglage de couche sur une publication à laquelle on n'est pas abonné.
     NotSubscribed,
     /// Le moteur média a échoué (remonté tel quel pour diagnostic).
@@ -109,6 +112,7 @@ impl fmt::Display for VoiceError {
             VoiceError::NotInRoom => f.write_str("absent du salon"),
             VoiceError::NotInSfu => f.write_str("participant pas en mode SFU"),
             VoiceError::NoSuchPublication => f.write_str("publication inexistante"),
+            VoiceError::NotOwner => f.write_str("publication appartenant à un autre participant"),
             VoiceError::NotSubscribed => f.write_str("pas abonné à cette publication"),
             VoiceError::Engine(e) => write!(f, "moteur média : {e}"),
         }
@@ -588,6 +592,33 @@ impl<E: MediaEngine> VoiceService<E> {
         Ok(producer)
     }
 
+    /// Le participant arrête un flux qu'il a publié (ex. stop partage d'écran).
+    /// Retire la publication ET ferme le producer côté serveur → les abonnés le
+    /// voient disparaître (réconciliation). Borné au propriétaire : fermer le flux
+    /// d'autrui est refusé ([`VoiceError::NotOwner`]). Le verrou d'état n'est
+    /// jamais tenu à travers l'`await` moteur (comme publish/subscribe).
+    pub async fn unpublish(
+        &self,
+        room: RoomId,
+        participant: ParticipantId,
+        producer: ProducerId,
+    ) -> Result<(), VoiceError> {
+        {
+            let mut rooms = self.rooms();
+            let state = rooms.get_mut(&room).ok_or(VoiceError::NotInRoom)?;
+            match state.publications.get(&producer) {
+                Some(pubb) if pubb.owner == participant => {
+                    state.publications.remove(&producer);
+                }
+                Some(_) => return Err(VoiceError::NotOwner),
+                None => return Err(VoiceError::NoSuchPublication),
+            }
+        }
+        // Hors verrou : fermeture réelle du flux moteur (idempotente).
+        self.engine.close_producer(&producer).await?;
+        Ok(())
+    }
+
     /// Le participant souscrit à une publication. Requiert le mode SFU (transport).
     /// `client_caps` = capabilities du client (blob opaque) ; retourne aussi les
     /// paramètres que le client doit appliquer (blob du moteur).
@@ -886,6 +917,32 @@ mod tests {
         assert_eq!(
             block_on(s.publish(room(), p(1), TrackKind::Audio, &blob())),
             Err(VoiceError::NotInSfu)
+        );
+    }
+
+    #[test]
+    fn unpublish_removes_own_screen_and_rejects_others() {
+        let s = svc();
+        block_on(s.join(room(), p(1))).unwrap();
+        block_on(s.join(room(), p(2))).unwrap();
+        let prod = block_on(s.publish(room(), p(1), TrackKind::Screen, &blob())).unwrap();
+        assert_eq!(s.publications(&room()).len(), 1);
+
+        // Un AUTRE participant ne peut pas fermer le flux de p1.
+        assert_eq!(
+            block_on(s.unpublish(room(), p(2), prod.clone())),
+            Err(VoiceError::NotOwner)
+        );
+        assert_eq!(s.publications(&room()).len(), 1, "refus = publication intacte");
+
+        // Le PROPRIÉTAIRE arrête son partage → la publication disparaît.
+        block_on(s.unpublish(room(), p(1), prod.clone())).unwrap();
+        assert!(s.publications(&room()).is_empty());
+
+        // Re-fermer un flux déjà disparu → NoSuchPublication (rien à fermer).
+        assert_eq!(
+            block_on(s.unpublish(room(), p(1), prod)),
+            Err(VoiceError::NoSuchPublication)
         );
     }
 


### PR DESCRIPTION
## Objectif

Le partage d'écran passe par le **SFU** (un seul upload, le serveur recopie à chaque spectateur) au lieu du **mesh** (une copie par spectateur, qui plafonne à ~4 personnes en partage d'écran). C'est le livrable "tenir tête à Discord" sur le vocal.

Tranche **testable au labo** (`/admin/sfu-lab`). Le screenshare mesh existant n'est pas touché (filet de sécurité).

## Ce que fait cette PR (P2-A + P2-B)

| Couche | Changement |
|--------|-----------|
| Moteur (`nodyx-sfu-mediasoup`) | router expose **VP8** + Opus (`router_codecs`), `produce` accepte l'écran (`Screen/Cam -> MediaKind::Video`), `close_producer` |
| Service (`nodyx-sfu`) | `unpublish` borné au propriétaire (`VoiceError::NotOwner`) |
| Daemon | route `POST /v1/close_producer` |
| Relais core | `voice:sfu_unpublish` -> broadcast `voice:sfu_producer_closed` |
| Client (`voiceSfu.ts`) | `sfuStartScreenShare` / `sfuStopScreenShare`, consumers vidéo -> store écran, arrêt net, anti self-consume |
| Labo | bouton "Partager l'écran" + grille de rendu des écrans reçus |

**Arrêt net** : stop -> le producer serveur ferme -> les spectateurs voient l'écran disparaître immédiatement (pas d'image figée).

## Tests

- Service `nodyx-sfu` : 29 (dont `unpublish_removes_own_screen_and_rejects_others`)
- Moteur `nodyx-sfu-mediasoup` : 5 (VP8 exposé sans casser Opus, garde-fou Direct)
- Core : 33 (voice-sfu + voice-bascule)
- Frontend : `svelte-check` + `tsc` propres

Note : `nodyx-sfu-mediasoup` est hors-workspace (worker C++), donc non couvert par la CI `--workspace` ; testé en local.

## Protocole de test manuel (après déploiement)

Deux comptes sur `/admin/sfu-lab`, même UUID de canal :
1. les deux rejoignent via SFU (daemon `SFU_MESH_THRESHOLD=0`)
2. l'un clique "Partager l'écran" -> l'autre voit l'écran
3. "Arrêter" -> l'écran disparaît net

## Suite (hors PR)

- **P2-C** : UI/UX de visionnage refaite façon Discord (scène + chat du salon + fenêtre flottante persistante), branchement dans les vrais canaux via `voice.ts`/`voiceBascule.ts`
- **P2-D** : simulcast (servir à chacun la couche adaptée)
