### PR TITLE
fix(vocal): le partage d'écran clignotait en noir (srcObject réassigné à chaque re-rendu)

### DIFF
--- a/nodyx-frontend/src/lib/components/MediaCenter.svelte
+++ b/nodyx-frontend/src/lib/components/MediaCenter.svelte
@@ -89,11 +89,16 @@
     }
 
     // ── Svelte action: bind MediaStream to <video> srcObject ───────
+    // ⚠ Réassigner srcObject réinitialise l'élément (noir jusqu'à la keyframe) même
+    // pour le même objet : on ne le fait que si le flux change réellement.
     function streamSrc(node: HTMLVideoElement, stream: MediaStream) {
         node.srcObject = stream
         return {
-            update(s: MediaStream) { node.srcObject = s },
-            destroy()              { node.srcObject = null },
+            update(s: MediaStream) {
+                if (node.srcObject === s) return
+                node.srcObject = s
+            },
+            destroy() { node.srcObject = null },
         }
     }
 

--- a/nodyx-frontend/src/lib/components/MemberScreenPreview.svelte
+++ b/nodyx-frontend/src/lib/components/MemberScreenPreview.svelte
@@ -30,11 +30,16 @@
             : y - 4
     )
 
+    // ⚠ Réassigner srcObject réinitialise l'élément (noir jusqu'à la keyframe) même
+    // pour le même objet : on ne le fait que si le flux change réellement.
     function streamSrc(node: HTMLVideoElement, s: MediaStream) {
         node.srcObject = s
         return {
-            update(ns: MediaStream) { node.srcObject = ns },
-            destroy()              { node.srcObject = null },
+            update(ns: MediaStream) {
+                if (node.srcObject === ns) return
+                node.srcObject = ns
+            },
+            destroy() { node.srcObject = null },
         }
     }
 </script>

--- a/nodyx-frontend/src/lib/components/StageView.svelte
+++ b/nodyx-frontend/src/lib/components/StageView.svelte
@@ -98,11 +98,17 @@
     function onWindowMouseUp() { pipDragging = false }
 
     // ── Stream → <video> Svelte action ────────────────────────────
+    // ⚠ Réassigner srcObject réinitialise l'élément vidéo (l'algorithme de chargement
+    // du média s'exécute MÊME pour le même objet) : image noire jusqu'à la keyframe
+    // suivante. Le store étant republié souvent, ça donnait un clignotement rapide.
     function streamSrc(node: HTMLVideoElement, stream: MediaStream) {
         node.srcObject = stream
         return {
-            update(s: MediaStream) { node.srcObject = s },
-            destroy()             { node.srcObject = null },
+            update(s: MediaStream) {
+                if (node.srcObject === s) return
+                node.srcObject = s
+            },
+            destroy() { node.srcObject = null },
         }
     }
 

--- a/nodyx-frontend/src/lib/components/VoiceRoom.svelte
+++ b/nodyx-frontend/src/lib/components/VoiceRoom.svelte
@@ -110,10 +110,20 @@
 	const connected = $derived(voiceState.active && voiceState.channelId === selectedChannel.id);
 	const peerCount = $derived(connected ? voiceState.peers.length + 1 : 0);
 
+	// ⚠ Ne JAMAIS réassigner srcObject sans avoir vérifié qu'il change vraiment.
+	// Assigner srcObject déclenche l'algorithme de chargement du média MÊME quand on
+	// réassigne le même objet : l'élément est réinitialisé, devient noir, et doit
+	// attendre une nouvelle keyframe. Comme le store est republié à chaque
+	// frémissement du roster (parole, niveaux…), on obtenait un clignotement noir
+	// très rapide. C'était le bug « rave party » du partage d'écran, mesh comme SFU.
 	function srcStream(node: HTMLVideoElement, stream: MediaStream | null) {
 		node.srcObject = stream ?? null;
 		return {
-			update(s: MediaStream | null) { node.srcObject = s ?? null; },
+			update(s: MediaStream | null) {
+				const next = s ?? null;
+				if (node.srcObject === next) return;
+				node.srcObject = next;
+			},
 			destroy() { node.srcObject = null; },
 		};
 	}

