### PR TITLE
fix(ci): forcer bash, le conteneur Debian utilise sh (pas de pipefail)

### DIFF
--- a/.github/workflows/release-sfu.yml
+++ b/.github/workflows/release-sfu.yml
@@ -67,6 +67,12 @@ jobs:
     needs: prepare
     runs-on: ${{ matrix.runner }}
     container: debian:11
+    # ⚠ Dans un conteneur Debian, le shell par défaut est `sh` (dash), PAS bash. Or
+    # `set -o pipefail` n'existe pas en `sh` : le script meurt à sa première ligne,
+    # avec un log qui ne montre même pas l'erreur. On impose bash explicitement.
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Le symptôme

Le binaire **se compilait bien** (mediasoup compris) et la vérification passait, mais **l'envoi à la release échouait sans montrer la moindre erreur**.

## La cause

Dans un conteneur Debian, le shell par défaut des étapes est **`sh` (dash)**, pas bash :

```
shell: sh -e {0}
```

Or l'étape d'envoi commence par `set -euo pipefail`, et **`pipefail` n'existe pas en `sh`**. Le script **meurt à sa toute première ligne**, avant d'avoir rien tenté, et le log n'affiche que le script échoué, **sans sortie**.

Les étapes précédentes passaient parce qu'elles utilisaient `set -eux`, **sans pipefail**.

## Le correctif

On impose **bash** sur le job.

## Bonus : le verdict glibc est tombé

La vérification a livré son résultat : le binaire n'exige que **`GLIBC_2.30`**.

| Système | glibc | Compatible ? |
|---|---|---|
| Debian 11 | 2.31 | ✅ |
| Ubuntu 22.04 | 2.35 | ✅ |
| Debian 12 | 2.36 | ✅ |
| Ubuntu 24.04 | 2.39 | ✅ |

**Le pari du conteneur Debian 11 est gagné**, et il est désormais **mesuré**, plus supposé.