### PR TITLE
fix(sfu): fermer les consumers/transports orphelins (fuite mémoire sur instance longue)

### DIFF
--- a/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
+++ b/nodyx-p2p/crates/nodyx-sfu-mediasoup/src/engine.rs
@@ -644,6 +644,22 @@ impl MediaEngine for MediasoupEngine {
         Ok(())
     }
 
+    async fn close_consumer(&self, consumer: &ConsumerId) -> Result<()> {
+        // Même logique : retrait du registre = Drop = fermeture. Sans ce nettoyage,
+        // les consumers dont le producer a disparu (ou dont l'abonné est parti)
+        // restent dans la Map et s'y accumulent = fuite.
+        self.inner.consumers.lock().unwrap().remove(&consumer.0);
+        Ok(())
+    }
+
+    async fn close_transport(&self, transport: &TransportHandle) -> Result<()> {
+        // Retirer l'Arc du registre : quand c'est la dernière référence, le
+        // transport se ferme, et mediasoup casse en cascade ses producers/consumers
+        // côté serveur. Idempotent.
+        self.inner.transports.lock().unwrap().remove(&transport.0);
+        Ok(())
+    }
+
     async fn resume_consumer(&self, consumer: &ConsumerId) -> Result<()> {
         // Le client a créé son consumer : on peut laisser couler. mediasoup demande
         // alors une keyframe au producer, qui arrivera à un décodeur EXISTANT.

--- a/nodyx-p2p/crates/nodyx-sfu/src/lib.rs
+++ b/nodyx-p2p/crates/nodyx-sfu/src/lib.rs
@@ -182,6 +182,14 @@ pub trait MediaEngine: Send + Sync {
     /// d'écran). Idempotent : un producer déjà fermé/inconnu n'est PAS une erreur
     /// (un nettoyage doit toujours pouvoir aboutir).
     async fn close_producer(&self, producer: &ProducerId) -> Result<()>;
+    /// Ferme un consumer (nettoyage : son producer a disparu, ou son abonné part).
+    /// Sans ça, les consumers morts s'accumulent dans le registre du moteur = fuite
+    /// mémoire sur une instance qui tourne longtemps. Idempotent.
+    async fn close_consumer(&self, consumer: &ConsumerId) -> Result<()>;
+    /// Ferme un transport (au départ d'un participant). En fermant le transport,
+    /// le moteur casse en cascade tous ses producers/consumers côté serveur.
+    /// Idempotent : un transport déjà parti n'est pas une erreur.
+    async fn close_transport(&self, transport: &TransportHandle) -> Result<()>;
     /// Reprend un consumer créé en pause. La VIDÉO démarre en pause : sans ça, la
     /// keyframe part avant que le décodeur du client n'existe → écran noir jusqu'à
     /// la suivante (clignotement). Le client appelle ceci une fois son consumer
@@ -248,6 +256,12 @@ impl MediaEngine for NullEngine {
         Ok((ConsumerId(self.next("consumer")), client_caps.clone()))
     }
     async fn close_producer(&self, _producer: &ProducerId) -> Result<()> {
+        Ok(())
+    }
+    async fn close_consumer(&self, _consumer: &ConsumerId) -> Result<()> {
+        Ok(())
+    }
+    async fn close_transport(&self, _transport: &TransportHandle) -> Result<()> {
         Ok(())
     }
     async fn resume_consumer(&self, _consumer: &ConsumerId) -> Result<()> {

--- a/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
+++ b/nodyx-p2p/crates/nodyx-sfu/src/voice.rs
@@ -229,6 +229,20 @@ struct RoomState {
     router: Option<RouterHandle>,
 }
 
+/// Un flux (`producer`) disparaît : retire de TOUS les participants leur abonnement
+/// à ce flux (il est devenu un fantôme : un consumer qui lit un producer fermé) et
+/// renvoie les [`ConsumerId`] correspondants, à fermer côté moteur. Sans ça, ces
+/// abonnements et leurs consumers s'accumulent tant que le salon vit = fuite.
+fn drop_subscribers_of(state: &mut RoomState, producer: &ProducerId) -> Vec<ConsumerId> {
+    let mut orphaned = Vec::new();
+    for p in state.participants.values_mut() {
+        if let Some(c) = p.subscriptions.remove(producer) {
+            orphaned.push(c);
+        }
+    }
+    orphaned
+}
+
 // ── Le service ──────────────────────────────────────────────────────────────
 
 /// Orchestrateur métier du vocal. Générique sur le moteur : `VoiceService<NullEngine>`
@@ -406,26 +420,58 @@ impl<E: MediaEngine> VoiceService<E> {
     }
 
     async fn remove(&self, room: RoomId, participant: ParticipantId) -> Result<(), VoiceError> {
-        let router_to_close = {
+        let (producers, consumers, transports, router_to_close) = {
             let mut rooms = self.rooms();
             let Some(state) = rooms.get_mut(&room) else {
                 return Err(VoiceError::NotInRoom);
             };
-            if state.participants.remove(&participant).is_none() {
+            let Some(gone) = state.participants.remove(&participant) else {
                 return Err(VoiceError::NotInRoom);
-            }
-            // Ses publications disparaissent (les abonnés seront notifiés par le signaling).
+            };
+
+            // Objets moteur DU PARTANT : ses consumers (ses abonnements) et ses
+            // transports (send/recv). Sans les fermer, ils survivent dans les
+            // registres du moteur jusqu'à la fermeture du salon = fuite.
+            let mut consumers: Vec<ConsumerId> = gone.subscriptions.into_values().collect();
+            let transports: Vec<TransportHandle> =
+                [gone.send_transport, gone.recv_transport].into_iter().flatten().collect();
+
+            // Ses publications disparaissent, et chacune rend fantômes les
+            // abonnements des AUTRES : on les purge et on récupère leurs consumers.
+            let producers: Vec<ProducerId> = state
+                .publications
+                .iter()
+                .filter(|(_, pubb)| pubb.owner == participant)
+                .map(|(id, _)| id.clone())
+                .collect();
             state.publications.retain(|_, pubb| pubb.owner != participant);
+            for prod in &producers {
+                consumers.extend(drop_subscribers_of(state, prod));
+            }
+
             // Dernier parti : on ferme le salon et on libère le routeur moteur.
-            if state.participants.is_empty() {
-                let router = state.router.take();
+            let router = if state.participants.is_empty() {
+                let r = state.router.take();
                 rooms.remove(&room);
-                router
+                r
             } else {
                 None
-            }
+            };
+            (producers, consumers, transports, router)
         };
 
+        // Hors verrou : nettoyage moteur, tout idempotent. Fermer les transports
+        // casse en cascade les producers/consumers restants côté serveur ; on retire
+        // aussi explicitement du registre pour ne rien y laisser traîner.
+        for p in producers {
+            let _ = self.engine.close_producer(&p).await;
+        }
+        for c in consumers {
+            let _ = self.engine.close_consumer(&c).await;
+        }
+        for t in transports {
+            let _ = self.engine.close_transport(&t).await;
+        }
         if let Some(router) = router_to_close {
             self.engine.close_room(router).await?;
         }
@@ -617,7 +663,7 @@ impl<E: MediaEngine> VoiceService<E> {
         participant: ParticipantId,
         producer: ProducerId,
     ) -> Result<(), VoiceError> {
-        {
+        let orphaned = {
             let mut rooms = self.rooms();
             let state = rooms.get_mut(&room).ok_or(VoiceError::NotInRoom)?;
             match state.publications.get(&producer) {
@@ -627,9 +673,15 @@ impl<E: MediaEngine> VoiceService<E> {
                 Some(_) => return Err(VoiceError::NotOwner),
                 None => return Err(VoiceError::NoSuchPublication),
             }
-        }
-        // Hors verrou : fermeture réelle du flux moteur (idempotente).
+            // Le flux disparaît : les consumers qui le lisaient deviennent fantômes.
+            drop_subscribers_of(state, &producer)
+        };
+        // Hors verrou : fermeture réelle du flux moteur + de ses consumers orphelins
+        // (tout est idempotent : un objet déjà parti n'est pas une erreur).
         self.engine.close_producer(&producer).await?;
+        for c in orphaned {
+            let _ = self.engine.close_consumer(&c).await;
+        }
         Ok(())
     }
 
@@ -1041,6 +1093,51 @@ mod tests {
             block_on(s.unpublish(room(), p(1), prod)),
             Err(VoiceError::NoSuchPublication)
         );
+    }
+
+    #[test]
+    fn unpublish_purges_subscribers_no_ghost() {
+        let s = svc();
+        for i in 1..=3 {
+            block_on(s.join(room(), p(i))).unwrap();
+        }
+        let prod = block_on(s.publish(room(), p(1), TrackKind::Screen, &blob())).unwrap();
+        block_on(s.subscribe(room(), p(2), prod.clone(), &blob())).unwrap();
+        block_on(s.subscribe(room(), p(3), prod.clone(), &blob())).unwrap();
+        assert_eq!(block_on(s.subscriptions(&room())).len(), 2);
+
+        // p1 arrête son partage → les DEUX abonnements doivent disparaître : sans le
+        // nettoyage, ils restaient en fantômes (un consumer qui lit un flux fermé).
+        block_on(s.unpublish(room(), p(1), prod)).unwrap();
+        assert!(
+            block_on(s.subscriptions(&room())).is_empty(),
+            "les abonnements au flux fermé doivent être purgés"
+        );
+        assert!(s.publications(&room()).is_empty());
+    }
+
+    #[test]
+    fn leaving_purges_own_and_others_subscriptions() {
+        let s = svc();
+        for i in 1..=3 {
+            block_on(s.join(room(), p(i))).unwrap();
+        }
+        let prod1 = block_on(s.publish(room(), p(1), TrackKind::Screen, &blob())).unwrap();
+        let prod2 = block_on(s.publish(room(), p(2), TrackKind::Screen, &blob())).unwrap();
+        // p3 consomme les deux écrans ; p1 consomme l'écran de p2.
+        block_on(s.subscribe(room(), p(3), prod1.clone(), &blob())).unwrap();
+        block_on(s.subscribe(room(), p(3), prod2.clone(), &blob())).unwrap();
+        block_on(s.subscribe(room(), p(1), prod2.clone(), &blob())).unwrap();
+        assert_eq!(block_on(s.subscriptions(&room())).len(), 3);
+
+        // p1 part. Son flux (prod1) disparaît → l'abonnement de p3 à prod1 est purgé.
+        // Et son PROPRE abonnement (p1 → prod2) part avec lui. Reste : p3 → prod2.
+        block_on(s.leave(room(), p(1))).unwrap();
+        let subs = block_on(s.subscriptions(&room()));
+        assert_eq!(subs.len(), 1, "reste seulement l'abonnement de p3 au flux de p2");
+        assert_eq!(subs[0].subscriber, p(3));
+        assert_eq!(subs[0].producer, prod2);
+        assert_eq!(s.publications(&room()).len(), 1); // seul le flux de p2 subsiste
     }
 
     #[test]


### PR DESCRIPTION
## Trouvé par la mesure

L'audit du daemon (`/v1/subscriptions`) montrait des **abonnements fantômes** : des consumers dont le producer avait disparu, affichés `kind=?`. Sur une instance qui tourne **longtemps** avec du va-et-vient (partages qui démarrent/s'arrêtent, gens qui entrent/sortent), ils **s'accumulent = fuite mémoire**.

À corriger **avant** un soak, sinon le soak ne fait que confirmer la fuite.

## Deux points de fuite

**1. `unpublish`** fermait le producer mais laissait **intacts les abonnements des spectateurs** à ce flux. Chaque `Participant.subscriptions` gardait une entrée morte, et le registre `consumers` du moteur gardait l'objet fermé.

**2. `remove` (leave/kick)** retirait le partant et ses publications, mais **ne fermait rien côté moteur** (ses producers/consumers/transports survivaient dans les registres jusqu'à la fermeture du salon), et **ne purgeait pas** les abonnements des **autres** à ses flux disparus.

## Le correctif

- **Moteur** : `close_consumer` + `close_transport` (retrait du registre = Drop = fermeture réelle ; fermer un transport **casse en cascade** ses producers/consumers côté serveur). Idempotents, même patron que `close_producer`.
- **Service** : helper `drop_subscribers_of` — quand un flux disparaît, purger **tous** les abonnements qui le lisaient et récupérer leurs consumers à fermer. Appelé par `unpublish` (le flux arrêté) et par `remove` (chaque flux du partant). `remove` ferme **aussi** les objets moteur du partant lui-même.

Tout le nettoyage moteur est **hors verrou** et **idempotent**.

## Tests

2 tests service (`unpublish` sans fantôme ; `leave` purge ses abonnements **et** ceux des autres à ses flux). Service **33**, moteur **5**, workspace vert.