### PR TITLE
feat(sfu): le partage d'écran des vrais canaux passe par le SFU quand le canal est basculé

### DIFF
--- a/nodyx-frontend/src/lib/voice.ts
+++ b/nodyx-frontend/src/lib/voice.ts
@@ -991,6 +991,7 @@ export function leaveVoice(): void {
   // en mesh pur (aucune session SFU ⇒ no-op). Puis on repart de mesh.
   void bascule.basculeLeaveSfu()
   _stopSfuStatsPolling()
+  _stopSfuScreenMirror()
   _channelMode = 'mesh'
 
   if (_socket) {
@@ -1149,6 +1150,21 @@ export async function startScreenShare(
   const w = quality === '4k' ? 3840 : quality === '1080p' ? 1920 : 1280
   const h = quality === '4k' ? 2160 : quality === '1080p' ? 1080 : 720
 
+  // Canal basculé en SFU : le partage passe par le serveur. UN seul upload, qui
+  // est recopié à chaque spectateur, au lieu d'une copie PAR spectateur (le mur
+  // du mesh vers ~4 personnes). Les stores de l'UI sont alimentés par le miroir
+  // SFU, donc la Scène et le salon affichent ça sans rien savoir du changement.
+  if (_channelMode === 'sfu') {
+    await bascule.basculeStartScreenShare({
+      displaySurface,
+      width:      w,
+      height:     h,
+      frameRate:  fps,
+      maxBitrate: screenShareMaxBitrate(quality, fps),
+    })
+    return
+  }
+
   try {
     const displayStream = await navigator.mediaDevices.getDisplayMedia({
       video: {
@@ -1196,6 +1212,14 @@ export async function startScreenShare(
 
 export function stopScreenShare(): void {
   const { channelId } = get(voiceStore)
+
+  // En SFU, c'est le producer SERVEUR qu'il faut fermer (le mesh ne porte aucune
+  // piste vidéo dans ce mode). Le miroir remet localScreenStore/screenShareStore
+  // à zéro, et les spectateurs voient l'écran disparaître net (voice:sfu_unpublish).
+  if (_channelMode === 'sfu') {
+    void bascule.basculeStopScreenShare()
+    return
+  }
 
   if (_screenStream) {
     _screenStream.getTracks().forEach(t => t.stop())
@@ -1360,6 +1384,45 @@ async function _pollSfuStats(): Promise<void> {
   })
 }
 
+// ── Miroir des écrans SFU vers les stores de l'UI (P2) ───────────────────────
+// En SFU, les écrans arrivent par voiceSfu, clés par userId. L'UI, elle, lit
+// remoteScreenStore, clé par socketId. On REFLÈTE donc les uns dans les autres via
+// le roster, exactement comme le poller de stats. Résultat : aucun composant d'UI
+// à toucher, la Scène et le salon affichent l'SFU comme ils affichaient le mesh.
+let _unsubSfuScreens:       (() => void) | null = null
+let _unsubSfuLocalScreen:   (() => void) | null = null
+let _unsubRosterForScreens: (() => void) | null = null
+
+function _syncSfuScreens(): void {
+  const peers = get(voiceStore).peers
+  const map   = new Map<string, MediaStream>()
+  for (const sc of get(bascule.basculeScreensStore)) {
+    const peer = peers.find(p => p.userId === sc.userId)
+    if (peer) map.set(peer.socketId, sc.stream)
+  }
+  remoteScreenStore.set(map)
+}
+
+function _startSfuScreenMirror(): void {
+  _stopSfuScreenMirror()
+  _unsubSfuScreens = bascule.basculeScreensStore.subscribe(() => _syncSfuScreens())
+  // Le roster peut se peupler APRÈS l'arrivée d'un flux : sans ça, le mapping
+  // userId → socketId échouerait une fois et l'écran ne s'afficherait jamais.
+  _unsubRosterForScreens = voiceStore.subscribe(() => {
+    if (_channelMode === 'sfu') _syncSfuScreens()
+  })
+  _unsubSfuLocalScreen = bascule.basculeLocalScreenStore.subscribe(stream => {
+    localScreenStore.set(stream)
+    screenShareStore.set(stream !== null)
+  })
+}
+
+function _stopSfuScreenMirror(): void {
+  _unsubSfuScreens?.();       _unsubSfuScreens = null
+  _unsubRosterForScreens?.(); _unsubRosterForScreens = null
+  _unsubSfuLocalScreen?.();   _unsubSfuLocalScreen = null
+}
+
 function onVoiceModeEvent({ channelId, mode }: { channelId: string; mode: 'sfu' | 'mesh' }): void {
   if (mode === 'sfu') {
     if (_channelMode !== 'mesh') return            // déjà en switching/sfu
@@ -1372,15 +1435,27 @@ function onVoiceModeEvent({ channelId, mode }: { channelId: string; mode: 'sfu' 
       _channelMode = 'mesh'
       void bascule.basculeLeaveSfu()               // on lâche l'SFU, le mesh (jamais lâché) reste
       _stopSfuStatsPolling()
+      _stopSfuScreenMirror()
     }
   }
 }
 
 function onSfuCommitEvent(_payload: { channelId: string }): void {
   _channelMode = 'sfu'
+  // Un partage d'écran mesh EN COURS doit suivre la bascule. On capture sa piste
+  // AVANT le teardown : le démontage ferme les PC mais ne stoppe pas le flux local,
+  // donc on peut le republier tel quel vers l'SFU. Sans ça il faudrait rouvrir le
+  // sélecteur d'écran, ce que le navigateur refuse hors geste utilisateur : le
+  // partage mourrait à la bascule.
+  const meshScreen = _screenStream
   // Instant zéro-coupure : joue l'SFU, coupe puis démonte le mesh.
   bascule.basculeCommit(_meshMutePlayback, _meshTeardownConnections)
-  _startSfuStatsPolling() // le panneau réseau se remplit depuis l'SFU
+  _startSfuStatsPolling()  // le panneau réseau se remplit depuis l'SFU
+  _startSfuScreenMirror()  // les écrans SFU alimentent les stores de l'UI
+  if (meshScreen) {
+    _screenStream = null   // le mesh ne le porte plus, l'SFU prend le relais
+    void bascule.basculeStartScreenShare({ existingStream: meshScreen })
+  }
 }
 
 async function onOffer({ from, sdp, channelId }: { from: string; sdp: RTCSessionDescriptionInit; channelId: string }): Promise<void> {

--- a/nodyx-frontend/src/lib/voiceBascule.test.ts
+++ b/nodyx-frontend/src/lib/voiceBascule.test.ts
@@ -6,14 +6,25 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const { sfuJoin, sfuLeave, sfuIsActive, sfuSetConsumerPlayingCallback, sfuCollectStats } = vi.hoisted(() => ({
+const {
+  sfuJoin, sfuLeave, sfuIsActive, sfuSetConsumerPlayingCallback, sfuCollectStats,
+  sfuStartScreenShare, sfuStopScreenShare, sfuScreensStore, sfuLocalScreenStore,
+} = vi.hoisted(() => ({
   sfuJoin:                       vi.fn(async () => {}),
   sfuLeave:                      vi.fn(async () => {}),
   sfuIsActive:                   vi.fn(() => true),
   sfuSetConsumerPlayingCallback: vi.fn(),
   sfuCollectStats:               vi.fn(async () => ({ rtt: null, connType: 'unknown', perUser: new Map() })),
+  // Partage d'écran SFU (P2) : voiceBascule les ré-exporte pour voice.ts.
+  sfuStartScreenShare:           vi.fn(async () => null),
+  sfuStopScreenShare:            vi.fn(async () => {}),
+  sfuScreensStore:               { subscribe: vi.fn(() => () => {}) },
+  sfuLocalScreenStore:           { subscribe: vi.fn(() => () => {}) },
 }))
-vi.mock('./voiceSfu', () => ({ sfuJoin, sfuLeave, sfuIsActive, sfuSetConsumerPlayingCallback, sfuCollectStats }))
+vi.mock('./voiceSfu', () => ({
+  sfuJoin, sfuLeave, sfuIsActive, sfuSetConsumerPlayingCallback, sfuCollectStats,
+  sfuStartScreenShare, sfuStopScreenShare, sfuScreensStore, sfuLocalScreenStore,
+}))
 
 import { basculeBeginSwitch, basculeJoinDirectSfu, basculeLeaveSfu, basculeCommit } from './voiceBascule'
 

--- a/nodyx-frontend/src/lib/voiceBascule.ts
+++ b/nodyx-frontend/src/lib/voiceBascule.ts
@@ -10,13 +10,28 @@
 // jouer (crossfade par personne). Donc pour chacun : mesh OU SFU, jamais les deux,
 // jamais le vide. voice.ts fournit les opérations mesh (pas d'import circulaire).
 
-import { sfuJoin, sfuLeave, sfuIsActive, sfuSetConsumerPlayingCallback, sfuCollectStats } from './voiceSfu'
+import {
+  sfuJoin, sfuLeave, sfuIsActive, sfuSetConsumerPlayingCallback, sfuCollectStats,
+  sfuStartScreenShare, sfuStopScreenShare, sfuScreensStore, sfuLocalScreenStore,
+} from './voiceSfu'
 
 type Emitter = { emit: (event: string, payload: unknown) => void }
 
 // Stats de la session SFU (RTT/type + perte/gigue par userId), pour alimenter le
 // même panneau réseau que le mesh. voice.ts fait le mapping userId → socketId.
 export const basculeCollectStats = sfuCollectStats
+
+// ── Partage d'écran sur SFU (P2) ─────────────────────────────────────────────
+// En SFU, le partageur envoie UNE seule fois vers le serveur, qui recopie à chaque
+// spectateur. En mesh il envoyait une copie PAR spectateur : c'est le mur des ~4
+// personnes. voice.ts branche ces opérations quand le canal est en mode SFU, et
+// reflète les écrans reçus dans SES stores (mapping userId → socketId par le roster).
+export const basculeStartScreenShare = sfuStartScreenShare
+export const basculeStopScreenShare  = sfuStopScreenShare
+/** Écrans distants reçus via le SFU (producerId + userId + flux). */
+export const basculeScreensStore     = sfuScreensStore
+/** Mon écran partagé via le SFU (aperçu local), null si je ne partage pas. */
+export const basculeLocalScreenStore = sfuLocalScreenStore
 
 // Cas A/C : le canal bascule (ou j'arrive pendant switching). On établit l'SFU en
 // PARALLÈLE du mesh, en JOUANT tout de suite ; `onSfuPeerPlaying(userId)` coupe le

--- a/nodyx-frontend/src/lib/voiceSfu.ts
+++ b/nodyx-frontend/src/lib/voiceSfu.ts
@@ -477,35 +477,69 @@ export function sfuSetMuted(muted: boolean): void {
   }
 }
 
+/** Contraintes de capture, alignées sur celles du mesh (l'utilisateur choisit sa
+ *  surface, sa qualité et son fps : le chemin SFU doit les honorer pareil). */
+export interface SfuScreenShareOptions {
+  displaySurface?: string
+  width?:          number
+  height?:         number
+  frameRate?:      number
+  maxBitrate?:     number
+  contentHint?:    'motion' | 'detail'
+  /** Flux DÉJÀ capturé à republier tel quel (migration d'un partage mesh en cours
+   *  vers l'SFU au moment de la bascule). Sans ça il faudrait rouvrir le sélecteur
+   *  d'écran, ce que le navigateur refuse hors geste utilisateur : le partage
+   *  mourrait à la bascule. */
+  existingStream?: MediaStream
+}
+
 /** Partager son écran via le SFU (P2). getDisplayMedia → produce vidéo (VP8) sur
  *  le sendTransport existant (à côté du micro). Une seule couche en v1 (le
  *  simulcast arrive après). Retourne le flux local (aperçu) ou null si annulé.
  *  Le partage passe par le SFU : un seul upload, le serveur recopie à chacun. */
-export async function sfuStartScreenShare(opts?: { maxBitrate?: number }): Promise<MediaStream | null> {
+export async function sfuStartScreenShare(opts: SfuScreenShareOptions = {}): Promise<MediaStream | null> {
   const s = _session
   if (!s) { log('⚠ pas de session SFU active'); return null }
   if (s.screenProducer) { log('⚠ partage déjà en cours'); return get(sfuLocalScreenStore) }
 
+  const fps = opts.frameRate ?? 30
   let display: MediaStream
-  try {
-    display = await navigator.mediaDevices.getDisplayMedia({
-      video: { frameRate: { ideal: 30, max: 60 } },
-      audio: false, // le son d'onglet arrivera en P3 ; v1 = vidéo seule
-    })
-  } catch (e) {
-    log(`partage annulé : ${(e as Error).message}`) // l'utilisateur a fermé le sélecteur
-    return null
+  if (opts.existingStream) {
+    // Migration d'un partage mesh en cours : on republie la piste déjà capturée.
+    display = opts.existingStream
+    log('→ republication de l\'écran déjà partagé (migration mesh → SFU)')
+  } else {
+    try {
+      display = await navigator.mediaDevices.getDisplayMedia({
+        video: {
+          displaySurface: opts.displaySurface,
+          width:     opts.width  ? { ideal: opts.width }  : undefined,
+          height:    opts.height ? { ideal: opts.height } : undefined,
+          frameRate: { ideal: fps, max: fps },
+          cursor:    'always',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        audio: false, // le son d'onglet arrivera en P3 ; v1 = vidéo seule
+      })
+    } catch (e) {
+      log(`partage annulé : ${(e as Error).message}`) // l'utilisateur a fermé le sélecteur
+      return null
+    }
   }
 
   const track = display.getVideoTracks()[0]
   if (!track) { display.getTracks().forEach(t => t.stop()); log('✘ aucune piste vidéo'); return null }
+
+  // Aide l'encodeur : 60 fps ⇒ du mouvement (jeu) → fluidité ; sinon (slides,
+  // code, bureau) → netteté du texte. Même heuristique que le mesh.
+  try { track.contentHint = opts.contentHint ?? (fps >= 60 ? 'motion' : 'detail') } catch { /* non supporté */ }
 
   try {
     s.screenStream = display
     s.screenProducer = await s.sendTransport.produce({
       track,
       appData: { source: 'screen' },
-      encodings: [{ maxBitrate: opts?.maxBitrate ?? 2_500_000 }], // v1 : 1 couche
+      encodings: [{ maxBitrate: opts.maxBitrate ?? 2_500_000 }], // v1 : 1 couche
     })
     // Le bouton « Arrêter le partage » natif du navigateur termine la piste.
     track.onended = () => { void sfuStopScreenShare() }


### PR DESCRIPTION
## Le gain

C'est ce que tout le reste préparait.

En **mesh**, le partageur uploade sa vidéo **une fois par spectateur**. À 720p (~2,5 Mbps), cinq spectateurs = **~12 Mbps d'upload** sur SA machine. Une fibre plafonne, un mobile s'effondre : c'est le mur des ~4 personnes.

En **SFU**, il uploade **une seule fois** et le serveur recopie. Son upload **ne dépend plus du nombre de spectateurs**.

## Doctrine (CDC §D3)

Le SFU ne prend le partage **que si le canal est déjà basculé en SFU**. En mesh, le chemin d'avant est **strictement inchangé** : c'est le filet de sécurité.

## `voice.ts` (sanctuaire, additif)

- **`startScreenShare`** : en SFU, publie vers le serveur en honorant la **surface, la qualité, le fps et le plafond de débit** déjà choisis par l'utilisateur (même calcul `screenShareMaxBitrate`). Sinon, mesh inchangé.
- **`stopScreenShare`** : en SFU, ferme le producer **serveur** (`voice:sfu_unpublish`) → les spectateurs voient l'écran disparaître **net**, sans image figée.
- **Miroir des écrans SFU vers les stores de l'UI** : `voiceSfu` publie les écrans par `userId`, l'UI lit `remoteScreenStore` par `socketId`. On reflète via le **roster**, exactement comme le poller de stats de la bascule. **Aucun composant d'UI n'est touché** : la Scène et le salon affichent le SFU comme ils affichaient le mesh.
- **Migration à la bascule** : un partage mesh **en cours** suit la bascule. On capture sa piste **avant** le teardown (qui ferme les PC mais **ne stoppe pas** le flux local) et on la republie telle quelle vers le SFU. Sans ça il faudrait **rouvrir le sélecteur d'écran**, ce que le navigateur refuse hors geste utilisateur : le partage **mourrait** à la bascule.

## Autres couches

`voiceSfu.ts` : `sfuStartScreenShare` accepte les mêmes contraintes que le mesh (surface / résolution / fps / bitrate / `contentHint`) et un `existingStream` pour la migration. `voiceBascule.ts` ré-exporte les opérations et les stores (pas d'import circulaire).

## Tests

`svelte-check` **0 erreur**, build prod OK, **14 tests front verts** (mock `voiceSfu` complété avec les nouveaux exports).
