### PR TITLE
fix(sfu): la vidéo clignotait en noir (consumer non pausé = keyframe perdue)

### DIFF
--- a/nodyx-core/src/socket/voiceSfu.ts
+++ b/nodyx-core/src/socket/voiceSfu.ts
@@ -272,6 +272,25 @@ export function registerVoiceSfuHandlers(socket: Socket, server: Server): void {
     cb({ ok: true, consumerId: res.data.consumer, params: parseBlob(res.data.params) })
   })
 
+  // ── voice:sfu_resume — reprend un consumer créé en pause ───────────────────
+  // La VIDÉO est servie en pause : sinon la keyframe part avant que le décodeur du
+  // navigateur n'existe, et l'écran reste noir jusqu'à la keyframe suivante (le
+  // clignotement). Le client appelle ceci une fois SON consumer créé ; le daemon
+  // vérifie qu'il s'agit bien de SON abonnement.
+  socket.on('voice:sfu_resume', async (payload: unknown, cb: unknown) => {
+    if (!isAck(cb)) return
+    const { channelId, consumerId } = (payload ?? {}) as Record<string, unknown>
+    if (!(await guard('voice:sfu_resume', channelId, cb))) return
+    if (typeof consumerId !== 'string' || consumerId.length === 0 || consumerId.length > 200) {
+      cb({ ok: false, error: 'bad_consumer' }); return
+    }
+
+    const res = await sfuFetch('/v1/resume_consumer', {
+      room: channelId, participant: userId, consumer: consumerId,
+    })
+    cb(res.ok ? { ok: true } : { ok: false, error: res.error })
+  })
+
   // ── voice:sfu_publications — liste des flux du salon (§17-A) ───────────────
   socket.on('voice:sfu_publications', async (channelId: unknown, cb: unknown) => {
     if (!isAck(cb)) return

--- a/nodyx-frontend/src/lib/voiceSfu.ts
+++ b/nodyx-frontend/src/lib/voiceSfu.ts
@@ -363,6 +363,12 @@ async function consumeOne(sock: Socket, producerId: string, userId: string, kind
       // Écran/cam : pas de <audio>. On expose le flux (rendu par un <video> UI).
       const stream = new MediaStream([consumer.track])
       sfuScreensStore.update(l => [...l.filter(x => x.producerId !== producerId), { producerId, userId, stream }])
+      // Le consumer vidéo est servi EN PAUSE par le serveur : on ne le reprend
+      // qu'ICI, une fois créé et branché. Sinon la keyframe partirait avant que le
+      // décodeur n'existe → écran noir jusqu'à la suivante (le clignotement). La
+      // reprise redemande une keyframe, cette fois à un décodeur prêt.
+      const rs = await emitAck(sock, 'voice:sfu_resume', { channelId: s.channelId, consumerId: consumer.id })
+      if (!rs.ok) log(`⚠ reprise du flux vidéo : ${rs.error}`)
       log(`✓ écran de ${userId} reçu`)
     } else {
       // Audio : un <audio> par flux, détaché du DOM.

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/bin/nodyx-sfud.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/bin/nodyx-sfud.rs
@@ -43,8 +43,8 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
 use nodyx_sfu::{
-    Direction, Mode, ParticipantId, ProducerId, RoomId, SignalingBlob, TrackKind, VoiceConfig,
-    VoiceService,
+    ConsumerId, Direction, Mode, ParticipantId, ProducerId, RoomId, SignalingBlob, TrackKind,
+    VoiceConfig, VoiceService,
 };
 use nodyx_sfu_mediasoup::engine::MediasoupEngine;
 
@@ -208,6 +208,21 @@ async fn route(app: &App, path: &str, body: &serde_json::Value) -> (u16, serde_j
             let client = SignalingBlob(field(body, "client").unwrap_or("{}").to_string());
             match app.svc.publish(r, p, kind, &client).await {
                 Ok(prod) => ok_json(serde_json::json!({ "producer": prod.0 })),
+                Err(e) => err_json(409, e.to_string()),
+            }
+        }
+
+        "/v1/resume_consumer" => {
+            let (Some(r), Some(p), Some(cons)) = (room(), participant(), field(body, "consumer"))
+            else {
+                return err_json(400, "room, participant et consumer requis");
+            };
+            match app
+                .svc
+                .resume_consumer(r, p, ConsumerId(cons.to_string()))
+                .await
+            {
+                Ok(()) => ok_json(serde_json::json!({ "resumed": true })),
                 Err(e) => err_json(409, e.to_string()),
             }
         }

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
@@ -570,10 +570,10 @@ impl MediaEngine for MediasoupEngine {
         client_caps: &SignalingBlob,
     ) -> Result<(ConsumerId, SignalingBlob)> {
         let (t, router_key) = self.transport_of(&transport.0)?;
-        let ms_producer_id = {
+        let (ms_producer_id, producer_kind) = {
             let map = self.inner.producers.lock().unwrap();
             map.get(&producer.0)
-                .map(|(p, _)| p.id())
+                .map(|(p, _)| (p.id(), p.kind()))
                 .ok_or_else(|| MediaError::NotFound(format!("producer {}", producer.0)))?
         };
         // Capabilities du client si fournies (WebRTC), sinon celles du router
@@ -582,7 +582,16 @@ impl MediaEngine for MediasoupEngine {
             Ok(c) => c,
             Err(_) => consumer_caps(self.router_of(&router_key)?.rtp_capabilities()),
         };
-        let options = ConsumerOptions::new(ms_producer_id, caps);
+        let mut options = ConsumerOptions::new(ms_producer_id, caps);
+        // VIDÉO : le consumer DOIT démarrer en PAUSE, puis être repris quand le
+        // client l'a créé (cf. resume_consumer). Sinon mediasoup pousse la keyframe
+        // AVANT que le décodeur du navigateur n'existe → écran noir jusqu'à la
+        // keyframe suivante, d'où le clignotement. La reprise redemande une keyframe
+        // à un décodeur, lui, prêt. L'AUDIO n'a pas de keyframe : on le laisse
+        // non-pausé (chemin prouvé en prod, on n'y touche pas).
+        if producer_kind == MediaKind::Video {
+            options.paused = true;
+        }
         let consumer = match t.as_ref() {
             AnyTransport::Direct(d) => d.consume(options).await,
             AnyTransport::WebRtc(w) => w.consume(options).await,
@@ -606,6 +615,21 @@ impl MediaEngine for MediasoupEngine {
         // réconciliation client). Idempotent : absent = déjà fermé, on ne se
         // plaint pas (un stop de partage doit toujours pouvoir aboutir).
         self.inner.producers.lock().unwrap().remove(&producer.0);
+        Ok(())
+    }
+
+    async fn resume_consumer(&self, consumer: &ConsumerId) -> Result<()> {
+        // Le client a créé son consumer : on peut laisser couler. mediasoup demande
+        // alors une keyframe au producer, qui arrivera à un décodeur EXISTANT.
+        let c = {
+            let map = self.inner.consumers.lock().unwrap();
+            map.get(&consumer.0)
+                .cloned()
+                .ok_or_else(|| MediaError::NotFound(format!("consumer {}", consumer.0)))?
+        };
+        c.resume()
+            .await
+            .map_err(|e| MediaError::Engine(format!("resume_consumer: {e}")))?;
         Ok(())
     }
 

--- a/nodyx-p2p/crates/nodyx-sfu/src/lib.rs
+++ b/nodyx-p2p/crates/nodyx-sfu/src/lib.rs
@@ -175,6 +175,11 @@ pub trait MediaEngine: Send + Sync {
     /// d'écran). Idempotent : un producer déjà fermé/inconnu n'est PAS une erreur
     /// (un nettoyage doit toujours pouvoir aboutir).
     async fn close_producer(&self, producer: &ProducerId) -> Result<()>;
+    /// Reprend un consumer créé en pause. La VIDÉO démarre en pause : sans ça, la
+    /// keyframe part avant que le décodeur du client n'existe → écran noir jusqu'à
+    /// la suivante (clignotement). Le client appelle ceci une fois son consumer
+    /// créé ; la reprise redemande une keyframe à un décodeur prêt.
+    async fn resume_consumer(&self, consumer: &ConsumerId) -> Result<()>;
     /// Force la couche servie à un abonné (adaptation bande passante).
     async fn set_preferred_layer(&self, consumer: &ConsumerId, layer: Layer) -> Result<()>;
     /// Relaie un flux vers un nœud SFU distant (cascade fédérée, PipeTransport).
@@ -231,6 +236,9 @@ impl MediaEngine for NullEngine {
         Ok((ConsumerId(self.next("consumer")), client_caps.clone()))
     }
     async fn close_producer(&self, _producer: &ProducerId) -> Result<()> {
+        Ok(())
+    }
+    async fn resume_consumer(&self, _consumer: &ConsumerId) -> Result<()> {
         Ok(())
     }
     async fn set_preferred_layer(&self, _consumer: &ConsumerId, _layer: Layer) -> Result<()> {

--- a/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
+++ b/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
@@ -619,6 +619,29 @@ impl<E: MediaEngine> VoiceService<E> {
         Ok(())
     }
 
+    /// L'abonné a créé son consumer côté client : on reprend le flux serveur.
+    /// La VIDÉO est servie en pause (sinon la keyframe part avant que le décodeur
+    /// du client n'existe → écran noir clignotant) ; c'est ici qu'elle repart, et
+    /// mediasoup redemande une keyframe à un décodeur cette fois prêt.
+    /// Borné à SES propres abonnements : on ne reprend pas le flux d'autrui.
+    pub async fn resume_consumer(
+        &self,
+        room: RoomId,
+        subscriber: ParticipantId,
+        consumer: ConsumerId,
+    ) -> Result<(), VoiceError> {
+        {
+            let rooms = self.rooms();
+            let state = rooms.get(&room).ok_or(VoiceError::NotInRoom)?;
+            let p = state.participants.get(&subscriber).ok_or(VoiceError::NotInRoom)?;
+            if !p.subscriptions.values().any(|c| c == &consumer) {
+                return Err(VoiceError::NotSubscribed);
+            }
+        }
+        self.engine.resume_consumer(&consumer).await?;
+        Ok(())
+    }
+
     /// Le participant souscrit à une publication. Requiert le mode SFU (transport).
     /// `client_caps` = capabilities du client (blob opaque) ; retourne aussi les
     /// paramètres que le client doit appliquer (blob du moteur).
@@ -960,6 +983,32 @@ mod tests {
         // régler la couche servie à p2 → OK
         block_on(s.set_preferred_layer(room(), p(2), prod, Layer::LOWEST)).unwrap();
         assert_eq!(consumer, consumer.clone());
+    }
+
+    #[test]
+    fn resume_consumer_only_for_own_subscription() {
+        let s = svc();
+        block_on(s.join(room(), p(1))).unwrap();
+        block_on(s.join(room(), p(2))).unwrap();
+        block_on(s.join(room(), p(3))).unwrap();
+        let prod = block_on(s.publish(room(), p(1), TrackKind::Screen, &blob())).unwrap();
+        let (consumer, _) = block_on(s.subscribe(room(), p(2), prod, &blob())).unwrap();
+
+        // L'abonné reprend SON flux (la vidéo est servie en pause : c'est ici
+        // qu'elle repart, avec une keyframe pour un décodeur enfin prêt).
+        block_on(s.resume_consumer(room(), p(2), consumer.clone())).unwrap();
+
+        // Un TIERS ne peut pas reprendre le consumer de p2.
+        assert_eq!(
+            block_on(s.resume_consumer(room(), p(3), consumer)),
+            Err(VoiceError::NotSubscribed)
+        );
+
+        // Un consumer inconnu non plus.
+        assert_eq!(
+            block_on(s.resume_consumer(room(), p(2), ConsumerId("nope".into()))),
+            Err(VoiceError::NotSubscribed)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Le symptôme

En SFU, le partage d'écran **clignote** : écran noir, avec une image qui apparaît de temps en temps.

Le réseau était pourtant **parfait** : 0 % de perte, 21 ms de ping, 11 ms de gigue, badge SFU. Ce n'était donc **pas** un problème de transport.

## La cause

Nos consumers étaient créés **non pausés**. mediasoup pousse alors le flux, **et donc la keyframe**, dès la création du consumer **serveur**, c'est-à-dire souvent **avant que le décodeur du navigateur n'existe**.

La keyframe est perdue. Or **sans keyframe, rien ne peut être décodé** : écran noir jusqu'à la keyframe **suivante**. D'où le clignotement.

**L'audio n'a pas de keyframe.** Il n'était donc pas concerné, ce qui explique pourquoi il fonctionnait parfaitement depuis le début et pourquoi le bug ne s'est révélé qu'avec la vidéo.

## Le correctif (patron officiel mediasoup)

La **vidéo est servie en pause**, et n'est **reprise qu'une fois le consumer créé côté client**. La reprise fait redemander une keyframe par mediasoup, cette fois à un décodeur **qui existe**.

| Couche | Changement |
|---|---|
| Moteur | `consume()` met `paused: true` pour un producer **vidéo** (l'audio reste non pausé : chemin prouvé en prod, on n'y touche pas) + `resume_consumer` |
| Service | `resume_consumer` borné à **ses propres abonnements** (+ test) |
| Daemon | route `POST /v1/resume_consumer` |
| Relais core | event `voice:sfu_resume` |
| Client | reprend le consumer **après** l'avoir créé et branché sur la vidéo |

## Tests

Rust **35** (service 30 + moteur 5), core `tsc` **0**, frontend **0 erreur**, **14 tests** front.

## Déploiement

Le **moteur** a changé : le binaire `nodyx-sfud` doit être reconstruit et le daemon redémarré, en plus du déploiement core + frontend.
