### PR TITLE
feat(content): taille dédiée pour un embed Twitch avec chat

### DIFF
--- a/nodyx-frontend/src/app.css
+++ b/nodyx-frontend/src/app.css
@@ -510,6 +510,23 @@ select option {
     border: 1px solid rgb(55 65 81);
     margin: 0.75rem 0;
 }
+
+/* ── Embed Twitch AVEC chat : <iframe data-type="twitch-chat"> ───────────────
+   Un lecteur seul se contente du 16/9 ci-dessus. Avec le chat, Twitch colle une
+   colonne d'environ 340px à droite : un 16/9 sur une large colonne d'article
+   donnerait un bloc démesurément haut, et la vidéo resterait letterboxée. On lui
+   donne donc une hauteur fixe confortable et on borne la largeur pour que la
+   vidéo garde une taille lisible à côté du chat. */
+.nodyx-prose iframe[data-type="twitch-chat"] {
+    aspect-ratio: auto;
+    height: 480px;
+    max-width: 1000px;
+}
+@media (max-width: 640px) {
+    /* Sous ~660px, Twitch empile le chat SOUS la vidéo : il faut de la hauteur,
+       sinon les deux sont écrasés. */
+    .nodyx-prose iframe[data-type="twitch-chat"] { height: 560px; }
+}
 /* Wrapper YouTube injecté par l'extension */
 .nodyx-prose .youtube-wrapper,
 .nodyx-content .tiptap .youtube-wrapper {


### PR DESCRIPTION
Le CSS imposait un 16/9 à tous les iframes : correct pour un lecteur seul, inadapté à un embed Twitch avec chat (colonne de ~340px à droite, d'où un bloc trop haut et une vidéo letterboxée). iframe[data-type=twitch-chat] obtient une hauteur fixe et une largeur bornée, avec plus de hauteur sous 640px (Twitch y empile le chat sous la vidéo). Le choix chat/sans chat reste par embed via l'URL.