### PR TITLE
fix(forum): aligner les colonnes de stats des sous-forums sur les parents

### DIFF
--- a/nodyx-frontend/src/routes/forum/+page.svelte
+++ b/nodyx-frontend/src/routes/forum/+page.svelte
@@ -183,6 +183,10 @@
 									</div>
 								{/if}
 							</div>
+							<!-- Cale : le forum parent se termine par un chevron. Tout étant aligné
+							     depuis le bord droit, sans cette cale de même largeur les colonnes
+							     du sous-forum se décalent de 32px et ne tombent plus en face. -->
+							<div class="w-4 shrink-0" aria-hidden="true"></div>
 						</a>
 						{/each}
 					</div>


### PR DESCRIPTION
Les compteurs des sous-forums tombaient 32px à droite de ceux des parents : le parent se termine par un chevron (w-4 + gap-4) qui pousse ses colonnes vers la gauche, sans contrepartie côté sous-forum. Ajout d'une cale de même largeur en fin de ligne pour que les deux aient la même géométrie.