### PR TITLE
feat(sfu): simulcast du partage d'écran (chaque spectateur reçoit la qualité que son lien supporte)

### DIFF
--- a/nodyx-frontend/src/lib/voiceSfu.ts
+++ b/nodyx-frontend/src/lib/voiceSfu.ts
@@ -540,12 +540,34 @@ export async function sfuStartScreenShare(opts: SfuScreenShareOptions = {}): Pro
   // code, bureau) → netteté du texte. Même heuristique que le mesh.
   try { track.contentHint = opts.contentHint ?? (fps >= 60 ? 'motion' : 'detail') } catch { /* non supporté */ }
 
+  // ── Simulcast (CDC §6) ──────────────────────────────────────────────────────
+  // Le partageur émet PLUSIEURS qualités en parallèle ; le SFU sert à CHAQUE
+  // spectateur celle que SA bande passante supporte. Avec une seule couche (ce
+  // qu'on faisait), le plus faible impose sa limite : il décroche, ou tout le monde
+  // descend avec lui. Là, celui qui est en 4G reçoit la petite couche sans rien
+  // imposer aux autres.
+  //
+  // Les couches vont de la PLUS BASSE à la PLUS HAUTE (exigé par mediasoup-client).
+  // `S1T3` ajoute 3 couches TEMPORELLES : le SFU peut alors baisser le nombre
+  // d'images par seconde AVANT de sacrifier la résolution, ce qui est exactement ce
+  // qu'on veut pour du texte et du code (on préfère du net qui saccade un peu à du
+  // flou fluide).
+  const high = opts.maxBitrate ?? 2_500_000
+  const encodings = [
+    { rid: 'q', scaleResolutionDownBy: 4, maxBitrate: Math.round(high / 8), scalabilityMode: 'S1T3' },
+    { rid: 'h', scaleResolutionDownBy: 2, maxBitrate: Math.round(high / 3), scalabilityMode: 'S1T3' },
+    { rid: 'f', scaleResolutionDownBy: 1, maxBitrate: high,                 scalabilityMode: 'S1T3' },
+  ]
+
   try {
     s.screenStream = display
     s.screenProducer = await s.sendTransport.produce({
       track,
       appData: { source: 'screen' },
-      encodings: [{ maxBitrate: opts.maxBitrate ?? 2_500_000 }], // v1 : 1 couche
+      encodings,
+      // Démarrer l'encodeur assez haut : sinon il rampe depuis un débit minuscule
+      // et l'image reste molle plusieurs secondes.
+      codecOptions: { videoGoogleStartBitrate: 1000 },
     })
     // Le bouton « Arrêter le partage » natif du navigateur termine la piste.
     track.onended = () => { void sfuStopScreenShare() }

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
@@ -93,6 +93,12 @@ fn vp8_capability() -> RtpCodecCapability {
     }
 }
 
+/// Débit sortant disponible au DÉMARRAGE de l'estimation de bande passante.
+/// Le défaut mediasoup (600 kbps) est calibré pour de l'audio : avec de la vidéo,
+/// l'estimateur part de si bas qu'il sert durablement la couche la plus basse. On
+/// part à 1,5 Mbps ; l'estimateur ajuste ensuite à la réalité du lien.
+const INITIAL_OUTGOING_BITRATE: u32 = 1_500_000;
+
 /// Codecs du router : Opus (audio, P1) + VP8 (vidéo/screenshare, P2). Les DEUX
 /// routers (local et « remote worker » du pipe de fédération) DOIVENT partager
 /// exactement cette liste, sinon le pipe mismatch. Source unique = cette fonction.
@@ -443,12 +449,19 @@ impl MediaEngine for MediasoupEngine {
                     send_buffer_size: None,
                     recv_buffer_size: None,
                 };
