### PR TITLE
feat(voice): le VRAI équaliseur aussi sur la scène du salon (le plus visible)

### DIFF
--- a/nodyx-frontend/src/lib/components/Table.svelte
+++ b/nodyx-frontend/src/lib/components/Table.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { voiceStore, setPeerVolume, inputLevel, peerStatsStore, getQuality, kickPeer, voiceChannelMembersStore } from '$lib/voice'
 	import { jukeboxStore, initJukebox, cleanupJukebox, mountYTPlayer, jukeboxLoad } from '$lib/jukebox'
+	import VoiceEqualizer from '$lib/components/VoiceEqualizer.svelte'
 	import { goto } from '$app/navigation'
 	import { PUBLIC_API_URL } from '$env/static/public'
 	import { page } from '$app/stores'
@@ -430,16 +431,28 @@
 								{p.isMe ? 'Vous' : p.username}
 							</span>
 
-							<!-- 7-bar EQ — gradient violet → cyan, 16px tall -->
-							<div class="flex items-end gap-[2.5px] transition-opacity duration-300"
-							     style="height:16px; opacity:{isSpeaking || myActive ? 1 : 0};">
-								{#each [
-									{c:'var(--nx-accent-deep)',d:'0.00s'},{c:'var(--nx-accent-2-strong)',d:'0.14s'},{c:'var(--nx-accent-2-mid)',d:'0.05s'},
-									{c:'var(--nx-accent-2-soft)',d:'0.22s'},{c:'var(--nx-cyan-soft)',d:'0.09s'},{c:'#22d3ee',d:'0.17s'},
-									{c:'var(--nx-cyan-soft)',d:'0.03s'}
-								] as bar}
-									<div class="w-[2.5px] rounded-sm eq-bar" style="background:{bar.c}; animation-delay:{bar.d}"></div>
-								{/each}
+							<!-- ÉQUALISEUR RÉEL — dégradé violet → cyan.
+							     Avant : une animation CSS en boucle (animation-delay), donc le
+							     MÊME dessin pour tout le monde, en permanence. Maintenant chaque
+							     barre suit le vrai spectre de la personne. Ici on a la place, donc
+							     on est plus généreux qu'en sidebar (plus haut, plus large).
+							     Au repos les barres retombent d'elles-mêmes : on garde l'EQ
+							     visible en sourdine plutôt que de le faire disparaître, ça montre
+							     que la personne est là, simplement silencieuse. -->
+							<div class="transition-opacity duration-300"
+							     style="opacity:{isSpeaking || myActive ? 1 : 0.35};">
+								<VoiceEqualizer
+									socketId={p.socketId}
+									isMe={p.isMe}
+									height={26}
+									barWidth={3.5}
+									gap={3}
+									colors={[
+										'var(--nx-accent-deep)', 'var(--nx-accent-2-strong)', 'var(--nx-accent-2-mid)',
+										'var(--nx-accent-2-soft)', 'var(--nx-cyan-soft)', '#22d3ee',
+										'var(--nx-cyan-soft)',
+									]}
+								/>
 							</div>
 						</div>
 
@@ -678,14 +691,6 @@
 	}
 
 	/* ── Barres égaliseur ────────────────────────────────────────────────── */
-	@keyframes eq-dance {
-		0%, 100% { height: 25%; }
-		50%       { height: 100%; }
-	}
-	.eq-bar {
-		height: 100%;
-		animation: eq-dance 0.75s ease-in-out infinite;
-	}
 
 	/* ── Mini vinyle Jukebox ─────────────────────────────────────────────── */
 	@keyframes vinyl-spin {

--- a/nodyx-frontend/src/lib/components/VoiceEqualizer.svelte
+++ b/nodyx-frontend/src/lib/components/VoiceEqualizer.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     // ── Équaliseur vocal RÉEL ────────────────────────────────────────────────
     //
-    // Remplace les anciennes barres FACTICES (une animation CSS `vc-wave` en
-    // boucle, déclenchée par le booléen `speaking` : elles ondulaient pareil
-    // qu'on chuchote ou qu'on crie).
+    // Remplace les barres FACTICES (une animation CSS en boucle, déclenchée par
+    // le seul booléen `speaking` : elles ondulaient à l'identique qu'on chuchote
+    // ou qu'on crie, et toutes les personnes avaient exactement le même dessin).
     //
     // Ici on lit le VRAI spectre de la personne via son AnalyserNode, en
     // `requestAnimationFrame`. On ne passe PAS par le store : à 60 fps ça
@@ -18,17 +18,30 @@
         isMe = false,
         bars = 3,
         color = '#4ade80',
+        colors = null,
+        height = 12,
+        barWidth = 2.5,
+        gap = 2,
     }: {
         socketId?: string | null
-        isMe?: boolean
-        bars?: number
-        color?: string
+        isMe?:     boolean
+        /** Nombre de barres (ignoré si `colors` est fourni). */
+        bars?:     number
+        /** Couleur unique. */
+        color?:    string
+        /** Couleur PAR barre (dégradé) : sa longueur fixe le nombre de barres. */
+        colors?:   string[] | null
+        height?:   number
+        barWidth?: number
+        gap?:      number
     } = $props()
 
