### PR TITLE
feat(forum): un index vivant (dernier message, compteurs, statistiques)

### DIFF
--- a/nodyx-core/src/models/community.ts
+++ b/nodyx-core/src/models/community.ts
@@ -26,6 +26,18 @@ export interface CommunityMember {
   grade_color:  string | null
 }
 
+// Dernier message d'une catégorie : de quoi montrer qu'elle est vivante sur
+// l'index du forum. On n'expose QUE le pseudo et l'avatar de l'auteur, jamais
+// l'utilisateur brut (pas de fuite de données personnelles).
+export interface CategoryLastPost {
+  thread_id:    string
+  thread_slug:  string | null
+  thread_title: string
+  username:     string
+  avatar:       string | null
+  created_at:   Date
+}
+
 export interface Category {
   id:           string
   community_id: string
@@ -35,8 +47,22 @@ export interface Category {
   position:     number
   parent_id:    string | null
   thread_count: number
+  post_count:   number
+  last_post:    CategoryLastPost | null
   created_at:   Date
   updated_at:   Date
+}
+
+// Ligne SQL brute : le dernier message revient à plat (une colonne par champ),
+// il est replié en objet `last_post` dans getCategoryTree.
+interface CategoryRow extends Omit<Category, 'last_post'> {
+  depth:             number
+  last_thread_id:    string | null
+  last_thread_slug:  string | null
+  last_thread_title: string | null
+  last_username:     string | null
+  last_avatar:       string | null
+  last_created_at:   Date | null
 }
 
 export function generateCategorySlug(name: string): string {
@@ -202,24 +228,53 @@ export async function getCategories(communityId: string): Promise<Category[]> {
 
 // Returns categories as a recursive tree (root categories with nested children).
 // Uses a PostgreSQL recursive CTE — depth is unbounded.
+//
+// Porte aussi de quoi rendre un index de forum VIVANT : le nombre de messages et
+// surtout le DERNIER message de chaque catégorie. Sans ce dernier, un index n'est
+// qu'un annuaire de portes ; avec lui, on voit ce qui se passe derrière chacune.
+//
+// Perf : la récursion ne sert QU'À découvrir l'arbre (id/parent/profondeur). Les
+// données coûteuses sont jointes UNE SEULE FOIS à la fin, pas à chaque niveau de
+// récursion. Le dernier message passe par un LEFT JOIN LATERAL (un LIMIT 1 par
+// catégorie), ce qui reste linéaire même quand le forum grossit.
 export async function getCategoryTree(communityId: string): Promise<CategoryNode[]> {
-  const { rows } = await db.query<Category>(
+  const { rows } = await db.query<CategoryRow>(
     `WITH RECURSIVE cat_tree AS (
-       SELECT c.*,
-              (SELECT COUNT(*)::int FROM threads t WHERE t.category_id = c.id) AS thread_count,
-              0 AS depth
+       SELECT c.id, c.parent_id, 0 AS depth
        FROM categories c
        WHERE c.community_id = $1 AND c.parent_id IS NULL
 
        UNION ALL
 
-       SELECT c.*,
-              (SELECT COUNT(*)::int FROM threads t WHERE t.category_id = c.id) AS thread_count,
-              ct.depth + 1
+       SELECT c.id, c.parent_id, ct.depth + 1
        FROM categories c
        JOIN cat_tree ct ON c.parent_id = ct.id
      )
-     SELECT * FROM cat_tree ORDER BY depth, position, name`,
+     SELECT c.*,
+            ct.depth,
+            (SELECT COUNT(*)::int FROM threads t WHERE t.category_id = c.id) AS thread_count,
+            (SELECT COUNT(*)::int
+               FROM posts p JOIN threads t ON t.id = p.thread_id
+              WHERE t.category_id = c.id) AS post_count,
+            lp.thread_id    AS last_thread_id,
+            lp.thread_slug  AS last_thread_slug,
+            lp.thread_title AS last_thread_title,
+            lp.username     AS last_username,
+            lp.avatar       AS last_avatar,
+            lp.created_at   AS last_created_at
+       FROM cat_tree ct
+       JOIN categories c ON c.id = ct.id
+       LEFT JOIN LATERAL (
+         SELECT t.id AS thread_id, t.slug AS thread_slug, t.title AS thread_title,
+                u.username, u.avatar, p.created_at
+           FROM posts p
+           JOIN threads t ON t.id = p.thread_id
+           JOIN users   u ON u.id = p.author_id
+          WHERE t.category_id = c.id
+          ORDER BY p.created_at DESC
+          LIMIT 1
+       ) lp ON true
+      ORDER BY ct.depth, c.position, c.name`,
     [communityId]
   )
 
@@ -228,7 +283,22 @@ export async function getCategoryTree(communityId: string): Promise<CategoryNode
   const roots: CategoryNode[] = []
 
   for (const row of rows) {
-    map.set(row.id, { ...row, children: [] })
+    // Le dernier message est remonté à plat par SQL : on le replie en objet, et
+    // on n'expose QUE username + avatar de son auteur (jamais l'utilisateur brut).
+    const { last_thread_id, last_thread_slug, last_thread_title,
+            last_username, last_avatar, last_created_at, ...cat } = row
+    map.set(row.id, {
+      ...cat,
+      last_post: last_thread_id ? {
+        thread_id:    last_thread_id,
+        thread_slug:  last_thread_slug,
+        thread_title: last_thread_title!,
+        username:     last_username!,
+        avatar:       last_avatar,
+        created_at:   last_created_at!,
+      } : null,
+      children: [],
+    })
   }
   for (const row of rows) {
     const node = map.get(row.id)!

--- a/nodyx-frontend/src/routes/forum/+page.svelte
+++ b/nodyx-frontend/src/routes/forum/+page.svelte
@@ -24,6 +24,24 @@
 
 	// Toutes les catégories racines + leurs enfants à plat
 	const topLevel = $derived(categories.filter((c: any) => !c.parent_id));
+
+	// ── Statistiques du forum ────────────────────────────────────────────────
+	// Les totaux se déduisent des catégories DÉJÀ chargées (racines + enfants) :
+	// aucun appel réseau supplémentaire. Le nombre de membres vient du layout,
+	// qui interroge déjà /instance/info pour toute l'application.
+	const allCats  = $derived([...topLevel, ...topLevel.flatMap((c: any) => c.children ?? [])]);
+	const totThreads = $derived(allCats.reduce((n: number, c: any) => n + (c.thread_count ?? 0), 0));
+	const totPosts   = $derived(allCats.reduce((n: number, c: any) => n + (c.post_count ?? 0), 0));
+	const totMembers = $derived(($page.data as any).memberCount ?? 0);
+
+	// Le membre le plus récemment actif sur le forum : c'est l'auteur du dernier
+	// message toutes catégories confondues.
+	const lastPoster = $derived(
+		allCats
+			.map((c: any) => c.last_post)
+			.filter(Boolean)
+			.sort((a: any, b: any) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())[0] ?? null
+	);
 </script>
 
 <svelte:head>
@@ -74,17 +92,49 @@
 						{/if}
 					</div>
 
-					<!-- Stats -->
-					<div class="flex items-center gap-6 shrink-0 text-right">
-						<div class="hidden sm:flex flex-col items-end">
+					<!-- Compteurs : sujets ET messages, comme sur un vrai index de forum -->
+					<div class="hidden sm:flex shrink-0 items-center gap-5 text-right">
+						<div class="flex flex-col items-end w-12">
 							<span class="text-sm font-bold text-gray-300 tabular-nums">{cat.thread_count ?? 0}</span>
 							<span class="text-[10px] text-gray-600 uppercase tracking-wide">{tFn('common.topics')}</span>
 						</div>
-						<svg class="w-4 h-4 text-gray-700 group-hover:text-indigo-400 transition-colors"
-						     fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-							<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
-						</svg>
+						<div class="flex flex-col items-end w-12">
+							<span class="text-sm font-bold text-gray-400 tabular-nums">{cat.post_count ?? 0}</span>
+							<span class="text-[10px] text-gray-600 uppercase tracking-wide">messages</span>
+						</div>
 					</div>
+
+					<!-- Dernier message : c'est LUI qui montre que le forum est vivant.
+					     Sans, on ne voit que des portes ; avec, on voit ce qu'il y a derrière. -->
+					<div class="hidden lg:flex shrink-0 w-56 items-center gap-2.5 pl-5
+					            border-l border-white/[.06]">
+						{#if cat.last_post}
+							{#if cat.last_post.avatar}
+								<img src={cat.last_post.avatar} alt=""
+								     class="w-8 h-8 rounded-full object-cover shrink-0"/>
+							{:else}
+								<div class="w-8 h-8 rounded-full shrink-0 flex items-center justify-center text-[10px] font-black text-white"
+								     style="background: linear-gradient(135deg, var(--nx-accent-2-strong), var(--nx-cyan-deep))">
+									{cat.last_post.username?.[0]?.toUpperCase() ?? '?'}
+								</div>
+							{/if}
+							<div class="min-w-0 flex-1">
+								<p class="truncate text-[11px] font-semibold text-gray-300 group-hover:text-white transition-colors">
+									{cat.last_post.thread_title}
+								</p>
+								<p class="truncate text-[10px] text-gray-600">
+									{cat.last_post.username} · {timeAgo(cat.last_post.created_at)}
+								</p>
+							</div>
+						{:else}
+							<span class="text-[11px] text-gray-700">Aucun message</span>
+						{/if}
+					</div>
+
+					<svg class="w-4 h-4 shrink-0 text-gray-700 group-hover:text-indigo-400 transition-colors"
+					     fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
+					</svg>
 				</a>
 
 				<!-- Sous-catégories -->
@@ -111,8 +161,27 @@
 									<p class="text-[11px] text-gray-700 mt-0.5 line-clamp-1">{sub.description}</p>
 								{/if}
 							</div>
-							<div class="shrink-0 text-right hidden sm:block">
-								<span class="text-xs font-bold text-gray-500 tabular-nums">{sub.thread_count ?? 0}</span>
+							<!-- Compteurs compacts : le sous-forum reste secondaire -->
+							<div class="hidden sm:flex shrink-0 items-center gap-5 text-right">
+								<span class="w-12 text-xs font-bold text-gray-500 tabular-nums">{sub.thread_count ?? 0}</span>
+								<span class="w-12 text-xs font-bold text-gray-600 tabular-nums">{sub.post_count ?? 0}</span>
+							</div>
+							<!-- Dernier message, en plus discret que le forum parent -->
+							<div class="hidden lg:flex shrink-0 w-56 items-center gap-2 pl-5 border-l border-white/[.04]">
+								{#if sub.last_post}
+									{#if sub.last_post.avatar}
+										<img src={sub.last_post.avatar} alt="" class="w-6 h-6 rounded-full object-cover shrink-0"/>
+									{:else}
+										<div class="w-6 h-6 rounded-full shrink-0 flex items-center justify-center text-[9px] font-black text-white"
+										     style="background: linear-gradient(135deg, var(--nx-accent-2-strong), var(--nx-cyan-deep))">
+											{sub.last_post.username?.[0]?.toUpperCase() ?? '?'}
+										</div>
+									{/if}
+									<div class="min-w-0 flex-1">
+										<p class="truncate text-[10px] font-medium text-gray-500">{sub.last_post.thread_title}</p>
+										<p class="truncate text-[9px] text-gray-700">{timeAgo(sub.last_post.created_at)}</p>
+									</div>
+								{/if}
 							</div>
 						</a>
 						{/each}
@@ -124,6 +193,37 @@
 
 		<!-- ── Sidebar : activité récente ────────────────────────────── -->
 		<aside class="space-y-4">
+
+			<!-- Statistiques : la carte d'identité du forum en un coup d'oeil.
+			     Calculées depuis les données déjà chargées, aucun appel en plus. -->
+			<div class="border border-white/[.06]" style="background: rgba(255,255,255,.025)">
+				<div class="px-4 py-3 border-b border-white/5">
+					<span class="text-[10px] font-black uppercase tracking-[.15em] text-gray-500">Statistiques</span>
+				</div>
+				<div class="px-4 py-3 space-y-2">
+					<div class="flex items-baseline justify-between">
+						<span class="text-[11px] text-gray-600">{tFn('common.topics')}</span>
+						<span class="text-xs font-bold text-gray-300 tabular-nums">{totThreads.toLocaleString('fr-FR')}</span>
+					</div>
+					<div class="flex items-baseline justify-between">
+						<span class="text-[11px] text-gray-600">Messages</span>
+						<span class="text-xs font-bold text-gray-300 tabular-nums">{totPosts.toLocaleString('fr-FR')}</span>
+					</div>
+					<div class="flex items-baseline justify-between">
+						<span class="text-[11px] text-gray-600">Membres</span>
+						<span class="text-xs font-bold text-gray-300 tabular-nums">{totMembers.toLocaleString('fr-FR')}</span>
+					</div>
+					{#if lastPoster}
+						<div class="flex items-center justify-between gap-2 pt-2 border-t border-white/[.05]">
+							<span class="shrink-0 text-[11px] text-gray-600">Dernier message</span>
+							<span class="truncate text-[11px] font-semibold" style="color: var(--nx-accent-2-soft)">
+								{lastPoster.username}
+							</span>
+						</div>
+					{/if}
+				</div>
+			</div>
+
 			<div class="border border-white/[.06]" style="background: rgba(255,255,255,.025)">
 				<div class="flex items-center justify-between px-4 py-3 border-b border-white/5">
 					<span class="text-[10px] font-black uppercase tracking-[.15em] text-gray-500">{tFn('forum.recent_activity')}</span>


### PR DESCRIPTION
L'index n'affichait que le nombre de sujets : la mise en page était bonne, la donnée manquait. getCategoryTree porte maintenant le nombre de messages et le dernier message par catégorie (récursion réduite à la découverte de l'arbre, LEFT JOIN LATERAL pour le dernier message, PII limitée au pseudo + avatar). Front : colonnes sujets/messages, bloc dernier message avec avatar rond, version compacte sur les sous-forums, encart Statistiques (totaux déduits des données déjà chargées, zéro appel en plus). Core : typecheck OK + 401 tests verts.