### PR TITLE
fix(tasks): tableau en pleine largeur, et nettoyage ponctuation

### DIFF
--- a/SPECS/NODYX_MEDIA_ENGINE_RUST.md
+++ b/SPECS/NODYX_MEDIA_ENGINE_RUST.md
@@ -142,3 +142,21 @@ sont, et ils ont une porte de sortie souveraine ». Changement de nature.
   petit. Découper en jalons prouvables, ne jamais tout jouer d'un coup.
 - **Ne pas confondre** confort de dev (Rust) et topologie réseau (ICE) : la valeur est dans
   l'ICE complet, pas dans le langage.
+
+---
+
+## 11. Partage et remerciements (communauté Rust)
+
+Ce moteur s'appuiera sur le travail de la communauté Rust (webrtc-rs ou str0m, l'écosystème
+async, les crates STUN/ICE). Quand il sera prouvé, on veut :
+
+- lui donner une **page dédiée** qui explique l'approche et **remercie** les projets sur
+  lesquels il repose, sans prétention ;
+- envisager de sortir la partie réutilisable en **crate ouverte** (le cœur du produit reste
+  AGPL sur Nodyx ; une brique moteur générique pourrait être partagée sous une licence
+  adaptée, à décider), pour qu'elle serve à d'autres auto-hébergeurs ;
+- documenter **honnêtement** ce qui marche et ce qui ne marche pas (le taux de perçage réel
+  mesuré), pour que ce soit utile et pas un argument marketing.
+
+C'est cohérent avec l'ADN du projet : rendre à l'écosystème ce qu'il nous a donné. Et si ça
+sert un jour à d'autres, tant mieux.

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -1171,7 +1171,7 @@
             {/if}
 
 
-            <div class="w-full flex-1 flex flex-col {$page.url.pathname === '/' || $page.url.pathname.startsWith('/chat') || $page.url.pathname.startsWith('/admin') || $page.url.pathname.startsWith('/users/') || $page.url.pathname.startsWith('/feed') || $page.url.pathname.startsWith('/settings') || $page.url.pathname.startsWith('/garden') || $page.url.pathname.startsWith('/calendar') || $page.url.pathname.startsWith('/discover') || $page.url.pathname.startsWith('/wiki') || $page.url.pathname.startsWith('/library') || $page.url.pathname.startsWith('/dm') ? '' : $page.url.pathname.startsWith('/forum') ? 'px-4 sm:px-6 py-8' : 'max-w-5xl mx-auto px-4 py-8'}">
+            <div class="w-full flex-1 flex flex-col {$page.url.pathname === '/' || $page.url.pathname.startsWith('/chat') || $page.url.pathname.startsWith('/admin') || $page.url.pathname.startsWith('/users/') || $page.url.pathname.startsWith('/feed') || $page.url.pathname.startsWith('/settings') || $page.url.pathname.startsWith('/garden') || $page.url.pathname.startsWith('/calendar') || $page.url.pathname.startsWith('/discover') || $page.url.pathname.startsWith('/wiki') || $page.url.pathname.startsWith('/library') || $page.url.pathname.startsWith('/dm') ? '' : ($page.url.pathname.startsWith('/forum') || $page.url.pathname.startsWith('/tasks')) ? 'px-4 sm:px-6 py-8' : 'max-w-5xl mx-auto px-4 py-8'}">
                 {@render children()}
             </div>
         </main>

--- a/nodyx-frontend/src/routes/tasks/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/tasks/[id]/+page.svelte
@@ -191,7 +191,7 @@
 	}
 </script>
 
-<svelte:head><title>{board.name} — Tâches — Nodyx</title></svelte:head>
+<svelte:head><title>{board.name} · Tâches · Nodyx</title></svelte:head>
 
 <!-- ── Header ──────────────────────────────────────────────────────────────── -->
 <div class="flex items-center gap-3 mb-6 flex-wrap">
@@ -219,7 +219,7 @@
 	{/if}
 
 	{#if board.description}
-		<span class="text-sm text-gray-500 hidden sm:inline">— {board.description}</span>
+		<span class="text-sm text-gray-500 hidden sm:inline">· {board.description}</span>
 	{/if}
 
 	{#if data.canManage}
@@ -476,7 +476,7 @@
 					class="w-full rounded-lg bg-gray-800 border border-gray-700 px-3 py-2 text-sm text-gray-200
 					       focus:outline-none focus:border-indigo-600"
 				>
-					<option value={null}>— Personne</option>
+					<option value={null}>Aucun</option>
 					{#each members as m}
 						<option value={m.id}>{m.username}</option>
 					{/each}


### PR DESCRIPTION
## La vraie cause de la largeur

Ce n'était pas les colonnes mais le **layout**. Toute page non listée reçoit `max-w-5xl mx-auto` (**1024px, centré**). `/tasks` n'y était pas, alors que le chat, l'admin, le wiki le sont. Le tableau était donc **plafonné à 1024px** quoi qu'on fasse aux colonnes.

`/tasks` passe en **pleine largeur avec padding**, comme le forum. Combiné aux colonnes élastiques (`flex-1`) posées juste avant, elles remplissent enfin l'espace, et la troncature de droite disparaît.

## Au passage

- Nettoyage des tirets cadratins du module Tâches (titre d'onglet, préfixe de description, option d'assignation vide).
- CDC section 11 : partage et remerciements à la communauté Rust (page dédiée, et brique réutilisable envisagée quand le moteur natif sera prouvé).

## Tests

svelte-check 0 erreur.