### PR TITLE
feat(install): empaqueter le SFU, pour qu'il appartienne au projet et plus à un serveur

### DIFF
--- a/.github/workflows/release-sfu.yml
+++ b/.github/workflows/release-sfu.yml
@@ -1,0 +1,140 @@
+name: Release nodyx-sfud
+
+# Publie les binaires PRÉCOMPILÉS du daemon SFU, pour que install.sh les télécharge
+# au lieu de faire compiler mediasoup chez l'utilisateur (≈10 min de compilation et
+# toute une chaîne C++ à installer : rédhibitoire dans un installeur).
+#
+# ⚠ POURQUOI UN CONTENEUR DEBIAN 11
+# Un binaire lié à la glibc ne tourne QUE sur une glibc >= celle de compilation.
+# install.sh annonce Ubuntu 22.04/24.04 et Debian 11/12/13 :
+#     Debian 11 = glibc 2.31   ← le plus ancien qu'on supporte
+#     Ubuntu 22.04 = 2.35 · Debian 12 = 2.36 · Ubuntu 24.04 = 2.39
+# Compiler sur le runner par défaut (Ubuntu 24.04, glibc 2.39) produirait un binaire
+# qui REFUSE DE DÉMARRER sur la moitié des systèmes annoncés, avec un message
+# incompréhensible pour l'utilisateur. On compile donc sur la plus ANCIENNE cible.
+#
+# Note : l'envoi des binaires se fait en `curl` sur l'API GitHub, sans action tierce
+# ni CLI supplémentaire (le conteneur Debian est nu).
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag de la release (ex. sfu-v0.1.0)"
+        required: true
+  push:
+    tags:
+      - 'sfu-v*'
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    name: Préparer la release
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.rel.outputs.tag }}
+      id:  ${{ steps.rel.outputs.id }}
+    steps:
+      - name: Créer la release si elle n'existe pas, et récupérer son id
+        id: rel
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          cat > /tmp/notes.md <<'NOTES'
+          Binaires précompilés du daemon SFU (vocal et partage d'écran scalables).
+
+          Compilés sur **Debian 11 (glibc 2.31)** : ils démarrent donc sur Debian 11/12/13
+          et Ubuntu 22.04/24.04, en **amd64** et **arm64**.
+
+          Le worker mediasoup est compilé **dans** le binaire : aucune chaîne C++ à
+          installer chez l'utilisateur, aucun fichier annexe. `install.sh` les télécharge
+          automatiquement.
+          NOTES
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" \
+              --title "nodyx-sfud $TAG" --notes-file /tmp/notes.md
+          fi
+          ID=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" --jq .id)
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "id=$ID"   >> "$GITHUB_OUTPUT"
+
+  build:
+    name: "build ${{ matrix.arch }}"
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+    container: debian:11
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Dépendances de compilation
+        run: |
+          set -eux
+          apt-get update
+          # build-essential + python3 : mediasoup compile un worker C++ et installe
+          # lui-même meson/ninja via pip. git : requis par actions/checkout.
+          apt-get install -y --no-install-recommends \
+            build-essential pkg-config git curl ca-certificates jq \
+            python3 python3-pip python3-setuptools binutils file
+
+      - name: Rust (toolchain stable)
+        run: |
+          set -eux
+          curl -fsSL --proto '=https' --tlsv1.2 https://sh.rustup.rs \
+            | sh -s -- -y --profile minimal --default-toolchain stable
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Compiler nodyx-sfud
+        working-directory: nodyx-p2p/crates/nodyx-sfu-mediasoup
+        run: cargo build --release --bin nodyx-sfud
+
+      - name: Vérifier le binaire (autonomie + glibc réellement exigée)
+        working-directory: nodyx-p2p/crates/nodyx-sfu-mediasoup
+        run: |
+          set -eux
+          BIN=target/release/nodyx-sfud
+          file "$BIN"
+          # Le worker mediasoup est compilé DANS le binaire : rien d'exotique ne doit
+          # apparaître ici (libc / libm / libgcc / libstdc++ seulement).
+          ldd "$BIN" || true
+          # La glibc exigée détermine sur quels systèmes le binaire démarrera. On la
+          # journalise pour ne PAS la découvrir chez un utilisateur.
+          echo "── glibc maximale exigée ──"
+          objdump -T "$BIN" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -uV | tail -1
+          mv "$BIN" "nodyx-sfud-linux-${{ matrix.arch }}"
+
+      - name: Envoyer le binaire à la release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REL_ID: ${{ needs.prepare.outputs.id }}
+        working-directory: nodyx-p2p/crates/nodyx-sfu-mediasoup
+        run: |
+          set -euo pipefail
+          NAME="nodyx-sfud-linux-${{ matrix.arch }}"
+          # Remplacer un asset déjà présent (re-run du workflow) : sinon l'API refuse.
+          OLD=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
+                "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/$REL_ID/assets" \
+                | jq -r --arg n "$NAME" '.[] | select(.name==$n) | .id')
+          if [ -n "$OLD" ]; then
+            curl -fsSL -X DELETE -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/assets/$OLD"
+          fi
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Content-Type: application/octet-stream" \
+            --data-binary @"$NAME" \
+            "https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$REL_ID/assets?name=$NAME" \
+            -o /dev/null
+          echo "✓ $NAME publié"

