### PR TITLE
feat(tasks): cartes riches, l'éditeur Nodyx remplace le champ texte brut

### DIFF
--- a/nodyx-core/src/routes/tasks.ts
+++ b/nodyx-core/src/routes/tasks.ts
@@ -10,6 +10,20 @@ import { validate }    from '../middleware/validate'
 import { rateLimit }   from '../middleware/rateLimit'
 import { requireAuth } from '../middleware/auth'
 import { db }          from '../config/database'
+import { sanitize }    from '../utils/sanitize'
+import { rehostExternalImages } from '../services/inlineImageRehost'
+
+// La description d'une carte vient de l'éditeur riche (HTML). Deux règles :
+// - à l'ÉCRITURE : rehost des <img> externes PUIS sanitize (patron du forum) ;
+// - à la LECTURE : sanitize AUSSI, car les descriptions écrites avant l'éditeur
+//   riche n'ont jamais été assainies (texte libre), et ça vaut pour TOUTES les
+//   instances auto-hébergées, pas seulement la nôtre. Rendre du contenu
+//   utilisateur en {@html} sans ce filet serait une XSS.
+async function cleanDescription(raw: string): Promise<string> {
+  if (!raw) return ''
+  const rehost = await rehostExternalImages(raw)
+  return sanitize(rehost.html)
+}
 
 // ── getCommunityId (cached) ────────────────────────────────────────────────────
 