-    // Repos = barres basses mais visibles (comme l'ancien rendu au repos).
-    const FLOOR = 0.2
+    // Repos = barres basses mais visibles (la personne est là, elle se tait).
+    const FLOOR = 0.18
 
-    let levels = $state<number[]>(Array(bars).fill(FLOOR))
+    const count = $derived(colors?.length ?? bars)
+
+    let levels = $state<number[]>([])
     let raf: number | null = null
     let buf: Uint8Array<ArrayBuffer> | null = null
 
@@ -38,6 +51,7 @@
     }
 
     function tick(): void {
+        const n = count
         const a = analyser()
         if (a) {
             if (!buf || buf.length !== a.frequencyBinCount) buf = new Uint8Array(a.frequencyBinCount)
@@ -46,20 +60,23 @@
             // couvre jusqu'à ~24 kHz : lire tout le spectre écraserait les barres
             // (le haut est vide en permanence). On ne garde donc que le début.
             const usable   = Math.min(buf.length, 36)
-            const bandSize = Math.max(1, Math.floor(usable / bars))
+            const bandSize = Math.max(1, Math.floor(usable / n))
             const out: number[] = []
-            for (let i = 0; i < bars; i++) {
+            for (let i = 0; i < n; i++) {
                 let sum = 0
                 for (let j = 0; j < bandSize; j++) sum += buf[i * bandSize + j]
                 const v = sum / (bandSize * 160)     // 0..255 par bin → ~0..1
                 out.push(Math.max(FLOOR, Math.min(1, v)))
             }
             levels = out
+        } else if (levels.length !== n) {
+            levels = Array(n).fill(FLOOR)
         }
         raf = requestAnimationFrame(tick)
     }
 
     $effect(() => {
+        levels = Array(count).fill(FLOOR)
         raf = requestAnimationFrame(tick)
         return () => {
             if (raf !== null) cancelAnimationFrame(raf)
@@ -70,9 +87,12 @@
     onDestroy(() => { if (raf !== null) cancelAnimationFrame(raf) })
 </script>
 
-<div class="vc-eq shrink-0" aria-label="Parle">
+<div class="vc-eq" style="height: {height}px; gap: {gap}px" aria-hidden="true">
     {#each levels as l, i (i)}
-        <span class="vc-eq-bar" style="transform: scaleY({l}); background: {color}"></span>
+        <span
+            class="vc-eq-bar"
+            style="width: {barWidth}px; transform: scaleY({l}); background: {colors?.[i] ?? color}"
+        ></span>
     {/each}
 </div>
 
@@ -80,13 +100,10 @@
     .vc-eq {
         display: flex;
         align-items: flex-end;
-        gap: 2px;
-        height: 12px;
-        width: 14px;
+        flex-shrink: 0;
     }
     .vc-eq-bar {
         display: block;
-        width: 2.5px;
         height: 100%;
         border-radius: 1px;
         transform-origin: bottom center;


### PR DESCRIPTION
Les barres de la sidebar étaient corrigées, mais pas celles de la zone principale (les plus regardées) : EQ 7 barres animé par @keyframes eq-dance en boucle, identique pour tous. Elles suivent maintenant le vrai spectre de chaque personne, en profitant de la place (26px de haut, dégradé violet->cyan conservé). VoiceEqualizer accepte hauteur/largeur/écart/couleur par barre. Nettoyage du CSS mort.