### PR TITLE
fix(tasks): le crayon d'édition ne faisait rien (structuredClone sur un proxy réactif)

### DIFF
--- a/nodyx-frontend/src/routes/tasks/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/tasks/[id]/+page.svelte
@@ -277,7 +277,7 @@
 							<p class="flex-1 text-sm text-gray-200 leading-snug">{card.title}</p>
 							<div class="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
 								<button
-									onclick={() => editingCard = structuredClone(card)}
+									onclick={() => editingCard = $state.snapshot(card)}
 									class="text-gray-600 hover:text-indigo-400 text-xs leading-none"
 									title="Modifier"
 								>✎</button>


### PR DESCRIPTION
## Le symptôme

Cliquer sur le crayon d'une carte n'ouvrait jamais la modale. **Ce n'est pas une régression des cartes riches : le bouton était mort depuis l'écriture du module**, et personne n'avait essayé de modifier une carte avant de s'en servir pour de vrai. Le dogfooding paie une deuxième fois.

## La cause

Le clic faisait `structuredClone(card)`. Or `card` sort d'un état réactif Svelte 5 : c'est un **Proxy**, et `structuredClone` **refuse de cloner un Proxy**. Exception `DataCloneError` dans le gestionnaire, qui meurt en silence : rien ne s'affiche, seule la console le montre.

## Le fix

`$state.snapshot(card)`, prévu par Svelte 5 exactement pour ça : copie simple et profonde, sûre à modifier dans la modale sans toucher l'état du tableau.

Le clone de la ligne 11 est sain, lui : il copie les données brutes du serveur, avant qu'elles ne deviennent réactives.

## Tests

svelte-check 0 erreur, build prod OK.