--- a/install.sh
+++ b/install.sh
@@ -187,6 +187,8 @@ T_EN[help_yes]='    --yes, -y          Auto-confirm all prompts'
 T_FR[help_yes]='    --yes, -y          Répondre oui à toutes les confirmations'
 T_EN[help_no_turn]='    --no-turn          Skip nodyx-turn installation'
 T_FR[help_no_turn]='    --no-turn          Ne pas installer nodyx-turn'
+T_EN[help_no_sfu]='    --no-sfu           Skip nodyx-sfud (voice stays in mesh mode)'
+T_FR[help_no_sfu]='    --no-sfu           Ne pas installer nodyx-sfud (le vocal reste en mesh)'
 T_EN[help_no_subdomain]='    --no-subdomain     Skip nodyx.org subdomain registration'
 T_FR[help_no_subdomain]='    --no-subdomain     Ne pas enregistrer le sous-domaine nodyx.org'
 T_EN[help_lang]='    --lang=en|fr       UI language (default: auto from $LANG, fallback en)'
@@ -557,6 +559,32 @@ T_EN[turn_not_binary]="The downloaded file is not a valid binary.\nURL: %s"
 T_FR[turn_not_binary]="Le fichier téléchargé n'est pas un binaire valide.\nURL : %s"
 T_EN[turn_started]='nodyx-turn started (IP: %s, UDP port 3478)'
 T_FR[turn_started]='nodyx-turn démarré (IP: %s, port UDP 3478)'
