### PR TITLE
feat(sfu): partager son écran fait basculer le canal en SFU, sans attendre de quorum

### DIFF
--- a/nodyx-core/src/socket/voice.ts
+++ b/nodyx-core/src/socket/voice.ts
@@ -223,6 +223,18 @@ export function registerVoiceHandlers(socket: Socket, server: Server): void {
     bascule.onSfuReady(server, channelId, socket.id)
   })
 
+  // ── voice:screenshare_intent — le partage d'écran DÉCLENCHE la bascule ─────
+  // Le partage est précisément le moment où le mesh s'écroule (le partageur y
+  // uploade sa vidéo une fois PAR spectateur). On ne l'attend donc pas : dès qu'un
+  // partage commence, on bascule, sans quorum. Le client, lui, a déjà capturé son
+  // écran et le publie en mesh ; il migrera vers le SFU au commit, sans redemander
+  // l'écran à l'utilisateur. No-op si le canal est déjà en bascule ou en SFU, ou si
+  // le flag est off (mesh strictement inchangé).
+  socket.on('voice:screenshare_intent', ({ channelId }: { channelId: string }) => {
+    if (!isUuid(channelId)) return
+    bascule.onScreenShare(server, channelId)
+  })
+
   // ── voice:kick — moderator action ─────────────────────────────────────────
   // Forces a peer out of a voice channel. Permitted to community
   // owner / admin / moderator. Moderators cannot kick admins or owners.

--- a/nodyx-core/src/socket/voiceBascule.ts
+++ b/nodyx-core/src/socket/voiceBascule.ts
@@ -53,6 +53,24 @@ export function onSeatCount(server: Server, channelId: string, count: number): v
   startSwitch(server, channelId)
 }
 
+// Quelqu'un commence un PARTAGE D'ÉCRAN : on bascule tout de suite, SANS attendre
+// de quorum.
+//
+// Pourquoi ignorer le seuil ici : le partage d'écran est PRÉCISÉMENT le moment où le
+// mesh s'écroule. Le partageur y uploade sa vidéo UNE FOIS PAR SPECTATEUR, et il
+// plafonne vers 4 personnes. Attendre un quorum pour basculer, c'est attendre que le
+// mesh souffre avant de le soulager : ça n'a aucun sens.
+//
+// On ignore aussi le cooldown : c'est une action DÉLIBÉRÉE de l'utilisateur, pas une
+// bascule automatique déclenchée par une composition de canal. Il a le droit de
+// réessayer.
+export function onScreenShare(server: Server, channelId: string): void {
+  if (!enabled(channelId)) return
+  if (channelMode(channelId) !== 'mesh') return   // déjà en bascule ou en SFU : rien à faire
+  _cooldown.delete(channelId)
+  startSwitch(server, channelId)
+}
+
 function startSwitch(server: Server, channelId: string): void {
   _mode.set(channelId, 'switching')
   _ready.set(channelId, new Set())

--- a/nodyx-core/src/tests/voice-bascule.test.ts
+++ b/nodyx-core/src/tests/voice-bascule.test.ts
@@ -53,6 +53,56 @@ describe('déclencheur', () => {
   })
 })
 
