### PR TITLE
feat(sfu): point d'observation des abonnements (distingue « pas souscrit » de « resté en pause »)

### DIFF
--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/bin/nodyx-sfud.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/bin/nodyx-sfud.rs
@@ -301,6 +301,27 @@ async fn route(app: &App, path: &str, body: &serde_json::Value) -> (u16, serde_j
             ok_json(serde_json::json!({ "publications": pubs }))
         }
 
+        "/v1/subscriptions" => {
+            let Some(r) = room() else { return err_json(400, "room requis") };
+            let subs = app
+                .svc
+                .subscriptions(&r)
+                .await
+                .iter()
+                .map(|s| {
+                    let state: serde_json::Value =
+                        serde_json::from_str(&s.state.0).unwrap_or(serde_json::Value::Null);
+                    serde_json::json!({
+                        "subscriber": s.subscriber.0,
+                        "producer": s.producer.0,
+                        "consumer": s.consumer.0,
+                        "state": state,
+                    })
+                })
+                .collect::<Vec<_>>();
+            ok_json(serde_json::json!({ "room": r.0, "subscriptions": subs }))
+        }
+
         "/v1/screenshare" => {
             let Some(r) = room() else { return err_json(400, "room requis") };
             let on = body.get("on").and_then(|v| v.as_bool()).unwrap_or(false);

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
@@ -646,6 +646,28 @@ impl MediaEngine for MediasoupEngine {
         Ok(())
     }
 
+    async fn consumer_state(&self, consumer: &ConsumerId) -> Result<SignalingBlob> {
+        let c = {
+            let map = self.inner.consumers.lock().unwrap();
+            map.get(&consumer.0)
+                .cloned()
+                .ok_or_else(|| MediaError::NotFound(format!("consumer {}", consumer.0)))?
+        };
+        // `paused` = pause demandée par NOUS (la vidéo démarre en pause et doit être
+        // reprise) ; `producer_paused` = la source elle-même s'est tue. Un consumer
+        // en pause n'envoie RIEN : c'est indiscernable, côté débit, d'un consumer
+        // qui n'existe pas. D'où ce diagnostic.
+        Ok(SignalingBlob(
+            serde_json::json!({
+                "kind": c.kind(),
+                "paused": c.paused(),
+                "producerPaused": c.producer_paused(),
+                "producerId": c.producer_id(),
+            })
+            .to_string(),
+        ))
+    }
+
     async fn set_preferred_layer(&self, consumer: &ConsumerId, layer: Layer) -> Result<()> {
         // Simulcast : le partageur émet plusieurs couches, le SFU en sert UNE par
         // spectateur. mediasoup choisit tout seul selon la bande passante estimée du

--- a/nodyx-p2p/crates/nodyx-sfu/src/lib.rs
+++ b/nodyx-p2p/crates/nodyx-sfu/src/lib.rs
@@ -180,6 +180,11 @@ pub trait MediaEngine: Send + Sync {
     /// la suivante (clignotement). Le client appelle ceci une fois son consumer
     /// créé ; la reprise redemande une keyframe à un décodeur prêt.
     async fn resume_consumer(&self, consumer: &ConsumerId) -> Result<()>;
+    /// État réel d'un consumer (blob de DIAGNOSTIC : kind, en pause ou non…).
+    /// Sans ça on ne peut pas distinguer « le spectateur n'a jamais souscrit » de
+    /// « il a souscrit mais son flux est resté en pause » : deux pannes qui se
+    /// ressemblent (aucune vidéo ne part) et qui appellent des correctifs opposés.
+    async fn consumer_state(&self, consumer: &ConsumerId) -> Result<SignalingBlob>;
     /// Force la couche servie à un abonné (adaptation bande passante).
     async fn set_preferred_layer(&self, consumer: &ConsumerId, layer: Layer) -> Result<()>;
     /// Relaie un flux vers un nœud SFU distant (cascade fédérée, PipeTransport).
@@ -240,6 +245,11 @@ impl MediaEngine for NullEngine {
     }
     async fn resume_consumer(&self, _consumer: &ConsumerId) -> Result<()> {
         Ok(())
+    }
+    async fn consumer_state(&self, consumer: &ConsumerId) -> Result<SignalingBlob> {
+        Ok(SignalingBlob(format!(
+            "{{\"engine\":\"null\",\"consumer\":\"{consumer}\"}}"
+        )))
     }
     async fn set_preferred_layer(&self, _consumer: &ConsumerId, _layer: Layer) -> Result<()> {
         Ok(())

--- a/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
+++ b/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
@@ -166,6 +166,18 @@ pub struct PublicationInfo {
     pub owner: ParticipantId,
 }
 
+/// Vue d'un ABONNEMENT (diagnostic) : qui consomme quoi, et dans quel état.
+/// Un consumer en pause n'envoie rien : côté débit, c'est indiscernable d'un
+/// consumer qui n'existe pas. Sans cette vue, ces deux pannes se confondent.
+#[derive(Debug, Clone)]
+pub struct SubscriptionInfo {
+    pub subscriber: ParticipantId,
+    pub producer: ProducerId,
+    pub consumer: ConsumerId,
+    /// Blob opaque du moteur : kind, paused, producerPaused…
+    pub state: SignalingBlob,
+}
+
 // ── État interne ────────────────────────────────────────────────────────────
 
 struct Participant {
@@ -617,6 +629,41 @@ impl<E: MediaEngine> VoiceService<E> {
         // Hors verrou : fermeture réelle du flux moteur (idempotente).
         self.engine.close_producer(&producer).await?;
         Ok(())
+    }
+
+    /// Tous les abonnements du salon, avec l'ÉTAT RÉEL de chaque consumer (moteur).
+    /// Outil de DIAGNOSTIC : répond à « le spectateur a-t-il seulement souscrit au
+    /// flux vidéo, et si oui son consumer est-il resté en pause ? ». Deux pannes qui
+    /// donnent le même symptôme (aucune vidéo servie) et deux correctifs opposés.
+    pub async fn subscriptions(&self, room: &RoomId) -> Vec<SubscriptionInfo> {
+        // On relève d'abord la liste (verrou court), puis on interroge le moteur
+        // hors verrou, comme partout ailleurs.
+        let flat: Vec<(ParticipantId, ProducerId, ConsumerId)> = {
+            let rooms = self.rooms();
+            let Some(state) = rooms.get(room) else {
+                return Vec::new();
+            };
+            state
+                .participants
+                .iter()
+                .flat_map(|(pid, p)| {
+                    p.subscriptions
+                        .iter()
+                        .map(|(prod, cons)| (pid.clone(), prod.clone(), cons.clone()))
+                })
+                .collect()
+        };
+
+        let mut out = Vec::with_capacity(flat.len());
+        for (subscriber, producer, consumer) in flat {
+            let state = self
+                .engine
+                .consumer_state(&consumer)
+                .await
+                .unwrap_or_else(|e| SignalingBlob(format!("{{\"error\":\"{e}\"}}")));
+            out.push(SubscriptionInfo { subscriber, producer, consumer, state });
+        }
+        out
     }
 
     /// L'abonné a créé son consumer côté client : on reprend le flux serveur.


### PR DESCRIPTION
## Pourquoi

Cet instrument a été construit **pendant** le debug du partage d'écran, parce qu'il **manquait**. Il a immédiatement tranché un problème sur lequel je tournais en rond.

**Un consumer vidéo en pause n'envoie rien.** Côté débit, c'est **strictement indiscernable** d'un consumer qui n'existe pas : les deux donnent « ~50 kbps servis au spectateur », c'est-à-dire **l'audio seul**.

Or ces deux pannes appellent des correctifs **opposés** :

| Ce qu'on observe | Cause possible | Correctif |
|---|---|---|
| 50 kbps servis | le spectateur n'a **jamais souscrit** au flux vidéo | signalisation |
| 50 kbps servis | il a souscrit mais son consumer est **resté en pause** | reprise du flux |

Sans moyen de les distinguer, on corrige **à l'aveugle**.

## Ce qui est ajouté

- **Trait + moteur** : `consumer_state` → blob de diagnostic (`kind`, `paused`, `producerPaused`, `producerId`), lu directement sur le `Consumer` mediasoup.
- **Service** : `subscriptions(room)` → **qui consomme quoi, avec l'état réel de chaque consumer**. Verrou court, appels moteur hors verrou, comme partout ailleurs.
- **Daemon** : route `POST /v1/subscriptions {room}`.

Complète `/v1/audit` (débits, ICE, perte) et `/v1/publications` (qui publie quoi).

## Tests

Rust : **35 tests verts** (service 30 + moteur 5).

## Note

Le binaire du daemon a déjà été reconstruit et déployé à la main pendant le diagnostic ; cette PR met le **code** dans Git.