### PR TITLE
fix(sfu): l'écran partagé n'apparaissait pas quand on rejoint un canal déjà en SFU

### DIFF
--- a/nodyx-frontend/src/lib/voice.ts
+++ b/nodyx-frontend/src/lib/voice.ts
@@ -1274,7 +1274,15 @@ function onVoiceInit({ channelId, peers, mySeatIndex, iceServers, mode }: {
   if (_channelMode === 'sfu') {
     // Arrivant tardif sur un canal DÉJÀ en SFU (§5) : aucun PC mesh, on rejoint
     // l'SFU directement (lecture immédiate). Le roster ci-dessus reste affiché.
-    void bascule.basculeJoinDirectSfu(channelId).then(() => _startSfuStatsPolling())
+    // Le MIROIR DES ÉCRANS doit démarrer ICI aussi, pas seulement au commit :
+    // sans ça, celui qui recharge sa page (ou arrive après la bascule) publie bien
+    // son écran au serveur mais rien ne le recopie vers les stores de l'UI, et il
+    // ne voit pas non plus l'écran des autres. Rien ne s'affiche, sans la moindre
+    // erreur : le flux est au serveur, c'est le pont vers l'UI qui manquait.
+    void bascule.basculeJoinDirectSfu(channelId).then(() => {
+      _startSfuStatsPolling()
+      _startSfuScreenMirror()
+    })
   } else {
     for (const peer of peers) {
       createPeerConn(peer.socketId, channelId, true)


### PR DESCRIPTION
## Symptôme

On partage son écran, la barre du navigateur confirme le partage, **aucune erreur nulle part** (daemon et core muets)... et **rien ne s'affiche**. Ni chez soi, ni chez les autres. L'onglet Écran reste grisé.

## Cause

Le **miroir** qui recopie les écrans SFU vers les stores de l'UI n'était accroché qu'au **commit** de la bascule.

Or on rejoint un canal **déjà en SFU** *sans* commit : `voice:init` annonce `mode='sfu'` → `basculeJoinDirectSfu`. Ce chemin démarrait bien le **poller de stats** (d'où le badge SFU et les 21 ms parfaitement affichés), mais **pas le miroir**.

Donc l'écran était **bien publié au serveur** (d'où l'absence totale d'erreur, et la barre du navigateur toujours active), mais **plus rien ne le recopiait** vers `remoteScreenStore` / `localScreenStore`, que l'UI lit.

## Deux cas très courants touchés

- **Recharger sa page** pendant que le canal est en SFU : précisément ce qu'on demande de faire après un déploiement.
- **Arriver dans un canal déjà basculé** : on ne voyait **jamais** l'écran du partageur.

## Correctif

Démarrer le miroir dans le chemin d'arrivée directe en SFU, exactement là où on démarre déjà le poller de stats.

## Tests

`svelte-check` 0 erreur, build prod OK, 14 tests front verts. Frontend uniquement (pas de rebuild daemon).