+describe('déclencheur : partage d\'écran (sans quorum)', () => {
+  it('un partage bascule TOUT DE SUITE, même seul, sans attendre le seuil', () => {
+    const { server, emits } = makeServer()
+    // Le seuil est à 3, on est seul : onSeatCount ne basculerait pas.
+    bascule.onSeatCount(server, CH, 1)
+    expect(bascule.channelMode(CH)).toBe('mesh')
+
+    // Mais partager son écran, c'est PRÉCISÉMENT le cas où le mesh s'écroule
+    // (une copie par spectateur) : on ne l'attend pas.
+    bascule.onScreenShare(server, CH)
+    expect(bascule.channelMode(CH)).toBe('switching')
+    expect(emits.map(e => e.ev)).toEqual(['voice:mode'])
+    expect(emits[0].payload).toMatchObject({ channelId: CH, mode: 'sfu' })
+  })
+
+  it('ignore le cooldown : un partage est une action DÉLIBÉRÉE, pas un automatisme', () => {
+    vi.useFakeTimers()
+    const { server, emits } = makeServer([{ id: 's1' }, { id: 's2' }, { id: 's3' }])
+    bascule.onSeatCount(server, CH, 3)          // switching
+    vi.advanceTimersByTime(10_000)              // personne ne confirme → abandon
+    expect(bascule.channelMode(CH)).toBe('mesh')
+
+    // Le cooldown bloquerait une nouvelle bascule automatique...
+    bascule.onSeatCount(server, CH, 3)
+    expect(bascule.channelMode(CH)).toBe('mesh')
+
+    // ...mais pas un partage d'écran : l'utilisateur a le droit de réessayer.
+    bascule.onScreenShare(server, CH)
+    expect(bascule.channelMode(CH)).toBe('switching')
+    expect(evs(emits)).toContain('voice:mode')
+  })
+
+  it('sans effet si le canal est DÉJÀ en SFU ou en bascule (pas de double départ)', () => {
+    const { server, emits } = makeServer()
+    bascule.onScreenShare(server, CH)
+    expect(bascule.channelMode(CH)).toBe('switching')
+    const n = emits.length
+    bascule.onScreenShare(server, CH)           // re-partage pendant la bascule
+    expect(emits).toHaveLength(n)               // rien de neuf
+  })
+
+  it('DORMANT : flag off ⇒ un partage ne bascule rien, le mesh est intact', () => {
+    process.env.VOICE_SFU_AUTO = 'false'
+    const { server, emits } = makeServer()
+    bascule.onScreenShare(server, CH)
+    expect(bascule.channelMode(CH)).toBe('mesh')
+    expect(emits).toHaveLength(0)
+  })
+})
+
 describe('porte "tous prêts" (zéro coupure)', () => {
   it('commit seulement quand TOUS les sockets sont prêts', async () => {
     const { server, emits } = makeServer([{ id: 's1' }, { id: 's2' }, { id: 's3' }])

--- a/nodyx-frontend/src/lib/voice.ts
+++ b/nodyx-frontend/src/lib/voice.ts
@@ -1174,12 +1174,27 @@ export async function startScreenShare(
         frameRate: { ideal: fps, max: fps },
         cursor:    'always',
       } as any,
-      audio: false,
+      // On capture le SON dès maintenant, même si le mesh ne sait pas le
+      // transporter : le canal va basculer en SFU (ci-dessous), et la migration
+      // republiera CETTE piste telle quelle. Sans elle, il faudrait rouvrir le
+      // sélecteur d'écran après la bascule, ce que le navigateur refuse hors geste
+      // utilisateur : le son serait perdu pour toute la session.
+      audio: true,
     })
 
     _screenStream = displayStream
     localScreenStore.set(displayStream)
     screenShareStore.set(true)
+
+    // Le partage d'écran est PRÉCISÉMENT le moment où le mesh s'écroule : le
+    // partageur y uploade sa vidéo UNE FOIS PAR SPECTATEUR, et il plafonne vers 4
+    // personnes. On demande donc la bascule TOUT DE SUITE, sans attendre un quorum.
+    //
+    // Le partage démarre quand même en mesh dans la foulée (aucun délai pour
+    // l'utilisateur), puis MIGRE vers le SFU au commit, image et son compris, sans
+    // rien lui redemander. Si le SFU n'est pas activé pour ce canal, l'event est un
+    // no-op : on reste en mesh, exactement comme avant.
+    _socket.emit('voice:screenshare_intent', { channelId })
 
     const videoTrack = displayStream.getVideoTracks()[0]
     videoTrack.onended = () => stopScreenShare()


### PR DESCRIPTION
## Le défaut

La bascule ne se déclenchait qu'à partir de **2 personnes** dans le vocal. Un partage lancé **en dessous du seuil** restait donc en **mesh** : **sans son** (le mesh capture `audio: false`) et avec **le mur des ~4 personnes**.

Le comportement dépendait d'une condition que l'utilisateur **ne voit pas**. Résultat : le partage avait du son **parfois**. C'est exactement le piège dans lequel on est tombé au test.

## Le raisonnement

Le partage d'écran est **précisément** le moment où le mesh s'écroule : le partageur y uploade sa vidéo **une fois par spectateur**.

**Attendre un quorum pour basculer, c'est attendre que le mesh souffre avant de le soulager.**

## Serveur

- `voiceBascule.onScreenShare()` : bascule **immédiate**, **seuil ignoré**.
- Le **cooldown est ignoré** aussi : un partage est une action **délibérée** de l'utilisateur, pas une bascule automatique déclenchée par une composition de canal. Il a le droit de réessayer.
- **No-op** si le canal est déjà en bascule ou en SFU, et si le flag est off : le **mesh reste strictement inchangé**.
- `voice:screenshare_intent` dans le relais (sanctuaire, additif).

## Client

- La capture mesh demande désormais le **son** (`audio: true`). Le mesh ne sait pas le transporter, mais **le canal va basculer**, et la migration republiera **cette piste telle quelle**.

  Sans elle, il faudrait **rouvrir le sélecteur d'écran** après la bascule, ce que le navigateur **refuse hors geste utilisateur** : le son serait **perdu pour toute la session**.
- Le partage **démarre en mesh dans la foulée** (aucun délai pour l'utilisateur) puis **migre vers le SFU au commit**, image et son compris, **sans rien lui redemander**.

Le mécanisme de migration **existait déjà** (il servait aux partages en cours au moment d'une bascule) : on le réutilise tel quel.

## Tests

**4 nouveaux** : bascule sans quorum, cooldown ignoré, pas de double départ, dormance flag off.
Core **401 tests**, frontend **0 erreur** + 14 tests.