+
+# §18b — SFU (nodyx-sfud) : vocal et partage d'écran scalables
+T_EN[step_sfu]='Installing nodyx-sfud (scalable voice & screen sharing)'
+T_FR[step_sfu]="Installation de nodyx-sfud (vocal et partage d'écran scalables)"
+T_EN[sfu_downloading]='Downloading nodyx-sfud %s (%s)...'
+T_FR[sfu_downloading]='Téléchargement de nodyx-sfud %s (%s)...'
+# Le SFU est un SUPPLÉMENT : s'il échoue, le vocal marche quand même (en mesh).
+# On ne fait donc JAMAIS échouer l'installation à cause de lui — on avertit.
+T_EN[sfu_skipped]="nodyx-sfud not installed — voice still works, in mesh mode.\nLimits: ~4 people in screen sharing, and screen sharing has no sound.\nReason: %s"
+T_FR[sfu_skipped]="nodyx-sfud non installé — le vocal fonctionne quand même, en mode mesh.\nLimites : ~4 personnes en partage d'écran, et le partage se fait sans son.\nRaison : %s"
+T_EN[sfu_reason_arch]='unsupported architecture (%s)'
+T_FR[sfu_reason_arch]='architecture non supportée (%s)'
+T_EN[sfu_reason_dl]='download failed (%s)'
+T_FR[sfu_reason_dl]='téléchargement impossible (%s)'
+T_EN[sfu_reason_notbin]='the downloaded file is not a valid binary'
+T_FR[sfu_reason_notbin]="le fichier téléchargé n'est pas un binaire valide"
+T_EN[sfu_reason_start]='the service did not start (see: journalctl -u nodyx-sfud)'
+T_FR[sfu_reason_start]='le service ne démarre pas (voir : journalctl -u nodyx-sfud)'
+# Serveur derrière NAT (mode Relay) : le SFU a besoin de ports média joignables de
+# l'extérieur, ce qu'un tunnel ne fournit pas. On ne demandera JAMAIS d'ouvrir un
+# port sur la box de l'utilisateur : c'est un engagement du projet.
+T_EN[sfu_relay_skipped]="Relay mode: nodyx-sfud is not installed (media ports are not reachable through a tunnel).\nVoice works in mesh mode: ~4 people in screen sharing, and no sound while sharing.\nLifting this limit will NOT require opening any port on your router — it is being worked on."
+T_FR[sfu_relay_skipped]="Mode Relay : nodyx-sfud n'est pas installé (les ports média ne sont pas joignables à travers un tunnel).\nLe vocal fonctionne en mode mesh : ~4 personnes en partage d'écran, et le partage se fait sans son.\nLever cette limite n'exigera AUCUNE ouverture de port sur ta box — c'est en cours."
+T_EN[sfu_started]='nodyx-sfud started (media ports %s, announced IP: %s)'
+T_FR[sfu_started]='nodyx-sfud démarré (ports média %s, IP annoncée : %s)'
+
 T_EN[step_firewall]='Configuring the firewall'
 T_FR[step_firewall]='Configuration du pare-feu'
 T_EN[ufw_existing_saved]='Existing UFW rules saved to %s'
@@ -1119,6 +1147,8 @@ NODYX_RELAY_VERSION="v0.1.4-p2p"
 _FORCE_MODE=""        # upgrade | repair | reinstall | wipe (bypass detection menu)
 _AUTO_YES=false       # --yes : passer toutes les confirmations
 SKIP_TURN=false       # --no-turn
+SKIP_SFU=false        # --no-sfu
+_SFU_INSTALLED=false  # vrai seulement si le daemon SFU tourne réellement
 SKIP_SUBDOMAIN=false  # --no-subdomain
 _ARG_DOMAIN=""  _ARG_SLUG=""  _ARG_NAME=""
 _ARG_ADMIN_USER=""  _ARG_ADMIN_EMAIL=""  _ARG_ADMIN_PASS=""
@@ -1131,6 +1161,7 @@ for _arg in "$@"; do
     --wipe)               _FORCE_MODE="wipe"      ;;
     --yes|-y)             _AUTO_YES=true           ;;
     --no-turn)            SKIP_TURN=true           ;;
+    --no-sfu)             SKIP_SFU=true            ;;
     --no-subdomain)       SKIP_SUBDOMAIN=true      ;;
     --domain=*)           _ARG_DOMAIN="${_arg#*=}" ;;
     --slug=*)             _ARG_SLUG="${_arg#*=}"   ;;
@@ -1159,6 +1190,7 @@ for _arg in "$@"; do
       echo "$(t help_options_header)"
       echo "$(t help_yes)"
       echo "$(t help_no_turn)"
+      echo "$(t help_no_sfu)"
       echo "$(t help_no_subdomain)"
       echo "$(t help_lang)"
       echo "$(t help_help)"
