### PR TITLE
feat(voice): éditeur Nodyx + modération dans le chat du salon vocal

### DIFF
--- a/nodyx-frontend/src/lib/components/StageChat.svelte
+++ b/nodyx-frontend/src/lib/components/StageChat.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    // ── Chat du salon, DANS la scène ──────────────────────────────────────────
+    // ── Chat du salon, DANS la scène ET dans le salon vocal ───────────────────
     //
     // Autonome par nécessité : les messages de la page chat sont un état LOCAL de
     // cette page. La scène vit au-dessus des pages (VoicePanel → +layout) et doit
@@ -9,10 +9,18 @@
     //
     // ⚠ On n'émet JAMAIS `chat:leave` : la page chat gère son propre cycle de vie,
     // un leave émis d'ici la sortirait de la room et lui couperait ses messages.
+    //
+    // Parité avec le chat principal : mêmes events (`chat:send/edit/delete`, reçus
+    // `chat:message_edited/deleted`), même éditeur Nodyx (TipTap) dans un modal, et
+    // la MÊME modération (supprimer le sien ou tout si admin, modifier le sien).
+    // Pensé MOBILE D'ABORD : actions au TAP (le survol n'existe pas au doigt), et
+    // l'éditeur riche s'ouvre en plein écran sur mobile, en carte sur desktop.
 
     import { socket } from '$lib/socket'
+    import { page } from '$app/stores'
     import { linkifyHtml } from '$lib/linkify'
     import { renderCustomEmojis, customEmojisStore } from '$lib/customEmojis'
+    import NodyxEditor from '$lib/components/editor/NodyxEditor.svelte'
 
     let {
         channelId,
@@ -23,16 +31,32 @@
     type StageMessage = {
         id:              string
         channel_id:      string
+        author_id:       string
         author_username: string
         author_avatar:   string | null
         content:         string | null
         created_at:      string
         is_deleted?:     boolean
+        is_edited?:      boolean
     }
 
-    let messages = $state<StageMessage[]>([])
-    let draft    = $state('')
-    let listEl   = $state<HTMLDivElement | null>(null)
+    let messages   = $state<StageMessage[]>([])
+    let draft      = $state('')
+    let listEl     = $state<HTMLDivElement | null>(null)
+    let openMenuId = $state<string | null>(null)   // message dont les actions sont dépliées
+
+    // ── Éditeur riche (modal) ─────────────────────────────────────────────────
+    let richOpen    = $state(false)
+    let richContent = $state('')
+    let richInitial = $state('')
+    let editingId   = $state<string | null>(null)  // null = nouveau message ; sinon édition
+    let editorKey   = $state(0)                     // remonte l'éditeur à chaque ouverture
+
+    // ── Qui suis-je (pour la modération) ──────────────────────────────────────
+    const me      = $derived(($page.data as { user?: { id?: string; role?: string } })?.user)
+    const userId  = $derived(me?.id ?? '')
+    const isAdmin = $derived(me?.role === 'owner' || me?.role === 'admin')
+    const canActOn = (m: StageMessage) => m.author_id === userId || isAdmin
 
     const emojis = $derived($customEmojisStore)
 
@@ -57,15 +81,26 @@
             messages = [...messages, msg]
             scrollToBottom()
         }
+        const onEdited = (p: { messageId: string; content: string }) => {
+            messages = messages.map(m => m.id === p.messageId ? { ...m, content: p.content, is_edited: true } : m)
+        }
+        const onDeleted = (p: { messageId: string }) => {
+            messages = messages.map(m => m.id === p.messageId ? { ...m, is_deleted: true, content: null } : m)
+        }
         sock.on('chat:history', onHistory)
         sock.on('chat:message', onMessage)
+        sock.on('chat:message_edited', onEdited)
+        sock.on('chat:message_deleted', onDeleted)
 
         return () => {
             sock.off('chat:history', onHistory)
             sock.off('chat:message', onMessage)
+            sock.off('chat:message_edited', onEdited)
+            sock.off('chat:message_deleted', onDeleted)
         }
     })
 
