### PR TITLE
fix(content): live Twitch en deux iframes (lecteur + chat), sans toucher la CSP

### DIFF
--- a/nodyx-core/src/utils/sanitize.ts
+++ b/nodyx-core/src/utils/sanitize.ts
@@ -80,12 +80,18 @@ export function sanitize(raw: string): string {
     allowedAttributes: ALLOWED_ATTRS,
     // Embeds vidéo : uniquement les domaines de lecteur OFFICIELS de chaque
     // plateforme (pas une page quelconque du site). Twitch permet d'intégrer un
-    // live dans un post ; son lecteur EXIGE un paramètre `parent=<domaine>`
-    // correspondant au site qui l'affiche, sinon il refuse de démarrer.
+    // live dans un post : le LECTEUR vit sur player.twitch.tv, le CHAT sur
+    // www.twitch.tv/embed/<chaine>/chat. Les deux EXIGENT un paramètre
+    // `parent=<domaine>` correspondant au site qui les affiche.
+    //
+    // ⚠ `embed.twitch.tv` (le layout tout-en-un lecteur+chat) est VOLONTAIREMENT
+    // absent : la CSP de prod ne l'autorise pas en frame-src. L'ajouter ici
+    // poserait un piège, le sanitizer le laisserait passer et le navigateur le
+    // bloquerait, sans que l'auteur comprenne pourquoi son embed est mort.
     allowedIframeHostnames: [
       'www.youtube.com', 'youtube.com', 'www.youtube-nocookie.com',
       'player.vimeo.com', 'vimeo.com',
-      'player.twitch.tv', 'embed.twitch.tv',
+      'player.twitch.tv', 'www.twitch.tv',
     ],
     transformTags: {
       'nodyx-audio-player': (tagName, attribs) => {

--- a/nodyx-frontend/src/app.css
+++ b/nodyx-frontend/src/app.css
@@ -511,21 +511,31 @@ select option {
     margin: 0.75rem 0;
 }
 
-/* ── Embed Twitch AVEC chat : <iframe data-type="twitch-chat"> ───────────────
-   Un lecteur seul se contente du 16/9 ci-dessus. Avec le chat, Twitch colle une
-   colonne d'environ 340px à droite : un 16/9 sur une large colonne d'article
-   donnerait un bloc démesurément haut, et la vidéo resterait letterboxée. On lui
-   donne donc une hauteur fixe confortable et on borne la largeur pour que la
-   vidéo garde une taille lisible à côté du chat. */
-.nodyx-prose iframe[data-type="twitch-chat"] {
-    aspect-ratio: auto;
-    height: 480px;
+/* ── Live Twitch : <div class="twitch-live"> = lecteur + chat ────────────────
+   Twitch sert le LECTEUR sur player.twitch.tv et le CHAT sur www.twitch.tv :
+   deux iframes distinctes. (Le layout tout-en-un d'embed.twitch.tv serait plus
+   simple, mais notre CSP ne l'autorise pas en frame-src.)
+   On les pose donc côte à côte, largeur bornée pour que la vidéo reste lisible,
+   et on EMPILE sur écran étroit où deux colonnes ne tiennent pas. */
+.nodyx-prose .twitch-live {
+    display: flex;
+    gap: 0.5rem;
     max-width: 1000px;
+    margin: 0.75rem 0;
 }
-@media (max-width: 640px) {
-    /* Sous ~660px, Twitch empile le chat SOUS la vidéo : il faut de la hauteur,
-       sinon les deux sont écrasés. */
-    .nodyx-prose iframe[data-type="twitch-chat"] { height: 560px; }
+.nodyx-prose .twitch-live iframe {
+    margin: 0;
+    aspect-ratio: auto;       /* le 16/9 générique ne vaut pas pour ce duo */
+    height: 460px;
+}
+.nodyx-prose .twitch-live iframe[data-type="twitch-player"] { flex: 1 1 auto; min-width: 0; }
+.nodyx-prose .twitch-live iframe[data-type="twitch-chat"]   { flex: 0 0 320px; }
+
+@media (max-width: 900px) {
+    .nodyx-prose .twitch-live { flex-direction: column; }
+    /* Le lecteur retrouve son 16/9 naturel, le chat passe dessous. */
+    .nodyx-prose .twitch-live iframe[data-type="twitch-player"] { aspect-ratio: 16 / 9; height: auto; }
+    .nodyx-prose .twitch-live iframe[data-type="twitch-chat"]   { flex: 0 0 auto; width: 100%; height: 320px; }
 }
 /* Wrapper YouTube injecté par l'extension */
 .nodyx-prose .youtube-wrapper,


### PR DESCRIPTION
embed.twitch.tv s'affichait « Ce contenu est bloqué » : la CSP de prod (config Caddy vivante) autorise player.twitch.tv / www.twitch.tv / clips.twitch.tv mais PAS embed.twitch.tv. On reste dans l'autorisé plutôt que de toucher Caddy en prod (zone rouge documentée) : lecteur via player.twitch.tv + chat via www.twitch.tv/embed/<chaine>/chat, dans un conteneur .twitch-live côte à côte qui s'empile sous 900px. Sanitizer : embed.twitch.tv retiré (piège : autorisé à l'écriture mais bloqué par la CSP), www.twitch.tv ajouté. Core : 401 tests verts.