### PR TITLE
feat(voice): les statuts dans le roster du canal (muet, sourd, partage)

### DIFF
--- a/nodyx-core/src/socket/index.ts
+++ b/nodyx-core/src/socket/index.ts
@@ -35,6 +35,12 @@ declare module 'socket.io' {
     nameFontUrl?:      string | null
     grade?:            { name: string; color: string } | null
     status?:           { emoji: string; text: string } | null
+    /** État vocal volatile (muet / sourd / partage d'écran), publié par le client
+     *  via `voice:state`. Sert à enrichir le roster d'un canal vocal
+     *  (`voice:channel_update`) : sans lui, l'écran d'un canal qu'on n'a PAS
+     *  rejoint ne peut pas montrer qui est muet, sourd ou en train de partager.
+     *  Volatile par nature : rien en base, remis à zéro à chaque `voice:join`. */
+    voiceState?:       { muted: boolean; deafened: boolean; sharing: boolean } | null
   }
 }
 

--- a/nodyx-core/src/socket/rateLimiter.ts
+++ b/nodyx-core/src/socket/rateLimiter.ts
@@ -36,6 +36,9 @@ export const RATE_RULES: Record<string, RuleConfig[]> = {
   'whisper:message':      [{ limit: 5,  windowMs: 1_000  }],
   'whisper:typing':       [{ limit: 3,  windowMs: 1_000  }],
   'voice:speaking':       [{ limit: 10, windowMs: 1_000  }],
+  // muet/sourd/partage : gestes humains, rares. Borné car chaque envoi rediffuse
+  // le roster du canal (fetchSockets), donc on ne veut pas que ça puisse spammer.
+  'voice:state':          [{ limit: 5,  windowMs: 2_000  }],
   'jukebox:update':       [{ limit: 5,  windowMs: 1_000  }],
   'jukebox:request_sync': [{ limit: 3,  windowMs: 1_000  }],
   'voice:ping':           [{ limit: 3,  windowMs: 1_000  }],

--- a/nodyx-core/src/socket/voice.ts
+++ b/nodyx-core/src/socket/voice.ts
@@ -118,6 +118,11 @@ async function broadcastVoiceChannelUpdate(
       username:  s.data.username,
       avatar:    s.data.avatar ?? null,
       seatIndex: seatsMap.get(s.id) ?? 0,
+      // État volatile publié par le client (voice:state). Permet à l'écran d'un
+      // canal NON rejoint de montrer qui est muet / sourd / en train de partager.
+      muted:     s.data.voiceState?.muted    === true,
+      deafened:  s.data.voiceState?.deafened === true,
+      sharing:   s.data.voiceState?.sharing  === true,
     }))
   // Emit to presence (sidebar overview) AND voice room (handles presence-join timing edge cases)
   server.to('presence').to(voiceRoom(channelId)).emit('voice:channel_update', { channelId, members })
@@ -171,6 +176,11 @@ export function registerVoiceHandlers(socket: Socket, server: Server): void {
         avatar:    s.data.avatar ?? null,
         seatIndex: seatsMap.get(s.id) ?? 0,
       }))
+
+    // État vocal volatile : on repart propre à chaque arrivée (un rejoin ne doit
+    // pas traîner le « muet » d'une session précédente). Le client republie son
+    // état réel juste après, via voice:state.
+    socket.data.voiceState = null
 
     // Join the room
     socket.join(room)
@@ -315,6 +325,28 @@ export function registerVoiceHandlers(socket: Socket, server: Server): void {
     // Must be in the voice room to broadcast speaking state to its members.
     if (!socket.rooms.has(voiceRoom(channelId))) return
     socket.to(voiceRoom(channelId)).emit('voice:speaking', { socketId: socket.id, userId, speaking })
+  })
+
+  // ── voice:state — muet / sourd / partage, pour le roster du canal ─────────
+  // Le roster (voice:channel_update) ne portait que l'identité : l'écran d'un
+  // canal qu'on n'a PAS rejoint ne pouvait donc pas montrer qui est muet, sourd
+  // ou en train de partager. Le client publie ici son état ; on le garde sur le
+  // socket (volatile, rien en base) et on rediffuse le roster.
+  socket.on('voice:state', (
+    { channelId, muted, deafened, sharing }:
+    { channelId: string; muted?: unknown; deafened?: unknown; sharing?: unknown },
+  ) => {
+    if (checkRateLimit(userId, 'voice:state')) return
+    if (!isUuid(channelId)) return
+    // Doit être DANS le vocal : on ne publie pas l'état d'un canal qu'on ne
+    // fréquente pas.
+    if (!socket.rooms.has(voiceRoom(channelId))) return
+    socket.data.voiceState = {
+      muted:    muted    === true,
+      deafened: deafened === true,
+      sharing:  sharing  === true,
+    }
+    void broadcastVoiceChannelUpdate(server, channelId)
   })
 
   // ── voice:ping — keep presence alive + refresh sidebar for caller ──────────

