### PR TITLE
feat(voice): un équaliseur RÉEL par personne (fini les barres factices)

### DIFF
--- a/nodyx-frontend/src/lib/components/VoiceEqualizer.svelte
+++ b/nodyx-frontend/src/lib/components/VoiceEqualizer.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+    // ── Équaliseur vocal RÉEL ────────────────────────────────────────────────
+    //
+    // Remplace les anciennes barres FACTICES (une animation CSS `vc-wave` en
+    // boucle, déclenchée par le booléen `speaking` : elles ondulaient pareil
+    // qu'on chuchote ou qu'on crie).
+    //
+    // Ici on lit le VRAI spectre de la personne via son AnalyserNode, en
+    // `requestAnimationFrame`. On ne passe PAS par le store : à 60 fps ça
+    // re-rendrait tout le roster pour rien. Même patron que le visualiseur du
+    // lecteur audio (AudioRecorder), adapté à la voix.
+
+    import { onDestroy } from 'svelte'
+    import { getPeerAnalyser, getLocalAnalyser } from '$lib/voice'
+
+    let {
+        socketId = null,
+        isMe = false,
+        bars = 3,
+        color = '#4ade80',
+    }: {
+        socketId?: string | null
+        isMe?: boolean
+        bars?: number
+        color?: string
+    } = $props()
+
+    // Repos = barres basses mais visibles (comme l'ancien rendu au repos).
+    const FLOOR = 0.2
+
+    let levels = $state<number[]>(Array(bars).fill(FLOOR))
+    let raf: number | null = null
+    let buf: Uint8Array<ArrayBuffer> | null = null
+
+    function analyser(): AnalyserNode | null {
+        if (isMe) return getLocalAnalyser()
+        return socketId ? getPeerAnalyser(socketId) : null
+    }
+
+    function tick(): void {
+        const a = analyser()
+        if (a) {
+            if (!buf || buf.length !== a.frequencyBinCount) buf = new Uint8Array(a.frequencyBinCount)
+            a.getByteFrequencyData(buf)
+            // La voix vit dans le BAS du spectre (~85 Hz à 3,5 kHz). L'analyser
+            // couvre jusqu'à ~24 kHz : lire tout le spectre écraserait les barres
+            // (le haut est vide en permanence). On ne garde donc que le début.
+            const usable   = Math.min(buf.length, 36)
+            const bandSize = Math.max(1, Math.floor(usable / bars))
+            const out: number[] = []
+            for (let i = 0; i < bars; i++) {
+                let sum = 0
+                for (let j = 0; j < bandSize; j++) sum += buf[i * bandSize + j]
+                const v = sum / (bandSize * 160)     // 0..255 par bin → ~0..1
+                out.push(Math.max(FLOOR, Math.min(1, v)))
+            }
+            levels = out
+        }
+        raf = requestAnimationFrame(tick)
+    }
+
+    $effect(() => {
+        raf = requestAnimationFrame(tick)
+        return () => {
+            if (raf !== null) cancelAnimationFrame(raf)
+            raf = null
+        }
+    })
+
+    onDestroy(() => { if (raf !== null) cancelAnimationFrame(raf) })
+</script>
+
+<div class="vc-eq shrink-0" aria-label="Parle">
+    {#each levels as l, i (i)}
+        <span class="vc-eq-bar" style="transform: scaleY({l}); background: {color}"></span>
+    {/each}
+</div>
+
+<style>
+    .vc-eq {
+        display: flex;
+        align-items: flex-end;
+        gap: 2px;
+        height: 12px;
+        width: 14px;
+    }
+    .vc-eq-bar {
+        display: block;
+        width: 2.5px;
+        height: 100%;
+        border-radius: 1px;
+        transform-origin: bottom center;
+        /* Court, pour lisser le rendu sans traîner derrière la voix. */
+        transition: transform 60ms linear;
+    }
+</style>

--- a/nodyx-frontend/src/lib/components/VoicePanel.svelte
+++ b/nodyx-frontend/src/lib/components/VoicePanel.svelte
@@ -1290,6 +1290,4 @@ input[type=range]::-moz-range-thumb:hover {
 }
 
 
-@keyframes sound-wave {}
-@keyframes sound-wave-small {}
 </style>

--- a/nodyx-frontend/src/lib/voice.ts
+++ b/nodyx-frontend/src/lib/voice.ts
@@ -642,6 +642,23 @@ export async function toggleSpeaker(): Promise<boolean> {
   return toSpeaker
 }
 
+// ── Accès au signal (pour un équaliseur RÉEL) ────────────────────────────────
+// Le VAD calcule déjà un niveau par personne… mais n'en garde qu'un booléen
+// `speaking`. Du coup toute barre de niveau ne pouvait être que FACTICE (une
+// animation CSS en boucle). On expose donc l'analyser lui-même : un composant
+// peut y lire le vrai spectre en `requestAnimationFrame`, sans passer par le
+// store (pas de re-render du roster à 60 fps).
+
+/** Analyser d'un pair (tap passif sur son flux entrant). */
+export function getPeerAnalyser(socketId: string): AnalyserNode | null {
+  return _peerAudio.get(socketId)?.analyser ?? null
+}
+
+/** Analyser de MON micro (en sortie de la chaîne de traitement). */
+export function getLocalAnalyser(): AnalyserNode | null {
+  return _localChain?.analyser ?? null
+}
+
 function destroyPeerAudio(socketId: string): void {
   const node = _peerAudio.get(socketId)
   if (node) {

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -18,6 +18,7 @@
 	import CommandPalette from '$lib/components/CommandPalette.svelte';
 	import MatrixRain from '$lib/components/MatrixRain.svelte';
 	import MemberScreenPreview from '$lib/components/MemberScreenPreview.svelte';
+	import VoiceEqualizer from '$lib/components/VoiceEqualizer.svelte';
 	import MaintenanceBanner from '$lib/components/MaintenanceBanner.svelte';
 	import NodyxVersionBadge from '$lib/components/NodyxVersionBadge.svelte';
 	import FloatingReactions from '$lib/components/FloatingReactions.svelte';
@@ -1065,11 +1066,10 @@
 
 										<!-- Right: wave bars if speaking, else status icons -->
 										{#if m.speaking && !m.muted && !m.deafened}
-											<div class="vc-wave-bars shrink-0" aria-label="Parle">
-												<span class="vc-bar" style="animation-delay:0s"></span>
-												<span class="vc-bar" style="animation-delay:0.18s"></span>
-												<span class="vc-bar" style="animation-delay:0.09s"></span>
-											</div>
+											<!-- Équaliseur RÉEL : lit le vrai spectre de la personne
+											     (avant : une animation CSS en boucle, identique quoi
+											     qu'on dise). -->
+											<VoiceEqualizer socketId={m.socketId} isMe={m.isMe} />
 										{:else}
 											<div class="flex items-center gap-0.5 shrink-0">
 												{#if m.deafened}
@@ -1877,26 +1877,7 @@
 }
 
 /* Animated equalizer bars — shown when a member is speaking */
-.vc-wave-bars {
-	display: flex;
-	align-items: flex-end;
-	gap: 2px;
-	height: 12px;
-	width: 14px;
-}
-.vc-bar {
-	display: block;
-	width: 2.5px;
-	background: #4ade80;
-	border-radius: 1px;
-	transform-origin: bottom center;
-	animation: vc-wave 0.65s ease-in-out infinite;
-	height: 100%;
-}
-@keyframes vc-wave {
-	0%, 100% { transform: scaleY(0.25); opacity: 0.55 }
-	50%       { transform: scaleY(1);    opacity: 1    }
-}
+
 
 /* ── Layout channel sub-labels (Texte / Vocal) ───────────────────────────── */
 .lch-sublabel {


### PR DESCRIPTION
Les barres du roster vocal étaient une animation CSS en boucle déclenchée par le booléen speaking (identiques qu'on chuchote ou qu'on crie). Cause racine : le VAD calcule un niveau par personne puis le JETTE (ne garde qu'un booléen). On expose les analysers (getPeerAnalyser/getLocalAnalyser) et un composant VoiceEqualizer lit le vrai spectre en rAF, hors du store, réglé pour la voix (bas du spectre). Nettoyage du code mort (vc-wave, @keyframes sound-wave vides).