### PR TITLE
feat(voice): bouton haut-parleur (Android/desktop) via setSinkId

### DIFF
--- a/nodyx-frontend/src/lib/components/StageView.svelte
+++ b/nodyx-frontend/src/lib/components/StageView.svelte
@@ -5,6 +5,7 @@
         remoteScreenStore,
         stopScreenShare,
         voiceStore,
+        registerSinkElement,
     } from '$lib/voice'
     import StageChat from './StageChat.svelte'
 
@@ -194,6 +195,13 @@
         if (!el) return
         el.volume = screenVolume / 100
         el.muted  = screenMuted
+    })
+
+    // Le son d'écran suit la sortie choisie (écouteur/haut-parleur), comme les voix.
+    $effect(() => {
+        const el = screenAudioElem
+        if (!el) return
+        return registerSinkElement(el)
     })
 
     // Filet de sécurité mobile : un clic sur une commande relance la lecture si le

--- a/nodyx-frontend/src/lib/components/VoicePanel.svelte
+++ b/nodyx-frontend/src/lib/components/VoicePanel.svelte
@@ -4,6 +4,7 @@
         startPTT, stopPTT, inputLevel, setPeerVolume, kickPeer,
         peerStatsStore, getQuality, voiceFullStore, voiceKickedStore,
         startScreenShare, stopScreenShare, screenShareStore, remoteScreenStore,
+        audioOutputStore, toggleSpeaker, refreshAudioOutputs,
         type VoicePeer, type PeerStats, type NetQuality,
     } from '$lib/voice'
     import { getPeerVolume, savePeerVolume } from '$lib/voiceSettings'
@@ -44,7 +45,11 @@
     const level         = $derived($inputLevel)
     const statsMap      = $derived($peerStatsStore)
     const isSharing     = $derived($screenShareStore)
+    const speaker       = $derived($audioOutputStore)
     const remoteScreens = $derived($remoteScreenStore)
+
+    // Disponibilité du bouton haut-parleur (setSinkId : Android/desktop, pas iOS).
+    onMount(() => { void refreshAudioOutputs() })
     const anySharing    = $derived(isSharing || remoteScreens.size > 0)
     const shareCount    = $derived(remoteScreens.size + (isSharing ? 1 : 0))
 
@@ -735,6 +740,33 @@
                                 </svg>
                             {/if}
                         </button>
