### PR TITLE
feat(sfu): le partage d'écran emporte son son (onglet, jeu, vidéo)

### DIFF
--- a/nodyx-core/src/socket/voiceSfu.ts
+++ b/nodyx-core/src/socket/voiceSfu.ts
@@ -209,7 +209,10 @@ export function registerVoiceSfuHandlers(socket: Socket, server: Server): void {
     if (!isAck(cb)) return
     const { channelId, kind, rtpParameters } = (payload ?? {}) as Record<string, unknown>
     if (!(await guard('voice:sfu_produce', channelId, cb))) return
-    if (kind !== 'audio' && kind !== 'screen' && kind !== 'cam') {
+    // 'screenaudio' = le SON de l'écran partagé (onglet, jeu, vidéo). C'est de
+    // l'audio au sens média, mais une SOURCE distincte du micro : le spectateur le
+    // rattache au flux vidéo du partageur au lieu de le prendre pour une voix.
+    if (kind !== 'audio' && kind !== 'screen' && kind !== 'screenaudio' && kind !== 'cam') {
       cb({ ok: false, error: 'bad_kind' }); return
     }
     const client = boundedJson(rtpParameters)

--- a/nodyx-frontend/src/lib/components/StageView.svelte
+++ b/nodyx-frontend/src/lib/components/StageView.svelte
@@ -320,11 +320,15 @@
                     <span><kbd class="stage-kbd">Échap</kbd> fermer</span>
                 </div>
 
-                <!-- Main video — double-clic = plein écran -->
+                <!-- Vidéo principale : double-clic = plein écran.
+                     Le son de l'écran partagé vit DANS ce flux : c'est donc ici qu'il
+                     sort. On coupe le son de SON PROPRE partage (on l'entend déjà en
+                     vrai : le rejouer ferait un écho, voire un larsen). -->
                 <video
                     bind:this={focusVideoElem}
                     use:streamSrc={focusedEntry.stream}
-                    autoplay playsinline muted
+                    autoplay playsinline
+                    muted={focusedEntry.isLocal}
                     ondblclick={requestFullscreen}
                     class="w-full h-full object-contain cursor-pointer"
                     title="Double-clic pour plein écran"
@@ -522,9 +526,12 @@
     <!-- Main video -->
     <div class="relative bg-black" style="aspect-ratio: 16 / 9">
         {#if focusedEntry}
+            <!-- En fenêtre flottante aussi, on entend l'écran qu'on regarde (et jamais
+                 le sien : ce serait un écho). -->
             <video
                 use:streamSrc={focusedEntry.stream}
-                autoplay playsinline muted
+                autoplay playsinline
+                muted={focusedEntry.isLocal}
                 class="w-full h-full object-contain"
             ></video>
             {#if !focusedEntry.isLocal}

--- a/nodyx-frontend/src/lib/components/VoiceRoom.svelte
+++ b/nodyx-frontend/src/lib/components/VoiceRoom.svelte
@@ -3,7 +3,7 @@
 	import NodyxCanvas  from '$lib/components/NodyxCanvas.svelte';
 	import VoiceJukebox from '$lib/components/VoiceJukebox.svelte';
 	import { localScreenStore, remoteScreenStore, screenShareStore } from '$lib/voice';
-	import { openStage } from '$lib/stageStore';
+	import { openStage, stageOpenStore } from '$lib/stageStore';
 	import StageChat from './StageChat.svelte';
 	import { jukeboxStore } from '$lib/jukebox';
 	import type { Socket } from 'socket.io-client';
@@ -325,9 +325,13 @@
 			{@const peer = voiceState.peers.find((p: any) => p.socketId === socketId)}
 			<div class="relative group/sc overflow-hidden bg-black min-w-0 min-h-0"
 			     style="border: 1px solid rgba(59,130,246,0.25);">
+				<!-- Le son de l'écran partagé vit DANS ce flux. On le laisse sortir ici,
+				     SAUF quand la Scène est ouverte : elle joue déjà le même flux, et on
+				     entendrait tout en double. Un seul endroit parle à la fois. -->
 				<video
 					class="w-full h-full object-contain cursor-pointer"
 					autoplay playsinline
+					muted={$stageOpenStore}
 					use:srcStream={stream}
 					onclick={() => openStage()}
 					ondblclick={(e) => (e.currentTarget as HTMLVideoElement).requestFullscreen?.()}

--- a/nodyx-frontend/src/lib/voiceSfu.ts
+++ b/nodyx-frontend/src/lib/voiceSfu.ts
@@ -81,6 +81,12 @@ interface Session {
   producer:      import('mediasoup-client').types.Producer | null
   screenProducer: import('mediasoup-client').types.Producer | null
   screenStream:  MediaStream | null
+  /** Le SON de mon écran partagé (onglet, jeu, vidéo), s'il a été capturé. */
+  screenAudioProducer: import('mediasoup-client').types.Producer | null
+  /** Son d'écran reçu AVANT l'image du même partageur (l'ordre d'arrivée des deux
+   *  flux n'est pas garanti) : on le garde ici et on l'attache dès que l'image
+   *  arrive, sinon il serait perdu. */
+  pendingScreenAudio: Map<string, MediaStreamTrack>
   consumers:     Map<string, import('mediasoup-client').types.Consumer>
   audioEls:      Map<string, HTMLAudioElement>
   offNewProducer: (() => void) | null
@@ -220,10 +226,14 @@ export async function sfuJoin(channelId: string): Promise<void> {
     const sendTransport = device.createSendTransport(join.sendTransportParams as never)
     wireTransport(sendTransport, 'send')
     sendTransport.on('produce', ({ kind, rtpParameters, appData }, callback, errback) => {
-      // `kind` = nature média ('audio'|'video'). Le "kind SFU" distingue en plus
-      // l'écran de la cam via appData (transmis tel quel par mediasoup-client).
+      // `kind` = nature média ('audio'|'video'). Le "kind SFU" distingue en plus la
+      // SOURCE via appData (transmis tel quel par mediasoup-client) : le son de
+      // l'écran est de l'audio, mais ce n'est pas le micro, et le spectateur doit
+      // pouvoir le rattacher à l'image plutôt que le prendre pour une voix.
       const source = (appData as { source?: string } | undefined)?.source
-      const sfuKind = kind === 'audio' ? 'audio' : source === 'cam' ? 'cam' : 'screen'
+      const sfuKind = kind === 'audio'
+        ? (source === 'screenaudio' ? 'screenaudio' : 'audio')
+        : (source === 'cam' ? 'cam' : 'screen')
       log(`→ produce ${sfuKind} (rtpParameters au SFU)`)
       emitAck(sock, 'voice:sfu_produce', { channelId, kind: sfuKind, rtpParameters })
         .then(r => r.ok
@@ -238,6 +248,7 @@ export async function sfuJoin(channelId: string): Promise<void> {
       channelId, device, sendTransport, recvTransport,
       micTrack: null, producer: null,
       screenProducer: null, screenStream: null,
+      screenAudioProducer: null, pendingScreenAudio: new Map(),
       consumers: new Map(), audioEls: new Map(), offNewProducer: null,
       maintain: null, onVisibility: null,
     }
@@ -325,14 +336,30 @@ const _sfuPrevPackets = new Map<string, { received: number; lost: number }>()
  *  flux (les publications listent TOUT le salon, moi compris). Le broadcast
  *  new_producer exclut déjà l'émetteur, mais pas la liste des publications. */
 function isOwnProducer(s: Session, producerId: string): boolean {
-  return producerId === s.producer?.id || producerId === s.screenProducer?.id
+  return producerId === s.producer?.id
+    || producerId === s.screenProducer?.id
+    || producerId === s.screenAudioProducer?.id
 }
 
 /** Ferme et oublie le consumer d'un flux (audio OU écran) : par réconciliation
  *  (producer disparu) ou par arrêt net (voice:sfu_producer_closed). Idempotent. */
 function closeConsumerFor(s: Session, producerId: string): void {
   const consumer = s.consumers.get(producerId)
-  if (consumer) { try { consumer.close() } catch { /* déjà fermé */ } s.consumers.delete(producerId) }
+  if (consumer) {
+    // Si c'était le SON d'un écran, il vit dans le MediaStream de cette image : on
+    // l'en retire, sinon la balise <video> resterait avec une piste morte.
+    const track = consumer.track
+    for (const sc of get(sfuScreensStore)) {
+      if (sc.stream.getTracks().includes(track)) {
+        try { sc.stream.removeTrack(track) } catch { /* flux déjà démonté */ }
+      }
+    }
+    for (const [uid, t] of s.pendingScreenAudio) {
+      if (t === track) s.pendingScreenAudio.delete(uid)
+    }
+    try { consumer.close() } catch { /* déjà fermé */ }
+    s.consumers.delete(producerId)
+  }
   const el = s.audioEls.get(producerId)
   if (el) { try { el.pause(); el.srcObject = null } catch { /* mort */ } s.audioEls.delete(producerId) }
   sfuConsumersStore.update(l => l.filter(c => c.producerId !== producerId))
@@ -359,9 +386,30 @@ async function consumeOne(sock: Socket, producerId: string, userId: string, kind
 
     sfuConsumersStore.update(list => [...list, { consumerId: consumer.id, producerId, userId, kind }])
 
-    if (params.kind === 'video') {
+    if (kind === 'screenaudio') {
+      // Le SON de l'écran d'un partageur. On le met dans le MÊME MediaStream que son
+      // IMAGE : il sort alors de la balise <video> avec elle, donc volume, coupure et
+      // cycle de vie suivent l'image sans plomberie séparée.
+      const screen = get(sfuScreensStore).find(x => x.userId === userId)
+      if (screen) {
+        screen.stream.addTrack(consumer.track)
+        log(`✓ son de l'écran de ${userId} rattaché à son image`)
+      } else {
+        // L'ordre d'arrivée des deux flux n'est pas garanti : si le son précède
+        // l'image, on le garde et on l'attachera quand l'image arrivera.
+        s.pendingScreenAudio.set(userId, consumer.track)
+        log(`son de l'écran de ${userId} reçu avant l'image : mis de côté`)
+      }
+    } else if (params.kind === 'video') {
       // Écran/cam : pas de <audio>. On expose le flux (rendu par un <video> UI).
       const stream = new MediaStream([consumer.track])
+      // Son de l'écran arrivé en premier ? On le rattache maintenant.
+      const waiting = s.pendingScreenAudio.get(userId)
+      if (waiting) {
+        stream.addTrack(waiting)
+        s.pendingScreenAudio.delete(userId)
+        log(`✓ son de l'écran de ${userId} rattaché (il attendait l'image)`)
+      }
       sfuScreensStore.update(l => [...l.filter(x => x.producerId !== producerId), { producerId, userId, stream }])
       // Le consumer vidéo est servi EN PAUSE par le serveur : on ne le reprend
       // qu'ICI, une fois créé et branché. Sinon la keyframe partirait avant que le
@@ -525,7 +573,12 @@ export async function sfuStartScreenShare(opts: SfuScreenShareOptions = {}): Pro
           cursor:    'always',
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any,
-        audio: false, // le son d'onglet arrivera en P3 ; v1 = vidéo seule
+        // On DEMANDE le son de l'écran (onglet, jeu, vidéo). Le navigateur propose
+        // alors une case « partager le son » dans son sélecteur. L'utilisateur peut
+        // la refuser, et certaines surfaces (une fenêtre isolée) n'en ont pas :
+        // dans ce cas il n'y a simplement pas de piste audio, et le partage se fait
+        // en silence comme avant. Rien ne doit dépendre de sa présence.
+        audio: true,
       })
     } catch (e) {
       log(`partage annulé : ${(e as Error).message}`) // l'utilisateur a fermé le sélecteur
@@ -575,6 +628,25 @@ export async function sfuStartScreenShare(opts: SfuScreenShareOptions = {}): Pro
     track.onended = () => { void sfuStopScreenShare() }
     sfuLocalScreenStore.set(display)
     log('✓ écran publié au SFU')
+
+    // Le SON de l'écran, s'il y en a un (l'utilisateur a coché « partager le son »,
+    // et la surface choisie en a). C'est un BONUS : s'il échoue, on garde l'image.
+    // Un supplément ne doit JAMAIS coûter la fonction principale.
+    const soundTrack = display.getAudioTracks()[0]
+    if (soundTrack) {
+      try {
+        s.screenAudioProducer = await s.sendTransport.produce({
+          track: soundTrack,
+          appData: { source: 'screenaudio' },
+        })
+        log('✓ son de l\'écran publié')
+      } catch (e) {
+        log(`⚠ son de l'écran non publié (${(e as Error).message}) : l'image reste partagée`)
+        s.screenAudioProducer = null
+      }
+    } else {
+      log('partage sans son (non coché, ou surface sans audio)')
+    }
     return display
   } catch (e) {
     display.getTracks().forEach(t => t.stop())
@@ -591,16 +663,25 @@ export async function sfuStartScreenShare(opts: SfuScreenShareOptions = {}): Pro
 export async function sfuStopScreenShare(): Promise<void> {
   const s = _session
   if (!s) return
-  const producerId = s.screenProducer?.id ?? null
+  // L'image ET le son : deux producers, deux fermetures. En oublier un laisserait le
+  // son de l'écran continuer chez les spectateurs après l'arrêt du partage.
+  const videoId = s.screenProducer?.id ?? null
+  const soundId = s.screenAudioProducer?.id ?? null
   try { s.screenProducer?.close() } catch { /* déjà fermé */ }
+  try { s.screenAudioProducer?.close() } catch { /* déjà fermé */ }
   s.screenProducer = null
+  s.screenAudioProducer = null
   try { s.screenStream?.getTracks().forEach(t => t.stop()) } catch { /* déjà stoppé */ }
   s.screenStream = null
   sfuLocalScreenStore.set(null)
 
   const sock = get(socketStore)
-  if (sock && producerId) {
-    await emitAck(sock, 'voice:sfu_unpublish', { channelId: s.channelId, producerId })
+  if (sock) {
+    for (const producerId of [videoId, soundId]) {
+      if (producerId) {
+        await emitAck(sock, 'voice:sfu_unpublish', { channelId: s.channelId, producerId })
+      }
+    }
   }
   log('partage d\'écran arrêté')
 }
@@ -748,6 +829,8 @@ function cleanup(): void {
   }
   try { s.producer?.close() } catch { /* déjà fermé */ }
   try { s.screenProducer?.close() } catch { /* déjà fermé */ }
+  try { s.screenAudioProducer?.close() } catch { /* déjà fermé */ }
+  s.pendingScreenAudio.clear()
   try { s.micTrack?.stop() } catch { /* déjà stoppé */ }
   try { s.screenStream?.getTracks().forEach(t => t.stop()) } catch { /* déjà stoppé */ }
   try { s.sendTransport.close() } catch { /* déjà fermé */ }

--- a/nodyx-frontend/src/routes/admin/sfu-lab/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/sfu-lab/+page.svelte
@@ -196,7 +196,9 @@
         {#each remoteScreens as sc (sc.producerId)}
           <div class="relative aspect-video overflow-hidden rounded-lg border border-zinc-700 bg-black">
             <!-- svelte-ignore a11y_media_has_caption -->
-            <video use:bindStream={sc.stream} autoplay playsinline muted class="h-full w-full object-contain"></video>
+            <!-- Pas muet : le son de l'écran partagé vit dans ce flux, c'est ici qu'on
+                 l'entend (l'aperçu local, lui, reste muet pour éviter l'écho). -->
+            <video use:bindStream={sc.stream} autoplay playsinline class="h-full w-full object-contain"></video>
             <span class="absolute bottom-2 left-2 rounded-full bg-black/70 px-2 py-0.5 text-[10px] font-semibold text-white">{sc.userId}</span>
           </div>
         {/each}

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/bin/nodyx-sfud.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/bin/nodyx-sfud.rs
@@ -94,6 +94,7 @@ fn kind_of(s: &str) -> Option<TrackKind> {
     match s {
         "audio" => Some(TrackKind::Audio),
         "screen" => Some(TrackKind::Screen),
+        "screenaudio" => Some(TrackKind::ScreenAudio),
         "cam" => Some(TrackKind::Cam),
         _ => None,
     }
@@ -292,6 +293,7 @@ async fn route(app: &App, path: &str, body: &serde_json::Value) -> (u16, serde_j
                         "kind": match p.kind {
                             TrackKind::Audio => "audio",
                             TrackKind::Screen => "screen",
+                            TrackKind::ScreenAudio => "screenaudio",
                             TrackKind::Cam => "cam",
                         },
                         "owner": p.owner.0,

--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
@@ -544,7 +544,9 @@ impl MediaEngine for MediasoupEngine {
         // TOUJOURS par WebRTC : le navigateur fournit ses rtpParameters. Le mode
         // Direct (sans navigateur) ne sait fabriquer que de l'audio Opus.
         let media_kind = match kind {
-            TrackKind::Audio => MediaKind::Audio,
+            // Le son de l'écran est de l'AUDIO au sens média : pas de keyframe, donc
+            // pas de pause/reprise, et rien à mettre en couches.
+            TrackKind::Audio | TrackKind::ScreenAudio => MediaKind::Audio,
             TrackKind::Screen | TrackKind::Cam => MediaKind::Video,
         };
         let (t, router_key) = self.transport_of(&transport.0)?;

--- a/nodyx-p2p/crates/nodyx-sfu/src/lib.rs
+++ b/nodyx-p2p/crates/nodyx-sfu/src/lib.rs
@@ -55,10 +55,17 @@ PipeHandle);
 // ── Types média ─────────────────────────────────────────────────────────────
 
 /// Nature d'un flux publié.
+///
+/// `ScreenAudio` est bien de l'AUDIO au sens média (pas de keyframe, pas de
+/// couches), mais c'est une SOURCE distincte du micro : c'est le son de l'écran
+/// partagé (onglet, jeu, vidéo). Le distinguer permet au spectateur de le rattacher
+/// au flux vidéo du partageur, et donc de le faire sortir de la balise `<video>`
+/// avec son image, au lieu de le confondre avec la voix de quelqu'un.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrackKind {
     Audio,
     Screen,
+    ScreenAudio,
     Cam,
 }
 

--- a/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
+++ b/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
@@ -579,7 +579,9 @@ impl<E: MediaEngine> VoiceService<E> {
         kind: TrackKind,
         client: &SignalingBlob,
     ) -> Result<ProducerId, VoiceError> {
-        if kind == TrackKind::Screen {
+        // Un partage d'écran force la bascule SFU. Son SON aussi : il n'arrive jamais
+        // seul, mais on ne veut pas dépendre de l'ordre d'arrivée des deux flux.
+        if matches!(kind, TrackKind::Screen | TrackKind::ScreenAudio) {
             self.ensure_sfu(room.clone()).await?;
         }
 
@@ -976,6 +978,31 @@ mod tests {
         assert_eq!(pubs[0].producer, prod);
         assert_eq!(pubs[0].kind, TrackKind::Screen);
         assert_eq!(pubs[0].owner, p(1));
+    }
+
+    #[test]
+    fn screen_audio_is_a_distinct_source_and_forces_sfu() {
+        let s = svc();
+        block_on(s.join(room(), p(1))).unwrap();
+        block_on(s.join(room(), p(2))).unwrap();
+        assert_eq!(s.mode(&room()), Some(Mode::Mesh));
+
+        // Le son de l'écran force la bascule comme l'écran lui-même : on ne dépend
+        // pas de l'ordre d'arrivée des deux flux.
+        let sound = block_on(s.publish(room(), p(1), TrackKind::ScreenAudio, &blob())).unwrap();
+        assert_eq!(s.mode(&room()), Some(Mode::Sfu));
+
+        let video = block_on(s.publish(room(), p(1), TrackKind::Screen, &blob())).unwrap();
+        let mic = block_on(s.publish(room(), p(1), TrackKind::Audio, &blob())).unwrap();
+
+        // Trois publications DISTINCTES : le son de l'écran n'est pas le micro.
+        let pubs = s.publications(&room());
+        assert_eq!(pubs.len(), 3);
+        let kind_of = |id: &ProducerId| pubs.iter().find(|p| &p.producer == id).unwrap().kind;
+        assert_eq!(kind_of(&sound), TrackKind::ScreenAudio);
+        assert_eq!(kind_of(&video), TrackKind::Screen);
+        assert_eq!(kind_of(&mic), TrackKind::Audio);
+        assert_ne!(TrackKind::ScreenAudio, TrackKind::Audio);
     }
 
     #[test]


### PR DESCRIPTION
## Le manque

Jusqu'ici on capturait l'écran avec `audio: false`. Les spectateurs voyaient une démo, une vidéo ou un jeu **sans l'entendre**.

## Le modèle

Le son de l'écran est de l'**audio** au sens média (pas de keyframe, rien à mettre en couches), mais c'est une **source distincte du micro**. Le distinguer permet au spectateur de le **rattacher à l'image du partageur**, au lieu de le prendre pour la voix de quelqu'un.

D'où un `TrackKind::ScreenAudio` à part entière :

| Couche | Changement |
|---|---|
| Moteur | `ScreenAudio` -> `MediaKind::Audio` (donc ni pause/reprise, ni couches) |
| Service | le son d'écran force la bascule SFU **comme l'écran** : on ne dépend pas de l'ordre d'arrivée des deux flux |
| Daemon | kind `screenaudio` accepté et resérialisé |
| Relais core | kind `screenaudio` accepté |

## Client

- `getDisplayMedia({ audio: true })` : le navigateur propose alors **« partager le son »**. L'utilisateur peut refuser, et certaines surfaces (une fenêtre isolée) n'en ont pas. Dans ce cas il n'y a **pas de piste audio** et le partage se fait en silence, **comme avant**. Rien ne dépend de sa présence.
- Le son est publié comme un **second producer**. C'est un **bonus** : **s'il échoue, on garde l'image**. Un supplément ne doit jamais coûter la fonction principale (leçon d'hier).
- À la réception, le son rejoint le **même `MediaStream` que l'image** : il sort donc de la balise `<video>` **avec elle**. Volume, coupure et cycle de vie suivent naturellement, sans plomberie séparée.
- **L'ordre d'arrivée des deux flux n'est pas garanti** : un son reçu **avant** son image est mis de côté et rattaché dès qu'elle arrive.
- L'arrêt ferme **les deux** producers, sinon le son continuerait chez les spectateurs après l'arrêt de l'image.

## Rendu : qui parle, et qui se tait

Le son sort là où on **regarde**, et nulle part ailleurs. Deux garde-fous :

- **on ne rejoue jamais son propre partage** : on l'entend déjà en vrai, le rejouer ferait un écho, voire un larsen ;
- **la tuile du salon se tait quand la Scène est ouverte** : elle joue déjà le même flux, on entendrait tout en double. Un seul endroit parle à la fois.

## Tests

Rust **36** (service 31 + moteur 5), core `tsc` **0**, frontend **0 erreur** + 14 tests.

## Déploiement

Le **moteur et le daemon** ont changé : rebuild du binaire `nodyx-sfud` + redémarrage, en plus du déploiement core + frontend.