### PR TITLE
fix(vocal): la Scène était prisonnière d'un contexte d'empilement (écran rogné, en-tête invisible)

### DIFF
--- a/nodyx-frontend/src/lib/components/StageView.svelte
+++ b/nodyx-frontend/src/lib/components/StageView.svelte
@@ -262,13 +262,13 @@
                 onclick={() => isPiP = true}
                 class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs transition-all"
                 style="background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.07); color: rgb(156,163,175);"
-                title="Mode PiP (P)"
+                title="Fenêtre flottante (P) : la Scène vous suit quand vous naviguez ailleurs"
             >
                 <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                     <rect x="2" y="3" width="20" height="14" rx="2"/>
                     <rect x="12" y="10" width="8" height="5" rx="1"/>
                 </svg>
-                <span class="hidden sm:inline">PiP</span>
+                <span class="hidden sm:inline">Fenêtre flottante</span>
             </button>
             <button
                 onclick={onclose}
@@ -313,9 +313,13 @@
                     {/if}
                 </div>
 
-                <!-- Keyboard hint -->
-                <div class="absolute top-4 right-4 z-10 text-[10px] select-none" style="color: rgba(255,255,255,0.12)">
-                    F — plein écran · P — PiP · Esc — fermer
+                <!-- Raccourcis : ils étaient en opacité 0.12, donc invisibles (on ne
+                     pouvait pas deviner « P »). Lisibles, et nommés en clair. -->
+                <div class="absolute top-4 right-4 z-10 flex items-center gap-2.5 rounded-full px-3 py-1.5 text-[10px] select-none"
+                     style="background: rgba(0,0,0,0.55); border: 1px solid rgba(255,255,255,0.1); color: rgba(255,255,255,0.6); backdrop-filter: blur(4px)">
+                    <span><kbd class="stage-kbd">F</kbd> plein écran</span>
+                    <span><kbd class="stage-kbd">P</kbd> fenêtre flottante</span>
+                    <span><kbd class="stage-kbd">Échap</kbd> fermer</span>
                 </div>
 
                 <!-- Main video — double-clic = plein écran -->
@@ -599,5 +603,20 @@
     .stage-ctrl-danger:hover {
         background: rgba(239,68,68,0.22);
         color: white;
+    }
+
+    .stage-kbd {
+        display: inline-block;
+        min-width: 1.1rem;
+        padding: 0 0.25rem;
+        margin-right: 0.15rem;
+        border-radius: 0.2rem;
+        background: rgba(255,255,255,0.12);
+        border: 1px solid rgba(255,255,255,0.18);
+        color: rgba(255,255,255,0.9);
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 9px;
+        line-height: 1.35;
+        text-align: center;
     }
 </style>

--- a/nodyx-frontend/src/lib/components/VoicePanel.svelte
+++ b/nodyx-frontend/src/lib/components/VoicePanel.svelte
@@ -10,7 +10,6 @@
 
     import VoiceSettings    from './VoiceSettings.svelte'
     import ScreenShareModal from './ScreenShareModal.svelte'
-    import StageView        from './StageView.svelte'
     import { stageOpenStore } from '$lib/stageStore'
     import { onMount } from 'svelte'
     import { t } from '$lib/i18n'
@@ -1049,9 +1048,12 @@
     {#if showShareModal}
         <ScreenShareModal onclose={() => showShareModal = false}/>
     {/if}
-    {#if $stageOpenStore}
-        <StageView onclose={() => $stageOpenStore = false}/>
-    {/if}
+    <!-- La Scène N'EST PLUS montée ici : ce composant vit dans <aside id="galaxy-sidebar">,
+         qui est `fixed` + `z-30` et crée donc un CONTEXTE D'EMPILEMENT. Un enfant en
+         z-[500] y reste prisonnier : la sidebar des membres (z-30, plus loin dans le
+         DOM) et l'en-tête peignaient par-dessus la Scène (écran rogné à droite,
+         en-tête de la Scène invisible). Elle est désormais montée à la RACINE de
+         +layout.svelte, pilotée par stageOpenStore. -->
 {/if}
 
 <style>

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -13,6 +13,8 @@
 	import { resolveTheme, themeToVars } from '$lib/profileThemes';
 	import { buildNameStyle, buildAnimClass, ensureFontLoaded, GOOGLE_FONTS_URL } from '$lib/nameEffects';
 	import VoicePanel from '$lib/components/VoicePanel.svelte';
+	import StageView from '$lib/components/StageView.svelte';
+	import { stageOpenStore } from '$lib/stageStore';
 	import CommandPalette from '$lib/components/CommandPalette.svelte';
 	import MatrixRain from '$lib/components/MatrixRain.svelte';
 	import MemberScreenPreview from '$lib/components/MemberScreenPreview.svelte';
@@ -1678,6 +1680,17 @@
      Modal éducatif anti-phishing. Activé via le store externalLinkGuard
      quand un composant (MessageBody, etc.) demande à ouvrir un lien externe. -->
 <ExternalLinkWarning />
+
+<!-- ── La Scène (partage d'écran) ────────────────────────────────────────────
+     Montée ICI, à la RACINE, et surtout PAS dans VoicePanel : celui-ci vit dans
+     <aside id="galaxy-sidebar">, qui est `fixed` + `z-30` et crée donc un contexte
+     d'empilement. Un enfant en z-[500] y restait prisonnier, et la sidebar des
+     membres (z-30, plus loin dans le DOM) peignait par-dessus la Scène : écran
+     rogné à droite, en-tête de la Scène (boutons Chat / PiP) invisible.
+     À la racine, le plein écran est vraiment plein écran. -->
+{#if $stageOpenStore}
+	<StageView onclose={() => stageOpenStore.set(false)} />
+{/if}
 
 <!-- ── Command Palette ────────────────────────────────────────────────────── -->
 <CommandPalette


### PR DESCRIPTION
## Trois symptômes, une seule cause

Après #251, la Scène s'ouvrait bien, mais :
- l'écran partagé était **décalé et tronqué sur la droite** ;
- les boutons **« Chat »** et **« Fenêtre flottante »** (dans l'en-tête de la Scène) n'apparaissaient **nulle part** : le chat semblait absent et le raccourci `P` était indevinable.

## La cause

`StageView` était monté dans `VoicePanel`, lui-même à l'intérieur de `<aside id="galaxy-sidebar">`, qui est `fixed` avec `z-30` et **crée donc un contexte d'empilement**. Un enfant en `z-[500]` y reste **prisonnier** : son `z-index` n'a de valeur qu'à l'intérieur de cet aside.

Conséquence : la **sidebar des membres** (`z-30`, plus loin dans le DOM) et l'**en-tête de l'app** peignaient **par-dessus** la Scène. Le `position: fixed; inset: 0` était correct, c'est la **peinture** qui était recouverte : d'où l'écran rogné à droite et l'en-tête de la Scène masqué.

## Le correctif

La Scène est montée à la **racine de `+layout.svelte`** (là où vivent déjà les autres overlays racine : modal de statut `z-[200]`, toasts `z-[9999]`), pilotée par `stageOpenStore`. Le plein écran est enfin vraiment plein écran.

## Découvrabilité (au passage)

- Les raccourcis étaient affichés en **opacité 0.12**, donc littéralement invisibles. Ils sont maintenant lisibles (puce contrastée, touches en `<kbd>`).
- **« PiP » devient « Fenêtre flottante »**, avec une infobulle expliquant qu'elle suit l'utilisateur quand il navigue ailleurs.

## Tests

`svelte-check` 0 erreur, build prod OK. Frontend uniquement.