+
+                        <!-- Haut-parleur (Android/desktop) : bascule écouteur <-> haut-parleur.
+                             Sur mobile, le son part dans l'écouteur dès qu'un micro tourne ;
+                             ce bouton le renvoie au haut-parleur. Absent sur iOS (pas de setSinkId). -->
+                        {#if speaker.supported}
+                            <button
+                                onclick={() => { void toggleSpeaker() }}
+                                class='p-2 rounded-lg transition-all duration-200 transform hover:scale-110 active:scale-95 relative min-w-[44px] min-h-[44px] flex items-center justify-center
+                                       {speaker.onSpeaker
+                                           ? 'bg-gradient-to-r from-indigo-600 to-indigo-500 text-white shadow-lg shadow-indigo-900/50 ring-1 ring-indigo-700/50'
+                                           : 'bg-gray-800/80 text-gray-300 hover:text-white hover:bg-gray-700 border border-gray-700'}'
+                                title={speaker.onSpeaker ? "Repasser dans l'écouteur" : 'Basculer sur le haut-parleur'}
+                                aria-label={speaker.onSpeaker ? "Repasser dans l'écouteur" : 'Basculer sur le haut-parleur'}
+                                style="pointer-events: auto; position: relative; z-index: 101;"
+                            >
+                                {#if speaker.onSpeaker}
+                                    <svg class='w-4 h-4' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2'>
+                                        <path stroke-linecap='round' stroke-linejoin='round' d='M11 5 6 9H2v6h4l5 4V5z'/>
+                                        <path stroke-linecap='round' stroke-linejoin='round' d='M15.54 8.46a5 5 0 0 1 0 7.07M19.07 4.93a10 10 0 0 1 0 14.14'/>
+                                    </svg>
+                                {:else}
+                                    <svg class='w-4 h-4' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2'>
+                                        <path stroke-linecap='round' stroke-linejoin='round' d='M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z'/>
+                                    </svg>
+                                {/if}
+                            </button>
+                        {/if}
 
                         <!-- Deafen -->
                         <button

--- a/nodyx-frontend/src/lib/voice.ts
+++ b/nodyx-frontend/src/lib/voice.ts
@@ -539,6 +539,7 @@ function createPeerAudio(socketId: string, stream: MediaStream): void {
   // Volume mémorisé pour CET utilisateur (par userId → survit refresh/reconnexion)
   const peer = get(voiceStore).peers.find(p => p.socketId === socketId)
   audioEl.volume    = peer?.userId ? getPeerVolume(peer.userId) / 100 : 1.0
+  if (_currentSinkId) void _applySink(audioEl)   // adopte la sortie choisie (haut-parleur)
   audioEl.play().catch(() => {
     // Chrome desktop bloque l'autoplay si le contexte geste-utilisateur a expiré.
     // On réessaie au prochain clic ou frappe clavier (une seule fois suffit).
@@ -579,6 +580,66 @@ function createPeerAudio(socketId: string, stream: MediaStream): void {
   }, 100)
 
   _peerAudio.set(socketId, { audioEl, source, analyser, vadInterval })
+}
+
+// ── Sortie audio (Android : écouteur <-> haut-parleur via setSinkId) ─────────
+// Sur mobile, dès qu'un micro tourne, le système route le son vers l'ÉCOUTEUR
+// (mode « appel »), d'où l'obligation de coller le téléphone à l'oreille.
+// setSinkId permet de rediriger vers le haut-parleur. On applique le choix à TOUS
+// les <audio> de lecture (voix + son d'écran) et on le mémorise pour que les
+// éléments créés ensuite l'adoptent. iOS n'expose pas ça : le bouton n'apparaît
+// que si setSinkId existe (Android/desktop).
+export const audioOutputStore = writable<{ supported: boolean; onSpeaker: boolean }>({
+  supported: false, onSpeaker: false,
+})
+let _currentSinkId = ''                                   // '' = sortie système par défaut
+const _extraSinkEls = new Set<HTMLMediaElement>()         // éléments hors roster (son d'écran)
+
+function _sinkSupported(): boolean {
+  return typeof HTMLMediaElement !== 'undefined'
+    && typeof (HTMLMediaElement.prototype as unknown as { setSinkId?: unknown }).setSinkId === 'function'
+}
+
+async function _applySink(el: HTMLMediaElement): Promise<void> {
+  try { await (el as unknown as { setSinkId(id: string): Promise<void> }).setSinkId(_currentSinkId) }
+  catch { /* device parti / non supporté : on ignore */ }
+}
+
+/** Enregistre un <audio> hors roster (ex. son d'écran) pour qu'il suive la sortie. */
+export function registerSinkElement(el: HTMLMediaElement): () => void {
+  _extraSinkEls.add(el)
+  if (_currentSinkId) void _applySink(el)
+  return () => { _extraSinkEls.delete(el) }
+}
+
+/** Disponibilité du bouton : setSinkId présent (Android/desktop, pas iOS). */
+export async function refreshAudioOutputs(): Promise<void> {
+  audioOutputStore.update(s => ({ ...s, supported: _sinkSupported() }))
+}
+
+/** Cherche l'id d'une sortie dont le libellé matche, sinon ''. */
+async function _findOutput(re: RegExp): Promise<string> {
+  try {
+    const devs = await navigator.mediaDevices.enumerateDevices()
+    const outs = devs.filter(d => d.kind === 'audiooutput')
+    const match = outs.find(d => re.test(d.label))
+    if (match) return match.deviceId
+    // Repli : une sortie qui n'est ni « default » ni « communications » est
+    // souvent le haut-parleur sur Android.
+    const other = outs.find(d => d.deviceId !== 'default' && d.deviceId !== 'communications')
+    return other?.deviceId ?? ''
+  } catch { return '' }
+}
+
+/** Bascule écouteur <-> haut-parleur, appliqué à toutes les sorties de lecture. */
+export async function toggleSpeaker(): Promise<boolean> {
+  const cur = get(audioOutputStore)
+  const toSpeaker = !cur.onSpeaker
+  _currentSinkId = toSpeaker ? await _findOutput(/speaker|haut.?parleur/i) : ''
+  for (const node of _peerAudio.values()) await _applySink(node.audioEl)
+  for (const el of _extraSinkEls) await _applySink(el)
+  audioOutputStore.set({ supported: cur.supported, onSpeaker: toSpeaker })
+  return toSpeaker
 }
 
 function destroyPeerAudio(socketId: string): void {


### PR DESCRIPTION
Sur mobile le son part dans l'écouteur dès qu'un micro tourne. Ce bouton redirige tout le son de l'appel (voix + son d'écran) vers le haut-parleur via setSinkId, appliqué à tous les <audio> de lecture + ceux créés ensuite. Affiché seulement si setSinkId existe (Android/desktop, pas iOS). À VALIDER sur un vrai Android : le comportement de setSinkId y est variable.