### PR TITLE
fix(tasks): les popups de l'éditeur étaient rognées dans la modale

### DIFF
--- a/nodyx-frontend/src/routes/tasks/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/tasks/[id]/+page.svelte
@@ -437,15 +437,17 @@
 			<div>
 				<span class="block text-xs font-medium text-gray-500 mb-1.5">Description</span>
 				<!-- Éditeur riche (liens, images, mise en forme). Le HTML est assaini
-				     CÔTÉ SERVEUR, à l'écriture et à la lecture. -->
-				<div class="max-h-72 overflow-y-auto rounded-lg">
-					<NodyxEditor
-						compact
-						initialContent={editingCard.description}
-						placeholder="Détails, liens, images, notes..."
-						onchange={(html) => { if (editingCard) editingCard.description = html }}
-					/>
-				</div>
+				     CÔTÉ SERVEUR, à l'écriture et à la lecture.
+				     ⚠ Ne PAS l'envelopper dans un conteneur à overflow : l'éditeur borne
+				     déjà sa hauteur lui-même (son contenu scrolle en interne) et sa racine
+				     est en overflow-visible EXPRÈS pour que les popups (lien, image...)
+				     puissent dépasser. Un wrapper overflow-y-auto les rognait. -->
+				<NodyxEditor
+					compact
+					initialContent={editingCard.description}
+					placeholder="Détails, liens, images, notes..."
+					onchange={(html) => { if (editingCard) editingCard.description = html }}
+				/>
 			</div>
 
 			<div class="grid grid-cols-2 gap-3">


### PR DESCRIPTION
## Le symptôme

En cliquant sur « insérer un lien » (ou image, vidéo...) dans l'éditeur d'une carte, la popup apparaissait **tronquée**, coupée au bord de son conteneur.

## La cause

J'avais enveloppé `NodyxEditor` dans un `div overflow-y-auto` pour borner sa hauteur dans la modale. Or l'éditeur borne **déjà** sa hauteur lui-même (son contenu scrolle en interne, `max-h-[55vh]` en compact) et sa racine est en `overflow-visible` **exprès** pour que les popups puissent dépasser.

Mon wrapper était donc à la fois inutile et nuisible : un ancêtre à overflow **clippe** tout ce qui déborde, popups comprises (et un `overflow-y` non-visible force aussi le clipping horizontal).

## Le fix

Suppression du wrapper, avec un commentaire pour que personne ne le remette.

## Tests

svelte-check 0 erreur, build prod OK.