### PR TITLE
fix(sfu): offrir un chemin TCP, sans quoi les réseaux qui bloquent l'UDP ne se connectent PAS DU TOUT

### DIFF
--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
@@ -439,8 +439,18 @@ impl MediaEngine for MediasoupEngine {
                     .map_err(|e| MediaError::Engine(format!("create_transport(direct): {e}")))?,
             ),
             Some((ip, announced)) => {
-                let listen = ListenInfo {
-                    protocol: Protocol::Udp,
+                // UDP **et** TCP. On n'annonçait que de l'UDP, et ça se payait cher :
+                // un client dont le réseau bloque l'UDP sur nos ports (opérateurs
+                // mobiles, réseaux d'entreprise, hôtels) ne se connectait PAS DU TOUT
+                // au média. Pas « moins bien » : son ICE restait à `new`, il ne
+                // recevait rien, et il voyait un écran noir sans le moindre message.
+                // Le défaut était invisible en Wi-Fi, où l'UDP passe.
+                //
+                // Avec un candidat TCP en plus, le navigateur bascule tout seul sur ce
+                // chemin quand l'UDP échoue. C'est plus lourd (retransmissions, files
+                // d'attente), mais c'est infiniment mieux que rien.
+                let listen = |protocol: Protocol| ListenInfo {
+                    protocol,
                     ip: *ip,
                     announced_address: announced.clone(),
                     port: None,
@@ -449,8 +459,9 @@ impl MediaEngine for MediasoupEngine {
                     send_buffer_size: None,
                     recv_buffer_size: None,
                 };
-                let mut opts =
-                    WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(listen));
+                let infos = WebRtcTransportListenInfos::new(listen(Protocol::Udp))
+                    .insert(listen(Protocol::Tcp));
+                let mut opts = WebRtcTransportOptions::new(infos);
                 // Estimation de bande passante : mediasoup démarre par défaut à
                 // 600 kbps de débit sortant disponible. C'est calibré pour de
                 // l'audio ; avec de la VIDÉO, l'estimateur part si bas qu'il sert


### PR DESCRIPTION
## Diagnostic par la mesure

Un téléphone en 4G affichait un **écran noir**. L'audit du daemon a montré la vraie cause, et ce n'était **ni le simulcast, ni la qualité, ni le décodage** :

```
PC        send/recv : ice = completed
Téléphone send/recv : ice = new        <- JAMAIS CONNECTÉ
Couche servie au téléphone : AUCUNE
```

Son ICE restait à `new` **en permanence** : ses transports média **ne se sont jamais établis**. On ne sert évidemment **aucune couche** à quelqu'un qu'on ne peut **pas joindre**.

## La cause

Le moteur n'annonçait **que des candidats UDP** (ports 40000-40999), et le pare-feu **n'ouvrait que l'UDP**.

Un client dont le réseau **bloque l'UDP** sur ces ports (**opérateurs mobiles, réseaux d'entreprise, hôtels**) ne pouvait **pas du tout** rejoindre le média. Pas « moins bien » : **rien**, et **sans le moindre message**.

Le défaut était **invisible en Wi-Fi**, où l'UDP passe. D'où des semaines de tests qui ne l'ont jamais révélé.

## La portée, qui dépasse largement le cas de départ

Ça ne concerne pas que la 4G d'un testeur. **Tout utilisateur derrière un réseau restrictif était exclu du vocal SFU, silencieusement.** C'est un défaut bien plus grave que le simulcast qu'on cherchait à valider.

## Le correctif

- Le transport annonce désormais un candidat **UDP et un candidat TCP**. Le navigateur bascule **tout seul** sur le TCP quand l'UDP échoue. C'est plus lourd (retransmissions, files d'attente), mais **infiniment mieux que rien**.
- `ufw allow 40000:40999/tcp`, sans quoi le candidat serait **annoncé mais injoignable**.

## Tests

Rust : 5 tests moteur verts.