--- a/nodyx-frontend/src/lib/voice.ts
+++ b/nodyx-frontend/src/lib/voice.ts
@@ -1403,12 +1403,24 @@ let _unsubRosterForScreens: (() => void) | null = null
 
 function _syncSfuScreens(): void {
   const peers = get(voiceStore).peers
-  const map   = new Map<string, MediaStream>()
+  const next  = new Map<string, MediaStream>()
   for (const sc of get(bascule.basculeScreensStore)) {
     const peer = peers.find(p => p.userId === sc.userId)
-    if (peer) map.set(peer.socketId, sc.stream)
+    if (peer) next.set(peer.socketId, sc.stream)
   }
-  remoteScreenStore.set(map)
+  // N'émettre QUE si le contenu a réellement changé. On est abonné au roster, qui
+  // frémit sans arrêt (parole, niveaux…) : republier une Map neuve à chaque fois
+  // ferait re-rendre l'UI et réattacher les <video> pour rien. Or réassigner
+  // srcObject réinitialise l'élément (noir jusqu'à la keyframe suivante).
+  const cur = get(remoteScreenStore)
+  if (cur.size === next.size) {
+    let identical = true
+    for (const [socketId, stream] of next) {
+      if (cur.get(socketId) !== stream) { identical = false; break }
+    }
+    if (identical) return
+  }
+  remoteScreenStore.set(next)
 }
 
 function _startSfuScreenMirror(): void {

--- a/nodyx-frontend/src/routes/admin/sfu-lab/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/sfu-lab/+page.svelte
@@ -48,11 +48,16 @@
   const remoteScreens = $derived($sfuScreensStore)
 
   // Action Svelte : branche un MediaStream sur le srcObject d'un <video>.
+  // ⚠ Réassigner srcObject réinitialise l'élément (noir jusqu'à la keyframe) même
+  // pour le même objet : on ne le fait que si le flux change réellement.
   function bindStream(node: HTMLVideoElement, stream: MediaStream) {
     node.srcObject = stream
     return {
-      update(s: MediaStream) { node.srcObject = s },
-      destroy()             { node.srcObject = null },
+      update(s: MediaStream) {
+        if (node.srcObject === s) return
+        node.srcObject = s
+      },
+      destroy() { node.srcObject = null },
     }
   }
 


### PR DESCRIPTION
## L'indice décisif

C'est le bug **« rave party »** signalé il y a une semaine sur le partage d'écran **mesh**. Il touchait **aussi le SFU**.

Or mesh et SFU ne partagent **ni transport, ni codec, ni serveur**. Ce qu'ils partagent, c'est le **rendu**. Le bug ne pouvait donc pas être dans le média.

## La cause

Les **cinq** actions Svelte qui branchent un `MediaStream` sur un `<video>` réassignaient `srcObject` **sans condition** dans leur `update` :

```ts
update(s) { node.srcObject = s }   // ← même quand s n'a pas changé
```

Or, d'après la spécification HTML, **assigner `srcObject` déclenche l'algorithme de chargement du média même quand on réassigne exactement le même objet**. L'élément est **réinitialisé** : il devient **noir** et doit attendre une **nouvelle keyframe**.

Comme le store est republié à **chaque frémissement du roster** (quelqu'un parle, un niveau bouge…), chaque republication réattachait le flux → réinitialisation → image noire. À répétition : **le clignotement rapide**.

## Le correctif

- Les cinq actions (`VoiceRoom`, `StageView`, `MemberScreenPreview`, `MediaCenter`, labo) ne réassignent `srcObject` **que si le flux change réellement**.
- Le **miroir SFU** n'émet plus une `Map` neuve quand le contenu est identique : il est abonné au roster, qui frémit sans arrêt. On coupe le bruit **à la source**.

**Corrige le mesh ET le SFU.**

## Tests

`svelte-check` 0 erreur, build prod OK, 14 tests front verts. Frontend uniquement.