@@ -2136,6 +2168,122 @@ SVC
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════
+#  NODYX-SFUD (SFU mediasoup) — vocal et partage d'écran scalables
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+#  Sans lui : le vocal fonctionne en MESH. Chacun envoie son flux à chacun, donc le
+#  partage d'écran plafonne vers 4 personnes (le partageur uploade UNE COPIE PAR
+#  SPECTATEUR) et se fait sans son.
+#  Avec lui : le partageur envoie UNE SEULE FOIS, le serveur recopie. Plus de mur,
+#  et le partage emporte son son.
+#
+#  ⚠ MODE RELAY : le SFU a besoin de ports média joignables depuis l'extérieur, ce
+#  qu'un tunnel ne fournit pas. On ne l'installe donc pas, et on ne demandera JAMAIS
+#  à l'utilisateur d'ouvrir un port sur sa box : c'est un engagement du projet. La
+#  levée passera par une pile ICE complète (perçage de NAT), pas par sa box.
+#
+#  Le SFU est un SUPPLÉMENT : s'il échoue, on AVERTIT et on continue. Le vocal marche
+#  sans lui. Faire échouer toute l'installation pour un bonus serait absurde.
+# ═══════════════════════════════════════════════════════════════════════════════
+_sfu_skip() { warn "$(printf "$(t sfu_skipped)" "$1")"; }
+
+if $RELAY_MODE; then
+  warn "$(t sfu_relay_skipped)"
+elif ! $SKIP_SFU; then
+  step "$(t step_sfu)"
+
+  _SFU_ARCH=""
+  case "$(uname -m)" in
+    x86_64)  _SFU_ARCH="amd64" ;;
+    aarch64) _SFU_ARCH="arm64" ;;
+  esac
+
+  if [[ -z "$_SFU_ARCH" ]]; then
+    _sfu_skip "$(printf "$(t sfu_reason_arch)" "$(uname -m)")"
+  else
+    _SFU_VERSION="sfu-v0.1.0"
+    _SFU_URL="https://github.com/Pokled/nodyx/releases/download/${_SFU_VERSION}/nodyx-sfud-linux-${_SFU_ARCH}"
+    info "$(printf "$(t sfu_downloading)" "${_SFU_VERSION}" "${_SFU_ARCH}")"
+    _SFU_TMP="$(mktemp /tmp/nodyx-sfud.XXXXXX)"
+
+    if ! curl -fsSL --max-time 180 "$_SFU_URL" -o "$_SFU_TMP"; then
+      rm -f "$_SFU_TMP"
+      _sfu_skip "$(printf "$(t sfu_reason_dl)" "${_SFU_URL}")"
+    elif ! file "$_SFU_TMP" 2>/dev/null | grep -q ELF; then
+      rm -f "$_SFU_TMP"
+      _sfu_skip "$(t sfu_reason_notbin)"
+    else
+      chmod +x "$_SFU_TMP"
+      mv -f "$_SFU_TMP" /usr/local/bin/nodyx-sfud
+
+      SFU_TOKEN="$(openssl rand -hex 32)"
+
+      # Le média écoute sur toutes les interfaces et ANNONCE l'IP publique : certains
+      # hébergeurs (AWS, GCP…) ne montrent jamais l'IP publique à la machine, un bind
+      # direct dessus échouerait.
+      cat > /etc/nodyx-sfud.env <<SFUENV
+# Généré par install.sh — le secret est partagé avec nodyx-core (VOICE_SFU_TOKEN)
+SFU_TOKEN=${SFU_TOKEN}
+
+# API interne : JAMAIS exposée, seul nodyx-core la contacte, en local.
+SFU_HTTP_ADDR=127.0.0.1:3901
+
+# Média : on écoute partout, on annonce l'IP publique aux navigateurs.
+SFU_LISTEN_IP=0.0.0.0
+SFU_ANNOUNCED_IP=${PUBLIC_IP}
+
+# Plage de ports média (ouverte dans le pare-feu, en UDP ET en TCP : le TCP est le
+# repli des réseaux qui bloquent l'UDP — entreprises, hôtels, certains opérateurs).
+SFU_RTC_MIN_PORT=40000
+SFU_RTC_MAX_PORT=40999
+
+# Le nombre de workers s'adapte tout seul à la machine (cœurs - réservés). Un cœur
+# reste hors de portée du média pour le reste des services.
+SFU_RESERVED_CORES=1
+
+# 0 = toute session passe par le SFU dès que nodyx-core le décide. C'est nodyx-core
+# qui arbitre mesh/SFU (VOICE_SFU_MESH_THRESHOLD), pas le daemon.
+SFU_MESH_THRESHOLD=0
+SFUENV
+      chown root:nodyx /etc/nodyx-sfud.env
+      chmod 640 /etc/nodyx-sfud.env
+
+      cat > /etc/systemd/system/nodyx-sfud.service <<SFUSVC
+[Unit]
+Description=Nodyx SFU daemon (mediasoup) — scalable voice & screen sharing
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/nodyx-sfud.env
+ExecStart=/usr/local/bin/nodyx-sfud
+Restart=on-failure
+RestartSec=5s
+User=nodyx
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target
+SFUSVC
+
+      systemctl daemon-reload
+      systemctl enable nodyx-sfud --quiet
+      systemctl restart nodyx-sfud
+      sleep 2
+
+      if systemctl is-active --quiet nodyx-sfud; then
+        _SFU_INSTALLED=true
+        ok "$(printf "$(t sfu_started)" "40000-40999" "${PUBLIC_IP}")"
+      else
+        _sfu_skip "$(t sfu_reason_start)"
+      fi
+    fi
+  fi
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
 #  FIREWALL (UFW)
 # ═══════════════════════════════════════════════════════════════════════════════
 step "$(t step_firewall)"