@@ -69,7 +83,7 @@ const UpdateColumnSchema = z.object({
 
 const CreateCardSchema = z.object({
   title:       z.string().min(1).max(200),
-  description: z.string().max(10000).optional().default(''),
+  description: z.string().max(100_000).optional().default(''),
   assignee_id: z.string().uuid().nullable().optional(),
   due_date:    z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable().optional(),
   priority:    z.enum(PRIORITIES).optional().default('normal'),
@@ -77,7 +91,7 @@ const CreateCardSchema = z.object({
 
 const UpdateCardSchema = z.object({
   title:       z.string().min(1).max(200).optional(),
-  description: z.string().max(10000).optional(),
+  description: z.string().max(100_000).optional(),
   assignee_id: z.string().uuid().nullable().optional(),
   due_date:    z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable().optional(),
   priority:    z.enum(PRIORITIES).optional(),
@@ -185,6 +199,14 @@ export default async function taskRoutes(app: FastifyInstance) {
          ORDER BY k.column_id, k.position ASC`,
         [id]
       )
+
+      // Filet pour l'existant : les descriptions écrites avant l'éditeur riche
+      // n'ont jamais été assainies (et ça vaut pour toutes les instances). On
+      // assainit donc aussi à la lecture. Pas de rehost ici : aucun appel réseau
+      // sur un GET.
+      for (const card of cards) {
+        card.description = card.description ? sanitize(card.description) : ''
+      }
 
       const cardsByColumn: Record<string, typeof cards> = {}
       for (const card of cards) {
@@ -395,11 +417,12 @@ export default async function taskRoutes(app: FastifyInstance) {
         [id]
       )
 
+      const description = await cleanDescription(body.description)
       const { rows: [card] } = await db.query(
         `INSERT INTO task_cards (column_id, title, description, assignee_id, due_date, priority, position, created_by)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
          RETURNING id, column_id, title, description, due_date, priority, position, created_by, created_at`,
-        [id, body.title, body.description, body.assignee_id ?? null, body.due_date ?? null, body.priority, max_pos + 1, userId]
+        [id, body.title, description, body.assignee_id ?? null, body.due_date ?? null, body.priority, max_pos + 1, userId]
       )
 
       const { rows: [enriched] } = await db.query(
@@ -457,7 +480,7 @@ export default async function taskRoutes(app: FastifyInstance) {
     const updates: string[] = ['updated_at = NOW()']
     const params: unknown[] = []
     if (body.title       !== undefined) { params.push(body.title);        updates.push(`title = $${params.length}`) }
-    if (body.description !== undefined) { params.push(body.description);  updates.push(`description = $${params.length}`) }
+    if (body.description !== undefined) { params.push(await cleanDescription(body.description)); updates.push(`description = $${params.length}`) }
     if (body.assignee_id !== undefined) {
       // null = désassigner ; sinon vérifier que l'assignee appartient à cette communauté
       if (body.assignee_id !== null) {

--- a/nodyx-frontend/src/routes/tasks/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/tasks/[id]/+page.svelte
@@ -3,6 +3,7 @@
 	import { goto } from '$app/navigation'
 	import type { PageData } from './$types'
 	import { untrack } from 'svelte'
+	import NodyxEditor from '$lib/components/editor/NodyxEditor.svelte'
 
 	let { data }: { data: PageData } = $props()
 
@@ -288,6 +289,14 @@
 							</div>
 						</div>
 
+						<!-- Description riche : HTML assaini côté serveur (écriture ET
+						     lecture), donc sûr à rendre. Bornée en hauteur sur la tuile. -->
+						{#if card.description}
+							<div class="task-card-desc mt-1.5 max-h-28 overflow-hidden text-xs leading-snug text-gray-400">
+								{@html card.description}
+							</div>
+						{/if}
+
 						<!-- Badges -->
 						<div class="flex flex-wrap gap-1.5 mt-2">
 							{#if card.priority !== 'normal'}
@@ -426,16 +435,17 @@
 
 			<!-- Description -->
 			<div>
-				<label for="task-edit-desc" class="block text-xs font-medium text-gray-500 mb-1.5">Description</label>
-				<textarea
-					id="task-edit-desc"
-					bind:value={editingCard.description}
-					rows="3"
-					maxlength="10000"
-					placeholder="Détails, liens, notes..."
-					class="w-full rounded-lg bg-gray-800 border border-gray-700 px-3 py-2 text-sm text-gray-200
-					       placeholder-gray-600 focus:outline-none focus:border-indigo-600 resize-none"
-				></textarea>
+				<span class="block text-xs font-medium text-gray-500 mb-1.5">Description</span>
+				<!-- Éditeur riche (liens, images, mise en forme). Le HTML est assaini
+				     CÔTÉ SERVEUR, à l'écriture et à la lecture. -->
+				<div class="max-h-72 overflow-y-auto rounded-lg">
+					<NodyxEditor
+						compact
+						initialContent={editingCard.description}
+						placeholder="Détails, liens, images, notes..."
+						onchange={(html) => { if (editingCard) editingCard.description = html }}
+					/>
+				</div>
 			</div>
 
 			<div class="grid grid-cols-2 gap-3">
@@ -496,3 +506,22 @@
 		</div>
 	</div>
 {/if}
+
+<style>
+	/* Contenu riche des cartes : venu de l'éditeur, assaini côté serveur. On borne
+	   ce qui pourrait casser une tuile étroite, sans imposer tout un thème. */
+	.task-card-desc :global(p)          { margin: 0 0 0.25rem 0; }
+	.task-card-desc :global(a)          { color: rgb(129, 140, 248); text-decoration: underline; }
+	.task-card-desc :global(a:hover)    { color: rgb(165, 180, 252); }
+	.task-card-desc :global(img)        { max-width: 100%; max-height: 6rem; border-radius: 0.375rem; margin: 0.25rem 0; }
+	.task-card-desc :global(pre)        { overflow-x: auto; background: rgb(17, 24, 39); border-radius: 0.375rem; padding: 0.375rem 0.5rem; margin: 0.25rem 0; }
+	.task-card-desc :global(code)       { font-size: 0.7rem; }
+	.task-card-desc :global(ul),
+	.task-card-desc :global(ol)         { margin: 0.25rem 0; padding-left: 1.1rem; }
+	.task-card-desc :global(h1),
+	.task-card-desc :global(h2),
+	.task-card-desc :global(h3),
+	.task-card-desc :global(h4)         { font-size: 0.8rem; font-weight: 600; color: rgb(209, 213, 219); margin: 0.25rem 0; }
+	.task-card-desc :global(blockquote) { border-left: 2px solid rgb(75, 85, 99); padding-left: 0.5rem; margin: 0.25rem 0; }
+	.task-card-desc :global(iframe)     { max-width: 100%; max-height: 8rem; }
+</style>


### PR DESCRIPTION
## Le premier mur du dogfooding

En pilotant le CDC du moteur média depuis le module Tâches, le premier manque a été immédiat : la description d'une carte était un simple textarea. Pas de lien cliquable (même une URL collée restait du texte mort), pas d'image, pas de mise en forme.

## Un seul geste règle les trois manques

Brancher NodyxEditor (TipTap, déjà utilisé par le forum, le wiki, le chat) sur la description : liens, images (upload authentifié intégré à l'éditeur), titres, listes, code, tableaux.

## Sécurité, le point central de cette PR

- À l'écriture : rehost des img externes puis sanitize (le patron exact du forum).
- À la lecture AUSSI : les descriptions écrites avant l'éditeur riche n'ont JAMAIS été assainies (l'ancienne API stockait du texte libre), et ça vaut pour toutes les instances auto-hébergées, pas seulement la nôtre. Rendre ces données en {@html} sans ce filet serait une XSS stockée. Pas de rehost à la lecture : aucun appel réseau sur un GET.

Limite de taille 10k vers 100k (le HTML est verbeux ; le forum autorise 500k).

## Tuile

La description riche s'affiche sous le titre, bornée en hauteur, avec des styles contraints (images 6rem max, liens indigo, code scrollable).

## Tests

core tsc 0 et 401 tests verts ; svelte-check 0 erreur, build prod OK.