--- a/nodyx-frontend/src/lib/components/Table.svelte
+++ b/nodyx-frontend/src/lib/components/Table.svelte
@@ -237,15 +237,46 @@
 					</p>
 					<div class="flex flex-wrap items-start justify-center gap-4 max-w-lg">
 						{#each present.slice(0, 8) as m (m.userId)}
-							<div class="flex w-16 flex-col items-center gap-1.5" title={m.username}>
-								<div class="h-12 w-12 overflow-hidden rounded-full transition-transform duration-300 hover:scale-110"
-								     style="box-shadow: 0 0 0 2px rgb(var(--nx-accent-2-rgb) / 0.5), 0 0 20px rgb(var(--nx-accent-2-rgb) / 0.25)">
-									{#if m.avatar}
-										<img src={m.avatar} alt={m.username} class="h-full w-full object-cover"/>
-									{:else}
-										<div class="flex h-full w-full items-center justify-center text-sm font-black text-white select-none"
-										     style="background: linear-gradient(135deg, var(--nx-accent-2-strong), var(--nx-cyan-deep))">
-											{m.username.charAt(0).toUpperCase()}
+							<div class="flex w-16 flex-col items-center gap-1.5"
+							     title="{m.username}{m.sharing ? ' · partage son écran' : ''}{m.deafened ? ' · écouteurs coupés' : m.muted ? ' · micro coupé' : ''}">
+								<div class="relative">
+									<div class="h-12 w-12 overflow-hidden rounded-full transition-transform duration-300 hover:scale-110"
+									     style="box-shadow: 0 0 0 2px {m.sharing ? '#3b82f6' : 'rgb(var(--nx-accent-2-rgb) / 0.5)'}, 0 0 20px {m.sharing ? 'rgba(59,130,246,0.35)' : 'rgb(var(--nx-accent-2-rgb) / 0.25)'}">
+										{#if m.avatar}
+											<img src={m.avatar} alt={m.username} class="h-full w-full object-cover"/>
+										{:else}
+											<div class="flex h-full w-full items-center justify-center text-sm font-black text-white select-none"
+											     style="background: linear-gradient(135deg, var(--nx-accent-2-strong), var(--nx-cyan-deep))">
+												{m.username.charAt(0).toUpperCase()}
+											</div>
+										{/if}
+									</div>
+
+									<!-- Badges d'état : la vraie vie du salon, visible AVANT d'entrer.
+									     Sourd prime sur muet (on n'entend déjà plus rien). -->
+									{#if m.sharing}
+										<div class="absolute -left-0.5 -top-0.5 flex h-4 w-4 items-center justify-center rounded-full"
+										     style="background:#3b82f6; border:2px solid #0d0d12" aria-label="Partage son écran">
+											<svg class="h-2 w-2" fill="none" stroke="white" stroke-width="3" viewBox="0 0 24 17">
+												<rect x="1" y="1" width="22" height="13" rx="2"/>
+											</svg>
+										</div>
+									{/if}
+									{#if m.deafened}
+										<div class="absolute -bottom-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full"
+										     style="background:#fb923c; border:2px solid #0d0d12" aria-label="Écouteurs coupés">
+											<svg class="h-2.5 w-2.5" fill="none" stroke="white" stroke-width="3" viewBox="0 0 24 24">
+												<path stroke-linecap="round" d="M3 18v-6a9 9 0 0118 0v6"/>
+												<path stroke-linecap="round" d="M2 2l20 20"/>
+											</svg>
+										</div>
+									{:else if m.muted}
+										<div class="absolute -bottom-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full"
+										     style="background:#ef4444; border:2px solid #0d0d12" aria-label="Micro coupé">
+											<svg class="h-2.5 w-2.5" fill="none" stroke="white" stroke-width="3" viewBox="0 0 24 24">
+												<path stroke-linecap="round" d="M12 15a3 3 0 003-3V6a3 3 0 00-6 0v6a3 3 0 003 3z"/>
+												<path stroke-linecap="round" d="M2 2l20 20"/>
+											</svg>
 										</div>
 									{/if}
 								</div>

--- a/nodyx-frontend/src/lib/voice.ts
+++ b/nodyx-frontend/src/lib/voice.ts
@@ -121,7 +121,17 @@ export const localScreenStore  = writable<MediaStream | null>(null)
 export const remoteScreenStore = writable<Map<string, MediaStream>>(new Map())
 
 // ── Voice channel member roster (populated by socket voice:channel_update) ──
-export interface VoiceChannelMember { userId: string; username: string; avatar: string | null }
+export interface VoiceChannelMember {
+  userId:    string
+  username:  string
+  avatar:    string | null
+  /** État publié par chaque membre via `voice:state` (cf serveur). Permet à
+   *  l'écran d'un canal qu'on n'a PAS rejoint de montrer la vraie vie du salon :
+   *  qui est muet, qui a coupé ses écouteurs, qui partage son écran. */
+  muted?:    boolean
+  deafened?: boolean
+  sharing?:  boolean
+}
 export const voiceChannelMembersStore = writable<Record<string, VoiceChannelMember[]>>({})
 
 // ── Voice join/leave toast events ────────────────────────────────────────────
@@ -1137,12 +1147,30 @@ export function kickPeer(targetSocketId: string): void {
   _socket.emit('voice:kick', { channelId, targetSocketId })
 }
 
+// ── Publication de MON état vocal (muet / sourd / partage) ──────────────────
+// Le serveur ne peut pas deviner ces états : ils vivent dans le navigateur. On
+// les lui publie donc à chaque changement, pour qu'il les mette dans le roster
+// du canal (voice:channel_update). Sans ça, l'écran d'un canal qu'on n'a PAS
+// rejoint ne peut pas montrer qui est muet, sourd ou en train de partager.
+// Appelé aux gestes humains (rares) : jamais dans une boucle.
+export function publishVoiceState(): void {
+  const s = get(voiceStore)
+  if (!_socket || !s.active || !s.channelId) return
+  _socket.emit('voice:state', {
+    channelId: s.channelId,
+    muted:     s.muted,
+    deafened:  s.deafened,
+    sharing:   get(screenShareStore),
+  })
+}
+
 export function toggleMute(): void {
   if (!_localStream) return
   const track = _localStream.getAudioTracks()[0]
   if (!track) return
   track.enabled = !track.enabled
   voiceStore.update(s => ({ ...s, muted: !track.enabled }))
+  publishVoiceState()
 }
 
 export function toggleDeafen(): void {
@@ -1154,6 +1182,7 @@ export function toggleDeafen(): void {
     }
     return { ...s, deafened }
   })
+  publishVoiceState()
 }
 
 export function togglePTTMode(): void {
@@ -1283,6 +1312,7 @@ export async function startScreenShare(
     _screenStream = displayStream
     localScreenStore.set(displayStream)
     screenShareStore.set(true)
+    publishVoiceState()   // le roster du canal doit montrer « partage son écran »
 
     // Le partage d'écran est PRÉCISÉMENT le moment où le mesh s'écroule : le
     // partageur y uploade sa vidéo UNE FOIS PAR SPECTATEUR, et il plafonne vers 4
@@ -1341,6 +1371,7 @@ export function stopScreenShare(): void {
 
   screenShareStore.set(false)
   localScreenStore.set(null)
+  publishVoiceState()
 
   if (!channelId) return
 


### PR DESCRIPTION
Suite de l'aperçu : on voyait qui est là, pas son état. nodyx-core (validé par le proprio) : SocketData.voiceState volatile (reset au join), handler voice:state calqué sur voice:speaking (rate-limit 5/2s car chaque envoi rediffuse le roster, isUuid, appartenance room), et broadcastVoiceChannelUpdate enrichi. Client : publishVoiceState() aux gestes humains seulement. UI : badges partage/sourd/muet sur les avatars de l'aperçu. Core : typecheck OK + 401 tests verts.