@@ -2161,6 +2309,14 @@ if ! $RELAY_MODE; then
     ufw allow 5349/tcp >/dev/null 2>&1
     ufw allow 5349/udp >/dev/null 2>&1
     ufw allow 49152:65535/udp >/dev/null 2>&1
+  fi
+  # Ports média du SFU. Le TCP n'est PAS un luxe : c'est le repli des réseaux qui
+  # bloquent l'UDP (entreprises, hôtels, certains opérateurs). Sans lui, ces
+  # utilisateurs ne se connectent PAS DU TOUT au vocal — pas « moins bien » : rien,
+  # avec un écran noir et aucun message.
+  if $_SFU_INSTALLED; then
+    ufw allow 40000:40999/udp >/dev/null 2>&1
+    ufw allow 40000:40999/tcp >/dev/null 2>&1
   fi
 fi
 ufw --force enable >/dev/null 2>&1
@@ -2294,6 +2450,30 @@ COREENV
 if $RELAY_MODE; then
   printf "\n# Fallback STUN (relay mode — nodyx-turn non installé)\nSTUN_FALLBACK_URLS=stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302\n" \
     >> "${NODYX_DIR}/nodyx-core/.env"
+fi
+
+# Brancher nodyx-core sur le SFU. Sans ces variables, le daemon tournerait pour rien :
+# le core ne lui parlerait jamais et tout le vocal resterait en mesh.
+if $_SFU_INSTALLED; then
+  cat >> "${NODYX_DIR}/nodyx-core/.env" <<SFUCORE
+
+# ── SFU (nodyx-sfud) : vocal et partage d'écran scalables ──────────────────────
+# Le secret est le même que dans /etc/nodyx-sfud.env.
+VOICE_SFU_URL=http://127.0.0.1:3901
+VOICE_SFU_TOKEN=${SFU_TOKEN}
+
+# Bascule automatique mesh → SFU.
+VOICE_SFU_AUTO=true
+
+# Vide = TOUS les canaux vocaux. (Renseigner des UUID pour limiter à certains.)
+VOICE_SFU_AUTO_CHANNELS=
+
+# À partir de combien de personnes un canal bascule tout seul. En dessous, le mesh
+# suffit et évite un aller-retour par le serveur.
+# ⚠ Un PARTAGE D'ÉCRAN bascule TOUJOURS, quel que soit ce seuil : c'est précisément
+# le moment où le mesh s'écroule (une copie envoyée PAR SPECTATEUR).
+VOICE_SFU_MESH_THRESHOLD=6
+SFUCORE
 fi
 
 cd "${NODYX_DIR}/nodyx-core"


