### PR TITLE
feat(vocal): la Scène devient la vraie vue du partage d'écran, avec le chat du salon

### DIFF
--- a/nodyx-frontend/src/lib/components/StageChat.svelte
+++ b/nodyx-frontend/src/lib/components/StageChat.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+    // ── Chat du salon, DANS la scène ──────────────────────────────────────────
+    //
+    // Autonome par nécessité : les messages de la page chat sont un état LOCAL de
+    // cette page. La scène vit au-dessus des pages (VoicePanel → +layout) et doit
+    // donc pouvoir suivre le fil du salon même quand la page chat n'est pas montée
+    // (fenêtre flottante, navigation ailleurs). Ce panneau rejoint donc lui-même la
+    // room et écoute le live.
+    //
+    // ⚠ On n'émet JAMAIS `chat:leave` : la page chat gère son propre cycle de vie,
+    // un leave émis d'ici la sortirait de la room et lui couperait ses messages.
+
+    import { socket } from '$lib/socket'
+    import { linkifyHtml } from '$lib/linkify'
+    import { renderCustomEmojis, customEmojisStore } from '$lib/customEmojis'
+
+    let { channelId, channelName = '' }: { channelId: string; channelName?: string } = $props()
+
+    type StageMessage = {
+        id:              string
+        channel_id:      string
+        author_username: string
+        author_avatar:   string | null
+        content:         string | null
+        created_at:      string
+        is_deleted?:     boolean
+    }
+
+    let messages = $state<StageMessage[]>([])
+    let draft    = $state('')
+    let listEl   = $state<HTMLDivElement | null>(null)
+
+    const emojis = $derived($customEmojisStore)
+
+    function scrollToBottom(): void {
+        queueMicrotask(() => { if (listEl) listEl.scrollTop = listEl.scrollHeight })
+    }
+
+    $effect(() => {
+        const sock = $socket
+        const id   = channelId
+        if (!sock || !id) return
+
+        sock.emit('chat:join', id)
+
+        const onHistory = (p: { channelId: string; messages: StageMessage[] }) => {
+            if (p.channelId !== id) return
+            messages = p.messages ?? []
+            scrollToBottom()
+        }
+        const onMessage = (msg: StageMessage) => {
+            if (msg.channel_id !== id) return
+            messages = [...messages, msg]
+            scrollToBottom()
+        }
+        sock.on('chat:history', onHistory)
+        sock.on('chat:message', onMessage)
+
+        return () => {
+            sock.off('chat:history', onHistory)
+            sock.off('chat:message', onMessage)
+        }
+    })
+
+    function send(): void {
+        const content = draft.trim()
+        const sock    = $socket
+        if (!content || !sock || !channelId) return
+        sock.emit('chat:send', { channelId, content })
+        draft = ''
+    }
+
+    // La scène écoute F / P / Échap sur window : en tapant un message on ne doit
+    // PAS déclencher le plein écran. On coupe la propagation à la source.
+    function onKeydown(e: KeyboardEvent): void {
+        e.stopPropagation()
+        if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send() }
+    }
+
+    function hhmm(iso: string): string {
+        try {
+            return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+        } catch { return '' }
+    }
+</script>
+
+<div class="flex h-full flex-col" style="background: rgba(6,6,12,0.75); border-left: 1px solid rgba(255,255,255,0.05)">
+
+    <!-- En-tête -->
+    <div class="flex shrink-0 items-center gap-2 px-4 py-3"
+         style="border-bottom: 1px solid rgba(255,255,255,0.05)">
+        <svg class="h-3.5 w-3.5 shrink-0" style="color: rgb(107,114,128)" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M21 12a9 9 0 1 1-4.2-7.6L21 3v9z"/>
+        </svg>
+        <span class="text-[11px] font-bold uppercase tracking-widest text-white">Chat du salon</span>
+        {#if channelName}
+            <span class="truncate text-[11px]" style="color: rgb(107,114,128)">{channelName}</span>
+        {/if}
+    </div>
+
+    <!-- Fil -->
+    <div bind:this={listEl} class="flex-1 space-y-3 overflow-y-auto px-4 py-3" style="scrollbar-width: thin">
+        {#if messages.length === 0}
+            <p class="pt-6 text-center text-xs" style="color: rgba(255,255,255,0.25)">
+                Aucun message pour l'instant.
+            </p>
+        {/if}
+        {#each messages as msg (msg.id)}
+            {#if !msg.is_deleted && msg.content}
+                <div class="flex gap-2.5">
+                    {#if msg.author_avatar}
+                        <img src={msg.author_avatar} alt={msg.author_username}
+                             class="mt-0.5 h-6 w-6 shrink-0 rounded-full object-cover"/>
+                    {:else}
+                        <div class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-indigo-700 text-[9px] font-bold text-white">
+                            {msg.author_username?.[0]?.toUpperCase() ?? '?'}
+                        </div>
+                    {/if}
+                    <div class="min-w-0 flex-1">
+                        <div class="flex items-baseline gap-2">
+                            <span class="truncate text-xs font-semibold text-white">{msg.author_username}</span>
+                            <span class="shrink-0 text-[10px]" style="color: rgb(75,85,99)">{hhmm(msg.created_at)}</span>
+                        </div>
+                        <div class="stage-msg break-words text-[13px]" style="color: rgb(209,213,219)">
+                            {@html renderCustomEmojis(linkifyHtml(msg.content ?? ''), emojis)}
+                        </div>
+                    </div>
+                </div>
+            {/if}
+        {/each}
+    </div>
+
+    <!-- Composeur -->
+    <div class="shrink-0 p-3" style="border-top: 1px solid rgba(255,255,255,0.05)">
+        <div class="flex items-end gap-2 rounded-lg px-3 py-2"
+             style="background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.07)">
+            <input
+                bind:value={draft}
+                onkeydown={onKeydown}
+                placeholder="Écrire un message…"
+                class="flex-1 bg-transparent text-[13px] text-gray-200 outline-none placeholder:text-gray-600"
+            />
+            <button
+                onclick={send}
+                disabled={!draft.trim()}
+                aria-label="Envoyer"
+                class="shrink-0 rounded-md p-1 transition-colors disabled:opacity-30"
+                style="color: rgb(165,180,252)"
+            >
+                <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12zm0 0h7.5"/>
+                </svg>
+            </button>
+        </div>
+    </div>
+</div>
+
+<style>
+    /* Le contenu vient de l'éditeur (HTML assaini côté serveur) : on borne juste
+       ce qui pourrait casser la colonne étroite du panneau. */
+    .stage-msg :global(p)   { margin: 0; }
+    .stage-msg :global(img) { max-width: 100%; height: auto; }
+    .stage-msg :global(a)   { color: rgb(129,140,248); text-decoration: underline; }
+    .stage-msg :global(pre) { overflow-x: auto; }
+</style>

--- a/nodyx-frontend/src/lib/components/StageView.svelte
+++ b/nodyx-frontend/src/lib/components/StageView.svelte
@@ -6,12 +6,26 @@
         stopScreenShare,
         voiceStore,
     } from '$lib/voice'
+    import StageChat from './StageChat.svelte'
 
     let { onclose }: { onclose: () => void } = $props()
 
     const localStream   = $derived($localScreenStore)
     const remoteScreens = $derived($remoteScreenStore)
     const peers         = $derived($voiceStore.peers)
+    const channelId     = $derived($voiceStore.channelId)
+
+    // ── Chat du salon dans la scène ───────────────────────────────────────────
+    // Fermé par défaut : l'écran doit être le plus grand possible (c'était LA
+    // plainte). Le choix est mémorisé d'une session à l'autre.
+    let showChat = $state(
+        typeof localStorage !== 'undefined' && localStorage.getItem('nodyx:stage:chat') === '1',
+    )
+    $effect(() => {
+        if (typeof localStorage !== 'undefined') {
+            localStorage.setItem('nodyx:stage:chat', showChat ? '1' : '0')
+        }
+    })
 
     // ── Unified stream list ────────────────────────────────────────
     type StreamEntry = {
@@ -155,6 +169,9 @@
 
     function onKeydown(e: KeyboardEvent) {
         if (isPiP) return
+        // On tape un message ? Les raccourcis (F/P) ne doivent PAS se déclencher.
+        const t = e.target as HTMLElement | null
+        if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return
         if (e.key === 'Escape') { e.stopPropagation(); onclose() }
         if (e.key === 'f' || e.key === 'F') requestFullscreen()
         if (e.key === 'p' || e.key === 'P') isPiP = true
@@ -226,6 +243,21 @@
 
         <!-- Right — controls -->
         <div class="flex items-center gap-2 shrink-0">
+            <button
+                onclick={() => showChat = !showChat}
+                class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs transition-all"
+                style="
+                    background: {showChat ? 'rgb(var(--nx-accent-rgb) / 0.14)' : 'rgba(255,255,255,0.04)'};
+                    border: 1px solid {showChat ? 'rgb(var(--nx-accent-rgb) / 0.45)' : 'rgba(255,255,255,0.07)'};
+                    color: {showChat ? 'rgb(165,180,252)' : 'rgb(156,163,175)'};
+                "
+                title="Chat du salon"
+            >
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M21 12a9 9 0 1 1-4.2-7.6L21 3v9z"/>
+                </svg>
+                <span class="hidden sm:inline">Chat</span>
+            </button>
             <button
                 onclick={() => isPiP = true}
                 class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs transition-all"
@@ -399,6 +431,13 @@
                         </div>
                     </button>
                 {/each}
+            </div>
+        {/if}
+
+        <!-- Chat du salon : suivre la conversation sans quitter la scène -->
+        {#if showChat && channelId}
+            <div class="w-80 xl:w-96 shrink-0">
+                <StageChat channelId={channelId}/>
             </div>
         {/if}
 

--- a/nodyx-frontend/src/lib/components/VoicePanel.svelte
+++ b/nodyx-frontend/src/lib/components/VoicePanel.svelte
@@ -11,6 +11,7 @@
     import VoiceSettings    from './VoiceSettings.svelte'
     import ScreenShareModal from './ScreenShareModal.svelte'
     import StageView        from './StageView.svelte'
+    import { stageOpenStore } from '$lib/stageStore'
     import { onMount } from 'svelte'
     import { t } from '$lib/i18n'
     import { voicePanelTarget } from '$lib/voicePanel'
@@ -32,8 +33,9 @@
     let { mode = 'float', extraClass = '' }: { mode?: 'float' | 'sidebar'; extraClass?: string } = $props()
 
     let showShareModal  = $state(false)
-    let showStage       = $state(false)
     let showVoiceSettings = $state(false)
+    // L'ouverture de la scène est PARTAGÉE (stageStore) : le salon doit pouvoir
+    // dire « ouvre ça en grand » sans passer par ce composant.
 
     const vs            = $derived($voiceStore)
     const peers         = $derived(vs.peers)
@@ -47,10 +49,13 @@
     const anySharing    = $derived(isSharing || remoteScreens.size > 0)
     const shareCount    = $derived(remoteScreens.size + (isSharing ? 1 : 0))
 
-    // Auto-ouvrir le Stage dès qu'un partage distant devient actif
+    // Auto-ouvrir la scène dès qu'un partage distant devient actif (on regarde
+    // tout de suite, comme Discord). Son PROPRE partage n'ouvre pas la scène en
+    // grand (on ne se met pas son propre écran en plein écran) : le salon en
+    // montre un aperçu cliquable.
     $effect(() => {
-        if (remoteScreens.size > 0 && !showStage) {
-            showStage = true
+        if (remoteScreens.size > 0 && !$stageOpenStore) {
+            $stageOpenStore = true
         }
     })
 
@@ -671,12 +676,12 @@
                         <!-- Stage button — visible when any share is active -->
                         {#if anySharing}
                             <button
-                                onclick={() => { showStage = !showStage; showShareModal = false }}
+                                onclick={() => { $stageOpenStore = !$stageOpenStore; showShareModal = false }}
                                 class='hidden sm:flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg transition-all duration-200 transform hover:scale-110 active:scale-95 relative
-                                       {showStage
+                                       {$stageOpenStore
                                            ? "bg-gradient-to-r from-red-600 to-rose-600 text-white shadow-lg shadow-red-500/50 ring-2 ring-red-400/50"
                                            : "text-red-400 border border-red-500/30 hover:border-red-400/50"}'
-                                style="pointer-events: auto; position: relative; z-index: 102; {!showStage ? 'background: rgba(239,68,68,0.08)' : ''}"
+                                style="pointer-events: auto; position: relative; z-index: 102; {!$stageOpenStore ? 'background: rgba(239,68,68,0.08)' : ''}"
                                 title="Ouvrir le Stage"
                             >
                                 <span class="w-1.5 h-1.5 rounded-full bg-current animate-pulse"></span>
@@ -690,7 +695,7 @@
 
                         <!-- Partager l'écran / Arrêter -->
                         <button
-                            onclick={() => { isSharing ? stopScreenShare() : (showShareModal = !showShareModal); showStage = false }}
+                            onclick={() => { isSharing ? stopScreenShare() : (showShareModal = !showShareModal); $stageOpenStore = false }}
                             class='hidden sm:flex p-2 rounded-lg transition-all duration-200 transform hover:scale-110 active:scale-95 relative
                                    {isSharing
                                        ? "bg-gradient-to-r from-emerald-600 to-teal-600 text-white shadow-lg shadow-emerald-500/50 ring-2 ring-emerald-400/50"
@@ -972,7 +977,7 @@
 
                 <!-- Stage (sidebar) -->
                 {#if anySharing}
-                    <button onclick={() => { showStage = !showStage }}
+                    <button onclick={() => { $stageOpenStore = !$stageOpenStore }}
                         title="Stage"
                         class="flex-1 flex items-center justify-center p-1.5 rounded-lg transition-colors text-red-400 bg-red-900/20">
                         <span class="w-1.5 h-1.5 rounded-full bg-current animate-pulse"></span>
@@ -1044,8 +1049,8 @@
     {#if showShareModal}
         <ScreenShareModal onclose={() => showShareModal = false}/>
     {/if}
-    {#if showStage}
-        <StageView onclose={() => showStage = false}/>
+    {#if $stageOpenStore}
+        <StageView onclose={() => $stageOpenStore = false}/>
     {/if}
 {/if}
 

--- a/nodyx-frontend/src/lib/components/VoiceRoom.svelte
+++ b/nodyx-frontend/src/lib/components/VoiceRoom.svelte
@@ -3,6 +3,7 @@
 	import NodyxCanvas  from '$lib/components/NodyxCanvas.svelte';
 	import VoiceJukebox from '$lib/components/VoiceJukebox.svelte';
 	import { localScreenStore, remoteScreenStore, screenShareStore } from '$lib/voice';
+	import { openStage } from '$lib/stageStore';
 	import { jukeboxStore } from '$lib/jukebox';
 	import type { Socket } from 'socket.io-client';
 
@@ -239,6 +240,8 @@
 
 <!-- ── Screen share panel ──────────────────────────────────────────────────── -->
 {#if showScreenShare && (localScreen || remoteScreens.size > 0)}
+	<!-- Aperçu dans le salon. La VRAIE lecture se fait sur la Scène (plein écran,
+	     non tronquée par les sidebars) : un clic sur un écran l'ouvre en grand. -->
 	<div class="shrink-0 grid gap-2 p-3 overflow-y-auto"
 	     style="grid-template-columns: repeat({gridCols}, 1fr); max-height: 55vh; background: #07070f; border-bottom: 1px solid rgba(255,255,255,0.05);">
 		{#if localScreen}
@@ -248,11 +251,22 @@
 					class="w-full h-full object-contain cursor-pointer"
 					autoplay muted playsinline
 					use:srcStream={localScreen}
+					onclick={() => openStage()}
 					ondblclick={(e) => (e.currentTarget as HTMLVideoElement).requestFullscreen?.()}
-					title="Double-clic pour plein écran"
+					title="Cliquer pour ouvrir en grand"
 				></video>
+				<!-- Ouvrir en grand (la scène n'est pas rognée par les sidebars) -->
+				<button
+					onclick={() => openStage()}
+					class="absolute inset-0 flex items-center justify-center opacity-0 group-hover/sc:opacity-100 transition-opacity duration-150"
+					style="background: rgba(0,0,0,0.35);"
+					title="Ouvrir en grand"
+				>
+					<span class="px-3 py-1.5 rounded-full text-[11px] font-semibold text-white"
+					      style="background: rgba(79,70,229,0.85); backdrop-filter: blur(4px);">Ouvrir en grand</span>
+				</button>
 				<!-- Badge -->
-				<span class="absolute bottom-2 left-2 text-[10px] text-white font-semibold px-2 py-0.5 rounded"
+				<span class="absolute bottom-2 left-2 text-[10px] text-white font-semibold px-2 py-0.5 rounded pointer-events-none"
 				      style="background: rgba(0,0,0,0.7);">Vous</span>
 				<!-- Fullscreen btn -->
 				<button
@@ -276,11 +290,22 @@
 					class="w-full h-full object-contain cursor-pointer"
 					autoplay playsinline
 					use:srcStream={stream}
+					onclick={() => openStage()}
 					ondblclick={(e) => (e.currentTarget as HTMLVideoElement).requestFullscreen?.()}
-					title="Double-clic pour plein écran"
+					title="Cliquer pour ouvrir en grand"
 				></video>
+				<!-- Ouvrir en grand -->
+				<button
+					onclick={() => openStage()}
+					class="absolute inset-0 flex items-center justify-center opacity-0 group-hover/sc:opacity-100 transition-opacity duration-150"
+					style="background: rgba(0,0,0,0.35);"
+					title="Ouvrir en grand"
+				>
+					<span class="px-3 py-1.5 rounded-full text-[11px] font-semibold text-white"
+					      style="background: rgba(79,70,229,0.85); backdrop-filter: blur(4px);">Ouvrir en grand</span>
+				</button>
 				<!-- Badge -->
-				<span class="absolute bottom-2 left-2 text-[10px] text-white font-semibold px-2 py-0.5 rounded"
+				<span class="absolute bottom-2 left-2 text-[10px] text-white font-semibold px-2 py-0.5 rounded pointer-events-none"
 				      style="background: rgba(0,0,0,0.7);">{peer?.username ?? 'Peer'}</span>
 				<!-- Live dot -->
 				<span class="absolute top-2 left-2 flex items-center gap-1 px-1.5 py-0.5 rounded"

--- a/nodyx-frontend/src/lib/stageStore.ts
+++ b/nodyx-frontend/src/lib/stageStore.ts
@@ -1,0 +1,24 @@
+// ── La Scène (StageView) : état d'ouverture PARTAGÉ ───────────────────────────
+//
+// StageView est monté par VoicePanel, lui-même monté dans +layout.svelte : la
+// scène vit donc AU-DESSUS des pages et survit à la navigation (c'est ce qui
+// permet la fenêtre flottante qui suit l'utilisateur d'une page à l'autre).
+//
+// Son ouverture était un état LOCAL de VoicePanel, donc impossible à déclencher
+// d'ailleurs (le salon ne pouvait pas dire « ouvre ça en grand »). On le sort ici
+// pour que n'importe quel composant puisse ouvrir la scène.
+
+import { writable } from 'svelte/store'
+
+/** La scène plein écran est-elle ouverte ? */
+export const stageOpenStore = writable<boolean>(false)
+
+/** Ouvrir la scène (ex. clic sur un écran partagé depuis le salon). */
+export function openStage(): void {
+  stageOpenStore.set(true)
+}
+
+/** Fermer la scène. */
+export function closeStage(): void {
+  stageOpenStore.set(false)
+}


### PR DESCRIPTION
## Le problème

Dans le salon, un partage d'écran est rendu comme une **bande capée à `55vh`**, en tuiles forcées **16:9**, coincée dans la colonne centrale **entre les deux sidebars**. Un écran large (ultrawide) y est écrasé et donne l'impression d'être tronqué.

La **Scène** (`StageView`), elle, est déjà plein écran, en `object-contain` (aucun rognage), et ne subit aucune sidebar. Mais elle n'était atteignable que depuis la barre vocale, et ne s'ouvrait automatiquement que quand **quelqu'un d'autre** partageait. Quand on partage soi-même, on restait donc coincé dans la bande écrasée.

## Ce que fait cette PR

- **`lib/stageStore.ts` (nouveau)** : l'ouverture de la Scène devient un état **partagé**. Elle était locale à `VoicePanel`, donc rien d'autre ne pouvait dire « ouvre ça en grand ».
- **Salon (`VoiceRoom`)** : un **clic sur un écran partagé ouvre la Scène** (survol : « Ouvrir en grand »). L'aperçu redevient un aperçu ; la lecture se fait dans la Scène, non tronquée.
- **`StageChat.svelte` (nouveau)** : **le chat du salon dans la Scène** (bouton « Chat », choix mémorisé). Autonome : il rejoint lui-même la room et écoute le live, parce que les messages sont un état **local** de la page chat alors que la Scène vit **au-dessus** des pages. Il n'émet **jamais** `chat:leave` (ça sortirait la page chat de la room).
- **`StageView`** : panneau de chat à droite + **garde-fou clavier** (les raccourcis `F`/`P` ne se déclenchent plus quand on tape un message).

## Fenêtre flottante

`StageView` est monté par `VoicePanel`, lui-même dans `+layout.svelte` : la Scène (et son mode PiP flottant déplaçable) **survit déjà à la navigation** entre les pages.

## Tests

`svelte-check` 0 erreur, build prod OK, 14 tests front verts. Frontend uniquement, aucun changement backend.

## Suite

Brancher le partage d'écran **SFU** (livré en #250, actif au labo) dans les vrais canaux, puis simulcast.