+    // ── Envoi rapide (une ligne, clavier natif) ───────────────────────────────
     function send(): void {
         const content = draft.trim()
         const sock    = $socket
@@ -79,6 +114,48 @@
     function onKeydown(e: KeyboardEvent): void {
         e.stopPropagation()
         if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send() }
+    }
+
+    // ── Éditeur riche (Nodyx / TipTap) ────────────────────────────────────────
+    function openRich(): void {
+        editingId = null
+        richInitial = ''
+        richContent = ''
+        editorKey++
+        richOpen = true
+    }
+    function startEdit(m: StageMessage): void {
+        openMenuId = null
+        editingId = m.id
+        richInitial = m.content ?? ''
+        richContent = m.content ?? ''
+        editorKey++
+        richOpen = true
+    }
+    function closeRich(): void {
+        richOpen = false
+        editingId = null
+        richContent = ''
+    }
+    function sendRich(): void {
+        const sock = $socket
+        const html = richContent.trim()
+        if (!sock || !html) return
+        if (editingId) {
+            sock.emit('chat:edit', { messageId: editingId, content: html })
+        } else if (channelId) {
+            sock.emit('chat:send', { channelId, content: html })
+        }
+        closeRich()
+    }
+
+    // ── Suppression ───────────────────────────────────────────────────────────
+    function confirmDelete(id: string): void {
+        openMenuId = null
+        const sock = $socket
+        if (!sock) return
+        if (typeof window !== 'undefined' && !window.confirm('Supprimer ce message ?')) return
+        sock.emit('chat:delete', { messageId: id })
     }
 
     function hhmm(iso: string): string {
@@ -123,7 +200,9 @@
             </p>
         {/if}
         {#each messages as msg (msg.id)}
-            {#if !msg.is_deleted && msg.content}
+            {#if msg.is_deleted}
+                <p class="pl-8 text-[11px] italic" style="color: rgba(255,255,255,0.25)">Message supprimé</p>
+            {:else if msg.content}
                 <div class="flex gap-2.5">
                     {#if msg.author_avatar}
                         <img src={msg.author_avatar} alt={msg.author_username}
@@ -137,6 +216,35 @@
                         <div class="flex items-baseline gap-2">
                             <span class="truncate text-xs font-semibold text-white">{msg.author_username}</span>
                             <span class="shrink-0 text-[10px]" style="color: rgb(75,85,99)">{hhmm(msg.created_at)}</span>
+                            {#if msg.is_edited}
+                                <span class="shrink-0 text-[9px]" style="color: rgb(75,85,99)">(modifié)</span>
+                            {/if}
+                            <!-- Actions : au TAP (mobile-first), pas au survol -->
+                            {#if canActOn(msg)}
+                                <div class="ml-auto flex shrink-0 items-center gap-0.5">
+                                    {#if openMenuId === msg.id}
+                                        {#if msg.author_id === userId}
+                                            <button onclick={() => startEdit(msg)} title="Modifier" aria-label="Modifier"
+                                                    class="rounded p-1 transition-colors hover:bg-white/10" style="color: rgb(129,140,248)">
+                                                <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+                                            </button>
+                                        {/if}
+                                        <button onclick={() => confirmDelete(msg.id)} title="Supprimer" aria-label="Supprimer"
+                                                class="rounded p-1 transition-colors hover:bg-white/10" style="color: rgb(248,113,113)">
+                                            <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4h6v2"/></svg>
+                                        </button>
+                                        <button onclick={() => openMenuId = null} title="Fermer" aria-label="Fermer"
+                                                class="rounded p-1 transition-colors hover:bg-white/10" style="color: rgb(107,114,128)">
+                                            <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                                        </button>
+                                    {:else}
+                                        <button onclick={() => openMenuId = msg.id} title="Actions" aria-label="Actions du message"
+                                                class="rounded p-1 transition-colors hover:bg-white/10" style="color: rgb(107,114,128)">
+                                            <svg class="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="5" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="12" cy="19" r="1.6"/></svg>
+                                        </button>
+                                    {/if}
+                                </div>
+                            {/if}
                         </div>
                         <div class="stage-msg break-words text-[13px]" style="color: rgb(209,213,219)">
                             {@html renderCustomEmojis(linkifyHtml(msg.content ?? ''), emojis)}
@@ -149,8 +257,19 @@
 
     <!-- Composeur -->
     <div class="shrink-0 p-3" style="border-top: 1px solid rgba(255,255,255,0.05)">
-        <div class="flex items-end gap-2 rounded-lg px-3 py-2"
+        <div class="flex items-center gap-2 rounded-lg px-3 py-2"
              style="background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.07)">
+            <button
+                onclick={openRich}
+                aria-label="Éditeur enrichi"
+                title="Éditeur enrichi (mise en forme, liens, images…)"
+                class="shrink-0 rounded-md p-1 transition-colors hover:bg-white/10"
+                style="color: rgb(107,114,128)"
+            >
+                <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 4h8a4 4 0 0 1 0 8H6zM6 12h9a4 4 0 0 1 0 8H6z"/>
+                </svg>
+            </button>
             <input
                 bind:value={draft}
                 onkeydown={onKeydown}
@@ -171,6 +290,49 @@
         </div>
     </div>
 </div>
+
+<!-- Éditeur riche : plein écran sur mobile, carte centrée sur desktop -->
+{#if richOpen}
+    <div class="fixed inset-0 z-[400] flex sm:items-center sm:justify-center sm:p-4"
+         style="background: rgba(0,0,0,0.7); backdrop-filter: blur(4px)">
+        <button class="absolute inset-0 cursor-default" aria-label="Fermer" onclick={closeRich}></button>
+        <div class="relative flex h-full w-full flex-col overflow-hidden sm:h-auto sm:max-h-[80vh] sm:max-w-lg sm:rounded-2xl"
+             style="background: #0a0a12; border: 1px solid rgb(var(--nx-accent-rgb) / 0.2)">
+            <div class="flex shrink-0 items-center justify-between px-5 py-4"
+                 style="border-bottom: 1px solid rgba(255,255,255,0.06)">
+                <h3 class="text-sm font-bold text-white">{editingId ? 'Modifier le message' : 'Nouveau message'}</h3>
+                <button onclick={closeRich} aria-label="Fermer"
+                        class="rounded-lg p-1.5 text-gray-500 transition-colors hover:text-white">
+                    <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="flex-1 overflow-y-auto p-4">
+                {#key editorKey}
+                    <NodyxEditor
+                        compact={false}
+                        initialContent={richInitial}
+                        onchange={(v) => { richContent = v }}
+                    />
+                {/key}
+            </div>
+            <div class="flex shrink-0 justify-end gap-3 px-5 py-4"
+                 style="border-top: 1px solid rgba(255,255,255,0.06)">
+                <button onclick={closeRich}
+                        class="rounded-lg px-4 py-2 text-sm font-medium text-gray-200 transition-colors"
+                        style="background: rgba(255,255,255,0.06)">
+                    Annuler
+                </button>
+                <button onclick={sendRich} disabled={!richContent.trim()}
+                        class="rounded-lg px-4 py-2 text-sm font-semibold text-white transition-all disabled:opacity-40"
+                        style="background: rgb(79,70,229)">
+                    {editingId ? 'Enregistrer' : 'Envoyer'}
+                </button>
+            </div>
+        </div>
+    </div>
+{/if}
 
 <style>
     /* Le contenu vient de l'éditeur (HTML assaini côté serveur) : on borne juste


### PR DESCRIPTION
Le chat du vocal (StageChat, partagé Stage + salon vocal) passe au niveau du chat principal : éditeur Nodyx (TipTap) dans un modal responsive (plein écran mobile, carte desktop), et modération au TAP (menu ⋮ : supprimer le sien ou tout si admin, modifier le sien). Réutilise les events backend existants (chat:send/edit/delete, chat:message_edited/deleted), zéro changement serveur. Mobile-first.