### PR DESCRIPTION
## Le constat

Jusqu'ici, `nodyx-sfud` était installé **à la main** sur une seule machine. **Un auto-hébergeur qui installait Nodyx n'avait aucun SFU** : il restait en mesh, donc avec le mur des ~4 personnes en partage d'écran, et un partage **sans son**.

On avait construit une fonctionnalité **pour un serveur**, pas pour le projet.

## Ce qui rend l'empaquetage possible

Le binaire est **autonome** : le worker mediasoup est compilé **dedans** (15 Mo, dépendances = `libc`/`libm`/`libgcc`). **Aucune chaîne C++ à installer** chez l'utilisateur, aucune compilation de 10 minutes.

## Le workflow de release (nouveau)

Construit et publie les binaires précompilés, **amd64 et arm64**.

**⚠ Dans un conteneur Debian 11, et c'est le point critique.** Un binaire lié à la glibc ne tourne que sur une glibc **>=** celle de compilation :

| Système annoncé par install.sh | glibc |
|---|---|
| Debian 11 | **2.31** ← le plus ancien |
| Ubuntu 22.04 | 2.35 |
| Debian 12 | 2.36 |
| Ubuntu 24.04 | 2.39 |

Compiler sur un runner récent aurait produit un binaire qui **refuse de démarrer sur la moitié des systèmes annoncés**, avec un message incompréhensible pour l'utilisateur. On compile donc sur **la plus ancienne cible supportée**, et le workflow **journalise la glibc réellement exigée** pour ne pas la découvrir chez quelqu'un.

## install.sh

- télécharge le binaire, génère un secret, écrit `/etc/nodyx-sfud.env` (`root:nodyx 640`), installe le service systemd, **l'active au boot**, et **branche nodyx-core dessus** (bascule automatique sur **tous** les canaux vocaux) ;
- **pare-feu : ports média en UDP _et_ en TCP.** Le TCP n'est pas un luxe : c'est le **repli des réseaux qui bloquent l'UDP** (entreprises, hôtels, opérateurs). Sans lui, ces utilisateurs ne se connectent **pas du tout** — pas « moins bien » : **rien**, écran noir, aucun message ;
- le média **écoute sur 0.0.0.0 et annonce l'IP publique** : certains hébergeurs (AWS, GCP) ne montrent jamais l'IP publique à la machine, un bind direct échouerait ;
- drapeau `--no-sfu`.

## Deux principes tenus

**1. Le SFU est un supplément.** S'il échoue (architecture, téléchargement, démarrage), on **avertit et on continue** : le vocal marche sans lui, en mesh. Faire échouer **toute** l'installation pour un bonus serait absurde.

**2. Zéro port à ouvrir** (engagement du projet). En **mode Relay** (serveur derrière NAT), le SFU **n'est pas installé** : ses ports média ne sont pas joignables à travers un tunnel. **On ne demandera jamais d'ouvrir un port sur la box de l'utilisateur.** Le message le dit, et annonce que la levée **n'exigera aucune configuration réseau** (pile ICE complète, perçage de NAT).

## Tests

`bash -n` et `shellcheck` propres, YAML du workflow valide.