+                let mut opts =
+                    WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(listen));
+                // Estimation de bande passante : mediasoup démarre par défaut à
+                // 600 kbps de débit sortant disponible. C'est calibré pour de
+                // l'audio ; avec de la VIDÉO, l'estimateur part si bas qu'il sert
+                // durablement la couche la plus basse (image molle) alors que le
+                // lien tient bien plus. On part plus haut : l'estimateur ajuste
+                // ensuite à la réalité du lien, à la hausse comme à la baisse.
+                opts.initial_available_outgoing_bitrate = INITIAL_OUTGOING_BITRATE;
                 AnyTransport::WebRtc(
-                    r.create_webrtc_transport(WebRtcTransportOptions::new(
-                        WebRtcTransportListenInfos::new(listen),
-                    ))
-                    .await
-                    .map_err(|e| MediaError::Engine(format!("create_transport(webrtc): {e}")))?,
+                    r.create_webrtc_transport(opts)
+                        .await
+                        .map_err(|e| MediaError::Engine(format!("create_transport(webrtc): {e}")))?,
                 )
             }
         };
@@ -633,8 +646,24 @@ impl MediaEngine for MediasoupEngine {
         Ok(())
     }
 
-    async fn set_preferred_layer(&self, _consumer: &ConsumerId, _layer: Layer) -> Result<()> {
-        // Audio : pas de couches. Deviendra réel avec le simulcast vidéo (P3).
+    async fn set_preferred_layer(&self, consumer: &ConsumerId, layer: Layer) -> Result<()> {
+        // Simulcast : le partageur émet plusieurs couches, le SFU en sert UNE par
+        // spectateur. mediasoup choisit tout seul selon la bande passante estimée du
+        // spectateur ; ceci PLAFONNE ce choix (ex. « ne me sers jamais au-dessus de
+        // la couche 1 »). Sur un flux mono-couche (audio, ou vidéo sans simulcast),
+        // c'est sans effet : on ne se plaint pas.
+        let c = {
+            let map = self.inner.consumers.lock().unwrap();
+            map.get(&consumer.0)
+                .cloned()
+                .ok_or_else(|| MediaError::NotFound(format!("consumer {}", consumer.0)))?
+        };
+        c.set_preferred_layers(ConsumerLayers {
+            spatial_layer: layer.spatial,
+            temporal_layer: Some(layer.temporal),
+        })
+        .await
+        .map_err(|e| MediaError::Engine(format!("set_preferred_layer: {e}")))?;
         Ok(())
     }
 


### PR DESCRIPTION
## Le problème

Jusqu'ici le partageur émettait **une seule couche**. Conséquence : **c'est le spectateur le plus faible qui impose sa limite**. Un participant en 4G décroche, ou bien tout le monde descend avec lui.

C'est précisément ce qui empêchait de tenir **15+ spectateurs** (objectif CDC §6).

## Le principe

Le partageur émet désormais **trois qualités en parallèle**, et le SFU sert à **chaque spectateur celle que sa bande passante supporte**. Celui qui est en 4G reçoit la petite couche **sans rien imposer aux autres**.

## Client (`voiceSfu`)

- **3 encodings** : résolution pleine, moitié, quart. Les débits sont dérivés du plafond **déjà choisi par l'utilisateur**. Ordonnés du plus bas au plus haut, comme l'exige mediasoup-client.
- **`scalabilityMode: S1T3`** : trois couches **temporelles** en plus. Le SFU peut alors baisser le **nombre d'images par seconde avant de sacrifier la résolution**. Pour du texte et du code, on préfère du **net qui saccade un peu** à du **flou fluide**.
- **`videoGoogleStartBitrate`** : sans ça l'encodeur rampe depuis un débit minuscule et l'image reste molle plusieurs secondes.

## Moteur

- **`initial_available_outgoing_bitrate` = 1,5 Mbps.** Le défaut mediasoup (**600 kbps**) est calibré pour de l'**audio** : avec de la vidéo, l'estimateur part de si bas qu'il sert **durablement la couche la plus basse**, alors que le lien tient bien davantage. On part plus haut, l'estimateur ajuste ensuite à la réalité.
- **`set_preferred_layer` devient réel** (c'était un **no-op**) : il plafonne la couche servie à un spectateur. Sans effet sur un flux mono-couche, et sans erreur.

## Tests

Rust **35** (service 30 + moteur 5), frontend **0 erreur** + 14 tests, builds OK.

## Déploiement

Le **moteur** a changé : rebuild du binaire `nodyx-sfud` + redémarrage du daemon, en plus du déploiement habituel.