### PR TITLE
docs: retirer les tirets cadratins de nodyx.dev

### DIFF
--- a/docs/en/AI-USAGE.md
+++ b/docs/en/AI-USAGE.md
@@ -1,33 +1,33 @@
 # AI Usage
 
-> By transparency — and because it's in the open-source spirit of this project — here's how artificial intelligence is involved in Nodyx development.
+> By transparency, and because it's in the open-source spirit of this project, here's how artificial intelligence is involved in Nodyx development.
 
 ## Context
 
-Nodyx is a solo project. One developer — me, Pokled — designs, codes, tests, and maintains the entire platform. AI is a tool that lets me develop at a speed that would otherwise be impossible alone, while keeping full control over every decision.
+Nodyx is a solo project. One developer (me, Pokled) designs, codes, tests, and maintains the entire platform. AI is a tool that lets me develop at a speed that would otherwise be impossible alone, while keeping full control over every decision.
 
 ## What the AI does
 
-- **Code generation** — Svelte components, Fastify routes, SQL migrations, bash scripts. I describe what I want, the AI produces a base, I read through it and adapt.
-- **Architecture & design thinking** — challenging my technical choices, anticipating problems, structuring complex features before implementing them.
-- **Debugging** — analyzing errors, tracing bugs in dense code, understanding unexpected behavior.
-- **Writing** — error messages, UI text, documentation, installation scripts.
-- **Refactoring** — improving readability, harmonizing patterns, cleaning up accumulated code.
+- **Code generation**: Svelte components, Fastify routes, SQL migrations, bash scripts. I describe what I want, the AI produces a base, I read through it and adapt.
+- **Architecture & design thinking**: challenging my technical choices, anticipating problems, structuring complex features before implementing them.
+- **Debugging**: analyzing errors, tracing bugs in dense code, understanding unexpected behavior.
+- **Writing**: error messages, UI text, documentation, installation scripts.
+- **Refactoring**: improving readability, harmonizing patterns, cleaning up accumulated code.
 
 ## What I do
 
 - **I read every line of code produced.** Nothing goes to production without me having read, understood, and validated it. The AI doesn't commit on my behalf.
-- **I make all architecture decisions.** The project vision, structural technical choices, trade-offs — that's me. The AI executes, I decide.
+- **I make all architecture decisions.** The project vision, structural technical choices, trade-offs, that's me. The AI executes, I decide.
 - **I test and validate.** On the real platform, not just by reading generated code.
-- **I fix the AI's mistakes.** It's wrong often — missing context, bad assumptions, unsuitable patterns. My job is also to catch those errors before they cause problems.
-- **I maintain project coherence over time.** The AI has no long memory of the project — I'm the one holding the thread.
+- **I fix the AI's mistakes.** It's wrong often: missing context, bad assumptions, unsuitable patterns. My job is also to catch those errors before they cause problems.
+- **I maintain project coherence over time.** The AI has no long memory of the project. I'm the one holding the thread.
 
 ## Tool
 
-I primarily use **Claude Code** by Anthropic — an AI assistant that operates directly in the command line within the repository. It can read files, search through code, write and modify files. Everything it does is visible and reversible via git.
+I primarily use **Claude Code** by Anthropic, an AI assistant that operates directly in the command line within the repository. It can read files, search through code, write and modify files. Everything it does is visible and reversible via git.
 
 ## Why be transparent about this
 
-Nodyx is licensed under AGPL-3.0. The source code is public, decisions are documented in git. It would be inconsistent to hide how the project is built. AI isn't cheating — it's a tool, like a compiler or a linter. What matters is the quality of the result and the accountability of the person who signs the code.
+Nodyx is licensed under AGPL-3.0. The source code is public, decisions are documented in git. It would be inconsistent to hide how the project is built. AI isn't cheating: it's a tool, like a compiler or a linter. What matters is the quality of the result and the accountability of the person who signs the code.
 
-If you find a bug or unexpected behavior, report it — AI or not, it's my code, it's my responsibility.
+If you find a bug or unexpected behavior, report it. AI or not, it's my code, it's my responsibility.

--- a/docs/en/ARCHITECTURE.md
+++ b/docs/en/ARCHITECTURE.md
@@ -1,5 +1,5 @@
-# NODYX — Architecture
-### Version 1.0 — Technical reference document
+# NODYX, Architecture
+### Version 1.0, Technical reference document
 
 ---
 
@@ -34,28 +34,28 @@ All routes start with `/api/v1/`
 
 ```
 /api/v1/
-├── health                  GET  — Infrastructure status
+├── health                  GET , Infrastructure status
 ├── auth/
-│   ├── register            POST — Account creation
-│   ├── login               POST — Login
-│   └── logout              POST — Logout
+│   ├── register            POST, Account creation
+│   ├── login               POST, Login
+│   └── logout              POST, Logout
 ├── communities/
-│   ├── /                   GET  — List communities
-│   ├── /                   POST — Create a community
-│   ├── /:slug              GET  — One community
-│   └── /:slug/members      GET  — Members
+│   ├── /                   GET , List communities
+│   ├── /                   POST, Create a community
+│   ├── /:slug              GET , One community
+│   └── /:slug/members      GET , Members
 ├── forums/
-│   ├── /:community         GET  — Forum categories
-│   ├── /categories         POST — Create a category
-│   ├── /threads            GET  — Thread list
-│   ├── /threads            POST — Create a thread
-│   ├── /threads/:id        GET  — One thread + posts
-│   └── /posts              POST — Create a post
+│   ├── /:community         GET , Forum categories
+│   ├── /categories         POST, Create a category
+│   ├── /threads            GET , Thread list
+│   ├── /threads            POST, Create a thread
+│   ├── /threads/:id        GET , One thread + posts
+│   └── /posts              POST, Create a post
 ├── users/
-│   ├── /:id                GET  — Public profile
-│   └── /me                 GET  — My profile
+│   ├── /:id                GET , Public profile
+│   └── /me                 GET , My profile
 └── search/
-    └── /                   GET  — Global search
+    └── /                   GET , Global search
 ```
 
 ---
@@ -71,7 +71,7 @@ Nodyx ships with **PostgreSQL 16**. This is a deliberate choice, not a lag.
 - **It's what Ubuntu 24.04 LTS ships by default.** `apt install postgresql` on a fresh Ubuntu 24.04 server installs PG 16. Picking the distro default keeps `install.sh` short, predictable, and free of third-party PPAs that admins might not trust. Less moving parts at install time means fewer breakages on real-world VPSes.
 - **Upstream support runs until November 2028.** PostgreSQL has a 5-year support window per major version. PG 16 is supported with security and bug fixes for 2+ more years. We are not on a deprecated version.
 - **Nodyx uses zero features specific to PG 17 or 18.** Our migrations rely on standard SQL plus widely-available extras: `JSONB`, `UUID`, `tsvector` full-text search, `CREATE INDEX CONCURRENTLY`, partial indexes, `IF NOT EXISTS` everywhere. These have been stable since PG 12+. We would gain literally nothing functional by upgrading.
-- **The performance and feature gains from 17/18 don't apply at our scale.** Improvements like streaming I/O, logical replication slot sync, or vectorized JSON path are aimed at multi-terabyte deployments or replication-heavy architectures. A Nodyx instance is "one community on one VPS" — these gains don't move the needle.
+- **The performance and feature gains from 17/18 don't apply at our scale.** Improvements like streaming I/O, logical replication slot sync, or vectorized JSON path are aimed at multi-terabyte deployments or replication-heavy architectures. A Nodyx instance is "one community on one VPS", these gains don't move the needle.
 
 **When we will migrate:**
 
@@ -164,7 +164,7 @@ users ----------< threads
 
 ---
 
-## 4. REDIS — USAGE
+## 4. REDIS, USAGE
 
 ```
 User sessions           nodyx:session:{token}       TTL 7 days
@@ -184,11 +184,11 @@ Plugins extend Nodyx without modifying the core.
 ```
 nodyx-plugins/
 └── my-plugin/
-    ├── plugin.json      — Plugin manifest
-    ├── index.ts         — Entry point
-    ├── routes/          — Additional API routes
-    ├── migrations/      — Additional PostgreSQL tables
-    └── ui/              — Additional SvelteKit components
+    ├── plugin.json     , Plugin manifest
+    ├── index.ts        , Entry point
+    ├── routes/         , Additional API routes
+    ├── migrations/     , Additional PostgreSQL tables
+    └── ui/             , Additional SvelteKit components
 ```
 
 ### plugin.json
@@ -205,11 +205,11 @@ nodyx-plugins/
 
 ### Available hooks
 ```
-onUserRegister      — After account creation
-onUserJoin          — After joining a community
-onThreadCreate      — After thread creation
-onPostCreate        — After post creation
-onCommunityCreate   — After community creation
+onUserRegister     , After account creation
+onUserJoin         , After joining a community
+onThreadCreate     , After thread creation
+onPostCreate       , After post creation
+onCommunityCreate  , After community creation
 ```
 
 ---
@@ -219,7 +219,7 @@ onCommunityCreate   — After community creation
 ```
 Authentication    Signed JWT + refresh token in Redis
 Passwords         bcrypt (cost factor 12)
-Rate limiting     Redis — 100 req/min per IP
+Rate limiting     Redis, 100 req/min per IP
 Validation        Zod on all inputs
 CORS              Configurable per instance
 Headers           Helmet.js (XSS, CSP, HSTS)
@@ -231,29 +231,29 @@ Headers           Helmet.js (XSS, CSP, HSTS)
 
 ```
 nodyx-core/src/
-├── index.ts                — Server entry point
-├── fortunes.ts             — Random quotes
+├── index.ts               , Server entry point
+├── fortunes.ts            , Random quotes
 ├── config/
-│   └── database.ts         — PostgreSQL + Redis connections
+│   └── database.ts        , PostgreSQL + Redis connections
 ├── routes/
-│   ├── auth.ts             — Authentication
-│   ├── communities.ts      — Communities
-│   ├── forums.ts           — Forum + threads + posts
-│   ├── users.ts            — Profiles
-│   └── search.ts           — Search
+│   ├── auth.ts            , Authentication
+│   ├── communities.ts     , Communities
+│   ├── forums.ts          , Forum + threads + posts
+│   ├── users.ts           , Profiles
+│   └── search.ts          , Search
 ├── models/
-│   ├── user.ts             — User model
-│   ├── community.ts        — Community model
-│   ├── thread.ts           — Thread model
-│   └── post.ts             — Post model
+│   ├── user.ts            , User model
+│   ├── community.ts       , Community model
+│   ├── thread.ts          , Thread model
+│   └── post.ts            , Post model
 ├── middleware/
-│   ├── auth.ts             — JWT verification
-│   ├── rateLimit.ts        — Redis rate limiting
-│   └── validate.ts         — Zod validation
+│   ├── auth.ts            , JWT verification
+│   ├── rateLimit.ts       , Redis rate limiting
+│   └── validate.ts        , Zod validation
 ├── migrations/
-│   └── 001_initial.sql     — Initial schema
+│   └── 001_initial.sql    , Initial schema
 └── plugins/
-    └── loader.ts           — Plugin loader
+    └── loader.ts          , Plugin loader
 ```
 
 ---
@@ -271,5 +271,5 @@ nodyx-core/src/
 
 ---
 
-*Version 1.0 — February 2026*
+*Version 1.0, February 2026*
 *"The network is the people."*

--- a/docs/en/AUDIO.md
+++ b/docs/en/AUDIO.md
@@ -1,6 +1,6 @@
 # Nodyx Audio Engine
 
-Nodyx includes a client-side audio processing chain designed to deliver broadcast-quality voice in any voice channel — without dedicated hardware, without external services, and without sending your audio anywhere but directly to your peers.
+Nodyx includes a client-side audio processing chain designed to deliver broadcast-quality voice in any voice channel, without dedicated hardware, without external services, and without sending your audio anywhere but directly to your peers.
 
 ---
 
@@ -21,7 +21,7 @@ Microphone
 [RNNoise WASM]       ← AI noise suppression (optional)
     │
     ▼
-[BiquadFilterNode ×3] ← Broadcast EQ — 3-band (optional)
+[BiquadFilterNode ×3] ← Broadcast EQ, 3-band (optional)
     │
     ▼
 WebRTC PeerConnection → peers
@@ -44,8 +44,8 @@ All settings are accessible via the ⚙ button in the voice bar (VoicePanel), pe
 Adjusts the input volume of your microphone before any processing.
 
 - `1.0` = no change (nominal level)
-- `2.0` = doubles the signal (+6 dB) — useful for quiet microphones
-- `0.5` = cuts the signal in half (−6 dB) — useful for loud/saturating mics
+- `2.0` = doubles the signal (+6 dB), useful for quiet microphones
+- `0.5` = cuts the signal in half (−6 dB), useful for loud/saturating mics
 
 ---
 
@@ -63,7 +63,7 @@ Virtually no impact on voice intelligibility. Recommended to leave on.
 
 ---
 
-### RNNoise — AI noise suppression
+### RNNoise, AI noise suppression
 
 **Default: disabled** *(requires `@jitsi/rnnoise-wasm`)*
 
@@ -79,9 +79,9 @@ It is effective against:
 
 ---
 
-### Broadcast Mode — 3-band EQ
+### Broadcast Mode, 3-band EQ
 
-**Default: disabled — Intensity: 60%**
+**Default: disabled, Intensity: 60%**
 
 This is the audio feature that sets Nodyx apart. Broadcast Mode applies a three-band equalizer tuned for the human voice, replicating the processing chain used in professional podcasting and radio broadcasting.
 
@@ -117,13 +117,13 @@ Controls the Opus codec bitrate applied to the next peer connection.
 
 | Bitrate | Use case |
 |---|---|
-| **32 kbps** | **Default — voice-optimized, works on VPNs and congested links** |
+| **32 kbps** | **Default, voice-optimized, works on VPNs and congested links** |
 | 64 kbps | Higher quality, good bandwidth |
 | 128 kbps | High-quality audio, music, or recording streams |
 
 Changes take effect on the **next connection** (reconnect to the voice channel to apply).
 
-> **Additional codec settings (v1.3):** DTX (Discontinuous Transmission) is disabled by default — it causes audio bursts when speech resumes on lossy links. Mono is forced to halve the bitrate without impacting voice intelligibility. FEC (Forward Error Correction) remains enabled for packet-loss resilience.
+> **Additional codec settings (v1.3):** DTX (Discontinuous Transmission) is disabled by default, it causes audio bursts when speech resumes on lossy links. Mono is forced to halve the bitrate without impacting voice intelligibility. FEC (Forward Error Correction) remains enabled for packet-loss resilience.
 
 ---
 

--- a/docs/en/CONTRIBUTING.md
+++ b/docs/en/CONTRIBUTING.md
@@ -12,9 +12,9 @@
 ## Before you start
 
 Read these files in this order:
-1. `ARCHITECTURE.md` — How Nodyx is built
-2. `MANIFESTO.md` — The soul of the project
-3. `ROADMAP.md` — Where we're going
+1. `ARCHITECTURE.md`, How Nodyx is built
+2. `MANIFESTO.md`, The soul of the project
+3. `ROADMAP.md`, Where we're going
 
 If you disagree with the Manifesto, Nodyx may not be the right project for you.
 And that's okay.
@@ -25,16 +25,16 @@ And that's okay.
 
 ### You can contribute freely in
 ```
-nodyx-plugins/    — Create plugins
-nodyx-themes/     — Create visual themes
-nodyx-docs/       — Improve documentation
-i18n/             — Translate into your language
-community/        — Community content
+nodyx-plugins/   , Create plugins
+nodyx-themes/    , Create visual themes
+nodyx-docs/      , Improve documentation
+i18n/            , Translate into your language
+community/       , Community content
 ```
 
 ### You cannot modify without validation
 ```
-nodyx-core/src/           — Main server code
+nodyx-core/src/          , Main server code
 nodyx-core/ARCHITECTURE.md
 nodyx-core/NODYX_CONTEXT.md
 docs/en/MANIFESTO.md
@@ -49,10 +49,10 @@ If you think something in the core should change, open an Issue and explain why.
 ### Minimal structure
 ```
 nodyx-plugins/my-plugin/
-├── plugin.json     — Required manifest
-├── index.ts        — Entry point
-├── README.md       — Documentation
-└── LICENSE         — License (MIT recommended)
+├── plugin.json    , Required manifest
+├── index.ts       , Entry point
+├── README.md      , Documentation
+└── LICENSE        , License (MIT recommended)
 ```
 
 ### Minimal plugin.json
@@ -122,12 +122,12 @@ Translation is the most accessible contribution. No coding required.
 
 ### Files to translate
 ```
-MANIFESTO.md    — The founding text
-THANKS.md       — Acknowledgements
-README.md       — Project overview
-CONTRIBUTING.md — This guide
-ARCHITECTURE.md — Technical reference
-ROADMAP.md      — Development roadmap
+MANIFESTO.md   , The founding text
+THANKS.md      , Acknowledgements
+README.md      , Project overview
+CONTRIBUTING.md, This guide
+ARCHITECTURE.md, Technical reference
+ROADMAP.md     , Development roadmap
 ```
 
 ### Translation rules
@@ -201,4 +201,4 @@ Your name will be there.
 ---
 
 *"The network is the people."*
-*AGPL-3.0 — The code belongs to its community.*
+*AGPL-3.0, The code belongs to its community.*

--- a/docs/en/CREATE-WIDGET.md
+++ b/docs/en/CREATE-WIDGET.md
@@ -2,7 +2,7 @@
 
 > **You don't need to be a developer.** If you can copy-paste code and edit a text file, you can build a widget and install it on your Nodyx community in under 10 minutes.
 
-Nodyx widgets are small pieces of code that appear on your homepage. Think of them like apps you install on a phone — except *you* can build them, and they're completely yours.
+Nodyx widgets are small pieces of code that appear on your homepage. Think of them like apps you install on a phone, except *you* can build them, and they're completely yours.
 
 ---
 
@@ -17,13 +17,13 @@ Then you'll package it as a `.zip` file and install it on your Nodyx instance in
 ## Table of Contents
 
 - [What is a Widget?](#what-is-a-widget)
-- [Step 1 — Set Up Your Files](#step-1-set-up-your-files)
-- [Step 2 — Write the manifest.json](#step-2-write-the-manifestjson)
-- [Step 3 — Write the Widget Code](#step-3-write-the-widget-code)
-- [Step 4 — Understand the Code](#step-4-understand-the-code)
-- [Step 5 — Package Your Widget](#step-5-package-your-widget)
-- [Step 6 — Install on Your Instance](#step-6-install-on-your-instance)
-- [Step 7 — Use it in the Homepage Builder](#step-7-use-it-in-the-homepage-builder)
+- [Step 1, Set Up Your Files](#step-1-set-up-your-files)
+- [Step 2, Write the manifest.json](#step-2-write-the-manifestjson)
+- [Step 3, Write the Widget Code](#step-3-write-the-widget-code)
+- [Step 4, Understand the Code](#step-4-understand-the-code)
+- [Step 5, Package Your Widget](#step-5-package-your-widget)
+- [Step 6, Install on Your Instance](#step-6-install-on-your-instance)
+- [Step 7, Use it in the Homepage Builder](#step-7-use-it-in-the-homepage-builder)
 - [Going Further](#going-further)
 
 ---
@@ -46,7 +46,7 @@ You write plain JavaScript. No React, no Vue, no npm, no Webpack. A text editor 
 
 ---
 
-## Step 1 — Set Up Your Files
+## Step 1, Set Up Your Files
 
 Create a folder on your computer called `welcome-banner`. Inside it, create two empty files:
 
@@ -63,7 +63,7 @@ You can use any text editor:
 
 ---
 
-## Step 2 — Write the manifest.json
+## Step 2, Write the manifest.json
 
 Open `manifest.json` and paste this:
 
@@ -109,7 +109,7 @@ Open `manifest.json` and paste this:
 
 | Field | What it does |
 |---|---|
-| `id` | Unique identifier — only lowercase letters, numbers, and hyphens |
+| `id` | Unique identifier, only lowercase letters, numbers, and hyphens |
 | `label` | The name shown in the Homepage Builder |
 | `version` | Follows `major.minor.patch` format |
 | `icon` | An emoji shown next to the widget name |
@@ -125,17 +125,17 @@ Open `manifest.json` and paste this:
 | `color` | A color picker |
 | `checkbox` | A toggle switch |
 | `number` | A numeric input |
-| `select` | A dropdown — add `options: [{value, label}]` |
+| `select` | A dropdown, add `options: [{value, label}]` |
 
 ---
 
-## Step 3 — Write the Widget Code
+## Step 3, Write the Widget Code
 
 Open `widget.iife.js` and paste this complete code:
 
 ```javascript:widget.iife.js
 (function () {
-  // ── Welcome Banner — Nodyx Widget ──────────────────────────────
+  // ── Welcome Banner, Nodyx Widget ──────────────────────────────
 
   var STYLE = `
     :host { display: block; }
@@ -264,15 +264,15 @@ Open `widget.iife.js` and paste this complete code:
 
 ---
 
-## Step 4 — Understand the Code
+## Step 4, Understand the Code
 
-Don't worry if you're not a developer — here's what each part does:
+Don't worry if you're not a developer, here's what each part does:
 
 ### The outer wrapper `(function () { ... })()`
 This is called an IIFE (Immediately Invoked Function Expression). It keeps your widget's code isolated so it doesn't interfere with the rest of the page. **Always wrap your widget in this.**
 
 ### The `STYLE` variable
-This is CSS — the visual design of your widget. It uses **Shadow DOM**, which means your styles are completely isolated. They won't affect the rest of the page, and the page's styles won't affect your widget.
+This is CSS, the visual design of your widget. It uses **Shadow DOM**, which means your styles are completely isolated. They won't affect the rest of the page, and the page's styles won't affect your widget.
 
 ### The `WelcomeBanner` class
 This is your widget. It extends `HTMLElement`, which means it becomes a real HTML element that the browser understands.
@@ -282,7 +282,7 @@ This is your widget. It extends `HTMLElement`, which means it becomes a real HTM
 | `connectedCallback()` | When the widget is first placed on the page |
 | `observedAttributes` | Which attribute changes should trigger a re-render |
 | `attributeChangedCallback()` | When a config value changes (live preview in builder) |
-| `_render()` | Your main render function — reads config, builds HTML |
+| `_render()` | Your main render function, reads config, builds HTML |
 
 ### Reading the config
 ```javascript
@@ -300,7 +300,7 @@ If your widget `id` is `my-countdown`, the tag name must be `nodyx-widget-my-cou
 
 ---
 
-## Step 5 — Package Your Widget
+## Step 5, Package Your Widget
 
 You need to create a `.zip` file containing both files **at the root** (not inside a subfolder).
 
@@ -326,11 +326,11 @@ Open the zip and verify the files are at the **root**, not inside a subfolder na
 
 ---
 
-## Step 6 — Install on Your Instance
+## Step 6, Install on Your Instance
 
 1. Go to your Nodyx admin panel: **Admin → Widgets**
 2. In the **"Install a widget"** section, drag and drop your `.zip` file (or click to browse)
-3. Watch the progress bar — Nodyx will validate the manifest, extract the files, and register the widget
+3. Watch the progress bar, Nodyx will validate the manifest, extract the files, and register the widget
 4. You'll see **"Installation successful!"** with your widget's name
 
 If you see an error, the most common causes are:
@@ -340,14 +340,14 @@ If you see an error, the most common causes are:
 
 ---
 
-## Step 7 — Use it in the Homepage Builder
+## Step 7, Use it in the Homepage Builder
 
 1. Go to **Admin → Homepage**
 2. Click **+ Add widget** on any position
-3. Scroll to the **"Installed"** section in the widget picker — your widget is there
+3. Scroll to the **"Installed"** section in the widget picker, your widget is there
 4. Fill in the config fields (Title, Message, Color, Show join button)
 5. Click **Save**
-6. Open your homepage — your widget is live!
+6. Open your homepage, your widget is live!
 
 ---
 
@@ -425,7 +425,7 @@ var style = cfg.style || 'dark';
 ---
 
 :::tip Study the example widget
-The **Video Player** demo widget available in **Admin → Widgets** is fully commented and open source. It handles YouTube, Vimeo, and direct MP4 URLs. Download it as a `.zip` and read the source — it's a great starting point.
+The **Video Player** demo widget available in **Admin → Widgets** is fully commented and open source. It handles YouTube, Vimeo, and direct MP4 URLs. Download it as a `.zip` and read the source, it's a great starting point.
 :::
 
 ---

--- a/docs/en/DOMAIN.md
+++ b/docs/en/DOMAIN.md
@@ -1,4 +1,4 @@
-# 🌐 Nodyx — Complete Domain Name Guide
+# 🌐 Nodyx, Complete Domain Name Guide
 
 > This guide answers the question everyone asks when installing Nodyx:
 > **"Do I need a domain? Which one? Why doesn't my No-IP work?"**
@@ -20,11 +20,11 @@
 
 There are three very different realities behind the word "domain", and confusing them is the source of most problems.
 
-### Type 1 — Real Domain (TLD)
+### Type 1, Real Domain (TLD)
 
 > `mycommunity.com`, `knittingclub.net`, `association.org`
 
-You **buy** this domain from a registrar (Namecheap, OVH, Porkbun…). You own it. You can change its **nameservers** freely — meaning you control who manages its DNS.
+You **buy** this domain from a registrar (Namecheap, OVH, Porkbun…). You own it. You can change its **nameservers** freely, meaning you control who manages its DNS.
 
 - ✅ Compatible with `install.sh`
 - ✅ Compatible with `install_tunnel.sh` (Cloudflare Tunnel)
@@ -34,20 +34,20 @@ You **buy** this domain from a registrar (Namecheap, OVH, Porkbun…). You own i
 
 ---
 
-### Type 2 — Free Dynamic DNS Subdomain (DDNS)
+### Type 2, Free Dynamic DNS Subdomain (DDNS)
 
 > `myserver.ddns.net` (No-IP), `mycommunity.duckdns.org` (DuckDNS), `mysite.mooo.com` (Afraid.org)
 
 You get a **subdomain** of a domain that belongs to No-IP, DuckDNS, etc. You do **not** own the root domain (`ddns.net`, `duckdns.org`). These services are designed to point a hostname to an IP that often changes (residential dynamic IP).
 
-- ✅ Compatible with `install.sh` *(only with manual Caddy config — not automated)*
-- ❌ **Incompatible with `install_tunnel.sh`** — [see why below](#-why-no-ip-duckdns-etc-dont-work-with-cloudflare-tunnel)
+- ✅ Compatible with `install.sh` *(only with manual Caddy config, not automated)*
+- ❌ **Incompatible with `install_tunnel.sh`**: [see why below](#-why-no-ip-duckdns-etc-dont-work-with-cloudflare-tunnel)
 - ⚠️ Unstable if your IP changes (residential without a static IP)
 - 🆓 Free
 
 ---
 
-### Type 3 — Subdomain Offered by Nodyx
+### Type 3, Subdomain Offered by Nodyx
 
 > `mycommunity.nodyx.org` (via the Nodyx directory)
 > `46-225-20-193.sslip.io` (via the server's public IP)
@@ -55,7 +55,7 @@ You get a **subdomain** of a domain that belongs to No-IP, DuckDNS, etc. You do 
 These subdomains are provided **automatically** by `install.sh`. No setup required.
 
 - ✅ Compatible with `install.sh` (ports 80/443 open)
-- ❌ **Incompatible with `install_tunnel.sh`** — `nodyx.org` is our DNS zone, not yours
+- ❌ **Incompatible with `install_tunnel.sh`**: `nodyx.org` is our DNS zone, not yours
 - ✅ Automatic HTTPS certificate via Let's Encrypt (Caddy)
 - 🆓 100% free, zero configuration
 
@@ -70,7 +70,7 @@ These subdomains are provided **automatically** by `install.sh`. No setup requir
 | **sslip.io** (auto from IP) | ✅ | ❌ | ✅ | ✅ (static IP) |
 | **No-IP / DuckDNS / Afraid** | ⚠️ manual | ❌ | ⚠️ manual | ⚠️ dynamic IP |
 | **Freenom (.tk, .ml, .ga…)** | ❌ service dead | ❌ | ❌ | ❌ |
-| **CF Quick Tunnel** (`trycloudflare.com`) | — | ⚠️ testing only | ✅ | ❌ URL changes |
+| **CF Quick Tunnel** (`trycloudflare.com`) |, | ⚠️ testing only | ✅ | ❌ URL changes |
 
 > **Legend:**
 > ✅ Compatible and automated
@@ -79,7 +79,7 @@ These subdomains are provided **automatically** by `install.sh`. No setup requir
 
 ---
 
-## 🗺️ Decision Tree — Which Script Should I Use?
+## 🗺️ Decision Tree, Which Script Should I Use?
 
 ```
 I want to install Nodyx on my server
@@ -143,7 +143,7 @@ It's that simple: **you must own the root domain** for Cloudflare to write DNS r
 
 ### Why sslip.io Doesn't Work with CF Tunnel Either
 
-`sslip.io` works through a magic DNS mechanism: `46-225-20-193.sslip.io` automatically resolves to `46.225.20.193`. It's a public domain managed by its creators — you don't own it. Same reasoning.
+`sslip.io` works through a magic DNS mechanism: `46-225-20-193.sslip.io` automatically resolves to `46.225.20.193`. It's a public domain managed by its creators, you don't own it. Same reasoning.
 
 ### The Only Real Solution
 
@@ -163,7 +163,7 @@ The good news: domains have become very affordable.
 | [OVH](https://ovh.com) | `.com`, `.net`, `.eu`… | ~$7–$12/year | French provider, FR support |
 | [Gandi](https://gandi.net) | `.com`, `.org`, `.net`… | ~$15/year | Ethical, privacy-focused |
 
-> 💡 **Tip:** If you're buying a domain for CF Tunnel, get it directly from **Cloudflare Registrar** — it skips the "change nameservers" step since it's managed natively.
+> 💡 **Tip:** If you're buying a domain for CF Tunnel, get it directly from **Cloudflare Registrar**: it skips the "change nameservers" step since it's managed natively.
 
 ### Cheapest Extensions to Get Started
 
@@ -176,7 +176,7 @@ The good news: domains have become very affordable.
 
 ## 🛠️ DNS Setup
 
-### With `install.sh` — Classic A Record
+### With `install.sh`, Classic A Record
 
 Once you have a domain, add these records in your registrar's DNS panel:
 
@@ -188,9 +188,9 @@ A      www    SERVER_IP      300
 
 Replace `SERVER_IP` with your server's public IP (displayed at the start of `install.sh`).
 
-> ⚠️ If your domain is proxied through Cloudflare (orange cloud), TURN port 3478 won't be accessible by domain name. `install.sh` uses the direct IP for the TURN URL — this is intentional and correct.
+> ⚠️ If your domain is proxied through Cloudflare (orange cloud), TURN port 3478 won't be accessible by domain name. `install.sh` uses the direct IP for the TURN URL, this is intentional and correct.
 
-### With `install_tunnel.sh` — Automatic CNAME
+### With `install_tunnel.sh`, Automatic CNAME
 
 You have **nothing to configure manually**. The script creates the CNAME automatically via `cloudflared tunnel route dns`. The only thing you need to do is add your domain to Cloudflare with its nameservers (Step 1 of the CF Tunnel guide).
 
@@ -201,5 +201,5 @@ You have **nothing to configure manually**. The script creates the CNAME automat
 - [Full Installation Guide](INSTALL.md)
 - [Cloudflare Tunnel Section in INSTALL.md](INSTALL.md#-hosting-at-home-without-opening-ports)
 - [Cloudflare Registrar](https://cloudflare.com/products/registrar/)
-- [Porkbun — affordable domains](https://porkbun.com)
+- [Porkbun, affordable domains](https://porkbun.com)
 - [What is sslip.io?](https://sslip.io)

--- a/docs/en/EMAIL.md
+++ b/docs/en/EMAIL.md
@@ -1,4 +1,4 @@
-# 📧 Nodyx — Setting up email
+# 📧 Nodyx, Setting up email
 
 > **Quick summary:** Nodyx works perfectly without email configured. But if a member forgets their password, you'll have to manually send them the reset link. Setting up email handles this automatically.
 
@@ -8,8 +8,8 @@
 
 Nodyx sends emails in two situations:
 
-- **Forgot password** — a member clicks "Forgot my password" and receives a secure link by email
-- **Welcome email** *(optional)* — a welcome message on registration
+- **Forgot password**: a member clicks "Forgot my password" and receives a secure link by email
+- **Welcome email** *(optional)*, a welcome message on registration
 
 That's it. Nodyx doesn't send newsletters, spam, or email notifications.
 
@@ -29,7 +29,7 @@ That's it. Nodyx doesn't send newsletters, spam, or email notifications.
 You need three pieces of information from your email provider:
 - **SMTP server address** (e.g. `smtp.brevo.com`)
 - **Your login** (usually your email address)
-- **Your SMTP password** (note: this may not be your regular password — some services generate a specific app password)
+- **Your SMTP password** (note: this may not be your regular password, some services generate a specific app password)
 
 Open the `.env` file in the `nodyx-core` folder and add these lines:
 
@@ -39,7 +39,7 @@ SMTP_PORT=587
 SMTP_SECURE=false
 SMTP_USER=your@email.com
 SMTP_PASS=your_smtp_password
-SMTP_FROM=noreply@your-domain.com   # optional — uses SMTP_USER if not set
+SMTP_FROM=noreply@your-domain.com   # optional, uses SMTP_USER if not set
 ```
 
 Then restart Nodyx:
@@ -51,9 +51,9 @@ pm2 restart nodyx-core
 
 ## Which provider to choose?
 
-You don't need a dedicated mail server. A simple account with a transactional email provider is enough — most have a free tier that's more than sufficient for a small community.
+You don't need a dedicated mail server. A simple account with a transactional email provider is enough, most have a free tier that's more than sufficient for a small community.
 
-### Brevo *(recommended — free, French company)*
+### Brevo *(recommended, free, French company)*
 
 **Why Brevo?**
 French company, GDPR compliant, 300 emails/day for free. More than enough for a community of a few hundred members.
@@ -103,7 +103,7 @@ SMTP_PASS=your_ovh_password
 
 ---
 
-### Infomaniak *(Swiss, ethical — ~€1/month)*
+### Infomaniak *(Swiss, ethical, ~€1/month)*
 
 If you want an address on your own domain hosted in Switzerland:
 
@@ -127,7 +127,7 @@ From the Nodyx admin panel → **Settings** → **Email**, you can send a test e
 If the email doesn't arrive:
 1. Check the credentials in `.env`
 2. Check that port 587 isn't blocked by your host (rare, but possible)
-3. Some providers require you to verify your sending domain — check their documentation
+3. Some providers require you to verify your sending domain, check their documentation
 
 ---
 

--- a/docs/en/INSTALL-TUNNEL.md
+++ b/docs/en/INSTALL-TUNNEL.md
@@ -1,4 +1,4 @@
-# 🌐 Nodyx — Tunnel Installation Guide
+# 🌐 Nodyx, Tunnel Installation Guide
 
 > **TL;DR** Got a server behind NAT (homelab, RPi, LXC) and no public IP? `install_tunnel.sh` configures Caddy + the rest of the stack so a reverse tunnel can point at it. Three modes: **Cloudflare Tunnel**, **Pangolin/newt**, or **custom** (frp, rathole, headscale, your own VPS proxy). No port 80/443 forwarding required. ☕
 
@@ -12,9 +12,9 @@ curl -fsSL https://raw.githubusercontent.com/Pokled/Nodyx/main/install_tunnel.sh
 
 - [When to use this installer](#-when-to-use-this-installer)
 - [Pick your mode](#-pick-your-mode)
-- [Mode A — Cloudflare Tunnel](#-mode-a-cloudflare-tunnel)
-- [Mode B — Pangolin (newt)](#-mode-b-pangolin-newt)
-- [Mode C — Custom reverse tunnel](#-mode-c-custom-reverse-tunnel)
+- [Mode A, Cloudflare Tunnel](#-mode-a-cloudflare-tunnel)
+- [Mode B, Pangolin (newt)](#-mode-b-pangolin-newt)
+- [Mode C, Custom reverse tunnel](#-mode-c-custom-reverse-tunnel)
 - [Troubleshooting](#-troubleshooting)
 - [What the installer hardens](#-what-the-installer-hardens)
 - [Re-running, upgrading, repairing](#-re-running-upgrading-repairing)
@@ -40,13 +40,13 @@ If your server has a public IP and you can open ports 80/443, use [`install.sh`]
 |---|---|---|
 | You already use Cloudflare DNS | **CF** | Easiest. cloudflared runs on your server, dials out to Cloudflare's edge, TLS terminates there |
 | You self-host a Pangolin VPS | **Pangolin** | Keeps everything in your hands. Uses `newt` Docker container as the tunnel client |
-| You have your own reverse tunnel (frp, rathole, headscale, ...) | **None** | Caddy listens on `127.0.0.1:80` — wire your tunnel client to it manually |
+| You have your own reverse tunnel (frp, rathole, headscale, ...) | **None** | Caddy listens on `127.0.0.1:80`, wire your tunnel client to it manually |
 
-You don't have to decide before running the script — it asks you and explains the tradeoffs.
+You don't have to decide before running the script, it asks you and explains the tradeoffs.
 
 ---
 
-## 🌩 Mode A — Cloudflare Tunnel
+## 🌩 Mode A, Cloudflare Tunnel
 
 **What you need**
 
@@ -61,17 +61,17 @@ curl -fsSL https://raw.githubusercontent.com/Pokled/Nodyx/main/install_tunnel.sh
 # Paste your install token when prompted.
 ```
 
-**After install** — in your Cloudflare dashboard:
+**After install**: in your Cloudflare dashboard:
 
 1. Open your tunnel → **Public Hostname** → **Add**
 2. Subdomain: empty | Domain: `your-domain.com` | Service: `HTTP` | URL: `localhost:80`
 3. Save. Visit `https://your-domain.com`. ✅
 
-**Voice/UDP** Voice and webcam will use public STUN servers — Cloudflare Tunnel doesn't carry UDP. If you need self-hosted TURN, see the [RELAY](RELAY.md) doc.
+**Voice/UDP** Voice and webcam will use public STUN servers, Cloudflare Tunnel doesn't carry UDP. If you need self-hosted TURN, see the [RELAY](RELAY.md) doc.
 
 ---
 
-## 🦔 Mode B — Pangolin (newt)
+## 🦔 Mode B, Pangolin (newt)
 
 This is the mode that surprised the most operators (see [discussion #23](https://github.com/Pokled/nodyx/discussions/23)). The script now handles it cleanly, but the topology is worth understanding.
 
@@ -79,7 +79,7 @@ This is the mode that surprised the most operators (see [discussion #23](https:/
 
 ```
                  ╔══════════════════════════════════════════════════╗
-                 ║  Method A — newt with --network host (RECOMMENDED) ║
+                 ║  Method A, newt with --network host (RECOMMENDED) ║
                  ╚══════════════════════════════════════════════════╝
 
    ┌─────────────────────────────────────┐         ┌──────────────┐
@@ -100,7 +100,7 @@ This is the mode that surprised the most operators (see [discussion #23](https:/
 
 ```
                  ╔════════════════════════════════════════════╗
-                 ║  Method B — newt in default Docker bridge   ║
+                 ║  Method B, newt in default Docker bridge   ║
                  ╚════════════════════════════════════════════╝
 
    ┌─────────────────────────────────────┐         ┌──────────────┐
@@ -127,7 +127,7 @@ The installer binds Caddy on **both** `127.0.0.1:80` and the host's primary LAN 
 
 > 💡 **Method A is preferred** because it doesn't depend on the host's LAN address being stable. If your DHCP lease changes, Method B would need re-pointing in Pangolin.
 
-### Method A — `--network host`
+### Method A, `--network host`
 
 ```bash
 docker run -d --name newt --network host --restart unless-stopped \
@@ -139,7 +139,7 @@ docker run -d --name newt --network host --restart unless-stopped \
 
 Pangolin → HTTP resource → `your-domain.com → http://localhost:80`
 
-### Method B — default bridge
+### Method B, default bridge
 
 ```bash
 docker run -d --name newt --restart unless-stopped \
@@ -165,11 +165,11 @@ docker exec newt wget -qO- http://192.168.1.42/api/v1/instance/info
 
 A response body with a JSON instance description means newt can reach Caddy. Anything else, see [Troubleshooting](#-troubleshooting).
 
-**Voice/UDP** Pangolin can carry UDP via "raw resources" — see Pangolin's docs. Without it, voice falls back to public STUN.
+**Voice/UDP** Pangolin can carry UDP via "raw resources", see Pangolin's docs. Without it, voice falls back to public STUN.
 
 ---
 
-## 🔧 Mode C — Custom reverse tunnel
+## 🔧 Mode C, Custom reverse tunnel
 
 Caddy listens on `127.0.0.1:80` and trusts `X-Forwarded-For` from the loopback / RFC1918 ranges. Wire any of these to it:
 
@@ -191,7 +191,7 @@ Caddy listens on `127.0.0.1:80` and trusts `X-Forwarded-For` from the loopback /
 | Symptom | Cause | Fix |
 |---|---|---|
 | newt is in default Docker bridge (`docker inspect newt -f '{{.HostConfig.NetworkMode}}'` returns `bridge`) and you targeted `localhost:80` in Pangolin | `localhost` inside newt is the newt container, not your host | Either switch to `--network host` (Method A) **or** change the Pangolin target to `http://<host-LAN-IP>:80` (Method B) |
-| Caddy isn't listening at all (`ss -ltn | grep :80` empty) | Service didn't start | `sudo nodyx-doctor` — it tells you exactly what's wrong |
+| Caddy isn't listening at all (`ss -ltn | grep :80` empty) | Service didn't start | `sudo nodyx-doctor`, it tells you exactly what's wrong |
 
 ### Page loads forever (spinning loader)
 
@@ -226,7 +226,7 @@ The script now does a connectivity preflight (DNS + outbound HTTPS to github.com
 
 ### `ufw` complains about not running
 
-You're inside an unprivileged LXC or Docker container without `NET_ADMIN`. The script now warns about this in preflight and asks for explicit confirmation. UFW won't work, but Nodyx itself will — your hypervisor must enforce the firewall instead.
+You're inside an unprivileged LXC or Docker container without `NET_ADMIN`. The script now warns about this in preflight and asks for explicit confirmation. UFW won't work, but Nodyx itself will, your hypervisor must enforce the firewall instead.
 
 ---
 
@@ -238,10 +238,10 @@ A short tour for operators who want to know what they're getting (or maintainers
 
 - **Bind addresses are mode-aware.** Loopback always; the LAN IP is added in Pangolin mode so newt-in-bridge can reach Caddy.
 - **`max_header_size 16KB`.** Default is 1MB and lets slow-header DoS chew workers. 16KB still fits CF Tunnel headers + cookies + JWT comfortably.
-- **`reverse_proxy` timeouts.** `dial_timeout 5s` (loopback should connect in <100ms), `response_header_timeout 30s` (covers Socket.IO long-poll without cutting WebSocket upgrades). No `read_timeout` — that would silently break WebSockets.
+- **`reverse_proxy` timeouts.** `dial_timeout 5s` (loopback should connect in <100ms), `response_header_timeout 30s` (covers Socket.IO long-poll without cutting WebSocket upgrades). No `read_timeout`, that would silently break WebSockets.
 - **Real-IP forwarding is mode-aware.** CF Tunnel uses `CF-Connecting-IP`; Pangolin and custom modes use `X-Forwarded-For`. Trusted only from loopback + RFC1918.
 - **Honeypot.** Common scanner paths (`/.env`, `/wp-admin`, `/.git/`, etc.) get rewritten to `/api/v1/_hp` so the backend can ban the source IP.
-- **Snippets** factor out `(security_headers)`, `(proxy_backend)`, `(proxy_frontend)` so `/api`, `/uploads`, `/socket.io`, the honeypot, and the SPA fallback all share the same hardening — drift between them is impossible.
+- **Snippets** factor out `(security_headers)`, `(proxy_backend)`, `(proxy_frontend)` so `/api`, `/uploads`, `/socket.io`, the honeypot, and the SPA fallback all share the same hardening, drift between them is impossible.
 
 ### No HSTS in tunnel modes
 
@@ -298,10 +298,10 @@ It checks every layer (system services, PM2, backend HTTP, Caddy bind addresses,
 
 ## 📚 See also
 
-- [INSTALL.md](INSTALL.md) — VPS-direct install (Caddy does Let's Encrypt itself)
-- [DOMAIN.md](DOMAIN.md) — domain setup walkthrough
-- [RELAY.md](RELAY.md) — Nodyx Relay (no domain needed, `your-slug.nodyx.org`)
-- [GitHub discussion #23](https://github.com/Pokled/nodyx/discussions/23) — original Pangolin Bad Gateway report
+- [INSTALL.md](INSTALL.md), VPS-direct install (Caddy does Let's Encrypt itself)
+- [DOMAIN.md](DOMAIN.md), domain setup walkthrough
+- [RELAY.md](RELAY.md), Nodyx Relay (no domain needed, `your-slug.nodyx.org`)
+- [GitHub discussion #23](https://github.com/Pokled/nodyx/discussions/23), original Pangolin Bad Gateway report
 
 ---
 

--- a/docs/en/INSTALL.md
+++ b/docs/en/INSTALL.md
@@ -1,8 +1,8 @@
-# 🚀 Nodyx — Complete Installation Guide
+# 🚀 Nodyx, Complete Installation Guide
 
 > **TL;DR:** Clone the repo on a Linux server, run `bash install.sh`, answer a few questions. Done. ☕
 >
-> **New — Nodyx Relay:** No domain and no open ports? Raspberry Pi, old PC, home router?
+> **New, Nodyx Relay:** No domain and no open ports? Raspberry Pi, old PC, home router?
 > **Choose option `[2] Nodyx Relay`** during installation → your instance goes live at `your-slug.nodyx.org` with zero configuration.
 > [→ Full Nodyx Relay guide](RELAY.md)
 
@@ -12,10 +12,10 @@
 
 - [Before You Start](#-before-you-start)
 - [Where to Host?](#-where-to-host)
-- [Do I Need a Domain Name?](#-do-i-need-a-domain-name) — [Complete Domain Guide →](DOMAIN.md)
+- [Do I Need a Domain Name?](#-do-i-need-a-domain-name), [Complete Domain Guide →](DOMAIN.md)
 - [Which Ports to Open?](#-which-ports-to-open)
-- [Installation — The Easy Way](#-installation--the-easy-way-recommended)
-- [Windows Users — WSL Guide](#-windows-users--wsl-guide)
+- [Installation, The Easy Way](#-installation--the-easy-way-recommended)
+- [Windows Users, WSL Guide](#-windows-users--wsl-guide)
 - [Home Server / Behind NAT](#-home-server--behind-nat)
 - [Hosting WITHOUT Opening Ports (Nodyx Relay, Cloudflare Tunnel, Tailscale)](#-hosting-at-home-without-opening-ports)
 - [Behind a VPN or WireGuard](#-behind-a-vpn-or-wireguard)
@@ -38,9 +38,9 @@
 | Bandwidth | 10 Mbps | 100 Mbps |
 | OS | Ubuntu 22.04 | Ubuntu 24.04 LTS |
 
-> 💡 **Real-world sizing:** A community of 50 active users runs comfortably on a €4/month VPS (Hetzner CX22, 2 vCPU / 4 GB RAM). Voice channels are P2P — they don't consume server bandwidth.
+> 💡 **Real-world sizing:** A community of 50 active users runs comfortably on a €4/month VPS (Hetzner CX22, 2 vCPU / 4 GB RAM). Voice channels are P2P, they don't consume server bandwidth.
 
-### PM2 Memory Limits — Automatically Adjusted by the Installer
+### PM2 Memory Limits, Automatically Adjusted by the Installer
 
 The installer detects the total RAM available and configures PM2 accordingly. No manual tuning needed.
 
@@ -50,7 +50,7 @@ The installer detects the total RAM available and configures PM2 accordingly. No
 | 1.5 – 3 GB (RPi 4 / small VPS) | 384 MB | 256 MB | 1 GB if needed | 1024 MB |
 | ≥ 3 GB (standard VPS) | 512 MB | 512 MB | 1 GB if needed | 1024 MB |
 
-> **Raspberry Pi note:** Use a **64-bit OS** (Raspberry Pi OS 64-bit or Ubuntu 24.04 ARM64). 32-bit is not supported. On a 1 GB Pi, the SvelteKit build can take ~8 minutes — this is normal.
+> **Raspberry Pi note:** Use a **64-bit OS** (Raspberry Pi OS 64-bit or Ubuntu 24.04 ARM64). 32-bit is not supported. On a 1 GB Pi, the SvelteKit build can take ~8 minutes, this is normal.
 
 ### Supported Operating Systems
 
@@ -65,7 +65,7 @@ The installer detects the total RAM available and configures PM2 accordingly. No
 | CentOS / RHEL / Fedora | ❌ Not supported | Use Docker instead |
 | Raspberry Pi OS | ✅ Supported | Use 64-bit version |
 
-### Only One Prerequisite — Git
+### Only One Prerequisite, Git
 
 The installer needs `git` to clone the Nodyx repository. Most VPS images don't include it by default. Install it first:
 
@@ -82,18 +82,18 @@ sudo apt-get update && sudo apt-get install -y git
 
 You don't need to install anything else manually. The script handles:
 
-- **Node.js 20 LTS** — JavaScript runtime
-- **PostgreSQL 16** — Main database
-- **Redis 7** — Cache & real-time sessions
-- **Coturn** — TURN/STUN relay for voice channels (WebRTC NAT traversal)
-- **Caddy** — Reverse proxy + automatic HTTPS (Let's Encrypt)
-- **PM2** — Process manager (auto-restart, boot startup)
+- **Node.js 20 LTS**: JavaScript runtime
+- **PostgreSQL 16**: Main database
+- **Redis 7**: Cache & real-time sessions
+- **Coturn**: TURN/STUN relay for voice channels (WebRTC NAT traversal)
+- **Caddy**: Reverse proxy + automatic HTTPS (Let's Encrypt)
+- **PM2**: Process manager (auto-restart, boot startup)
 
 ---
 
 ## 🖥️ Where to Host?
 
-### Option 1 — VPS (Recommended for beginners)
+### Option 1, VPS (Recommended for beginners)
 
 A VPS (Virtual Private Server) is a remote Linux machine you rent by the month. It's always online, has a fixed IP, and you can SSH into it from anywhere.
 
@@ -124,7 +124,7 @@ ssh root@YOUR_VPS_IP
 
 ---
 
-### Option 2 — Home Server
+### Option 2, Home Server
 
 A spare PC, an old laptop, or a Raspberry Pi plugged in at home. Works great, but requires:
 - A static IP **or** a DDNS service (see [Home Server section](#-home-server--behind-nat))
@@ -135,7 +135,7 @@ A spare PC, an old laptop, or a Raspberry Pi plugged in at home. Works great, bu
 
 ---
 
-### Option 3 — Windows with WSL (Testing / Development)
+### Option 3, Windows with WSL (Testing / Development)
 
 You can run Nodyx on Windows 10/11 using WSL2 (Windows Subsystem for Linux). This is great for testing or developing, but not ideal for a 24/7 production server.
 
@@ -147,7 +147,7 @@ You can run Nodyx on Windows 10/11 using WSL2 (Windows Subsystem for Linux). Thi
 
 **Short answer: No!** For a VPS with `install.sh`, the installer automatically creates a free domain `46-225-20-193.sslip.io` + a memorable alias `your-slug.nodyx.org`. HTTPS works without buying anything.
 
-**For `install_tunnel.sh` (Cloudflare Tunnel)**, a real domain you own is required — free subdomains like No-IP or DuckDNS do not work.
+**For `install_tunnel.sh` (Cloudflare Tunnel)**, a real domain you own is required, free subdomains like No-IP or DuckDNS do not work.
 
 > 📖 **[→ Complete Domain Guide: types, compatibility, decision tree, where to buy](DOMAIN.md)**
 >
@@ -162,10 +162,10 @@ You can run Nodyx on Windows 10/11 using WSL2 (Windows Subsystem for Linux). Thi
 | Home server, no open ports, CF domain | `install_tunnel.sh` → [tunnel guide](INSTALL-TUNNEL.md) |
 | Home server, no open ports, Pangolin VPS | `install_tunnel.sh` → [tunnel guide](INSTALL-TUNNEL.md#-mode-b-pangolin-newt) |
 | Home server, no open ports, custom tunnel (frp, rathole, ...) | `install_tunnel.sh` → [tunnel guide](INSTALL-TUNNEL.md#-mode-c-custom-reverse-tunnel) |
-| Home server, no open ports, No-IP/DuckDNS | ❌ not compatible — [see DOMAIN.md](DOMAIN.md) |
-| Home server, no open ports, no domain | Buy a domain ~$1/year — [see DOMAIN.md](DOMAIN.md) |
+| Home server, no open ports, No-IP/DuckDNS | ❌ not compatible, [see DOMAIN.md](DOMAIN.md) |
+| Home server, no open ports, no domain | Buy a domain ~$1/year, [see DOMAIN.md](DOMAIN.md) |
 
-> 💡 **Cloudflare tip:** If you use Cloudflare as your DNS provider, enable the orange cloud (proxy) for HTTP/HTTPS — free DDoS protection. **Disable the proxy (grey cloud) for any TURN subdomain** — voice channels won't work through CF's proxy.
+> 💡 **Cloudflare tip:** If you use Cloudflare as your DNS provider, enable the orange cloud (proxy) for HTTP/HTTPS, free DDoS protection. **Disable the proxy (grey cloud) for any TURN subdomain**: voice channels won't work through CF's proxy.
 
 ---
 
@@ -182,13 +182,13 @@ The `install.sh` script configures the firewall (UFW) automatically. Here's what
 | 5349 | TCP + UDP | TURN/STUN over TLS | ⚠️ Optional |
 | 49152–65535 | UDP | WebRTC media relay | ✅ Yes (voice channels) |
 
-> ❓ **What is a TURN relay?** When two users want to speak in a voice channel, they need a direct connection (P2P). If one of them is behind a NAT (like a 4G connection or a corporate network), the connection can't be established directly. The TURN relay acts as an intermediary — the voice goes through your server instead. This is only used as a fallback when P2P fails.
+> ❓ **What is a TURN relay?** When two users want to speak in a voice channel, they need a direct connection (P2P). If one of them is behind a NAT (like a 4G connection or a corporate network), the connection can't be established directly. The TURN relay acts as an intermediary, the voice goes through your server instead. This is only used as a fallback when P2P fails.
 
 ---
 
-## 🚀 Installation — The Easy Way (Recommended)
+## 🚀 Installation, The Easy Way (Recommended)
 
-### Step 1 — Clone the repository
+### Step 1, Clone the repository
 
 On your Linux server (via SSH):
 
@@ -203,7 +203,7 @@ Or download just the install script:
 curl -fsSL https://raw.githubusercontent.com/Pokled/Nodyx/main/install.sh -o install.sh
 ```
 
-### Step 2 — Run the installer
+### Step 2, Run the installer
 
 ```bash
 sudo bash install.sh
@@ -211,7 +211,7 @@ sudo bash install.sh
 
 > 🔐 The script must run as root (or with sudo). It installs system packages, configures the firewall, and sets up services.
 
-### Step 3 — Answer the questions
+### Step 3, Answer the questions
 
 The installer will ask you:
 
@@ -231,11 +231,11 @@ The installer will ask you:
 ? Admin password: ••••••••
 ```
 
-> 💡 **No domain?** Just press Enter — your instance will be accessible at `46-225-20-193.sslip.io` with automatic HTTPS. You can switch to your own domain later.
+> 💡 **No domain?** Just press Enter, your instance will be accessible at `46-225-20-193.sslip.io` with automatic HTTPS. You can switch to your own domain later.
 
 That's it. The script handles everything else automatically (≈ 3–10 minutes depending on your server speed).
 
-### Step 4 — Wait and enjoy ☕
+### Step 4, Wait and enjoy ☕
 
 The installer will show you a summary at the end:
 
@@ -255,11 +255,11 @@ The installer will show you a summary at the end:
 
 ---
 
-## 🪟 Windows Users — WSL Guide
+## 🪟 Windows Users, WSL Guide
 
 WSL (Windows Subsystem for Linux) lets you run Ubuntu directly inside Windows. Nodyx's `install.sh` runs perfectly inside WSL2.
 
-### Step 1 — Enable WSL2
+### Step 1, Enable WSL2
 
 Open **PowerShell as Administrator** and run:
 
@@ -271,30 +271,30 @@ This installs WSL2 and Ubuntu automatically. **Restart your PC** when prompted.
 
 > 💡 If WSL is already installed, update it: `wsl --update`
 
-### Step 2 — Open Ubuntu
+### Step 2, Open Ubuntu
 
 After restarting, search for **"Ubuntu"** in the Start menu and open it. The first time, it will ask you to create a username and password for Linux.
 
-### Step 3 — Update Ubuntu
+### Step 3, Update Ubuntu
 
 ```bash
 sudo apt update && sudo apt upgrade -y
 ```
 
-### Step 4 — Install Git (if needed)
+### Step 4, Install Git (if needed)
 
 ```bash
 sudo apt install -y git
 ```
 
-### Step 5 — Clone Nodyx
+### Step 5, Clone Nodyx
 
 ```bash
 git clone https://github.com/Pokled/Nodyx.git
 cd Nodyx
 ```
 
-### Step 6 — Run the installer
+### Step 6, Run the installer
 
 ```bash
 sudo bash install.sh
@@ -302,7 +302,7 @@ sudo bash install.sh
 
 > ⚠️ **WSL limitation:** Services started inside WSL don't automatically restart with Windows. For a 24/7 server, use a real Linux VPS or server. WSL is great for testing and development.
 
-> 💡 **Access from your Windows browser:** Once the install is done, open your browser and go to `http://localhost` — Nodyx will be there.
+> 💡 **Access from your Windows browser:** Once the install is done, open your browser and go to `http://localhost`, Nodyx will be there.
 
 ### Tips specific to WSL
 
@@ -322,20 +322,20 @@ sudo bash install.sh
 
 Running Nodyx on a machine at home (behind your router) requires a few extra steps.
 
-### Step 1 — Find your public IP
+### Step 1, Find your public IP
 
-Go to [whatismyip.com](https://whatismyip.com) — this is the IP the outside world sees.
+Go to [whatismyip.com](https://whatismyip.com), this is the IP the outside world sees.
 
-> ⚠️ **Problem:** Most home ISPs assign **dynamic IPs** — your public IP can change. Solution: use a DDNS service.
+> ⚠️ **Problem:** Most home ISPs assign **dynamic IPs**: your public IP can change. Solution: use a DDNS service.
 
-### Step 2 — Set up DDNS (if you don't have a static IP)
+### Step 2, Set up DDNS (if you don't have a static IP)
 
 A DDNS (Dynamic DNS) service maps a hostname to your current IP and updates automatically.
 
 **Free options:**
-- [DuckDNS](https://www.duckdns.org) — completely free, simple, reliable
-- [No-IP](https://noip.com) — free tier available
-- [Dynu](https://dynu.com) — free tier available
+- [DuckDNS](https://www.duckdns.org), completely free, simple, reliable
+- [No-IP](https://noip.com), free tier available
+- [Dynu](https://dynu.com), free tier available
 
 **Example with DuckDNS:**
 1. Sign up at duckdns.org
@@ -346,7 +346,7 @@ A DDNS (Dynamic DNS) service maps a hostname to your current IP and updates auto
    */5 * * * * curl -s "https://www.duckdns.org/update?domains=mycommunity&token=YOUR_TOKEN&ip=" > /dev/null
    ```
 
-### Step 3 — Port forwarding on your router
+### Step 3, Port forwarding on your router
 
 You need to forward traffic from your router to your server. The procedure varies by router brand.
 
@@ -370,9 +370,9 @@ You need to forward traffic from your router to your server. The procedure varie
 
 > 💡 **Give your server a fixed local IP:** In your router settings, look for **DHCP static lease** or **Address Reservation**. Bind your server's MAC address to a fixed local IP (e.g., `192.168.1.100`) so it never changes.
 
-### Step 4 — CGNAT (Carrier-Grade NAT)
+### Step 4, CGNAT (Carrier-Grade NAT)
 
-Some ISPs use CGNAT — your home connection shares a public IP with hundreds of other customers. In this case, port forwarding is **impossible**.
+Some ISPs use CGNAT, your home connection shares a public IP with hundreds of other customers. In this case, port forwarding is **impossible**.
 
 **How to check if you're behind CGNAT:**
 ```bash
@@ -382,18 +382,18 @@ Some ISPs use CGNAT — your home connection shares a public IP with hundreds of
 
 **Solutions if you're behind CGNAT:**
 1. **Ask your ISP** for a real public IP (sometimes free, sometimes a few €/month)
-2. **Use a cheap VPS as a relay** — run Nginx on the VPS and tunnel traffic to your home server via SSH:
+2. **Use a cheap VPS as a relay**: run Nginx on the VPS and tunnel traffic to your home server via SSH:
    ```bash
    # On your home server (creates a reverse tunnel)
    ssh -R 80:localhost:80 -R 443:localhost:443 user@VPS_IP -N
    ```
-3. **Use Cloudflare Tunnel** — free, no port forwarding needed, no VPS needed (but Cloudflare sees your traffic)
+3. **Use Cloudflare Tunnel**: free, no port forwarding needed, no VPS needed (but Cloudflare sees your traffic)
 
 ---
 
 ## 🚇 Hosting at Home WITHOUT Opening Ports
 
-Want to run Nodyx on a Raspberry Pi (or an old PC) at home, but don't want — or can't — open ports 80/443 on your router? No worries, there are free and simple solutions.
+Want to run Nodyx on a Raspberry Pi (or an old PC) at home, but don't want, or can't, open ports 80/443 on your router? No worries, there are free and simple solutions.
 
 ### Why Are Ports Required? (beginner explanation)
 
@@ -401,13 +401,13 @@ Think of your server as a house. For visitors from all over the world to ring yo
 1. Your house to have a **visible address** (public IP)
 2. The **door to be open** (ports 80 and 443 forwarded from your router to your server)
 
-If you don't want to open those doors, you use a **tunnel** — a middleman that receives visitors for you and lets them in through a service entrance you control, without exposing your house directly.
+If you don't want to open those doors, you use a **tunnel**: a middleman that receives visitors for you and lets them in through a service entrance you control, without exposing your house directly.
 
-> ⚠️ **Important:** Without HTTPS, **voice channels won't work** — browsers refuse to access the microphone/camera on non-secure HTTP. A tunnel solution is required to use all Nodyx features.
+> ⚠️ **Important:** Without HTTPS, **voice channels won't work**: browsers refuse to access the microphone/camera on non-secure HTTP. A tunnel solution is required to use all Nodyx features.
 
 ---
 
-### ⚡ Solution 0 — Nodyx Relay *(new recommendation — zero prerequisites)*
+### ⚡ Solution 0, Nodyx Relay *(new recommendation, zero prerequisites)*
 
 **Nodyx Relay** is Nodyx's built-in solution. No third-party account, no domain, no open ports.
 
@@ -425,7 +425,7 @@ If you don't want to open those doors, you use a **tunnel** — a middleman that
 
 ---
 
-### 🌩️ Solution 1 — Cloudflare Tunnel *(alternative if you already have a CF domain)*
+### 🌩️ Solution 1, Cloudflare Tunnel *(alternative if you already have a CF domain)*
 
 Cloudflare Tunnel creates an **outbound** connection from your server to Cloudflare's servers. No ports to open. Cloudflare receives visitors and forwards them to your server through this tunnel.
 
@@ -454,11 +454,11 @@ Cloudflare Tunnel creates an **outbound** connection from your server to Cloudfl
 > - Creates the tunnel, generates `config.yml`, registers DNS automatically
 > - Installs the systemd service and verifies everything is working
 >
-> **Steps 2–9 below are for reference only** — useful to understand what's happening, but you don't need to run them manually.
+> **Steps 2–9 below are for reference only**: useful to understand what's happening, but you don't need to run them manually.
 
 ---
 
-#### Step 1 — Create a Cloudflare account
+#### Step 1, Create a Cloudflare account
 
 1. Go to [dash.cloudflare.com](https://dash.cloudflare.com) and create a free account
 2. Click **"Add a site"** and enter your domain name
@@ -467,7 +467,7 @@ Cloudflare Tunnel creates an **outbound** connection from your server to Cloudfl
 5. Go to your registrar's control panel (where you bought the domain) and replace the DNS servers with Cloudflare's
 6. Wait 5–30 minutes for propagation (Cloudflare will confirm by email)
 
-#### Step 2 — Install `cloudflared` on your server
+#### Step 2, Install `cloudflared` on your server
 
 On your Raspberry Pi / Ubuntu/Debian server:
 
@@ -487,7 +487,7 @@ chmod +x /usr/local/bin/cloudflared
 cloudflared --version
 ```
 
-#### Step 3 — Log in to Cloudflare
+#### Step 3, Log in to Cloudflare
 
 ```bash
 cloudflared tunnel login
@@ -495,7 +495,7 @@ cloudflared tunnel login
 
 👆 This command shows a URL. **Copy it** and open it in your browser. Log in to your Cloudflare account and grant access. A certificate file is automatically downloaded to your server (in `~/.cloudflared/cert.pem`).
 
-#### Step 4 — Create the tunnel
+#### Step 4, Create the tunnel
 
 ```bash
 # Replace "my-community" with whatever name you want
@@ -504,7 +504,7 @@ cloudflared tunnel create my-community
 
 This creates a config file in `~/.cloudflared/`. Note the **tunnel ID** shown (e.g., `6ff42ae2-765d-4adf-8112-31c55c1551ef`).
 
-#### Step 5 — Configure the tunnel
+#### Step 5, Configure the tunnel
 
 Create the config file:
 
@@ -529,7 +529,7 @@ ingress:
   - service: http_status:404
 ```
 
-#### Step 6 — Create the DNS entries
+#### Step 6, Create the DNS entries
 
 ```bash
 # Point mycommunity.com to the tunnel
@@ -541,15 +541,15 @@ cloudflared tunnel route dns my-community api.mycommunity.com
 
 These commands automatically create DNS records in Cloudflare. No manual DNS panel work needed.
 
-#### Step 7 — Start the tunnel (test)
+#### Step 7, Start the tunnel (test)
 
 ```bash
 cloudflared tunnel run my-community
 ```
 
-If everything works, you'll see `INF Connection established` in the logs. Open `https://mycommunity.com` in your browser — Nodyx should appear!
+If everything works, you'll see `INF Connection established` in the logs. Open `https://mycommunity.com` in your browser, Nodyx should appear!
 
-#### Step 8 — Start the tunnel automatically on boot
+#### Step 8, Start the tunnel automatically on boot
 
 So the tunnel starts by itself when your server reboots:
 
@@ -565,7 +565,7 @@ systemctl start cloudflared
 systemctl status cloudflared
 ```
 
-#### Step 9 — Configure Nodyx to use this domain
+#### Step 9, Configure Nodyx to use this domain
 
 During installation, enter your domain `mycommunity.com` when the installer asks. Caddy will be configured, but with a Cloudflare Tunnel you can **disable Caddy** (Cloudflare handles HTTPS):
 
@@ -574,26 +574,26 @@ systemctl stop caddy
 systemctl disable caddy
 ```
 
-Then configure Nodyx to listen on HTTP (not HTTPS) on localhost — the Cloudflare Tunnel handles encryption.
+Then configure Nodyx to listen on HTTP (not HTTPS) on localhost, the Cloudflare Tunnel handles encryption.
 
 > 💡 **About voice channels:** Cloudflare Tunnel doesn't support UDP, so **voice channels will use your TURN relay** at your server's IP. For this to work, port **3478 UDP** must be open on your router. It's the only port strictly needed for voice. If you can't open it, voice will still work but in TCP relay mode (slightly higher latency).
 
 ---
 
-### 🦎 Solution 2 — Tailscale Funnel *(free, no domain needed)*
+### 🦎 Solution 2, Tailscale Funnel *(free, no domain needed)*
 
 Tailscale Funnel exposes your server to the internet via the Tailscale network, without opening ports. You get a free HTTPS URL like `https://myserver.tail1234.ts.net`.
 
 **What you need:**
 - A free Tailscale account → [tailscale.com](https://tailscale.com)
 
-#### Step 1 — Install Tailscale
+#### Step 1, Install Tailscale
 
 ```bash
 curl -fsSL https://tailscale.com/install.sh | sh
 ```
 
-#### Step 2 — Log in
+#### Step 2, Log in
 
 ```bash
 tailscale up
@@ -601,7 +601,7 @@ tailscale up
 
 A link appears → open it in your browser and sign in to your Tailscale account.
 
-#### Step 3 — Enable Funnel
+#### Step 3, Enable Funnel
 
 ```bash
 # Expose the frontend (port 4173) to the internet
@@ -614,7 +614,7 @@ Tailscale gives you a public HTTPS URL (e.g., `https://myserver.tail1234.ts.net`
 
 ---
 
-### 🖥️ Solution 3 — A small VPS *(the simplest and most reliable)*
+### 🖥️ Solution 3, A small VPS *(the simplest and most reliable)*
 
 Honestly, for a serious community accessible 24/7, **a VPS is the best option**. It costs less than a Netflix subscription and avoids all these tunnel headaches.
 
@@ -647,9 +647,9 @@ For most setups, **don't run a personal VPN on the same machine as Nodyx**. Use 
 
 ---
 
-### WireGuard P2P Mesh (Nodyx Federation — Phase 3)
+### WireGuard P2P Mesh (Nodyx Federation, Phase 3)
 
-> 🔭 **This is coming in Phase 3** — Nodyx nodes will form a WireGuard mesh network automatically, making the network truly decentralized and resilient.
+> 🔭 **This is coming in Phase 3**: Nodyx nodes will form a WireGuard mesh network automatically, making the network truly decentralized and resilient.
 
 Today, each Nodyx instance is independent. In the future, instances will connect via WireGuard tunnels to:
 - Share federation data (instance directory)
@@ -658,12 +658,12 @@ Today, each Nodyx instance is independent. In the future, instances will connect
 
 **If you already run WireGuard on your server** (e.g., as a personal VPN or between servers), you need to be careful:
 
-1. **Make sure Nodyx services bind to the correct interface** — the script binds to `0.0.0.0` by default (all interfaces), which is correct
-2. **Firewall rules** — UFW is set to allow the necessary ports on all interfaces. If you use WireGuard with strict routing, you may need to add WireGuard interface (`wg0`) rules manually:
+1. **Make sure Nodyx services bind to the correct interface**: the script binds to `0.0.0.0` by default (all interfaces), which is correct
+2. **Firewall rules**: UFW is set to allow the necessary ports on all interfaces. If you use WireGuard with strict routing, you may need to add WireGuard interface (`wg0`) rules manually:
    ```bash
    sudo ufw allow in on wg0 to any port 3478
    ```
-3. **TURN external IP** — the `install.sh` auto-detects your public IP via `api.ipify.org`. If your server routes outbound traffic through WireGuard, this might return the WireGuard peer's IP instead of your server's real IP. Fix it:
+3. **TURN external IP**: the `install.sh` auto-detects your public IP via `api.ipify.org`. If your server routes outbound traffic through WireGuard, this might return the WireGuard peer's IP instead of your server's real IP. Fix it:
    ```bash
    # Edit /etc/turnserver.conf
    # Change external-ip= to your actual public IP
@@ -709,7 +709,7 @@ sudo journalctl -u caddy -f
 sudo systemctl restart caddy
 ```
 
-> ⏳ **DNS propagation takes time** — if you just changed your DNS, wait 5–30 minutes and try again.
+> ⏳ **DNS propagation takes time**: if you just changed your DNS, wait 5–30 minutes and try again.
 
 ---
 
@@ -722,16 +722,16 @@ pm2 logs nodyx-core --lines 50
 ```
 
 Common causes:
-- **Wrong database password** — check `/opt/nodyx/nodyx-core/.env`
-- **PostgreSQL not running** — `sudo systemctl start postgresql`
-- **Redis not running** — `sudo systemctl start redis-server`
-- **Port 3000 already used** — `sudo lsof -i :3000`
+- **Wrong database password**: check `/opt/nodyx/nodyx-core/.env`
+- **PostgreSQL not running**: `sudo systemctl start postgresql`
+- **Redis not running**: `sudo systemctl start redis-server`
+- **Port 3000 already used**: `sudo lsof -i :3000`
 
 ---
 
 ### 🔴 Voice channels show "Relay (TURN)" instead of "P2P" for some users
 
-This is **normal and expected**. Users behind NAT (corporate networks, 4G, some ISPs) can't establish direct P2P connections. The TURN relay is the fallback — it works correctly, it's just using your server bandwidth.
+This is **normal and expected**. Users behind NAT (corporate networks, 4G, some ISPs) can't establish direct P2P connections. The TURN relay is the fallback, it works correctly, it's just using your server bandwidth.
 
 True P2P only works when both users have publicly reachable IPs or compatible NAT types.
 
@@ -773,8 +773,8 @@ pm2 logs nodyx-frontend --lines 50
 ```
 
 Common causes:
-- Frontend build failed — rebuild: `cd /opt/nodyx/nodyx-frontend && npm run build && pm2 restart nodyx-frontend`
-- Wrong `PUBLIC_API_URL` in `.env` — should be `https://yourdomain.com` (no `/api/v1`)
+- Frontend build failed, rebuild: `cd /opt/nodyx/nodyx-frontend && npm run build && pm2 restart nodyx-frontend`
+- Wrong `PUBLIC_API_URL` in `.env`, should be `https://yourdomain.com` (no `/api/v1`)
 
 ---
 
@@ -784,7 +784,7 @@ Common causes:
 
 1. Open `https://yourdomain.com` in your browser
 2. Log in with the admin credentials you set during installation
-3. You're the **owner** of the community — you have full access to the admin panel
+3. You're the **owner** of the community, you have full access to the admin panel
 
 ### Admin panel
 
@@ -889,7 +889,7 @@ cd nodyx-core && npm install && npm run build && pm2 restart nodyx-core
 cd ../nodyx-frontend && npm install && npm run build && pm2 restart nodyx-frontend
 ```
 
-> 💡 **Migrations run automatically** — the backend applies any new SQL migrations on startup.
+> 💡 **Migrations run automatically**: the backend applies any new SQL migrations on startup.
 
 ---
 
@@ -967,4 +967,4 @@ sudo apt-get remove --purge -y redis-server
 
 ---
 
-*Nodyx Installation Guide — v0.4.1 — March 2026*
+*Nodyx Installation Guide, v0.4.1, March 2026*

--- a/docs/en/MANIFESTO.md
+++ b/docs/en/MANIFESTO.md
@@ -1,5 +1,5 @@
-# NODYX — Manifesto
-### Version 1.0 — The immutable foundation
+# NODYX, Manifesto
+### Version 1.0, The immutable foundation
 
 ---
 
@@ -18,7 +18,7 @@ Then came the centralized platforms. Discord, Facebook, Slack. They said: *"It's
 
 The price? Invisible at first. Then heavier and heavier.
 
-Today millions of communities are locked inside private silos. Their discussions, their tutorials, their collective knowledge — invisible to Google, inaccessible without an account, condemned to vanish the day the platform changes its terms or shuts its doors. Discord accidentally killed a part of the internet. Not out of malice. Out of centralization.
+Today millions of communities are locked inside private silos. Their discussions, their tutorials, their collective knowledge, invisible to Google, inaccessible without an account, condemned to vanish the day the platform changes its terms or shuts its doors. Discord accidentally killed a part of the internet. Not out of malice. Out of centralization.
 
 **Nodyx was born to fix that.**
 
@@ -28,7 +28,7 @@ Today millions of communities are locked inside private silos. Their discussions
 
 Nodyx is a decentralized, open source, free community communication platform.
 
-It is the forum of the 2000s that hasn't aged, but has matured. It is Ventrilo with encryption. It is phpBB with a 2026 interface. It is TeamSpeak without a proprietary server. It is a place where a community can live, create, share, and grow — on its own terms, on its own machines.
+It is the forum of the 2000s that hasn't aged, but has matured. It is Ventrilo with encryption. It is phpBB with a 2026 interface. It is TeamSpeak without a proprietary server. It is a place where a community can live, create, share, and grow, on its own terms, on its own machines.
 
 Nodyx is made of modular building blocks. Anyone can add, modify, and share them. Nodyx does for digital communities what CMS platforms did for websites.
 
@@ -70,9 +70,9 @@ The code is public. Auditable. Forkable. If tomorrow an authority, a company, or
 
 ### 5. Modularity as respect for contributors
 
-Nodyx is a core surrounded by plugins. The core is stable, documented, protected. Plugins are the community's playground. A solo developer, a student, an enthusiast — all can contribute without having to understand the entire project. That is real open source.
+Nodyx is a core surrounded by plugins. The core is stable, documented, protected. Plugins are the community's playground. A solo developer, a student, an enthusiast, all can contribute without having to understand the entire project. That is real open source.
 
-### ⚠️ Absolute rule — Core untouchability
+### ⚠️ Absolute rule, Core untouchability
 
 **The Nodyx core can be modified by no one, for any reason, without explicit validation from the project's founding circle.**
 
@@ -110,7 +110,7 @@ We want to give the internet back its soul.
 
 ## Survival clause
 
-If one day Nodyx, under any pressure — legal, commercial, political — betrays one of these founding principles, this manifesto explicitly authorizes any community member to:
+If one day Nodyx, under any pressure, legal, commercial, political, betrays one of these founding principles, this manifesto explicitly authorizes any community member to:
 
 - Fork the project under a different name
 - Take the entirety of the code under the AGPL-3.0 license

--- a/docs/en/MODULE-SYSTEM.md
+++ b/docs/en/MODULE-SYSTEM.md
@@ -1,12 +1,12 @@
 # Module System
 
-> Available in Nodyx v2.2+. The Module System transforms every instance into a fully configurable community platform — no CLI, no code, no restarts.
+> Available in Nodyx v2.2+. The Module System transforms every instance into a fully configurable community platform, no CLI, no code, no restarts.
 
 :::info Related documentation
-**Module System** and **Homepage Builder** are two distinct but connected systems — read both to understand the full picture.
+**Module System** and **Homepage Builder** are two distinct but connected systems, read both to understand the full picture.
 - The **Module System** controls *what features exist* on your instance (forum, chat, voice, wiki…)
 - The **Homepage Builder** controls *what visitors see* on your public homepage (layout, widgets, theme)
-- A `website` module exposes widgets that appear in the Homepage Builder — but only when the module is active
+- A `website` module exposes widgets that appear in the Homepage Builder, but only when the module is active
 ::::
 
 ---
@@ -30,7 +30,7 @@ Every Nodyx instance is **two things at once**:
 └──────────────────────────────────────────────────┘
 ```
 
-A gaming clan, a sports club, an agricultural cooperative, a company — each activates only what it needs, with its own identity. One platform, infinite configurations.
+A gaming clan, a sports club, an agricultural cooperative, a company, each activates only what it needs, with its own identity. One platform, infinite configurations.
 
 ---
 
@@ -56,17 +56,17 @@ A widget can depend on a module (the `forum-preview` widget needs the `forum` mo
 
 ## The 4 Module Families
 
-### `core` — Always active, cannot be disabled
+### `core`, Always active, cannot be disabled
 
 | Module | Description |
 |---|---|
 | `auth` | Registration, login, sessions |
 | `members` | Profiles, roles, permissions |
-| `forum` | The main forum — the backbone |
+| `forum` | The main forum, the backbone |
 | `admin` | Administration panel |
 | `settings` | Instance configuration |
 
-### `community` — Internal tools (toggle on/off)
+### `community`, Internal tools (toggle on/off)
 
 These modules add functionality available to logged-in members.
 
@@ -85,9 +85,9 @@ These modules add functionality available to logged-in members.
 | `leaderboard` | Community rankings | Gaming, sports |
 | `tasks` | Lightweight task management | Companies, cooperatives |
 
-### `website` — Public face (homepage modules)
+### `website`, Public face (homepage modules)
 
-These modules build the public-facing side of your instance — no account required to see them.
+These modules build the public-facing side of your instance, no account required to see them.
 
 | Module | Description | Best for |
 |---|---|---|
@@ -105,7 +105,7 @@ These modules build the public-facing side of your instance — no account requi
 | `sponsors` | Sponsor / partner banner | Sports, events |
 | `stats` | Public counters (members, posts…) | All communities |
 
-### `integration` — External connections
+### `integration`, External connections
 
 | Module | Description |
 |---|---|
@@ -122,20 +122,20 @@ These modules build the public-facing side of your instance — no account requi
 | Module | Gaming | Sports club | Cooperative | Company |
 |---|:---:|:---:|:---:|:---:|
 | Forum | ✅ | ✅ | ✅ | ✅ |
-| Chat | ✅ | ✅ | — | ✅ |
-| Voice | ✅ | ✅ | — | ✅ |
+| Chat | ✅ | ✅ |, | ✅ |
+| Voice | ✅ | ✅ |, | ✅ |
 | Calendar | ✅ | ✅ | ✅ | ✅ |
-| Wiki | ✅ | — | ✅ | ✅ |
-| Files | — | ✅ | ✅ | ✅ |
+| Wiki | ✅ |, | ✅ | ✅ |
+| Files |, | ✅ | ✅ | ✅ |
 | DMs | ✅ | ✅ | ✅ | ✅ |
 | Polls | ✅ | ✅ | ✅ | ✅ |
-| Gallery | — | ✅ | ✅ | — |
-| Leaderboard | ✅ | ✅ | — | — |
-| Tasks | — | — | ✅ | ✅ |
-| Canvas | ✅ | — | — | — |
-| Map (public) | — | ✅ | ✅ | — |
-| Shop (public) | — | ✅ | ✅ | — |
-| Newsletter | — | ✅ | ✅ | ✅ |
+| Gallery |, | ✅ | ✅ |, |
+| Leaderboard | ✅ | ✅ |, |, |
+| Tasks |, |, | ✅ | ✅ |
+| Canvas | ✅ |, |, |, |
+| Map (public) |, | ✅ | ✅ |, |
+| Shop (public) |, | ✅ | ✅ |, |
+| Newsletter |, | ✅ | ✅ | ✅ |
 
 ---
 
@@ -153,7 +153,7 @@ Admin clicks "Enable" on a module
   → Zero downtime
 ```
 
-Disabling a module is equally clean — routes are unregistered, the UI element disappears, data is preserved.
+Disabling a module is equally clean, routes are unregistered, the UI element disappears, data is preserved.
 
 ---
 
@@ -223,7 +223,7 @@ modules/
 
 ---
 
-## Module Manager — Admin UI
+## Module Manager, Admin UI
 
 The admin sees three panels:
 
@@ -235,22 +235,22 @@ MODULE MANAGER                              [+ Add from marketplace]
 Filters: [All ▾]  [Community ▾]  [Active only]
 
 ● CORE (always active)
-  ✅ Forum          v2.1  — [Configure]
-  ✅ Members        v2.0  — [Configure]
+  ✅ Forum          v2.1 , [Configure]
+  ✅ Members        v2.0 , [Configure]
   ✅ Auth           v2.0
 
 ● COMMUNITY
-  ✅ Chat           v1.8  — [Configure]  [Disable]
-  ✅ Voice          v1.5  — [Configure]  [Disable]
-  ◻  Canvas         v1.2  — [Enable]
-  ◻  Wiki           v1.0  — [Enable]
-  ◻  Tasks          v0.9  — [Enable]  [Beta]
+  ✅ Chat           v1.8 , [Configure]  [Disable]
+  ✅ Voice          v1.5 , [Configure]  [Disable]
+  ◻  Canvas         v1.2 , [Enable]
+  ◻  Wiki           v1.0 , [Enable]
+  ◻  Tasks          v0.9 , [Enable]  [Beta]
 
 ● WEBSITE
-  ✅ Hero           v1.0  — [Configure]  [Disable]
-  ✅ Gallery        v1.1  — [Configure]  [Disable]
-  ◻  Shop           v0.8  — [Enable]  [Beta]
-  ◻  Newsletter     v1.0  — [Enable]
+  ✅ Hero           v1.0 , [Configure]  [Disable]
+  ✅ Gallery        v1.1 , [Configure]  [Disable]
+  ◻  Shop           v0.8 , [Enable]  [Beta]
+  ◻  Newsletter     v1.0 , [Enable]
 ```
 
 **2. Homepage Builder**
@@ -296,7 +296,7 @@ The Module System is currently in development. The first batch of modules ships 
 - **Core modules** already live: `forum`, `chat`, `voice`, `calendar`, `polls`, `dm`, `wiki`
 - **v2.2 targets**: formal activation/deactivation UI, `module.json` manifest loader, hot-reload routes, dynamic navigation
 - **v2.3 targets**: `gallery`, `files`, `newsletter`, `contact`, `shop` (beta)
-- **v3.0 target**: community marketplace — share and install modules from other instances
+- **v3.0 target**: community marketplace, share and install modules from other instances
 :::
 
 ---

--- a/docs/en/NEURAL-ENGINE.md
+++ b/docs/en/NEURAL-ENGINE.md
@@ -1,4 +1,4 @@
-# Neural Engine — Nodyx Guard Protocol
+# Neural Engine, Nodyx Guard Protocol
 
 Nodyx includes a Neural Engine powered by a local [Ollama](https://ollama.com) instance. Your AI runs on your own hardware. No data leaves your server.
 
@@ -19,7 +19,7 @@ The Guard Protocol is the chat moderation system driven by the Neural Engine. Wh
 |---|---|
 | Profanity / insults | ✅ Functional |
 | Spam (repeated text / flooding) | ✅ Functional |
-| URL blocking | ⚠️ Partial — not yet reliable |
+| URL blocking | ⚠️ Partial, not yet reliable |
 | Hate speech | ✅ Functional (model-dependent) |
 | Threats | ✅ Functional (model-dependent) |
 
@@ -31,7 +31,7 @@ The LLM receives the message and returns a toxicity score between 0 and 10:
 |---|---|---|
 | 0–4 | Clean / benign | Message delivered normally |
 | 5–7 | Borderline | Message delivered, logged |
-| 8–10 | Toxic / harmful | Message auto-deleted — Guard Protocol triggered |
+| 8–10 | Toxic / harmful | Message auto-deleted, Guard Protocol triggered |
 
 The threshold is configurable. A lower threshold = more aggressive moderation.
 
@@ -47,7 +47,7 @@ The current active model is configured in `nodyx-core/neural-config.json`:
 }
 ```
 
-`qwen2.5:3b` is the recommended model for moderation tasks — small enough to run on modest hardware (4 GB VRAM), fast enough for real-time chat analysis.
+`qwen2.5:3b` is the recommended model for moderation tasks, small enough to run on modest hardware (4 GB VRAM), fast enough for real-time chat analysis.
 
 ---
 
@@ -77,14 +77,14 @@ brew install ollama
 ### 2. Pull the recommended model
 
 ```bash
-ollama pull qwen2.5:3b     # recommended — fast, accurate, low VRAM
+ollama pull qwen2.5:3b     # recommended, fast, accurate, low VRAM
 ```
 
 Alternative models:
 
 | Model | Size | VRAM | Notes |
 |---|---|---|---|
-| `qwen2.5:3b` | 2.0 GB | 4 GB | **Recommended** — fast, good accuracy |
+| `qwen2.5:3b` | 2.0 GB | 4 GB | **Recommended**: fast, good accuracy |
 | `llama3.2:3b` | 2.0 GB | 4 GB | Good alternative |
 | `mistral` | 4.1 GB | 6 GB | Better quality, heavier |
 | `llama3.1:8b` | 4.9 GB | 8 GB | Best accuracy |
@@ -114,7 +114,7 @@ The Neural Engine panel is at `/admin/ai` (Admin sidebar → **Instance → Neur
 
 | Element | Description |
 |---|---|
-| Availability gauge | 12-segment bar — purple = Ollama ready, red = unreachable |
+| Availability gauge | 12-segment bar, purple = Ollama ready, red = unreachable |
 | Model list | All models detected on your Ollama instance, with size in GB |
 | Active indicator | Purple dot next to the currently selected model |
 | Scanner button | Re-scans Ollama for new or removed models |
@@ -125,7 +125,7 @@ The Neural Engine panel is at `/admin/ai` (Admin sidebar → **Instance → Neur
 
 The Neural Engine is built on a core principle: **your AI, your data, your rules**.
 
-- All inference runs locally — no calls to OpenAI, Anthropic, or any external API
+- All inference runs locally, no calls to OpenAI, Anthropic, or any external API
 - Message content analyzed by the LLM never leaves your server
 - Caddy proxy ensures Ollama is not exposed to the public internet
 - You choose the model, and you can stop it at any time
@@ -141,7 +141,7 @@ The Neural Engine is built on a core principle: **your AI, your data, your rules
 | Chat toxicity scoring (0–10) | ✅ Done |
 | Auto-delete above threshold | ✅ Done |
 | Guard Protocol UI | ✅ Done |
-| URL blocking | ⚠️ Partial — in progress |
-| Thread summarization | ⏳ Planned — Phase 4 |
-| Moderation suggestions for admins | ⏳ Planned — Phase 4 |
-| Configurable threshold via admin UI | ⏳ Planned — Phase 4 |
+| URL blocking | ⚠️ Partial, in progress |
+| Thread summarization | ⏳ Planned, Phase 4 |
+| Moderation suggestions for admins | ⏳ Planned, Phase 4 |
+| Configurable threshold via admin UI | ⏳ Planned, Phase 4 |

--- a/docs/en/OCTOGUARD.md
+++ b/docs/en/OCTOGUARD.md
@@ -210,9 +210,9 @@ When someone joins, OctoGuard can post a public welcome in a channel you choose,
 1. Open the **Bienvenue** tab.
 2. Switch on **Activer le message de bienvenue**.
 3. **Message public**: write your greeting. Three variables you can drop in:
-   - `{userMention}` — pings the new member (a clickable @name),
-   - `{user}` — their name as plain text,
-   - `{communityName}` — your instance's name.
+   - `{userMention}`, pings the new member (a clickable @name),
+   - `{user}`, their name as plain text,
+   - `{communityName}`, your instance's name.
    Example: `Welcome {userMention} to {communityName}! Read the rules and say hi in general.`
 4. **Channel cible (UUID)**: paste the ID of the channel where the message should appear.
 5. *(Optional)* **Auto-grade à l'inscription (UUID)**: paste a role ID, and every new member is automatically given that role the moment they sign up. Perfect for a "Newcomer" or "Member" role.
@@ -251,10 +251,10 @@ Your community can report messages they find abusive. Each report lands here as 
 
 A report moves through four states, and you can filter the queue by any of them:
 
-- **open** — fresh, waiting for you,
-- **reviewed** — you've looked at it (button **Marquer revu**),
-- **actioned** — you acted on it (muted, deleted, banned),
-- **dismissed** — not a real problem (button **Rejeter**).
+- **open**: fresh, waiting for you,
+- **reviewed**: you've looked at it (button **Marquer revu**),
+- **actioned**: you acted on it (muted, deleted, banned),
+- **dismissed**: not a real problem (button **Rejeter**).
 
 For each report you see the flagged message, who reported it and why. You record a **Résolution** so there's a permanent trace of what you decided, which protects you as much as the community.
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -11,7 +11,7 @@ It is the internet of the 2000s rebuilt with the tools of 2026.
 ## Why Nodyx exists
 
 Discord, Facebook, and Big Tech have locked millions of communities inside private silos.
-Discussions, tutorials, collective knowledge — invisible to Google, inaccessible without an account, condemned to disappear the day the platform shuts down.
+Discussions, tutorials, collective knowledge, invisible to Google, inaccessible without an account, condemned to disappear the day the platform shuts down.
 
 **Nodyx fixes that.**
 
@@ -20,8 +20,8 @@ Discussions, tutorials, collective knowledge — invisible to Google, inaccessib
 - Real-time community **chat** (Socket.IO)
 - **Voice** + screen sharing (WebRTC P2P)
 - **Self-hostable** on any server
-- **P2P network** — users are the network
-- **Open source** — AGPL-3.0
+- **P2P network**: users are the network
+- **Open source**: AGPL-3.0
 
 ---
 
@@ -38,30 +38,30 @@ NODYX_COMMUNITY_COUNTRY=US
 NODYX_COMMUNITY_SLUG=linux
 ```
 
-Instances discover each other through the **nodyx-directory** — the global registry *(Phase 2)*.
+Instances discover each other through the **nodyx-directory**: the global registry *(Phase 2)*.
 
 ---
 
 ## Project status
 
-**v2.0.0 — Private & Sovereign Communications**
+**v2.0.0, Private & Sovereign Communications**
 
 ```
 Forum                       ✓  Categories, threads, posts, reactions, thanks, tags, slugs
 Full-text search            ✓  PostgreSQL tsvector/GIN, highlighted excerpts
 Admin panel                 ✓  Dashboard, members, grades, bans, moderation
 SEO                         ✓  Sitemap, RSS, robots.txt, JSON-LD, canonical URLs
-Real-time chat              ✓  Socket.IO — channels, replies, pins, link previews, @mentions
-Voice channels              ✓  WebRTC P2P mesh — mute, deafen, PTT, noise filter
+Real-time chat              ✓  Socket.IO, channels, replies, pins, link previews, @mentions
+Voice channels              ✓  WebRTC P2P mesh, mute, deafen, PTT, noise filter
 Screen sharing              ✓  WebRTC screen share + clip recording
 P2P DataChannels            ✓  Instant typing, optimistic reactions, file transfer
 NodyxCanvas                 ✓  Collaborative P2P whiteboard in voice channels
-Notifications               ✓  reply, thanks, @mention — badge, center, auto-purge 30d
-Direct messages             ✓  1:1 DMs — E2E encrypted (ECDH P-256 + AES-256-GCM + ESY layer)
+Notifications               ✓  reply, thanks, @mention, badge, center, auto-purge 30d
+Direct messages             ✓  1:1 DMs, E2E encrypted (ECDH P-256 + AES-256-GCM + ESY layer)
   ↳ E2E shield              ✓  Live indicator (green/orange), ESY fingerprint tooltip
-  ↳ Barbarize animation     ✓  Encryption visualized — glyphs scramble then reveal in real-time
+  ↳ Barbarize animation     ✓  Encryption visualized, glyphs scramble then reveal in real-time
   ↳ Edit & delete           ✓  Inline edit with re-encryption, real-time delete for all participants
-Polls                       ✓  Choice / schedule / ranking — in chat and forum
+Polls                       ✓  Choice / schedule / ranking, in chat and forum
 Ban system                  ✓  User ban, IP ban, email ban
 Asset library               ✓  Frames, banners, badges, stickers, sounds, themes, fonts
 Profile themes              ✓  6 presets, per-user app-wide CSS, live editor
@@ -72,17 +72,17 @@ Federation                  ✓  Instance directory, Galaxy Bar (multi-instance 
 Gossip Protocol             ✓  Cross-instance event/thread indexing
 Nodyx Signet                ✓  Passwordless ECDSA P-256 auth PWA
 2FA (TOTP + Signet)         ✓  RFC 6238 TOTP + Signet as 2nd factor, priority chain
-nodyx-relay                 ✓  Rust TCP tunnel — home server, no open ports
-nodyx-turn                  ✓  Rust STUN/TURN — replaces coturn, voice through VPNs
+nodyx-relay                 ✓  Rust TCP tunnel, home server, no open ports
+nodyx-turn                  ✓  Rust STUN/TURN, replaces coturn, voice through VPNs
 Honeypot suite              ✓  Tarpit, canary files, fake logins, pixel, fingerprint, honeytokens, slowloris
-Olympus Hub                 ✓  Security command center — live dashboard, credential harvest, distributed blocklist
+Olympus Hub                 ✓  Security command center, live dashboard, credential harvest, distributed blocklist
 ```
 
 ---
 
 ## Installation
 
-### Option A — Docker (recommended)
+### Option A, Docker (recommended)
 
 The simplest method. Requires Docker Desktop or Docker Engine.
 
@@ -98,7 +98,7 @@ The API starts on `http://localhost:3000`
 
 ---
 
-### Option B — Windows Server without Docker (PowerShell Easy-Install)
+### Option B, Windows Server without Docker (PowerShell Easy-Install)
 
 A PowerShell script automates the full installation in under 15 minutes:
 Node.js, PostgreSQL, Redis, database configuration, migrations, and registration as a Windows service.
@@ -119,7 +119,7 @@ The script automatically installs and configures:
 
 ---
 
-### Option C — Manual installation (Linux/Mac/Windows)
+### Option C, Manual installation (Linux/Mac/Windows)
 
 **Prerequisites:** Node.js 20+, PostgreSQL 16+, Redis 7+
 
@@ -144,12 +144,12 @@ Apply migrations:
 ```bash
 # Linux/Mac (peer auth or password)
 PGPASSWORD=your_password psql -U nodyx_user -d nodyx -f src/migrations/001_initial.sql
-# Migrations are applied automatically at startup — no manual SQL needed
+# Migrations are applied automatically at startup, no manual SQL needed
 
 # Windows
 $env:PGPASSWORD="your_password"
 & "C:\Program Files\PostgreSQL\16\bin\psql.exe" -U nodyx_user -d nodyx -f src\migrations\001_initial.sql
-# Migrations are applied automatically at startup — no manual SQL needed
+# Migrations are applied automatically at startup, no manual SQL needed
 ```
 
 Start:
@@ -162,7 +162,7 @@ npm start         # production (node dist/)
 
 ---
 
-## HTTPS reverse proxy — Caddy (recommended)
+## HTTPS reverse proxy, Caddy (recommended)
 
 [Caddy](https://caddyserver.com) is a reverse proxy that automatically manages SSL certificates via Let's Encrypt. No manual SSL configuration.
 
@@ -189,7 +189,7 @@ See [`nodyx-core/.env.example`](../../nodyx-core/.env.example) for the full anno
 | `NODYX_COMMUNITY_NAME` | Yes | Community display name |
 | `NODYX_COMMUNITY_SLUG` | Yes | URL slug (lowercase letters, hyphens) |
 | `NODYX_COMMUNITY_LANGUAGE` | No | Language (default: `en`) |
-| `JWT_SECRET` | Yes | JWT secret — **32+ random characters in production** |
+| `JWT_SECRET` | Yes | JWT secret, **32+ random characters in production** |
 | `DB_HOST` / `DB_PORT` / `DB_NAME` | Yes | PostgreSQL connection |
 | `DB_USER` / `DB_PASSWORD` | Yes | PostgreSQL credentials |
 | `REDIS_HOST` / `REDIS_PORT` | No | Redis (default: `localhost:6379`) |
@@ -228,10 +228,10 @@ After `npm run seed`:
 
 ## Documentation
 
-- [ROADMAP.md](./ROADMAP.md) — The path to the complete vision
-- [ARCHITECTURE.md](./ARCHITECTURE.md) — How Nodyx is built
-- [CONTRIBUTING.md](./CONTRIBUTING.md) — How to contribute
-- [MANIFESTO.md](./MANIFESTO.md) — The founding principles
+- [ROADMAP.md](./ROADMAP.md), The path to the complete vision
+- [ARCHITECTURE.md](./ARCHITECTURE.md), How Nodyx is built
+- [CONTRIBUTING.md](./CONTRIBUTING.md), How to contribute
+- [MANIFESTO.md](./MANIFESTO.md), The founding principles
 
 ---
 
@@ -252,7 +252,7 @@ nodyx-docs/       →  Improve documentation
 
 ## License
 
-AGPL-3.0 — The code belongs to its community.
+AGPL-3.0, The code belongs to its community.
 
 If Nodyx betrays its principles, the Manifesto explicitly authorizes
 anyone to fork the project and continue.
@@ -261,7 +261,7 @@ anyone to fork the project and continue.
 
 ## Official supervisor
 
-**Iris** — Approves every commit since February 18, 2026. 🐱
+**Iris**: Approves every commit since February 18, 2026. 🐱
 
 ---
 

--- a/docs/en/RELAY.md
+++ b/docs/en/RELAY.md
@@ -1,8 +1,8 @@
-# ⚡ Nodyx Relay — Install without a domain or open ports
+# ⚡ Nodyx Relay, Install without a domain or open ports
 
-> **The problem:** You want to host Nodyx at home — on a Raspberry Pi, an old PC, your home router setup — but you don't have a domain, and your ISP blocks incoming ports.
+> **The problem:** You want to host Nodyx at home, on a Raspberry Pi, an old PC, your home router setup, but you don't have a domain, and your ISP blocks incoming ports.
 >
-> **The solution:** Nodyx Relay. A 9 MB Rust binary that establishes an **outbound** connection to our infrastructure, making your instance accessible at `your-slug.nodyx.org` — with zero configuration.
+> **The solution:** Nodyx Relay. A 9 MB Rust binary that establishes an **outbound** connection to our infrastructure, making your instance accessible at `your-slug.nodyx.org`, with zero configuration.
 
 ---
 
@@ -15,7 +15,7 @@
 - [Checking that the tunnel is active](#-checking-that-the-tunnel-is-active)
 - [Troubleshooting](#-troubleshooting)
 - [FAQ](#-faq)
-- [For the curious — Technical architecture](#-for-the-curious--technical-architecture)
+- [For the curious, Technical architecture](#-for-the-curious--technical-architecture)
 
 ---
 
@@ -41,7 +41,7 @@
 
 1. **You run `bash install.sh`** and choose option `[2] Nodyx Relay`
 2. **`nodyx-relay-client`** starts as a systemd service on your machine
-3. It establishes an **outbound TCP connection** (port 7443) to `relay.nodyx.org` — just like opening a website, not like opening a port
+3. It establishes an **outbound TCP connection** (port 7443) to `relay.nodyx.org`, just like opening a website, not like opening a port
 4. When someone visits `your-slug.nodyx.org`, the HTTPS request arrives at our VPS, the relay server routes it through the tunnel, and your machine responds
 5. **Your machine has no open ports.** Your router has nothing to forward. Your ISP only sees outbound traffic.
 
@@ -58,13 +58,13 @@
 | 64-bit Linux OS | ✅ Yes | Ubuntu 22.04/24.04, Debian 11/12, Raspberry Pi OS 64-bit |
 | Architecture | ✅ `x86_64` or `aarch64` | PC/VPS or Raspberry Pi 3/4/5 |
 
-> 💡 **Raspberry Pi 4, 8 GB RAM, Ubuntu Server 24.04 (arm64):** tested and validated in real-world conditions — March 1, 2026.
+> 💡 **Raspberry Pi 4, 8 GB RAM, Ubuntu Server 24.04 (arm64):** tested and validated in real-world conditions, March 1, 2026.
 
 ---
 
 ## 🚀 Installation
 
-### Method 1 — Interactive installer (recommended)
+### Method 1, Interactive installer (recommended)
 
 ```bash
 git clone https://github.com/Pokled/Nodyx.git && cd Nodyx && sudo bash install.sh
@@ -74,11 +74,11 @@ When the installer asks for the network mode, choose **`2`**:
 
 ```
   Network connection mode
-  ┌─ [1] Personal domain  — ports 80/443 open required
-  ├─ [2] Nodyx Relay       — recommended — no ports, no domain (RPi, home box, ...)
-  └─ [3] sslip.io auto     — free automatic domain, open ports required
+  ┌─ [1] Personal domain , ports 80/443 open required
+  ├─ [2] Nodyx Relay      , recommended, no ports, no domain (RPi, home box, ...)
+  └─ [3] sslip.io auto    , free automatic domain, open ports required
 
-  ? Choice [1/2/3] (default: 2 — Nodyx Relay):
+  ? Choice [1/2/3] (default: 2, Nodyx Relay):
 ```
 
 **The installer handles everything:**
@@ -91,7 +91,7 @@ When the installer asks for the network mode, choose **`2`**:
 
 ---
 
-### Method 2 — Binary only (existing installation)
+### Method 2, Binary only (existing installation)
 
 If you already have a Nodyx instance and just want to add the relay:
 
@@ -159,7 +159,7 @@ sudo journalctl -u nodyx-relay-client -f
 
 # What you should see in the logs:
 # → Connected to relay.nodyx.org:7443
-# → Registered as slug "your-slug" — OK
+# → Registered as slug "your-slug", OK
 # → Forwarding GET / → HTTP 200
 ```
 
@@ -218,11 +218,11 @@ Your local instance continues to work normally. Only access from the Internet vi
 
 **Q: Do voice channels work in Relay mode?**
 
-Voice channels use WebRTC, which requires a TURN server to traverse NAT. In Relay mode, coturn is not installed (the required UDP ports are not open). Voice calls between members on the same local network will work. For cross-network calls, an external TURN server is needed — this is what **Phase 3.0-B (nodyx-turn)** will solve in an integrated way.
+Voice channels use WebRTC, which requires a TURN server to traverse NAT. In Relay mode, coturn is not installed (the required UDP ports are not open). Voice calls between members on the same local network will work. For cross-network calls, an external TURN server is needed, this is what **Phase 3.0-B (nodyx-turn)** will solve in an integrated way.
 
 **Q: Is the relay free?**
 
-Yes, without limits during the beta period. We reserve the right to introduce reasonable limits if usage becomes excessive (bandwidth > several TB/month per instance, for example). The relay is open source — you can host your own.
+Yes, without limits during the beta period. We reserve the right to introduce reasonable limits if usage becomes excessive (bandwidth > several TB/month per instance, for example). The relay is open source, you can host your own.
 
 **Q: How do I change my slug?**
 
@@ -230,11 +230,11 @@ The slug is registered at installation time. To change it, contact nodyx.org sup
 
 **Q: Does the relay work with Docker?**
 
-Yes. The `nodyx-relay client` binary can run outside the Docker container — just point `--local-port` to the port exposed by your container (default 80).
+Yes. The `nodyx-relay client` binary can run outside the Docker container, just point `--local-port` to the port exposed by your container (default 80).
 
 ---
 
-## 🏗️ For the curious — Technical architecture
+## 🏗️ For the curious, Technical architecture
 
 ### The relay server (nodyx.org)
 
@@ -244,7 +244,7 @@ Port 7443 (public TCP)
     └── Authenticates via token (directory_instances table in PostgreSQL)
     └── Registers slug → TunnelHandle (DashMap in memory)
 
-Port 7001 (HTTP, local only — receives requests from Caddy)
+Port 7001 (HTTP, local only, receives requests from Caddy)
 └── Extracts slug from Host header
     ├── Slug with active tunnel → forward through TCP tunnel
     ├── Slug in DB with URL → 302 redirect
@@ -282,13 +282,13 @@ nodyx-p2p/
 └── crates/
     └── nodyx-relay/
         └── src/
-            ├── main.rs          — CLI (clap)
-            ├── protocol.rs      — types + framing
-            ├── server/          — relay server (VPS)
-            └── client/          — relay client (your machine)
+            ├── main.rs         , CLI (clap)
+            ├── protocol.rs     , types + framing
+            ├── server/         , relay server (VPS)
+            └── client/         , relay client (your machine)
 ```
 
 ---
 
-*Version 1.0 — March 1, 2026*
+*Version 1.0, March 1, 2026*
 *Validated on Raspberry Pi 4 (arm64), Ubuntu Server 24.04, no open ports.*

--- a/docs/en/ROADMAP.md
+++ b/docs/en/ROADMAP.md
@@ -1,5 +1,5 @@
-# NODYX — Roadmap
-### Version 2.7 — Streamer Hub (Soundboard + Deck) · then Stabilization Era
+# NODYX, Roadmap
+### Version 2.7, Streamer Hub (Soundboard + Deck) · then Stabilization Era
 
 ---
 
@@ -9,7 +9,7 @@
 
 ---
 
-## CURRENT STATE — June 2026
+## CURRENT STATE, June 2026
 
 | Phase | Title | Status |
 |---|---|---|
@@ -20,44 +20,44 @@
 | **Phase 4** | Platform enrichment (v1.4 → v1.8) | ✅ Complete |
 | **Phase 4.5** | Security hardening (v1.8.2) | ✅ Complete |
 | **Phase 4.6** | Active defense & runtime security (v1.9.0) | ✅ Complete |
-| **Phase 4.7** | 2FA — TOTP + Nodyx Signet as 2nd factor (v1.9.1) | ✅ Complete |
+| **Phase 4.7** | 2FA, TOTP + Nodyx Signet as 2nd factor (v1.9.1) | ✅ Complete |
 | **Phase 4.8** | Production stability & cross-runtime hardening (v1.9.3) | ✅ Complete |
 | **Phase 4.9** | Process isolation, test coverage & CI hardening (v1.9.4) | ✅ Complete |
 | **Phase 4.10** | Living Profile + Forum Redesign (v1.9.5) | ✅ Complete |
-| **Phase 4.11** | Private & Sovereign Communications — E2E DMs (v2.0) | ✅ Complete |
+| **Phase 4.11** | Private & Sovereign Communications, E2E DMs (v2.0) | ✅ Complete |
 | **Phase 4.12** | Homepage Builder + Widget SDK (v2.1) | ✅ Complete |
-| **Phase 4.13** | NodyxCanvas — Major upgrade (v2.2) | ✅ Complete |
+| **Phase 4.13** | NodyxCanvas, Major upgrade (v2.2) | ✅ Complete |
 | **Phase 4.14** | Universal Media Player + Builder Catalog Fusion + Tunnel Hardening (v2.3) | ✅ Complete |
 | **Phase 4.15** | Backup System Phase 1 + Live Maintenance Mode (v2.4) | ✅ Complete |
-| **Phase 4.16** | OctoGuard Phase 1 — Native auto-moderation (v2.6) | ✅ Complete (rollout) |
-| **Phase 4.17** | Streamer Hub — Soundboard, multi-page Deck, Playlists & OBS Scenes (v2.7) | ✅ Complete |
+| **Phase 4.16** | OctoGuard Phase 1, Native auto-moderation (v2.6) | ✅ Complete (rollout) |
+| **Phase 4.17** | Streamer Hub, Soundboard, multi-page Deck, Playlists & OBS Scenes (v2.7) | ✅ Complete |
 | **Phase 4.18** | Editor robustness + UX overhaul, SEO/GEO foundations, security sweep | ✅ Complete |
 | **Stabilization Era** | No new big features. Finish the Streamer Hub, then polish everything (security, network, perf, UX). Goal: a stable core that outlives its creator. | 🛠️ Active |
 | Phase 5 | Mobile + Nodes + Reactions + Discord import | ⏸️ Deferred (after stabilization) |
-| **Phase Horizon** | NODYX-ETHER — Physical layer sovereignty | 🌌 Vision |
-| **Phase Radio** | NODYX-RADIO — Internet radio + cooperative ad network | 📻 Vision |
+| **Phase Horizon** | NODYX-ETHER, Physical layer sovereignty | 🌌 Vision |
+| **Phase Radio** | NODYX-RADIO, Internet radio + cooperative ad network | 📻 Vision |
 
 ---
 
-## PHASE 1 — Forum MVP + Admin ✅ COMPLETE
+## PHASE 1, Forum MVP + Admin ✅ COMPLETE
 ### Goal: A community can install, configure, and live on Nodyx
 
 ### 1.1 Forum Backend
 - [x] Initial SQL migration (users, communities, categories, threads, posts)
-- [x] Migration 002 — user_profiles (bio, avatar, tags, links, social fields)
-- [x] Migration 003 — grades (grades, community_grades, community_members.grade_id)
-- [x] Migration 004 — social links (github, youtube, twitter, instagram, website)
-- [x] Migration 005 — categories.parent_id (infinite categories, recursive CTE)
-- [x] Migration 006 — threads.is_featured (featured articles)
-- [x] Migration 007 — post_reactions + post_thanks (emoji reactions + karma)
-- [x] Migration 008 — tags + thread_tags (community-scoped tags)
-- [x] Migration 009 — search_vector + GIN triggers (full-text search)
-- [x] Migration 010 — notifications (thread_reply, post_thanks, mention)
+- [x] Migration 002, user_profiles (bio, avatar, tags, links, social fields)
+- [x] Migration 003, grades (grades, community_grades, community_members.grade_id)
+- [x] Migration 004, social links (github, youtube, twitter, instagram, website)
+- [x] Migration 005, categories.parent_id (infinite categories, recursive CTE)
+- [x] Migration 006, threads.is_featured (featured articles)
+- [x] Migration 007, post_reactions + post_thanks (emoji reactions + karma)
+- [x] Migration 008, tags + thread_tags (community-scoped tags)
+- [x] Migration 009, search_vector + GIN triggers (full-text search)
+- [x] Migration 010, notifications (thread_reply, post_thanks, mention)
 - [x] Route POST /api/v1/auth/register
 - [x] Route POST /api/v1/auth/login + logout
 - [x] Route GET  /api/v1/communities + /communities/:slug
 - [x] Route POST /api/v1/communities/:slug/members (join/leave)
-- [x] Forum routes (categories, threads, posts) — full CRUD
+- [x] Forum routes (categories, threads, posts), full CRUD
 - [x] Thread title editing (author + mods)
 - [x] Emoji reactions on posts (6 emojis, toggle)
 - [x] Thanks button (+5 karma to author, 1 per user/post)
@@ -67,9 +67,9 @@
 - [x] JWT authentication middleware
 - [x] Redis rate limiting middleware
 - [x] Zod validation on all routes
-- [x] "Online" tracking — Redis heartbeat 900s TTL
-- [x] Instance routes — /instance/info, /instance/categories, /instance/threads/recent
-- [x] Admin routes — stats, members, threads (pin/lock/delete), categories, tags
+- [x] "Online" tracking, Redis heartbeat 900s TTL
+- [x] Instance routes, /instance/info, /instance/categories, /instance/threads/recent
+- [x] Admin routes, stats, members, threads (pin/lock/delete), categories, tags
 
 ### 1.2 SEO and indexing
 - [x] Forum routes rendered as static HTML (SvelteKit SSR)
@@ -86,26 +86,26 @@
 - [x] Recursive category tree (CategoryTree.svelte)
 - [x] Category + thread list page (with tag pills)
 - [x] Thread + posts page + reply form
-- [x] WYSIWYG editor (Tiptap — bold, code, tables, images, iframes)
+- [x] WYSIWYG editor (Tiptap, bold, code, tables, images, iframes)
 - [x] Registration / login form
 - [x] Complete user profiles (bio, tags, links, GitHub widget)
 - [x] Grade system (admin CRUD + colored badge)
-- [x] Instance directory (/communities — powered by nodyx.org)
-- [x] Full admin panel (/admin — 9 pages including Tags)
+- [x] Instance directory (/communities, powered by nodyx.org)
+- [x] Full admin panel (/admin, 9 pages including Tags)
 - [x] Adaptive navbar (search, notifications bell, Admin link)
-- [x] /search page — Threads/Posts tabs, highlighted excerpts
-- [x] /notifications page — list + mark read + 30s polling
+- [x] /search page, Threads/Posts tabs, highlighted excerpts
+- [x] /notifications page, list + mark read + 30s polling
 
 ### 1.4 Self-hosting
-- [x] `install.sh` — one-click VPS installer (ports 80/443, Let's Encrypt via Caddy, PM2, coturn, PostgreSQL, Redis)
-- [x] `install_tunnel.sh` — home server installer via Cloudflare Tunnel (no open ports, Raspberry Pi, home box)
+- [x] `install.sh`, one-click VPS installer (ports 80/443, Let's Encrypt via Caddy, PM2, coturn, PostgreSQL, Redis)
+- [x] `install_tunnel.sh`, home server installer via Cloudflare Tunnel (no open ports, Raspberry Pi, home box)
 - [x] docker-compose.yml (Nodyx + PostgreSQL + Redis)
 - [x] Multi-stage Dockerfile
 - [x] Seed script (demo data)
-- [x] PowerShell "Nodyx-Easy-Install" script — automates Node/PostgreSQL/Redis on Windows Server without Docker
+- [x] PowerShell "Nodyx-Easy-Install" script, automates Node/PostgreSQL/Redis on Windows Server without Docker
 - [x] Visual post-installation health check (braille spinner, PASS/WARN/FAIL score)
 - [x] 15-minute installation documentation
-- [x] Complete domain name guide (DOMAIN.md — types, compatibility, FAQ)
+- [x] Complete domain name guide (DOMAIN.md, types, compatibility, FAQ)
 - [x] Documented .env.example
 
 ### Phase 1 success criteria ✅
@@ -118,87 +118,87 @@ A non-developer can:
 
 ---
 
-## PHASE 2 — Real-time Chat + Directory + Network Identity ✅ COMPLETE
+## PHASE 2, Real-time Chat + Directory + Network Identity ✅ COMPLETE
 ### Goal: Members communicate live, the directory is real, each instance has its URL
 
 ### 2.1 Real-time chat ✅
 - [x] WebSocket (Socket.io) integrated into Fastify v5
 - [x] Text channels configurable by admin
-- [x] Real-time notifications (WebSocket — replaces 30s polling)
+- [x] Real-time notifications (WebSocket, replaces 30s polling)
 - [x] Message history persisted in PostgreSQL
 
-### 2.2 nodyx.org — Directory ✅
-- [x] Real global directory service — instance registration API
+### 2.2 nodyx.org, Directory ✅
+- [x] Real global directory service, instance registration API
 - [x] /communities page fed by the real directory (end of mock)
 - [x] Automatic instance registration on first startup
 - [x] Automatic ping every 5 minutes (live member count, online stats)
 
-### 2.3 Network identity — `slug.nodyx.org` ✅
+### 2.3 Network identity, `slug.nodyx.org` ✅
 - [x] Each instance chooses a unique slug at installation
 - [x] The slug is reserved with the nodyx.org directory (REST API)
 - [x] Wildcard DNS `*.nodyx.org` managed by our Cloudflare
 - [x] Caddy routes `slug.nodyx.org → node IP` (Cloudflare Origin Certificate)
-- [x] Admin has no DNS to configure — clean URL in 1 click
+- [x] Admin has no DNS to configure, clean URL in 1 click
 
-### 2.4 Voice channels — Network layer ✅
+### 2.4 Voice channels, Network layer ✅
 - [x] coturn server (STUN/TURN) configured and started by `install.sh`
 - [x] WebRTC signaling via Socket.io (`src/socket/voice.ts`)
-- [x] VoicePanel.svelte — floating bar + mic/camera/screen share controls
-- [x] VoiceSettings.svelte — configurable AudioContext chain
-- [x] MediaCenter.svelte — screen sharing + clips
+- [x] VoicePanel.svelte, floating bar + mic/camera/screen share controls
+- [x] VoiceSettings.svelte, configurable AudioContext chain
+- [x] MediaCenter.svelte, screen sharing + clips
 
 ---
 
-## PHASE 2.5 — Community customization + Light federation ✅ COMPLETE
+## PHASE 2.5, Community customization + Light federation ✅ COMPLETE
 ### Goal: Each instance is unique, and instances can share their creations
 
-### v0.6 — Asset library & Feature Garden ✅
+### v0.6, Asset library & Feature Garden ✅
 
-- [x] Migration 017 — `community_assets` (frames, banners, badges, stickers, avatars, wallpapers)
-- [x] Migration 018 — `user_equipped_assets` (profile customization slots)
-- [x] Migration 019 — `feature_seeds` (feature proposals)
-- [x] Migration 020 — `user_seed_balance` (3 seeds/week per user)
-- [x] Route `POST /api/v1/assets` — multipart upload with Sharp compression (WebP)
+- [x] Migration 017, `community_assets` (frames, banners, badges, stickers, avatars, wallpapers)
+- [x] Migration 018, `user_equipped_assets` (profile customization slots)
+- [x] Migration 019, `feature_seeds` (feature proposals)
+- [x] Migration 020, `user_seed_balance` (3 seeds/week per user)
+- [x] Route `POST /api/v1/assets`, multipart upload with Sharp compression (WebP)
 - [x] Full CRUD + like + equip/unequip routes for community assets
-- [x] `assetService.ts` — automatic thumbnails, resize, slot management
-- [x] `/library` page — asset gallery with category/tag/popularity filters
-- [x] `/library/[id]` page — asset detail with like, equip, Whisper button
-- [x] `/api/v1/garden` routes — proposals + seed voting + status change (admin)
-- [x] `/garden` page — proposal list, visual voting with seed counter
-- [x] User profile — display equipped assets (frame, banner, badge, wallpaper)
-- [x] `/users/me/edit` — manage asset slots on your own profile
+- [x] `assetService.ts`, automatic thumbnails, resize, slot management
+- [x] `/library` page, asset gallery with category/tag/popularity filters
+- [x] `/library/[id]` page, asset detail with like, equip, Whisper button
+- [x] `/api/v1/garden` routes, proposals + seed voting + status change (admin)
+- [x] `/garden` page, proposal list, visual voting with seed counter
+- [x] User profile, display equipped assets (frame, banner, badge, wallpaper)
+- [x] `/users/me/edit`, manage asset slots on your own profile
 
-### v0.7 — Federated assets + Whispers ✅
+### v0.7, Federated assets + Whispers ✅
 
-- [x] Migration 021 — `directory_assets` (federated asset snapshot from other instances)
-- [x] Migration 022 — `whisper_rooms` + `whisper_messages` (ephemeral rooms)
-- [x] Route `POST /api/directory/assets` — push assets to registry (Bearer token)
-- [x] Route `GET /api/directory/assets/search` — public multi-instance search
-- [x] Scheduler — push assets to `nodyx.org` every hour
-- [x] Scheduler — clean up expired whisper rooms every 10 minutes
-- [x] "🌐 All instances" tab in `/library` — federated assets from the directory
-- [x] `/api/v1/whispers` routes — create, retrieve, delete ephemeral rooms
-- [x] Socket.IO — `whisper:*` events (join, leave, message, typing, history, expired)
-- [x] `/whisper/[id]` page — real-time whisper room (iMessage-style, TTL displayed)
-- [x] "🤫 Whisper" button on asset pages — contextual room creation
-- [x] "🔗 Share" button — copies link with "✅ Copied!" feedback
-- [x] `linkify.ts` — clickable URLs in chat (`linkifyHtml`) and whispers (`linkifyText`)
+- [x] Migration 021, `directory_assets` (federated asset snapshot from other instances)
+- [x] Migration 022, `whisper_rooms` + `whisper_messages` (ephemeral rooms)
+- [x] Route `POST /api/directory/assets`, push assets to registry (Bearer token)
+- [x] Route `GET /api/directory/assets/search`, public multi-instance search
+- [x] Scheduler, push assets to `nodyx.org` every hour
+- [x] Scheduler, clean up expired whisper rooms every 10 minutes
+- [x] "🌐 All instances" tab in `/library`, federated assets from the directory
+- [x] `/api/v1/whispers` routes, create, retrieve, delete ephemeral rooms
+- [x] Socket.IO, `whisper:*` events (join, leave, message, typing, history, expired)
+- [x] `/whisper/[id]` page, real-time whisper room (iMessage-style, TTL displayed)
+- [x] "🤫 Whisper" button on asset pages, contextual room creation
+- [x] "🔗 Share" button, copies link with "✅ Copied!" feedback
+- [x] `linkify.ts`, clickable URLs in chat (`linkifyHtml`) and whispers (`linkifyText`)
 
 ---
 
-## PHASE 3 — P2P Infrastructure + Rust Foundation ✅ COMPLETE
+## PHASE 3, P2P Infrastructure + Rust Foundation ✅ COMPLETE
 ### Goal: Break free from third-party network dependencies. Build the decentralized core.
 
 > *"P2P is the soul. Rust is the body."*
 >
-> Nodyx will not replace Node.js or SvelteKit — they do their job perfectly.
+> Nodyx will not replace Node.js or SvelteKit, they do their job perfectly.
 > Rust will come **underneath**, invisible to the user, to handle the parts
 > that JavaScript can't do well: low-level networking, encryption, WireGuard, DHT.
-> The Rust layer communicates with nodyx-core via a local Unix socket — simple and decoupled.
+> The Rust layer communicates with nodyx-core via a local Unix socket, simple and decoupled.
 
 ---
 
-### 3.0 — `nodyx-p2p`: The Rust Foundation ✅ COMPLETE
+### 3.0, `nodyx-p2p`: The Rust Foundation ✅ COMPLETE
 
 #### Why Rust here?
 
@@ -241,191 +241,191 @@ nodyx-core    (Fastify/Node.js) ────────────────
                                     └─────────────────────┘
 ```
 
-#### Phase 3.0-A — `nodyx-relay-client` ✅ VALIDATED — March 1, 2026
+#### Phase 3.0-A, `nodyx-relay-client` ✅ VALIDATED, March 1, 2026
 
 > Replaces `install_tunnel.sh` + Cloudflare Tunnel. Zero domain required. Zero open ports.
 > **Tested in real conditions: Raspberry Pi 4, no open ports, no Cloudflare account.**
 
-- [x] Static Rust binary (9MB) — `tokio` + `hyper` + `tokio-postgres` + `clap` + `dashmap`
+- [x] Static Rust binary (9MB), `tokio` + `hyper` + `tokio-postgres` + `clap` + `dashmap`
 - [x] Outbound TCP connection to `relay.nodyx.org:7443` (our infrastructure)
 - [x] Bidirectional HTTP forwarding (JSON framing, 4-byte length prefix)
 - [x] Automatic `slug.nodyx.org` registration without DNS or CF account
 - [x] Automatic reconnection with exponential backoff (1s → 2s → 4s → max 30s)
-- [x] GitHub Release `v0.1.1-relay` — amd64 + arm64 binaries (fix: concurrent request handling)
+- [x] GitHub Release `v0.1.1-relay`, amd64 + arm64 binaries (fix: concurrent request handling)
 - [x] Integration in `install.sh`: option 2 "Nodyx Relay (recommended)"
 - [x] Client-side systemd service (`nodyx-relay-client.service`)
 
 **User result:** `bash install.sh` → choose "Relay" → get `mycommunity.nodyx.org` **with zero network configuration**.
 
-#### Phase 3.0-B — Browser P2P Nodes (WebRTC DataChannels) ✅ POC VALIDATED — March 2, 2026
+#### Phase 3.0-B, Browser P2P Nodes (WebRTC DataChannels) ✅ POC VALIDATED, March 2, 2026
 
 > Users' browsers become active relay nodes.
 > Direct peer-to-peer communication without server intermediary.
-> **Reuses the existing `voice.ts` signaling** — zero new server infrastructure needed.
+> **Reuses the existing `voice.ts` signaling**: zero new server infrastructure needed.
 
 **Approach:** Native WebRTC DataChannels + existing Socket.IO signaling (voice.ts pattern)
 **Not in this POC:** libp2p (overkill), DHT (2027+)
 
-**v0.8 — Two-browser POC ✅:**
-- [x] Add `p2p:offer`, `p2p:answer`, `p2p:ice` events to `voice.ts` (3 lines — same pattern as `voice:offer/answer/ice`)
-- [x] Create `nodyx-frontend/src/lib/p2p.ts` — RTCPeerConnection + DataChannel manager
-- [x] Peer discovery via existing Socket.IO (polite/impolite handshake — single initiator only)
-- [x] Use instance's own coturn (already installed) — no third-party STUN
-- [x] `ondatachannel` handler on responder side (critical — without it, responder never receives the channel)
+**v0.8, Two-browser POC ✅:**
+- [x] Add `p2p:offer`, `p2p:answer`, `p2p:ice` events to `voice.ts` (3 lines, same pattern as `voice:offer/answer/ice`)
+- [x] Create `nodyx-frontend/src/lib/p2p.ts`, RTCPeerConnection + DataChannel manager
+- [x] Peer discovery via existing Socket.IO (polite/impolite handshake, single initiator only)
+- [x] Use instance's own coturn (already installed), no third-party STUN
+- [x] `ondatachannel` handler on responder side (critical, without it, responder never receives the channel)
 - [x] UI indicator "⚡ P2P · N" in the text channel header (yellow when active, pulsing gray while connecting)
 - [x] Validated test: two browsers, direct DataChannel confirmed, messages not going through server
 
 **User result:** join any text channel → the ⚡ P2P indicator appears automatically when another member is present. Zero configuration.
 
-**v0.9 — 1-N Mesh ✅ DELIVERED — March 2, 2026:**
-- [x] Handle multiple simultaneous peer connections (Map of RTCPeerConnections — already in p2p.ts)
+**v0.9, 1-N Mesh ✅ DELIVERED, March 2, 2026:**
+- [x] Handle multiple simultaneous peer connections (Map of RTCPeerConnections, already in p2p.ts)
 - [x] Instant P2P typing indicators (~1–5ms, animated Discord-style bouncing dots)
 - [x] Optimistic reactions + spring physics pop animation (arrives before server roundtrip)
 - [x] Graceful fallback if WebRTC fails (12s ICE timeout, subtle toast, _hadAttempt/_hadSuccess flags)
 - [x] Asset transfer between peers (32 KB chunks, p2p:asset:* protocol, p2pAssetPeers store, ⚡ yellow button)
 
-#### Phase 3.0-C — `nodyx-turn` (replaces coturn) ✅ VALIDATED — March 4, 2026 / Updated March 8, 2026
+#### Phase 3.0-C, `nodyx-turn` (replaces coturn) ✅ VALIDATED, March 4, 2026 / Updated March 8, 2026
 
 > coturn is a 2000s C project. Complex to configure, significant attack surface.
-> **Replaced by a 2.9MB Rust binary — zero dependency, dynamic credentials.**
+> **Replaced by a 2.9MB Rust binary, zero dependency, dynamic credentials.**
 
-- [x] STUN/TURN server in Rust — RFC 5389 (STUN) + RFC 5766 (TURN)
+- [x] STUN/TURN server in Rust, RFC 5389 (STUN) + RFC 5766 (TURN)
 - [x] HMAC-SHA1 time-based credentials (username={expires}:{userId})
-- [x] MESSAGE-INTEGRITY on all TURN success responses (RFC 5389 §10.3) — required for Firefox/Chrome relay
-- [x] **TURN-over-TCP (RFC 6062)** — TCP:3478 alongside UDP:3478, shared allocation registry
+- [x] MESSAGE-INTEGRITY on all TURN success responses (RFC 5389 §10.3), required for Firefox/Chrome relay
+- [x] **TURN-over-TCP (RFC 6062)**: TCP:3478 alongside UDP:3478, shared allocation registry
 - [x] RFC 4571 framing (2-byte big-endian length prefix per TCP message)
-- [x] `ResponseSink` abstraction — all TURN handlers transport-agnostic (UDP and TCP unified)
+- [x] `ResponseSink` abstraction, all TURN handlers transport-agnostic (UDP and TCP unified)
 - [x] Rate limiter UDP per IP (30 pkt/sec) + allocation quotas (MAX_LIFETIME=300s) + ban map
 - [x] 2.9MB static binary, integrated in `install.sh`, systemd service
 - [x] Validated: STUN Binding Request → 0x0101 Binding Success ✅
-- [x] **Voice — Relay failover**: auto-switches to `iceTransportPolicy: relay` after sustained high packet loss (>25% × 3 polls)
-- [x] **Voice — Opus tuning**: 32 kbps default, DTX off, mono, FEC on — optimized for VPN/lossy links
+- [x] **Voice, Relay failover**: auto-switches to `iceTransportPolicy: relay` after sustained high packet loss (>25% × 3 polls)
+- [x] **Voice, Opus tuning**: 32 kbps default, DTX off, mono, FEC on, optimized for VPN/lossy links
 
-#### Phase 3.0-D — `nodyx-p2p` core (long-term vision 2027-2028)
+#### Phase 3.0-D, `nodyx-p2p` core (long-term vision 2027-2028)
 
 > The distributed core. When a node wants to contact another node directly, without going through us.
 > Immortal network: every piece of data replicated on 3+ nodes, auto-healing.
 
-- [ ] Kademlia DHT (via `libp2p`) — peer discovery without central server
-- [ ] WireGuard (via `wireguard-rs`) — encrypted direct tunnel between voluntary instances
-- [ ] Native ICE/STUN — NAT traversal without coturn for P2P connections
+- [ ] Kademlia DHT (via `libp2p`), peer discovery without central server
+- [ ] WireGuard (via `wireguard-rs`), encrypted direct tunnel between voluntary instances
+- [ ] Native ICE/STUN, NAT traversal without coturn for P2P connections
 - [ ] IPC API exposed to nodyx-core: `relay.register(slug)`, `peer.connect(slug)`, `network.peers()`
-- [ ] Gossip protocol — natural state propagation across the network
-- [ ] CRDTs — conflict-free distributed data (like counters, presence)
-- [ ] Replication factor 3 — auto-healing if a node goes down
+- [ ] Gossip protocol, natural state propagation across the network
+- [ ] CRDTs, conflict-free distributed data (like counters, presence)
+- [ ] Replication factor 3, auto-healing if a node goes down
 - [ ] If `nodyx.org` is unreachable, nodes find each other via DHT (resilience)
 
 ---
 
-### 3.1 — Voice Channels — Interface & Advanced Modes
-*(network layer already in place — Phase 2.4)*
+### 3.1, Voice Channels, Interface & Advanced Modes
+*(network layer already in place, Phase 2.4)*
 
-- [x] VoicePanel sidebar — fixed-position left panel with participant list (Galaxy Bar layout)
-- [x] Voice member interaction panel — click any member → real-time network stats (RTT / jitter / packet loss) + volume slider
-- [x] Self-monitoring panel — click yourself → live audio level meter, muted / deafened / PTT status badges
-- [x] VoiceSettings popup — large fixed-position modal (360px), escapes sidebar overflow with backdrop overlay
-- [x] Interaction buttons per peer — Profile link, Direct Message, File sharing + Mini-game (coming soon)
-- [ ] Amphitheater mode — 1→N broadcast (9 to 25+ people, video on "screen")
-- [ ] Nodes-as-a-Service — a Raspberry Pi can become a media relay to relieve the main server
+- [x] VoicePanel sidebar, fixed-position left panel with participant list (Galaxy Bar layout)
+- [x] Voice member interaction panel, click any member → real-time network stats (RTT / jitter / packet loss) + volume slider
+- [x] Self-monitoring panel, click yourself → live audio level meter, muted / deafened / PTT status badges
+- [x] VoiceSettings popup, large fixed-position modal (360px), escapes sidebar overflow with backdrop overlay
+- [x] Interaction buttons per peer, Profile link, Direct Message, File sharing + Mini-game (coming soon)
+- [ ] Amphitheater mode, 1→N broadcast (9 to 25+ people, video on "screen")
+- [ ] Nodes-as-a-Service, a Raspberry Pi can become a media relay to relieve the main server
 
-#### v1.0 — Collaborative Table ⏳ PLANNED
-*(P2P DataChannels foundation operational — v0.9)*
+#### v1.0, Collaborative Table ⏳ PLANNED
+*(P2P DataChannels foundation operational, v0.9)*
 
-> *The voice channel becomes a living space: play, work, listen to music, share files — all in one window. First self-hosted open-source to combine all four use cases.*
+> *The voice channel becomes a living space: play, work, listen to music, share files, all in one window. First self-hosted open-source to combine all four use cases.*
 
 **Visual Foundation**
-- [ ] SVG oval table — avatars positioned on ellipse (me = always at bottom, `getAvatarPositions` algorithm)
+- [ ] SVG oval table, avatars positioned on ellipse (me = always at bottom, `getAvatarPositions` algorithm)
 - [ ] Clear central zone (drag & drop, same SVG plane)
 - [ ] Avatar click → context menu (whisper, profile, challenge, mute)
 - [ ] `table:*` protocol in DataChannels (state, event, object:move/add/remove)
-- [ ] Host arbitrator — single source of truth, automatic election when host leaves
+- [ ] Host arbitrator, single source of truth, automatic election when host leaves
 - [ ] State persistence in DB (30s snapshot) + restore on reconnect
 - [ ] Audio waves on avatars (AnalyserNode + CSS custom property `--voice-intensity`)
 
 **Files & Presence**
 - [ ] Drag & drop file → shared on table for everyone (temporary)
-- [ ] Pin 📎 — file stays visible even when owner is offline
+- [ ] Pin 📎, file stays visible even when owner is offline
 - [ ] Drag file onto avatar → opens a Whisper with the file attached
 - [ ] Presence states: 🎙️ in voice / 🪑 at table / 🎮 in game
 
 **Widgets**
 - [ ] Random spin "Who goes first?" (CSS animation, result visible to all)
-- [ ] Shared timer — Pomodoro / Blitz / Custom (AudioContext for end sound)
+- [ ] Shared timer, Pomodoro / Blitz / Custom (AudioContext for end sound)
 - [ ] Persistent session scoreboard
-- [ ] Stage mode — "Take the floor" (quick vote, priority mic, others -20dB)
-- [ ] Spectator mode — forum members observe without participating (separate Socket.IO room)
+- [ ] Stage mode, "Take the floor" (quick vote, priority mic, others -20dB)
+- [ ] Spectator mode, forum members observe without participating (separate Socket.IO room)
 - [ ] Exportable session history (text or PDF)
 
 **Collaborative Jukebox**
-- [ ] Web Audio API player (play/pause/next) — P2P sync, original quality, no compression
+- [ ] Web Audio API player (play/pause/next), P2P sync, original quality, no compression
 - [ ] Individual volume (GainNode + localStorage, never broadcast to others)
 - [ ] Cover art: ID3 tags → MusicBrainz → Apple iTunes → IndexedDB cache
 - [ ] Collaborative playlists saved to DB
 - [ ] 👍👎 votes + smart priority queue
 - [ ] Crossfade between tracks (two overlapping GainNodes)
-- [ ] Timecode reactions (SoundCloud-style) — stored in DB, reappear on replay
+- [ ] Timecode reactions (SoundCloud-style), stored in DB, reappear on replay
 - [ ] Sleep timer with progressive fadeout
 
 **Templates & Plugins**
 - [ ] Template selector (host picks, broadcasts `table:theme:set` to all)
 - [ ] 3 official templates: Brasserie de Nuit, Table de Feutre, Pierre & Braise
-- [ ] Plugin system `plugins/table-templates/` — first example for community developers
+- [ ] Plugin system `plugins/table-templates/`, first example for community developers
 
 **Games (sequential progression)**
-- [ ] RPG dice (d4–d100) — 3D CSS animation + roll history visible to all
-- [ ] Chess — `chess.js` + SVG board + FEN state sync via DataChannel
-- [ ] Poker — state machine + per-player AES-GCM hand encryption
-- [ ] RPG / Warhammer — hex map, tokens (Library assets), fog of war *(long term)*
+- [ ] RPG dice (d4–d100), 3D CSS animation + roll history visible to all
+- [ ] Chess, `chess.js` + SVG board + FEN state sync via DataChannel
+- [ ] Poker, state machine + per-player AES-GCM hand encryption
+- [ ] RPG / Warhammer, hex map, tokens (Library assets), fog of war *(long term)*
 
-### 3.2 — Inter-instance mesh network
+### 3.2, Inter-instance mesh network
 *(depends on Phase 3.0-C)*
 
-- [ ] WireGuard mesh between voluntary instances — end-to-end encrypted tunnel
+- [ ] WireGuard mesh between voluntary instances, end-to-end encrypted tunnel
 - [ ] DHT for peer discovery without a central server
-- [ ] Gossip protocol — lightweight metadata synchronization between nodes
-- [ ] Distributed backup directory — if `nodyx.org` goes down, nodes maintain the directory
+- [ ] Gossip protocol, lightweight metadata synchronization between nodes
+- [ ] Distributed backup directory, if `nodyx.org` goes down, nodes maintain the directory
 - [ ] Automatic transition to direct P2P connection when available
-- [ ] Lightweight federation — a member of community A can interact with community B
+- [ ] Lightweight federation, a member of community A can interact with community B
 
 ---
 
-## PHASE 4 — Platform enrichment (v1.4 → v1.8) ✅ COMPLETE
+## PHASE 4, Platform enrichment (v1.4 → v1.8) ✅ COMPLETE
 ### Goal: Nodyx becomes the complete community platform
 
 **Delivered:**
-- [x] **NodyxCanvas** (v0.9) — P2P collaborative whiteboard in voice channels (CRDT LWW, voice-aware cursors, PNG export)
-- [x] **Profile theme system** (v1.0) — 6 built-in presets (Défaut, Minuit, Forêt, Chaleur, Rose, Verre), CSS variable engine (`--p-bg`, `--p-card-bg`, `--p-accent`…), live editor with color pickers, app-wide propagation (nav, sidebars, background)
-- [x] **Mobile-responsive UI** (v1.0) — chat channel drawer, bottom navigation bar, VoicePanel accessible on mobile, responsive forum + admin pages
-- [x] **Asset library 12 MB** (v1.0) — raised from 5 MB, per-type upload design guidelines
-- [x] **Chat — Reply/quote system** (v1.1) — reply_to_id on messages, preview bar in input, inline quote in message
-- [x] **Chat — Pinned messages** (v1.1) — sticky banner in channel header, admin pin/unpin
-- [x] **Chat — Link previews** (v1.1) — server-side Open Graph unfurl, Redis cache 1h, preview cards below messages
-- [x] **Chat — Mention badge** (v1.1) — red bubble on Chat nav icon when @mentioned, separate from notification bell
-- [x] **Presence — Custom user status** (v1.1) — emoji + text, 8 presets, persisted in Redis 24h, visible in sidebar
-- [x] **Presence — Offline members list** (v1.1) — collapsible section in sidebar, grayscale avatars
-- [x] **Plugins** (v1.1) — `plugins/` foundation with 3 official table-templates (Brasserie de Nuit, Table de Feutre, Pierre & Braise)
-- [x] **Direct Messages (DMs)** (v1.2) — private 1:1 conversations, `dm_conversations` + `dm_messages`, unread badge, Socket.IO `dm:send/typing/read`
-- [x] **Polls** (v1.2) — in chat (📊 button) and forum (thread creation + standalone), 3 types: choice / schedule / ranking, real-time Socket.IO results
-- [x] **Ban system** (v1.2) — IP ban, email ban, multi-layer enforcement (register, login, middleware), admin UI
-- [x] **nodyx-turn — TURN-over-TCP** (v1.3) — RFC 6062, TCP:3478, VPN/firewall bypass for voice
-- [x] **nodyx-turn — MESSAGE-INTEGRITY fix** (v1.3) — RFC 5389 §10.3, relay now works in Firefox, Chrome, all WebRTC clients
-- [x] **Voice — Relay failover** (v1.3) — auto-restart ICE with `iceTransportPolicy: relay` after 3 consecutive high-loss polls
-- [x] **Voice — Opus optimized** (v1.3) — 32 kbps default, DTX off, mono, FEC on
-- [x] **Event Calendar** (v1.6) — full CRUD, RSVP, cover upload, `/calendar` + `/calendar/[id]` + edit pages, `can_manage` (author OR mod/admin), extended sanitize-html — [SPEC 011](../en/specs/011-nodyx-event-calendar/SPEC.md)
-- [x] **Gossip Protocol** (v1.6) — `announceEventsToDirectory()` every 10 min, `/discover` multi-type (communities + threads + events)
-- [x] **Global Search Gossip-based** (v1.5) — `network_index` FTS GIN PostgreSQL, `announceThreadsToDirectory()`, `/discover` with search bar and cross-instance cards, opt-in `NODYX_GLOBAL_INDEXING=true` — [SPEC 010](../en/specs/010-nodyx-global-search/SPEC.md)
-- [x] **Admin — Enriched Dashboard** (v1.7) — extended stats (events/polls/assets/chat/DMs), dual 7-day activity chart (posts + new members), top 5 contributors, recent registrations
-- [x] **System Announcements** (v1.7) — color-coded banners (6 variants) admin-created, user-dismissible, optional expiry, live preview — `/admin/announcements`
-- [x] **Moderation Log** (v1.7) — audit trail for 11 admin action types, action/actor filters, pagination — `/admin/audit-log`, migrations 045-046
-- [x] **Lightweight task system** (v1.8) — community Kanban boards, configurable columns, cards with assignee/due date/priority, native HTML5 drag & drop, `/tasks`
+- [x] **NodyxCanvas** (v0.9), P2P collaborative whiteboard in voice channels (CRDT LWW, voice-aware cursors, PNG export)
+- [x] **Profile theme system** (v1.0), 6 built-in presets (Défaut, Minuit, Forêt, Chaleur, Rose, Verre), CSS variable engine (`--p-bg`, `--p-card-bg`, `--p-accent`…), live editor with color pickers, app-wide propagation (nav, sidebars, background)
+- [x] **Mobile-responsive UI** (v1.0), chat channel drawer, bottom navigation bar, VoicePanel accessible on mobile, responsive forum + admin pages
+- [x] **Asset library 12 MB** (v1.0), raised from 5 MB, per-type upload design guidelines
+- [x] **Chat, Reply/quote system** (v1.1), reply_to_id on messages, preview bar in input, inline quote in message
+- [x] **Chat, Pinned messages** (v1.1), sticky banner in channel header, admin pin/unpin
+- [x] **Chat, Link previews** (v1.1), server-side Open Graph unfurl, Redis cache 1h, preview cards below messages
+- [x] **Chat, Mention badge** (v1.1), red bubble on Chat nav icon when @mentioned, separate from notification bell
+- [x] **Presence, Custom user status** (v1.1), emoji + text, 8 presets, persisted in Redis 24h, visible in sidebar
+- [x] **Presence, Offline members list** (v1.1), collapsible section in sidebar, grayscale avatars
+- [x] **Plugins** (v1.1), `plugins/` foundation with 3 official table-templates (Brasserie de Nuit, Table de Feutre, Pierre & Braise)
+- [x] **Direct Messages (DMs)** (v1.2), private 1:1 conversations, `dm_conversations` + `dm_messages`, unread badge, Socket.IO `dm:send/typing/read`
+- [x] **Polls** (v1.2), in chat (📊 button) and forum (thread creation + standalone), 3 types: choice / schedule / ranking, real-time Socket.IO results
+- [x] **Ban system** (v1.2), IP ban, email ban, multi-layer enforcement (register, login, middleware), admin UI
+- [x] **nodyx-turn, TURN-over-TCP** (v1.3), RFC 6062, TCP:3478, VPN/firewall bypass for voice
+- [x] **nodyx-turn, MESSAGE-INTEGRITY fix** (v1.3), RFC 5389 §10.3, relay now works in Firefox, Chrome, all WebRTC clients
+- [x] **Voice, Relay failover** (v1.3), auto-restart ICE with `iceTransportPolicy: relay` after 3 consecutive high-loss polls
+- [x] **Voice, Opus optimized** (v1.3), 32 kbps default, DTX off, mono, FEC on
+- [x] **Event Calendar** (v1.6), full CRUD, RSVP, cover upload, `/calendar` + `/calendar/[id]` + edit pages, `can_manage` (author OR mod/admin), extended sanitize-html, [SPEC 011](../en/specs/011-nodyx-event-calendar/SPEC.md)
+- [x] **Gossip Protocol** (v1.6), `announceEventsToDirectory()` every 10 min, `/discover` multi-type (communities + threads + events)
+- [x] **Global Search Gossip-based** (v1.5), `network_index` FTS GIN PostgreSQL, `announceThreadsToDirectory()`, `/discover` with search bar and cross-instance cards, opt-in `NODYX_GLOBAL_INDEXING=true`, [SPEC 010](../en/specs/010-nodyx-global-search/SPEC.md)
+- [x] **Admin, Enriched Dashboard** (v1.7), extended stats (events/polls/assets/chat/DMs), dual 7-day activity chart (posts + new members), top 5 contributors, recent registrations
+- [x] **System Announcements** (v1.7), color-coded banners (6 variants) admin-created, user-dismissible, optional expiry, live preview, `/admin/announcements`
+- [x] **Moderation Log** (v1.7), audit trail for 11 admin action types, action/actor filters, pagination, `/admin/audit-log`, migrations 045-046
+- [x] **Lightweight task system** (v1.8), community Kanban boards, configurable columns, cards with assignee/due date/priority, native HTML5 drag & drop, `/tasks`
 
 ---
 
-## PHASE 4.5 — Security Hardening ✅ COMPLETE
+## PHASE 4.5, Security Hardening ✅ COMPLETE
 ### Goal: Harden every surface area before Phase 5 opens the platform to broader use
 
 > *"Shipped fast. Now make it bulletproof."*
-> Full security audit conducted March 2026 — before any Phase 5 work begins.
+> Full security audit conducted March 2026, before any Phase 5 work begins.
 
 ### Audit scope and results
 
@@ -436,230 +436,230 @@ nodyx-core    (Fastify/Node.js) ────────────────
 ### Vulnerability categories fixed
 
 **SQL Injection**
-- [x] `gardenService` — parameterized queries replacing raw string interpolation
-- [x] `notifications` routes — all dynamic filters hardened
+- [x] `gardenService`, parameterized queries replacing raw string interpolation
+- [x] `notifications` routes, all dynamic filters hardened
 
 **JWT**
-- [x] Algorithm confusion attack — explicit `algorithms: ['HS256']` enforced on all `jwt.verify()` calls
+- [x] Algorithm confusion attack, explicit `algorithms: ['HS256']` enforced on all `jwt.verify()` calls
 
 **SSRF / DNS Rebinding**
-- [x] Open Graph unfurl (`chat:unfurl`) — private IP range blocklist (RFC 1918 + loopback + link-local), hostname resolution check before fetch
+- [x] Open Graph unfurl (`chat:unfurl`), private IP range blocklist (RFC 1918 + loopback + link-local), hostname resolution check before fetch
 
 **Socket.IO IDOR**
-- [x] `chat:react` — ownership/membership check before applying reaction
-- [x] `chat:delete` — author or admin validation, no cross-channel deletion
-- [x] `voice:stats` — channel membership verified before exposing peer stats
-- [x] `jukebox` events — room membership enforced on all queue mutations
+- [x] `chat:react`, ownership/membership check before applying reaction
+- [x] `chat:delete`, author or admin validation, no cross-channel deletion
+- [x] `voice:stats`, channel membership verified before exposing peer stats
+- [x] `jukebox` events, room membership enforced on all queue mutations
 
 **CSS / XSS Injection**
-- [x] Profile themes — CSS variable values sanitized, no `url()` / `expression()` / `javascript:` allowed
-- [x] Font CSS injection — `font-family` values restricted to allowlist
-- [x] GIF URLs — scheme validation + domain allowlist before rendering
+- [x] Profile themes, CSS variable values sanitized, no `url()` / `expression()` / `javascript:` allowed
+- [x] Font CSS injection, `font-family` values restricted to allowlist
+- [x] GIF URLs, scheme validation + domain allowlist before rendering
 
 **Authentication**
-- [x] Enrollment rate limiting — Nodyx Signet registration endpoint protected
-- [x] Logout session cleanup — JWT invalidated in Redis on explicit logout
-- [x] Assignee validation — task assignee must be a community member
+- [x] Enrollment rate limiting, Nodyx Signet registration endpoint protected
+- [x] Logout session cleanup, JWT invalidated in Redis on explicit logout
+- [x] Assignee validation, task assignee must be a community member
 
 **Cryptography / Input**
-- [x] WebP RIFF validation — asset uploads verify magic bytes before Sharp processing
-- [x] SMTP header injection — newline stripping on all user-supplied email headers
+- [x] WebP RIFF validation, asset uploads verify magic bytes before Sharp processing
+- [x] SMTP header injection, newline stripping on all user-supplied email headers
 
 ---
 
-## PHASE 4.6 — Active Defense & Runtime Security ✅ COMPLETE
-### Goal: Turn the platform into an active defender — detect, deter, and alert in real time
+## PHASE 4.6, Active Defense & Runtime Security ✅ COMPLETE
+### Goal: Turn the platform into an active defender, detect, deter, and alert in real time
 
 > *"The best firewall is one that thinks."*
 > Phase 4.6 builds on the static hardening of 4.5 with dynamic, runtime security systems.
 
-- [x] **Honeypot** — 25+ scanner paths trapped (`.env`, `.git`, `wp-admin`, `phpmyadmin`, shells, backups…); tarpit 3–7s; geolocation; terminal scare page; DB logging + fail2ban auto-ban
-- [x] **fail2ban** — 5 jails: SSH, SSH repeat offenders (permanent), HTTP auth brute force, honeypot (7 days), permanent blacklist
-- [x] **`nodyx-auth.log`** — auth route now feeds the fail2ban jail on every failed login (was previously inert)
-- [x] **Permanent IP blacklist** — `nodyx-permban` jail (`bantime = -1`) + DB `ip_bans` for known bad actors
-- [x] **Discord security monitoring** — real-time embeds for honeypot hits, brute force, admin login, new IP detection, new registrations
-- [x] **Argon2id** — new password hashing standard (OWASP 2026); bcrypt hashes transparently migrated on next login
-- [x] **Chat anti-spam** — dual sliding window rate limiter (burst + sustained); client-side cooldown UI
-- [x] **Content filter** — Nazi/hate symbols (6 Unicode codepoints), image allowlist (Tenor/Giphy only), configurable domain blocklist
-- [x] **Optional NSFW scan** — `nsfwjs` + TensorFlow.js on image upload (`NSFW_SCAN=true`)
-- [x] **Upload rate limiting** — 10 uploads / 10 minutes / user
-- [x] **Email verification** — mandatory when SMTP configured; login blocked for unverified accounts
-- [x] **Log rotation** — daily rotation, 90-day retention, compressed
-- [x] **Tracking pixel** (v1.9.2) — 1×1 transparent PNG embedded in scare page (`GET /_hp_px/:incidentId`); logged to `honeypot_pixel_hits`; Discord alert on revisits (>30s threshold); cross-correlates pixel IP with original attacker IP
-- [x] **Credential harvesting traps** (v1.9.2) — 12 login paths trigger a convincing fake WordPress login form; credentials logged to `honeypot_credential_attempts`; Discord "🔑 Credential Harvest" embed on submission
-- [x] **Canary files** (v1.9.2) — 11 file patterns (`.env`, SQL dumps, `id_rsa`, `wp-config.php`…) serve realistic fake credentials; deterministic PRNG seeded by IP — same attacker always sees the same fake data; Discord "📄 Canary" embed
-- [x] **Canvas fingerprint** (v1.9.2) — browser JS in scare page POSTs fingerprint hash to `/_hp_fp`; upserted in `honeypot_fingerprints`; Discord "🔍 Fingerprint Reconnu" if visits > 1 (across different IPs)
-- [x] **Honeytokens** (v1.9.2) — 3 invisible + 1 quasi-invisible link embedded in scare page HTML; click → Discord "🎯 HONEYTOKEN CLICKED"; high-confidence human attacker signal
-- [x] **Slowloris inverse** (v1.9.2) — `reply.hijack()` streams scare page byte-by-byte (96B/180ms browsers, 256B/80ms bots); ties up attacker threads for 45–90s; `raw.destroyed` guard prevents crashes
-- [x] **Olympus Hub** (v1.9.2) — security command center: global stats, 48h timeline, top IPs, "PIÈGES ACTIFS" trap aggregation, "CREDENTIAL HARVEST" masked table, "ATTAQUANTS RÉCURRENTS" fingerprint list, tracking pixel section, federated distributed blocklist
+- [x] **Honeypot**: 25+ scanner paths trapped (`.env`, `.git`, `wp-admin`, `phpmyadmin`, shells, backups…); tarpit 3–7s; geolocation; terminal scare page; DB logging + fail2ban auto-ban
+- [x] **fail2ban**: 5 jails: SSH, SSH repeat offenders (permanent), HTTP auth brute force, honeypot (7 days), permanent blacklist
+- [x] **`nodyx-auth.log`**: auth route now feeds the fail2ban jail on every failed login (was previously inert)
+- [x] **Permanent IP blacklist**: `nodyx-permban` jail (`bantime = -1`) + DB `ip_bans` for known bad actors
+- [x] **Discord security monitoring**: real-time embeds for honeypot hits, brute force, admin login, new IP detection, new registrations
+- [x] **Argon2id**: new password hashing standard (OWASP 2026); bcrypt hashes transparently migrated on next login
+- [x] **Chat anti-spam**: dual sliding window rate limiter (burst + sustained); client-side cooldown UI
+- [x] **Content filter**: Nazi/hate symbols (6 Unicode codepoints), image allowlist (Tenor/Giphy only), configurable domain blocklist
+- [x] **Optional NSFW scan**: `nsfwjs` + TensorFlow.js on image upload (`NSFW_SCAN=true`)
+- [x] **Upload rate limiting**: 10 uploads / 10 minutes / user
+- [x] **Email verification**: mandatory when SMTP configured; login blocked for unverified accounts
+- [x] **Log rotation**: daily rotation, 90-day retention, compressed
+- [x] **Tracking pixel** (v1.9.2), 1×1 transparent PNG embedded in scare page (`GET /_hp_px/:incidentId`); logged to `honeypot_pixel_hits`; Discord alert on revisits (>30s threshold); cross-correlates pixel IP with original attacker IP
+- [x] **Credential harvesting traps** (v1.9.2), 12 login paths trigger a convincing fake WordPress login form; credentials logged to `honeypot_credential_attempts`; Discord "🔑 Credential Harvest" embed on submission
+- [x] **Canary files** (v1.9.2), 11 file patterns (`.env`, SQL dumps, `id_rsa`, `wp-config.php`…) serve realistic fake credentials; deterministic PRNG seeded by IP, same attacker always sees the same fake data; Discord "📄 Canary" embed
+- [x] **Canvas fingerprint** (v1.9.2), browser JS in scare page POSTs fingerprint hash to `/_hp_fp`; upserted in `honeypot_fingerprints`; Discord "🔍 Fingerprint Reconnu" if visits > 1 (across different IPs)
+- [x] **Honeytokens** (v1.9.2), 3 invisible + 1 quasi-invisible link embedded in scare page HTML; click → Discord "🎯 HONEYTOKEN CLICKED"; high-confidence human attacker signal
+- [x] **Slowloris inverse** (v1.9.2), `reply.hijack()` streams scare page byte-by-byte (96B/180ms browsers, 256B/80ms bots); ties up attacker threads for 45–90s; `raw.destroyed` guard prevents crashes
+- [x] **Olympus Hub** (v1.9.2), security command center: global stats, 48h timeline, top IPs, "PIÈGES ACTIFS" trap aggregation, "CREDENTIAL HARVEST" masked table, "ATTAQUANTS RÉCURRENTS" fingerprint list, tracking pixel section, federated distributed blocklist
 
 ---
 
-## PHASE 4.7 — Two-Factor Authentication ✅ COMPLETE
+## PHASE 4.7, Two-Factor Authentication ✅ COMPLETE
 ### Goal: Add a strong second factor without sacrificing UX
 
 > *"Something you know + something you have."*
 > Phase 4.7 layers cryptographic 2FA on top of the existing auth stack, with Nodyx Signet as the premium path.
 
-- [x] **TOTP (RFC 6238)** — compatible with any authenticator app (Google Authenticator, Aegis, Bitwarden); QR code setup; 6-digit confirmation; Redis-backed 5-min pending session
-- [x] **2FA via Nodyx Signet** — if user has a registered Signet device, Signet is used as 2nd factor (ECDSA P-256 > shared TOTP secret); full reuse of existing challenge/approval infrastructure
-- [x] **Priority chain** — Signet > TOTP > direct login; system selects the strongest available factor automatically
-- [x] **Settings UI** — enable/disable 2FA with QR code display and confirmation code flow
-- [x] **Login UI** — seamless second-step: TOTP code input or Signet auto-triggered waiting screen
-- [x] **Nodyx Signet PWA rebuild** — stale `nexusnode.app` placeholders replaced with `nodyx.org`
+- [x] **TOTP (RFC 6238)**: compatible with any authenticator app (Google Authenticator, Aegis, Bitwarden); QR code setup; 6-digit confirmation; Redis-backed 5-min pending session
+- [x] **2FA via Nodyx Signet**: if user has a registered Signet device, Signet is used as 2nd factor (ECDSA P-256 > shared TOTP secret); full reuse of existing challenge/approval infrastructure
+- [x] **Priority chain**: Signet > TOTP > direct login; system selects the strongest available factor automatically
+- [x] **Settings UI**: enable/disable 2FA with QR code display and confirmation code flow
+- [x] **Login UI**: seamless second-step: TOTP code input or Signet auto-triggered waiting screen
+- [x] **Nodyx Signet PWA rebuild**: stale `nexusnode.app` placeholders replaced with `nodyx.org`
 
 ---
 
-## PHASE 4.8 — Production stability & cross-runtime hardening ✅ COMPLETE
-### Goal: Make Nodyx imperturbable — every shared state between runtimes consistent, every failure scenario handled
+## PHASE 4.8, Production stability & cross-runtime hardening ✅ COMPLETE
+### Goal: Make Nodyx imperturbable, every shared state between runtimes consistent, every failure scenario handled
 
 > *"A system is only as stable as its weakest assumption."*
-> Phase 4.8 is a full surgical audit across the entire stack — Node.js, Rust, Caddy, PM2, systemd —
+> Phase 4.8 is a full surgical audit across the entire stack, Node.js, Rust, Caddy, PM2, systemd -
 > identifying and eliminating silent failure modes that looked fine in development but would corrupt state in production.
 
-- [x] **Redis keyPrefix audit — Node.js** — `ioredis keyPrefix: 'nodyx:'` is the single source of truth; all manual `nodyx:` prefixes removed from auth.ts, adminOnly.ts, socket/index.ts, scheduler.ts, index.ts, routes/admin.ts and 6 test files (double-prefix like `nodyx:nodyx:heartbeat:` was silently writing dead keys)
-- [x] **Redis keyPrefix audit — Rust** — Rust has no ioredis keyPrefix; all 11 shared keys now carry `nodyx:` prefix manually: `banned:`, `user_sessions:`, `login_rate:`, `register_rate:`, `reset_rate:`, `resend_verify:`, `resend_verify_ip:` (auth.rs), `banned:` × 2 + `user_sessions:` + `heartbeat:*` scan (admin.rs), `rate:search:` (directory.rs)
-- [x] **Cross-runtime ban coherence** — bans set by Node.js (admin panel) or Rust (login ban-cache) are now visible to both runtimes
-- [x] **Cross-runtime rate limiting** — login/register/reset/resend-verify rate limits are now shared: an attacker can no longer bypass Node.js rate limiting by hitting the Rust endpoint
-- [x] **Online count fixed** — admin dashboard online member count was always 0 (Rust was scanning `heartbeat:*` instead of `nodyx:heartbeat:*`)
-- [x] **Session invalidation on password change** — `user_sessions:{id}` index now consistent between both runtimes; changing password invalidates sessions from both Node.js and Rust logins
-- [x] **Scheduler fetch timeouts** — `AbortSignal.timeout()` added to all 4 previously unguarded outbound HTTP calls (pingDirectory 8s, pushAssetsToDirectory 15s, announceThreadsToDirectory 10s, announceEventsToDirectory 10s)
-- [x] **Caddy — Rust failover** — all 18 `localhost:3100` blocks switched to `lb_policy first` + `fail_duration 30s`; if nodyx-server (Rust) is unreachable, Caddy automatically falls back to nodyx-core (Node.js) — zero downtime on Rust crash
-- [x] **install.sh — version centralized** — single `NODYX_VERSION` variable used consistently across `.env` generation, directory registration payload, and post-install summary
-- [x] **install.sh — generated Caddyfile hardened** — both relay and normal mode now include security headers, honeypot block, and `header_up -X-Forwarded-For` on all API routes
-- [x] **PM2 memory guards** — `max_memory_restart` added to all 4 processes (512M core, 256M frontend, 256M hub, 128M docs)
-- [x] **Log rotation** — `/etc/logrotate.d/nodyx-auth` — daily, 30-day retention, compressed
-- [x] **systemd rebrand** — `nodyx-relay.service` description and `SyslogIdentifier` updated to `nodyx-relay`
+- [x] **Redis keyPrefix audit, Node.js**: `ioredis keyPrefix: 'nodyx:'` is the single source of truth; all manual `nodyx:` prefixes removed from auth.ts, adminOnly.ts, socket/index.ts, scheduler.ts, index.ts, routes/admin.ts and 6 test files (double-prefix like `nodyx:nodyx:heartbeat:` was silently writing dead keys)
+- [x] **Redis keyPrefix audit, Rust**: Rust has no ioredis keyPrefix; all 11 shared keys now carry `nodyx:` prefix manually: `banned:`, `user_sessions:`, `login_rate:`, `register_rate:`, `reset_rate:`, `resend_verify:`, `resend_verify_ip:` (auth.rs), `banned:` × 2 + `user_sessions:` + `heartbeat:*` scan (admin.rs), `rate:search:` (directory.rs)
+- [x] **Cross-runtime ban coherence**: bans set by Node.js (admin panel) or Rust (login ban-cache) are now visible to both runtimes
+- [x] **Cross-runtime rate limiting**: login/register/reset/resend-verify rate limits are now shared: an attacker can no longer bypass Node.js rate limiting by hitting the Rust endpoint
+- [x] **Online count fixed**: admin dashboard online member count was always 0 (Rust was scanning `heartbeat:*` instead of `nodyx:heartbeat:*`)
+- [x] **Session invalidation on password change**: `user_sessions:{id}` index now consistent between both runtimes; changing password invalidates sessions from both Node.js and Rust logins
+- [x] **Scheduler fetch timeouts**: `AbortSignal.timeout()` added to all 4 previously unguarded outbound HTTP calls (pingDirectory 8s, pushAssetsToDirectory 15s, announceThreadsToDirectory 10s, announceEventsToDirectory 10s)
+- [x] **Caddy, Rust failover**: all 18 `localhost:3100` blocks switched to `lb_policy first` + `fail_duration 30s`; if nodyx-server (Rust) is unreachable, Caddy automatically falls back to nodyx-core (Node.js), zero downtime on Rust crash
+- [x] **install.sh, version centralized**: single `NODYX_VERSION` variable used consistently across `.env` generation, directory registration payload, and post-install summary
+- [x] **install.sh, generated Caddyfile hardened**: both relay and normal mode now include security headers, honeypot block, and `header_up -X-Forwarded-For` on all API routes
+- [x] **PM2 memory guards**: `max_memory_restart` added to all 4 processes (512M core, 256M frontend, 256M hub, 128M docs)
+- [x] **Log rotation**: `/etc/logrotate.d/nodyx-auth`, daily, 30-day retention, compressed
+- [x] **systemd rebrand**: `nodyx-relay.service` description and `SyslogIdentifier` updated to `nodyx-relay`
 
 **Validation:** 63/63 Node.js tests green · Rust build 0 errors · Caddy validate OK
 
 ---
 
-## PHASE 4.9 — Process isolation, test coverage & CI hardening ✅ COMPLETE
+## PHASE 4.9, Process isolation, test coverage & CI hardening ✅ COMPLETE
 ### Goal: Zero root processes, full test coverage across both runtimes, reproducible CI pipeline
 
-- [x] **Process isolation — User=nodyx** — All application processes now run as the dedicated `nodyx` system user; only systemd and code-server remain root. Covers: `nexus-turn.service` (was root), `pm2-nodyx.service` (replaces `pm2-root.service`), `nodyx-relay.service` and `nodyx-server.service` (already nodyx). `/home/nodyx` created with PM2_HOME.
-- [x] **File permission tightening** — `nodyx-frontend/.env` and `nodyx-hub/.env` changed from 644 (world-readable) to `root:nodyx 640`; `uploads/` directory transferred to `nodyx:nodyx`
-- [x] **Node.js test suite — 181/181** — 6 new test files covering modules, polls, search, notifications, wiki, middleware-extended. Root causes fixed: `vi.resetAllMocks()` destroying Redis mock implementations, module-level `_communityId` cache isolation, `db.connect()` transaction mocking
-- [x] **Rust test suite — 18/18** — First Rust tests written for `nodyx-server`: `error.rs` (11 tests — all HTTP status codes, JSON body format, internal error no-leak, `Retry-After` header) + `extractors.rs` (7 tests — `Claims` serde rename, JWT decode, wrong secret rejection, expired token, malformed token)
-- [x] **Critical dependency pinning** — Security-sensitive packages pinned to exact versions in `nodyx-core/package.json`: `fastify`, `socket.io`, `jsonwebtoken`, `argon2`, `bcrypt`, `pg`, `ioredis`, `web-push` — prevents silent upgrades breaking production
-- [x] **CI pipeline hardened** — GitHub Actions updated: two parallel jobs (`test-node`, `test-rust`), npm cache, `npx tsc --noEmit` typecheck gate before vitest, Rust build + test with cargo cache
-- [x] **Migration gap filled** — `052_placeholder.sql` added to close the sequence gap between 051 and 053
+- [x] **Process isolation, User=nodyx**: All application processes now run as the dedicated `nodyx` system user; only systemd and code-server remain root. Covers: `nexus-turn.service` (was root), `pm2-nodyx.service` (replaces `pm2-root.service`), `nodyx-relay.service` and `nodyx-server.service` (already nodyx). `/home/nodyx` created with PM2_HOME.
+- [x] **File permission tightening**: `nodyx-frontend/.env` and `nodyx-hub/.env` changed from 644 (world-readable) to `root:nodyx 640`; `uploads/` directory transferred to `nodyx:nodyx`
+- [x] **Node.js test suite, 181/181**: 6 new test files covering modules, polls, search, notifications, wiki, middleware-extended. Root causes fixed: `vi.resetAllMocks()` destroying Redis mock implementations, module-level `_communityId` cache isolation, `db.connect()` transaction mocking
+- [x] **Rust test suite, 18/18**: First Rust tests written for `nodyx-server`: `error.rs` (11 tests, all HTTP status codes, JSON body format, internal error no-leak, `Retry-After` header) + `extractors.rs` (7 tests, `Claims` serde rename, JWT decode, wrong secret rejection, expired token, malformed token)
+- [x] **Critical dependency pinning**: Security-sensitive packages pinned to exact versions in `nodyx-core/package.json`: `fastify`, `socket.io`, `jsonwebtoken`, `argon2`, `bcrypt`, `pg`, `ioredis`, `web-push`, prevents silent upgrades breaking production
+- [x] **CI pipeline hardened**: GitHub Actions updated: two parallel jobs (`test-node`, `test-rust`), npm cache, `npx tsc --noEmit` typecheck gate before vitest, Rust build + test with cargo cache
+- [x] **Migration gap filled**: `052_placeholder.sql` added to close the sequence gap between 051 and 053
 
 **Validation:** 181/181 Node.js tests green · 18/18 Rust tests green · TypeScript 0 errors · All services active as nodyx user
 
 ---
 
-## PHASE 4.10 — Living Profile + Forum Redesign ✅ COMPLETE (v1.9.5)
+## PHASE 4.10, Living Profile + Forum Redesign ✅ COMPLETE (v1.9.5)
 ### Goal: Profiles that breathe, a forum that looks like a serious platform
 
-- [x] **Generative Banner** — unique Lissajous SVG per username, deterministic FNV-1a hash, SSR-safe, animated via `animateTransform`
-- [x] **Reputation Rings** — 3 animated concentric SVG rings (Longevity / Quality / Engagement), tooltips, link to `/reputation`
-- [x] **Activity Heatmap** — 53×7 GitHub-style grid, streak + record stats, fixed-position tooltip escaping `overflow-x: auto`
-- [x] **Activity endpoint** — `GET /api/v1/users/:username/activity` (UNION posts + threads, 365-day window)
-- [x] **Parallax hero** — banner scrolls at 35% of page speed, capped 60px
-- [x] **Avatar arcs** — 3 rotating SVG circles via `animateTransform` + glow pulse
-- [x] **Timeline** — temporal milestones + XP thresholds at bottom of profile
-- [x] **`/reputation` page** — full transparent formula documentation (Longevity, Quality with λ decay, Engagement)
-- [x] **Delete avatar / delete banner** — clears both `banner_url` AND `banner_asset_id` atomically
-- [x] **Forum redesign** — flat design, zero `rounded-*` (except avatars), full-width content, consistent with shell aesthetic
+- [x] **Generative Banner**: unique Lissajous SVG per username, deterministic FNV-1a hash, SSR-safe, animated via `animateTransform`
+- [x] **Reputation Rings**: 3 animated concentric SVG rings (Longevity / Quality / Engagement), tooltips, link to `/reputation`
+- [x] **Activity Heatmap**: 53×7 GitHub-style grid, streak + record stats, fixed-position tooltip escaping `overflow-x: auto`
+- [x] **Activity endpoint**: `GET /api/v1/users/:username/activity` (UNION posts + threads, 365-day window)
+- [x] **Parallax hero**: banner scrolls at 35% of page speed, capped 60px
+- [x] **Avatar arcs**: 3 rotating SVG circles via `animateTransform` + glow pulse
+- [x] **Timeline**: temporal milestones + XP thresholds at bottom of profile
+- [x] **`/reputation` page**: full transparent formula documentation (Longevity, Quality with λ decay, Engagement)
+- [x] **Delete avatar / delete banner**: clears both `banner_url` AND `banner_asset_id` atomically
+- [x] **Forum redesign**: flat design, zero `rounded-*` (except avatars), full-width content, consistent with shell aesthetic
 
 ---
 
-## PHASE 4.11 — Private & Sovereign Communications ✅ COMPLETE (v2.0)
-### Goal: DMs that no server can read — not even yours
+## PHASE 4.11, Private & Sovereign Communications ✅ COMPLETE (v2.0)
+### Goal: DMs that no server can read, not even yours
 
-- [x] **ECDH P-256 keypair** — generated in the browser, private key stored as non-extractable `CryptoKey` in IndexedDB, never leaves the client
-- [x] **AES-256-GCM encryption** — per-message random 12-byte IV, authenticated ciphertext stored in database
-- [x] **ESY Barbare layer** — per-instance second obfuscation layer on top of AES-GCM (byte-permutation table + xorshift32 PRNG noise, N rounds). Server sees only opaque base64
-- [x] **`instance.esy`** — generated once per instance, fingerprinted (`SHA-256` truncated), served via `/api/v1/instance/esy-public`
-- [x] **E2E shield** in DM header — green pulsing dot (both active), orange (partial), ESY fingerprint on hover
-- [x] **Barbarize animation** — expéditeur voit le texte se brouiller pendant le chiffrement, réceptionnaire voit la bulle se déchiffrer en temps réel (350ms)
-- [x] **Message edit with re-encryption** — editing an E2E message re-encrypts with the full ECDH + AES + ESY chain
-- [x] **Real-time delete** — soft-delete propagated instantly to all participants via Socket.IO
-- [x] **DM full-width redesign** — split layout glassmorphism, iMessage-style grouped bubbles
-- [x] **AudioContext fix** — single shared context for all peer VAD (Chrome 6-context-per-origin limit)
+- [x] **ECDH P-256 keypair**: generated in the browser, private key stored as non-extractable `CryptoKey` in IndexedDB, never leaves the client
+- [x] **AES-256-GCM encryption**: per-message random 12-byte IV, authenticated ciphertext stored in database
+- [x] **ESY Barbare layer**: per-instance second obfuscation layer on top of AES-GCM (byte-permutation table + xorshift32 PRNG noise, N rounds). Server sees only opaque base64
+- [x] **`instance.esy`**: generated once per instance, fingerprinted (`SHA-256` truncated), served via `/api/v1/instance/esy-public`
+- [x] **E2E shield** in DM header, green pulsing dot (both active), orange (partial), ESY fingerprint on hover
+- [x] **Barbarize animation**: expéditeur voit le texte se brouiller pendant le chiffrement, réceptionnaire voit la bulle se déchiffrer en temps réel (350ms)
+- [x] **Message edit with re-encryption**: editing an E2E message re-encrypts with the full ECDH + AES + ESY chain
+- [x] **Real-time delete**: soft-delete propagated instantly to all participants via Socket.IO
+- [x] **DM full-width redesign**: split layout glassmorphism, iMessage-style grouped bubbles
+- [x] **AudioContext fix**: single shared context for all peer VAD (Chrome 6-context-per-origin limit)
 
 ---
 
-## PHASE 4.12 — Homepage Builder + Widget SDK ✅ COMPLETE (v2.1)
+## PHASE 4.12, Homepage Builder + Widget SDK ✅ COMPLETE (v2.1)
 ### Goal: Every community gets its own fully customizable homepage
 
-- [x] **Homepage Builder** — drag-and-drop admin editor, 11 layout zones (banner, hero, stats-bar, main, sidebar, half ×2, trio ×3, footer ×4)
-- [x] **Plugin registry** — each native widget is a self-contained file, zero core changes to add new ones
-- [x] **4 native widgets Phase 1** — Hero Banner (live/event/night variants), Stats Bar (animated counters), Join Card, Announcement Banner
-- [x] **Visibility rules** — per-widget audience (all / guests / members) + scheduled start/end dates
-- [x] **Widget Store** — install external widgets via `.zip` upload (XHR progress bar, 4-step validation, extraction whitelist)
-- [x] **Dynamic Widget Loader** — Web Components loaded at runtime, no rebuild, no deploy
-- [x] **Widget SDK** — plain JS Custom Elements (Shadow DOM), `manifest.json` schema → auto-generated config fields in builder
-- [x] **Demo widget: Video Player** — YouTube / Vimeo / MP4 with live preview, source viewer, one-click install
+- [x] **Homepage Builder**: drag-and-drop admin editor, 11 layout zones (banner, hero, stats-bar, main, sidebar, half ×2, trio ×3, footer ×4)
+- [x] **Plugin registry**: each native widget is a self-contained file, zero core changes to add new ones
+- [x] **4 native widgets Phase 1**: Hero Banner (live/event/night variants), Stats Bar (animated counters), Join Card, Announcement Banner
+- [x] **Visibility rules**: per-widget audience (all / guests / members) + scheduled start/end dates
+- [x] **Widget Store**: install external widgets via `.zip` upload (XHR progress bar, 4-step validation, extraction whitelist)
+- [x] **Dynamic Widget Loader**: Web Components loaded at runtime, no rebuild, no deploy
+- [x] **Widget SDK**: plain JS Custom Elements (Shadow DOM), `manifest.json` schema → auto-generated config fields in builder
+- [x] **Demo widget: Video Player**: YouTube / Vimeo / MP4 with live preview, source viewer, one-click install
 
 ---
 
-## PHASE 4.13 — NodyxCanvas Major Upgrade ✅ COMPLETE (v2.2)
+## PHASE 4.13, NodyxCanvas Major Upgrade ✅ COMPLETE (v2.2)
 ### Goal: Turn the collaborative whiteboard into a full creative workspace
 
 > *"From a basic drawing tool to a real async collaboration platform."*
 > The canvas was rewritten from scratch with 4 dedicated UI components, 11 drawing tools,
-> a persistent undo/redo stack, and a board-scoped chat — all synchronized via CRDT Socket.IO.
+> a persistent undo/redo stack, and a board-scoped chat, all synchronized via CRDT Socket.IO.
 
-### 4.13.1 — UI Architecture (Sprint A)
+### 4.13.1, UI Architecture (Sprint A)
 
-- [x] **4 dedicated components** — CanvasLeftToolbar (tool selector), CanvasTopBar (contextual options), CanvasBottomBar (undo/zoom/grid), CanvasRightPanel (participants + chat)
-- [x] **CanvasLeftToolbar** — vertical tool selector with keyboard shortcut badges (V/P/T/N/R/C/S/A/X/I/F/E)
-- [x] **CanvasTopBar** — contextual controls per tool: pen (color + 6 widths), text (B/I/U/S + align + font + size + color), sticky (8-color palette), rect/circle (fill toggle + fill color + stroke color + stroke width), shape (5-type picker + fill + stroke), arrow (style + end cap + width), connector (type + style + start cap + end cap + color + width)
-- [x] **CanvasBottomBar** — Undo / Redo buttons (active/disabled state), Zoom− / % / Zoom+ / Reset, grid toggle (G), snap toggle
-- [x] **CanvasRightPanel** — collapsible right panel: participant list with real avatar, live tool indicator, color dot; board-scoped real-time chat with iMessage-style bubbles
-- [x] **Full keyboard shortcuts** — V P T N R C S A X I F E G + Ctrl+Z / Ctrl+Y / Ctrl+Shift+Z + Delete + Escape
-- [x] **Portal rendering** — canvas mounted on `document.body` via `use:portal`, bypasses `position:fixed` broken by CSS `transform` ancestors
-- [x] **Real user avatars** — participant panel shows actual user avatars with fallback to initials
-- [x] **Undo / Redo** — 50-op `UndoOp { id, before, after }` stack per session. Fixed CRDT LWW timestamp bug (`ts: Date.now()` on restore)
-- [x] **Snap to grid** — `snapV(v) = snapEnabled ? Math.round(v / 28) * 28 : v`, applies on creation + move + resize
-- [x] **Rich text rendering** — bold/italic via `ctx.font`, underline + strikethrough drawn manually (line at baseline), word-wrap with `buildTextLines()`
+- [x] **4 dedicated components**: CanvasLeftToolbar (tool selector), CanvasTopBar (contextual options), CanvasBottomBar (undo/zoom/grid), CanvasRightPanel (participants + chat)
+- [x] **CanvasLeftToolbar**: vertical tool selector with keyboard shortcut badges (V/P/T/N/R/C/S/A/X/I/F/E)
+- [x] **CanvasTopBar**: contextual controls per tool: pen (color + 6 widths), text (B/I/U/S + align + font + size + color), sticky (8-color palette), rect/circle (fill toggle + fill color + stroke color + stroke width), shape (5-type picker + fill + stroke), arrow (style + end cap + width), connector (type + style + start cap + end cap + color + width)
+- [x] **CanvasBottomBar**: Undo / Redo buttons (active/disabled state), Zoom− / % / Zoom+ / Reset, grid toggle (G), snap toggle
+- [x] **CanvasRightPanel**: collapsible right panel: participant list with real avatar, live tool indicator, color dot; board-scoped real-time chat with iMessage-style bubbles
+- [x] **Full keyboard shortcuts**: V P T N R C S A X I F E G + Ctrl+Z / Ctrl+Y / Ctrl+Shift+Z + Delete + Escape
+- [x] **Portal rendering**: canvas mounted on `document.body` via `use:portal`, bypasses `position:fixed` broken by CSS `transform` ancestors
+- [x] **Real user avatars**: participant panel shows actual user avatars with fallback to initials
+- [x] **Undo / Redo**: 50-op `UndoOp { id, before, after }` stack per session. Fixed CRDT LWW timestamp bug (`ts: Date.now()` on restore)
+- [x] **Snap to grid**: `snapV(v) = snapEnabled ? Math.round(v / 28) * 28 : v`, applies on creation + move + resize
+- [x] **Rich text rendering**: bold/italic via `ctx.font`, underline + strikethrough drawn manually (line at baseline), word-wrap with `buildTextLines()`
 
-### 4.13.2 — New tools (Sprint B)
+### 4.13.2, New tools (Sprint B)
 
-- [x] **Advanced shapes** — triangle, diamond, star (5-point), hexagon, cloud — drawn via `Path2D`, fill + stroke + optional label inside
-- [x] **Connectors** — straight / bezier / elbow lines, independent `startCap` and `endCap` (arrow/dot/none), solid/dashed/dotted style, 2-click creation with first-point indicator
-- [x] **Frames / Sections** — named rectangular regions with dashed border + semi-transparent fill + label above; inline name input overlay on creation
-- [x] **Image insertion** — drag & drop from desktop or file picker → multipart upload to `/api/v1/assets` (fields ordered before file for `@fastify/multipart`), async cache (`Map<string, HTMLImageElement>`), proportional sizing (max 400px)
-- [x] **Toolbar wired** — CanvasLeftToolbar and CanvasTopBar updated for shape, connector, frame, image tools
+- [x] **Advanced shapes**: triangle, diamond, star (5-point), hexagon, cloud, drawn via `Path2D`, fill + stroke + optional label inside
+- [x] **Connectors**: straight / bezier / elbow lines, independent `startCap` and `endCap` (arrow/dot/none), solid/dashed/dotted style, 2-click creation with first-point indicator
+- [x] **Frames / Sections**: named rectangular regions with dashed border + semi-transparent fill + label above; inline name input overlay on creation
+- [x] **Image insertion**: drag & drop from desktop or file picker → multipart upload to `/api/v1/assets` (fields ordered before file for `@fastify/multipart`), async cache (`Map<string, HTMLImageElement>`), proportional sizing (max 400px)
+- [x] **Toolbar wired**: CanvasLeftToolbar and CanvasTopBar updated for shape, connector, frame, image tools
 
-### 4.13.3 — Resize handles (Phase 1.1)
+### 4.13.3, Resize handles (Phase 1.1)
 
-- [x] **8 resize handles** — corners (nw/ne/sw/se) + midpoints (n/s/e/w) rendered in screen space after canvas transform, fixed 5px size at any zoom
-- [x] **Supported elements** — rect, circle, shape, frame, image, sticky
-- [x] **Live resize** — `applyResize()` updates x/y/w/h during drag, minimum size 12px, snap-aware
-- [x] **Undo/redo** — resize ops pushed to undo stack, restored via CRDT with fresh timestamp
+- [x] **8 resize handles**: corners (nw/ne/sw/se) + midpoints (n/s/e/w) rendered in screen space after canvas transform, fixed 5px size at any zoom
+- [x] **Supported elements**: rect, circle, shape, frame, image, sticky
+- [x] **Live resize**: `applyResize()` updates x/y/w/h during drag, minimum size 12px, snap-aware
+- [x] **Undo/redo**: resize ops pushed to undo stack, restored via CRDT with fresh timestamp
 
-### 4.13.4 — Bug fixes
+### 4.13.4, Bug fixes
 
-- [x] **CRDT undo fix** — `undo()` now restores `{ ...entry.before, ts: Date.now() }` instead of `entry.before` directly — prevents silent rejection by LWW check
-- [x] **Image upload field order** — text fields (`name`, `asset_type`) appended before file in FormData so `@fastify/multipart` can read them from the stream before encountering the binary
-- [x] **HTML structure** — frame name overlay correctly placed inside center container div (was causing parse error at line 1518)
+- [x] **CRDT undo fix**: `undo()` now restores `{ ...entry.before, ts: Date.now() }` instead of `entry.before` directly, prevents silent rejection by LWW check
+- [x] **Image upload field order**: text fields (`name`, `asset_type`) appended before file in FormData so `@fastify/multipart` can read them from the stream before encountering the binary
+- [x] **HTML structure**: frame name overlay correctly placed inside center container div (was causing parse error at line 1518)
 
 ---
 
-## PHASE 4.16 — OctoGuard Phase 1: Native auto-moderation ✅ COMPLETE (progressive rollout, v2.6)
-### Goal: Ship a fully admin-tunable in-core moderation suite — no external bot required, no centralized AI, ReDoS-safe
+## PHASE 4.16, OctoGuard Phase 1: Native auto-moderation ✅ COMPLETE (progressive rollout, v2.6)
+### Goal: Ship a fully admin-tunable in-core moderation suite, no external bot required, no centralized AI, ReDoS-safe
 
 > *"Admin freedom is non-negotiable. OctoGuard ships disabled, every rule is opt-in."*
 > Phase 1 is the native moderation track. The external Bot API + Python SDK + voice presence metadata is tracked separately as Phase 4 of the OctoGuard roadmap.
 
-- [x] **8 idempotent migrations** (088 → 091 plus the 5 OctoGuard-prefixed ones) — `automod_rules`, `welcome_settings`, `chat_mutes`, `commands`, `reports`, `webhooks`, ban-cache index, `community_bans.expires_at`
-- [x] **Auto-mod pipeline** — 50 ms timeout, fail-open, 5 matcher types: substring, word-boundary, regex, link allow/blocklist, emoji-flood
-- [x] **ReDoS protection** — Google `re2` linear-time engine (84 s native vs 0 ms `re2` confirmed in bench) plus `safe-regex` heuristic on pattern admission
-- [x] **6 actions** — `delete`, `warn`, `mute_timed`, `kick`, `ban` (with optional `community_bans.expires_at` for temporary bans), `report_only` (dry-run)
-- [x] **Welcome flow** — ghost `OctoGuard` bot user (`users.is_system=true`, login refused at auth route), public message in an admin-chosen channel with `{user}` / `{userMention}` / `{communityName}` variables, optional auto-grade on join. DM system message reserved for spec 019
-- [x] **Custom commands** — `!règles`, `!discord`, ... in markdown, Redis-backed per-channel cooldown (`SET NX EX`), allowed channels and roles configurable per command
-- [x] **Chat mutes** — `chat_mutes` table, global or per-channel scope, free-form duration (`15m`, `2h`, `1w`, permanent), Redis-cached 60 s, background purge worker
-- [x] **Reports queue** — member-driven signalements, anti-abuse rate limit per reporter + cooldown per target via Redis, admin inbox with mute/delete/dismiss actions
-- [x] **Audit log** — every action persisted to `admin_audit_log` with `event_id`, action type, target, metadata. Logger is fire-and-forget IIFE — caught by the pre-emptive bench: p95 dropped from 13 ms to 0.2 ms after switching from `await` to fire-and-forget
-- [x] **HMAC-SHA256 webhook** — outbound POST signed with `X-Octoguard-Signature: sha256=hex`, queued in Redis, worker fires async with 10 s timeout. The chat pipeline never pays the webhook latency
-- [x] **Admin UI** — `/admin/octoguard` with 8 tabs: overview, automod, welcome, commands, mutes, reports, logs, webhook. All CRUD with optimistic `enhance` forms
-- [x] **Kill-switch** — `OCTOGUARD_ENABLED=false` bypasses the entire pipeline. Rules table empty equals zero impact even when on. Progressive rollout pattern: enable → observe with empty rules → add 1 `report_only` rule → graduate to live
-- [x] **69 vitest tests** — `octoguard-matchers.test.ts` (matchers), `octoguard-commands.test.ts` (extractCommand), `octoguard-session-c.test.ts` (`assessPatternSafety`, `durationToExpiresAt`, `substituteVariables`, mutes, env migration)
-- [x] **`bench.ts` script** — dedicated performance benchmark proves p95 < 1 ms under load, caught the logger bottleneck before prod activation
+- [x] **8 idempotent migrations** (088 → 091 plus the 5 OctoGuard-prefixed ones), `automod_rules`, `welcome_settings`, `chat_mutes`, `commands`, `reports`, `webhooks`, ban-cache index, `community_bans.expires_at`
+- [x] **Auto-mod pipeline**: 50 ms timeout, fail-open, 5 matcher types: substring, word-boundary, regex, link allow/blocklist, emoji-flood
+- [x] **ReDoS protection**: Google `re2` linear-time engine (84 s native vs 0 ms `re2` confirmed in bench) plus `safe-regex` heuristic on pattern admission
+- [x] **6 actions**: `delete`, `warn`, `mute_timed`, `kick`, `ban` (with optional `community_bans.expires_at` for temporary bans), `report_only` (dry-run)
+- [x] **Welcome flow**: ghost `OctoGuard` bot user (`users.is_system=true`, login refused at auth route), public message in an admin-chosen channel with `{user}` / `{userMention}` / `{communityName}` variables, optional auto-grade on join. DM system message reserved for spec 019
+- [x] **Custom commands**: `!règles`, `!discord`, ... in markdown, Redis-backed per-channel cooldown (`SET NX EX`), allowed channels and roles configurable per command
+- [x] **Chat mutes**: `chat_mutes` table, global or per-channel scope, free-form duration (`15m`, `2h`, `1w`, permanent), Redis-cached 60 s, background purge worker
+- [x] **Reports queue**: member-driven signalements, anti-abuse rate limit per reporter + cooldown per target via Redis, admin inbox with mute/delete/dismiss actions
+- [x] **Audit log**: every action persisted to `admin_audit_log` with `event_id`, action type, target, metadata. Logger is fire-and-forget IIFE, caught by the pre-emptive bench: p95 dropped from 13 ms to 0.2 ms after switching from `await` to fire-and-forget
+- [x] **HMAC-SHA256 webhook**: outbound POST signed with `X-Octoguard-Signature: sha256=hex`, queued in Redis, worker fires async with 10 s timeout. The chat pipeline never pays the webhook latency
+- [x] **Admin UI**: `/admin/octoguard` with 8 tabs: overview, automod, welcome, commands, mutes, reports, logs, webhook. All CRUD with optimistic `enhance` forms
+- [x] **Kill-switch**: `OCTOGUARD_ENABLED=false` bypasses the entire pipeline. Rules table empty equals zero impact even when on. Progressive rollout pattern: enable → observe with empty rules → add 1 `report_only` rule → graduate to live
+- [x] **69 vitest tests**: `octoguard-matchers.test.ts` (matchers), `octoguard-commands.test.ts` (extractCommand), `octoguard-session-c.test.ts` (`assessPatternSafety`, `durationToExpiresAt`, `substituteVariables`, mutes, env migration)
+- [x] **`bench.ts` script**: dedicated performance benchmark proves p95 < 1 ms under load, caught the logger bottleneck before prod activation
 
 **Validation:** 69/69 OctoGuard tests green · bench p95 = 0.202 ms · production boot logs confirm `[octoguard] regex DoS protection: re2 native engine active` · `/api/v1/admin/octoguard/settings` returns 401 unauthenticated (adminOnly verified) · `OCTOGUARD_ENABLED` hot-swappable via PM2 `--update-env`
 
@@ -667,23 +667,23 @@ nodyx-core    (Fastify/Node.js) ────────────────
 
 ---
 
-## PHASE 5 — Mobile + Nodes + Reactions
+## PHASE 5, Mobile + Nodes + Reactions
 ### Goal: Nodyx in everyone's pocket, with structured knowledge
 
-- [ ] **DM reactions** — emoji reactions on private messages
-- [ ] **Discord import** — bulk import channels, threads, reactions, avatars from a Discord server export
-- [ ] **Bio enrichie Markdown** — TipTap editor on profile bio
-- [ ] **Système Merci backend** — `thanks` table, real Q score with λ decay (`e^{-λt}` weighting)
-- [ ] **Shareable profile card** — `/users/:username/card` SSR image (avatar + rings + stats), OG meta
-- [ ] **Nodes** (SPEC 013) — durable structured knowledge, Anchors, community-validated via Garden — [SPEC 013](../en/specs/013-node/SPEC.md)
-- [ ] **Module system** — 26 activatable modules from admin panel (CMS-style, CMS-inspired)
-- [ ] **Mobile — iOS** via Capacitor
-- [ ] **Mobile — Android** via Capacitor
+- [ ] **DM reactions**: emoji reactions on private messages
+- [ ] **Discord import**: bulk import channels, threads, reactions, avatars from a Discord server export
+- [ ] **Bio enrichie Markdown**: TipTap editor on profile bio
+- [ ] **Système Merci backend**: `thanks` table, real Q score with λ decay (`e^{-λt}` weighting)
+- [ ] **Shareable profile card**: `/users/:username/card` SSR image (avatar + rings + stats), OG meta
+- [ ] **Nodes** (SPEC 013), durable structured knowledge, Anchors, community-validated via Garden, [SPEC 013](../en/specs/013-node/SPEC.md)
+- [ ] **Module system**: 26 activatable modules from admin panel (CMS-style, CMS-inspired)
+- [ ] **Mobile, iOS** via Capacitor
+- [ ] **Mobile, Android** via Capacitor
 - [ ] **Desktop** via Tauri (.exe/.app/.sh ~10MB, standalone)
-- [ ] **Rust migration** — `nodyx-server` Axum crate replacing nodyx-core progressively (directory → auth → search → users → forums → Socket.IO)
-- [ ] **NodyxPoints** — inter-instance community reputation system
+- [ ] **Rust migration**: `nodyx-server` Axum crate replacing nodyx-core progressively (directory → auth → search → users → forums → Socket.IO)
+- [ ] **NodyxPoints**: inter-instance community reputation system
 - [ ] **Badges and levels**
-- [ ] **Galaxy Bar** — multi-instance switcher, decentralized SSO, bio-luminescent notifications — [SPEC 012](../en/specs/012-nodyx-galaxy-bar/SPEC.md)
+- [ ] **Galaxy Bar**: multi-instance switcher, decentralized SSO, bio-luminescent notifications, [SPEC 012](../en/specs/012-nodyx-galaxy-bar/SPEC.md)
 - [ ] **Documented public API** for third-party developers
 
 ---
@@ -691,7 +691,7 @@ nodyx-core    (Fastify/Node.js) ────────────────
 ## ROADMAP RULES
 
 1. Don't start a phase without the previous one being stable and in use
-2. Don't break what works — propose alternatives (e.g. Relay vs CF Tunnel vs open ports)
+2. Don't break what works, propose alternatives (e.g. Relay vs CF Tunnel vs open ports)
 3. Complexity is hidden: the user sees a button, the Rust layer handles the complexity
 4. Every addition must be consistent with the decentralized and sovereign aspect
 5. The core stays simple. Complexity goes into plugins.
@@ -703,7 +703,7 @@ nodyx-core    (Fastify/Node.js) ────────────────
 
 - Advertising
 - Data selling
-- Features that require a **mandatory** central server (`nodyx.org` is optional — without it, the instance remains fully functional on its own domain)
+- Features that require a **mandatory** central server (`nodyx.org` is optional, without it, the instance remains fully functional on its own domain)
 - Backdoors of any kind
 - Permanent dependency on a proprietary third-party service
 - Replacing Node.js or SvelteKit with Rust (every tool in its place)
@@ -712,7 +712,7 @@ nodyx-core    (Fastify/Node.js) ────────────────
 
 ---
 
-## PHASE HORIZON — NODYX-ETHER
+## PHASE HORIZON, NODYX-ETHER
 ### The physical layer. The last frontier.
 
 > *"Radio waves don't need permission."*
@@ -726,12 +726,12 @@ Fiber cables controlled by ISPs. Satellites controlled by corporations.
 The bridge that makes it possible: **CRDTs**.
 Already in Nodyx (NodyxCanvas). Already in production.
 The same CRDT that synchronizes a whiteboard stroke can synchronize a forum post
-over a LoRa link at 250 bps — even with a 2-hour delay.
+over a LoRa link at 250 bps, even with a 2-hour delay.
 
 ```
-Layer 1 — Local mesh     LoRa / Wi-Fi ad-hoc   0–50 km     no infrastructure
-Layer 2 — Regional radio HF / NVIS             500–3000 km  ionospheric bounce
-Layer 3 — Ionosphere     HF shortwave          Global       no cables, no satellites
+Layer 1, Local mesh     LoRa / Wi-Fi ad-hoc   0–50 km     no infrastructure
+Layer 2, Regional radio HF / NVIS             500–3000 km  ionospheric bounce
+Layer 3, Ionosphere     HF shortwave          Global       no cables, no satellites
 ```
 
 ```
@@ -743,7 +743,7 @@ nodyx-p2p/
 ```
 
 **nodyx-relay becomes a multi-path orchestrator:**
-`ethernet → wifi-mesh → lora → hf-radio` — automatic fallback, CRDT handles convergence.
+`ethernet → wifi-mesh → lora → hf-radio`, automatic fallback, CRDT handles convergence.
 
 **What this means in practice:**
 A community in a disaster zone. Fiber cut. 4G destroyed.
@@ -761,7 +761,7 @@ This is not a tomorrow feature. It is a **call to contributors:**
 
 ---
 
-## PHASE RADIO — NODYX-RADIO
+## PHASE RADIO, NODYX-RADIO
 ### Internet radio that finally has a reason to exist.
 
 > *"50,000 internet radio operators broadcasting into the void. Nodyx is the signal back."*
@@ -780,12 +780,12 @@ Living stations :  community → broadcast as expression
 ```
 
 **A Nodyx instance IS the community layer.** A radio station that runs Nodyx gets:
-- Forum (archives, discussions, show notes — indexed by all search engines)
+- Forum (archives, discussions, show notes, indexed by all search engines)
 - Live chat (listeners react in real-time during broadcasts)
 - Voice channels (open studio, backstage, listener Q&A)
 - Garden (community votes on upcoming programs)
 
-**The cooperative ad network — the missing economic model:**
+**The cooperative ad network, the missing economic model:**
 
 A small station with 80 listeners can't negotiate with advertisers alone.
 But 200 Nodyx-Radio stations with 80 listeners each = **16,000 local listeners**.
@@ -810,5 +810,5 @@ And because they can finally sustain themselves.
 
 ---
 
-*Version 2.2 — March 2026*
+*Version 2.2, March 2026*
 *"P2P is the soul. Rust is the body. Radio is the resilience. Community is the reason."*

--- a/docs/en/THANKS.md
+++ b/docs/en/THANKS.md
@@ -1,7 +1,7 @@
-# THANKS — Nodyx exists because of you
+# THANKS, Nodyx exists because of you
 
 > "If I have seen further, it is by standing on the shoulders of giants."
-> — Isaac Newton
+>, Isaac Newton
 
 Nodyx invented nothing. Nodyx assembled, with respect and gratitude,
 the work of thousands of developers who chose freedom over ownership.
@@ -31,15 +31,15 @@ the work of thousands of developers who chose freedom over ownership.
 
 ## 💜 Special mentions
 
-**Linux** — Without you none of this would exist.
+**Linux**: Without you none of this would exist.
 
-**Internet** — You were invented to bring us together.
+**Internet**: You were invented to bring us together.
 Nodyx makes sure you stay that way.
 
 ## 😺 Chief Supervisor
-**Iris** — For making sure the developer stayed focused.
+**Iris**: For making sure the developer stayed focused.
 
 ---
 
 *Nodyx is free because these projects were free before it.*
-*AGPL-3.0 — The code belongs to its community.*
+*AGPL-3.0, The code belongs to its community.*

--- a/docs/en/WHY-NODYX.md
+++ b/docs/en/WHY-NODYX.md
@@ -86,7 +86,7 @@ We owe sincere acknowledgment to every project working on this problem. Below is
 
 ### Heavy decentralized hitters
 
-**[Matrix](https://matrix.org)** — `github.com/matrix-org` / Element client: [github.com/element-hq/element-web](https://github.com/element-hq/element-web)
+**[Matrix](https://matrix.org)**: `github.com/matrix-org` / Element client: [github.com/element-hq/element-web](https://github.com/element-hq/element-web)
 The most mature open protocol in this space. Federated like email, end-to-end encrypted, with bridges to almost everything. If you want maximum interoperability and a long-term bet on a real protocol, start here.
 
 ### Discord-shaped clones
@@ -97,7 +97,7 @@ The closest visual feel to Discord. Built in Rust, fully open source, self-hosta
 **[Spacebar](https://github.com/spacebarchat/server)**
 A complete reimplementation of the Discord API. Existing Discord client mods often work against it. Excellent for technical communities that want compatibility.
 
-**[Fluxer](https://fluxer.app/)** — [github.com/fluxerapp/fluxer](https://github.com/fluxerapp/fluxer)
+**[Fluxer](https://fluxer.app/)**: [github.com/fluxerapp/fluxer](https://github.com/fluxerapp/fluxer)
 Newer entrant, gaining traction quickly. Strong customization, human support, and an active community of users testing daily. Worth watching.
 
 **[Haven](https://github.com/ancsemi/Haven)**
@@ -132,16 +132,16 @@ Every person who leaves a closed silo for an open alternative is a win, regardle
 
 > "I don't believe in turf wars. Each one brings their stone. If you also want to take part in an alternative, even modestly, come take a look. And if you prefer another solution, that's fine too. The important thing is that we stop letting ourselves be locked in. Let's support each other."
 >
-> *— from a [Reddit thread on Discord alternatives](https://www.reddit.com/r/BannedFromDiscord/comments/1swnq9b/), where this page started.*
+> *- from a [Reddit thread on Discord alternatives](https://www.reddit.com/r/BannedFromDiscord/comments/1swnq9b/), where this page started.*
 
 ---
 
 ## See also
 
-- [The Nodyx manifesto](MANIFESTO.md) — the full philosophical framing
-- [Installation guide](INSTALL.md) — if you decided to give it a shot
-- [Architecture overview](ARCHITECTURE.md) — what's under the hood
-- [Roadmap](ROADMAP.md) — where we're heading
+- [The Nodyx manifesto](MANIFESTO.md), the full philosophical framing
+- [Installation guide](INSTALL.md), if you decided to give it a shot
+- [Architecture overview](ARCHITECTURE.md), what's under the hood
+- [Roadmap](ROADMAP.md), where we're heading
 
 ---
 

--- a/nodyx-docs/src/lib/docs.server.ts
+++ b/nodyx-docs/src/lib/docs.server.ts
@@ -212,7 +212,7 @@ export async function buildSearchIndex(pages: Array<{ slug: string; title: strin
           .trim()
         const bodyPlain = stripMarkdown(body)
         // Prepend the heading text into the excerpt so heading-only queries match
-        const excerpt = (headingClean + ' — ' + bodyPlain).slice(0, 600)
+        const excerpt = (headingClean + ' : ' + bodyPlain).slice(0, 600)
         entries.push({
           slug:         page.slug,
           title:        page.title,

--- a/nodyx-docs/src/routes/+page.svelte
+++ b/nodyx-docs/src/routes/+page.svelte
@@ -44,7 +44,7 @@
       [0.50, 0.10, 3.5, '#818cf8', 0.45],
       [0.82, 0.22, 4,   '#06b6d4', 0.55],
       [0.25, 0.50, 5,   '#3b82f6', 0.35], // main-ish left
-      [0.55, 0.45, 7,   '#ffffff', 0.25], // CENTER — biggest
+      [0.55, 0.45, 7,   '#ffffff', 0.25], // CENTER, biggest
       [0.78, 0.55, 4,   '#818cf8', 0.5],
       [0.12, 0.75, 3.5, '#06b6d4', 0.65],
       [0.42, 0.80, 4,   '#3b82f6', 0.4],
@@ -180,13 +180,13 @@
     {
       icon: `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>`,
       title: 'Forum & threads',
-      desc: 'Categories, subcategories, threaded replies, rich editor, polls, pinned threads — flat, wide, professional by design.',
+      desc: 'Categories, subcategories, threaded replies, rich editor, polls, pinned threads, flat, wide, professional by design.',
       color: '#3b82f6',
     },
     {
       icon: `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>`,
       title: 'Real-time chat',
-      desc: 'Socket.IO powered channels, DMs, replies, pins, link unfurling, online presence — zero latency.',
+      desc: 'Socket.IO powered channels, DMs, replies, pins, link unfurling, online presence, zero latency.',
       color: '#8b5cf6',
     },
     {
@@ -198,7 +198,7 @@
     {
       icon: `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>`,
       title: 'P2P Relay',
-      desc: 'nodyx-relay lets you expose any instance behind a NAT. No port forwarding, no cloud lock-in — pure Rust TCP tunneling.',
+      desc: 'nodyx-relay lets you expose any instance behind a NAT. No port forwarding, no cloud lock-in, pure Rust TCP tunneling.',
       color: '#f59e0b',
     },
     {
@@ -210,12 +210,12 @@
     {
       icon: `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>`,
       title: 'Social Feed',
-      desc: 'A chronological follow feed — posts, replies, resonances. No algorithm, no engagement trap. Just the people you chose to follow.',
+      desc: 'A chronological follow feed, posts, replies, resonances. No algorithm, no engagement trap. Just the people you chose to follow.',
       color: '#10b981',
     },
     {
       icon: `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>`,
-      title: 'AGPL-3.0 — Free forever',
+      title: 'AGPL-3.0, Free forever',
       desc: 'Open source, copyleft, community-owned. Fork it, contribute, run it. No enterprise tier, no feature gating.',
       color: '#ef4444',
     },
@@ -232,19 +232,19 @@
       n: '02',
       title: 'Name your community',
       code: 'NODYX_COMMUNITY_NAME="The Hive"\nNODYX_COMMUNITY_SLUG="the-hive"',
-      desc: 'Set a handful of environment variables. Your instance, your name, your identity — no approval required.',
+      desc: 'Set a handful of environment variables. Your instance, your name, your identity, no approval required.',
     },
     {
       n: '03',
       title: 'Invite your people',
       code: 'https://your-domain.com/auth/register',
-      desc: 'Registration opens immediately. First user becomes admin. Start building — forum, channels, voice rooms are all ready.',
+      desc: 'Registration opens immediately. First user becomes admin. Start building, forum, channels, voice rooms are all ready.',
     },
   ]
 
   // ── Homepage Builder section animations ───────────────────────────────────
   onMount(() => {
-    // Entrance observer — fade + slide up on scroll into view
+    // Entrance observer, fade + slide up on scroll into view
     const obs = new IntersectionObserver((entries) => {
       for (const e of entries) {
         if (e.isIntersecting) {
@@ -256,7 +256,7 @@
     }, { threshold: 0.12 })
     document.querySelectorAll('.hb-entrance').forEach(el => obs.observe(el))
 
-    // Active row cycling — drives highlights in builder mockup
+    // Active row cycling, drives highlights in builder mockup
     const iv = setInterval(() => {
       activeRow = activeRow >= 3 ? 1 : activeRow + 1
     }, 2600)
@@ -266,14 +266,14 @@
 </script>
 
 <svelte:head>
-  <title>Nodyx Docs — Self-hosted community platform</title>
-  <meta name="description"        content="Official documentation for Nodyx — the open-source, self-hosted community platform. Forum + real-time chat + P2P voice. One command install." />
+  <title>Nodyx Docs, Self-hosted community platform</title>
+  <meta name="description"        content="Official documentation for Nodyx, the open-source, self-hosted community platform. Forum + real-time chat + P2P voice. One command install." />
   <link rel="canonical"           href="https://nodyx.dev" />
 
   <!-- Open Graph -->
   <meta property="og:type"        content="website" />
-  <meta property="og:title"       content="Nodyx Docs — Self-hosted community platform" />
-  <meta property="og:description" content="Official documentation for Nodyx — the open-source, self-hosted community platform. Forum + real-time chat + P2P voice. One command install." />
+  <meta property="og:title"       content="Nodyx Docs, Self-hosted community platform" />
+  <meta property="og:description" content="Official documentation for Nodyx, the open-source, self-hosted community platform. Forum + real-time chat + P2P voice. One command install." />
   <meta property="og:url"         content="https://nodyx.dev" />
   <meta property="og:image"       content="https://nodyx.dev/og-default.svg" />
   <meta property="og:image:width" content="1200" />
@@ -281,8 +281,8 @@
 
   <!-- Twitter/X card -->
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="Nodyx Docs — Self-hosted community platform" />
-  <meta name="twitter:description" content="Official documentation for Nodyx — open-source, self-hosted, P2P. Forum + Chat + Voice. One command install." />
+  <meta name="twitter:title"       content="Nodyx Docs, Self-hosted community platform" />
+  <meta name="twitter:description" content="Official documentation for Nodyx, open-source, self-hosted, P2P. Forum + Chat + Voice. One command install." />
   <meta name="twitter:image"       content="https://nodyx.dev/og-default.svg" />
 
   <!-- JSON-LD: WebSite + SearchAction -->
@@ -291,7 +291,7 @@
     "@type": "WebSite",
     "name": "Nodyx Docs",
     "url": "https://nodyx.dev",
-    "description": "Official documentation for Nodyx — the open-source, self-hosted community platform",
+    "description": "Official documentation for Nodyx, the open-source, self-hosted community platform",
     "inLanguage": "en",
     "publisher": { "@type": "Organization", "name": "Nodyx", "url": "https://nodyx.org" },
     "potentialAction": {
@@ -325,7 +325,7 @@
 
       <p class="hero-sub">
         Nodyx is a self-hosted, open-source community platform.<br>
-        Forum + real-time chat + voice channels — one server, one community, zero lock-in.
+        Forum + real-time chat + voice channels, one server, one community, zero lock-in.
       </p>
 
       <div class="install-box">
@@ -387,7 +387,7 @@
     </div>
     <div class="stat-sep"></div>
     <div class="stat">
-      <span class="stat-val">{instanceCount !== null ? instanceCount : '—'}</span>
+      <span class="stat-val">{instanceCount !== null ? instanceCount : '-'}</span>
       <span class="stat-label">
         {#if instanceCount !== null}
           <span class="stat-live-dot" aria-hidden="true"></span>
@@ -492,43 +492,43 @@
   <div class="section-inner">
     <div class="section-label">SCREENSHOTS</div>
     <h2 class="section-title">The real product. No mockup.</h2>
-    <p class="section-sub">Every screenshot taken from <a href="https://nodyx.org" target="_blank" rel="noopener noreferrer" style="color:var(--accent,#818cf8);text-decoration:none">nodyx.org</a> — the live production instance.</p>
+    <p class="section-sub">Every screenshot taken from <a href="https://nodyx.org" target="_blank" rel="noopener noreferrer" style="color:var(--accent,#818cf8);text-decoration:none">nodyx.org</a>, the live production instance.</p>
 
     <!-- Row 1: Hero screenshot full-width -->
     <div class="ss-hero-shot">
       <img src="/img/nodyx_home_page.png" alt="Nodyx homepage built with Grid Builder" loading="lazy"/>
-      <div class="ss-hero-caption">Homepage — assembled in the Grid Builder, live on nodyx.org</div>
+      <div class="ss-hero-caption">Homepage, assembled in the Grid Builder, live on nodyx.org</div>
     </div>
 
-    <!-- Row 2: 2-col grid — Forum + Chat -->
+    <!-- Row 2: 2-col grid, Forum + Chat -->
     <div class="ss-grid">
       <figure class="ss-fig">
-        <img src="/img/Nodyx_Forum.png" alt="Forum — categories and threads" loading="lazy"/>
-        <figcaption>Forum — categories, threads, rich editor, polls</figcaption>
+        <img src="/img/Nodyx_Forum.png" alt="Forum, categories and threads" loading="lazy"/>
+        <figcaption>Forum, categories, threads, rich editor, polls</figcaption>
       </figure>
       <figure class="ss-fig">
         <img src="/img/Nodyx_chat.png" alt="Real-time chat channels" loading="lazy"/>
-        <figcaption>Real-time chat — Socket.IO, DMs, replies, mentions</figcaption>
+        <figcaption>Real-time chat, Socket.IO, DMs, replies, mentions</figcaption>
       </figure>
       <figure class="ss-fig">
-        <img src="/img/Vocal_Nodyx_salon.png" alt="Voice channel — P2P WebRTC" loading="lazy"/>
-        <figcaption>Voice channels — P2P WebRTC mesh, noise cancellation</figcaption>
+        <img src="/img/Vocal_Nodyx_salon.png" alt="Voice channel, P2P WebRTC" loading="lazy"/>
+        <figcaption>Voice channels, P2P WebRTC mesh, noise cancellation</figcaption>
       </figure>
       <figure class="ss-fig">
-        <img src="/img/Nodyx_grid_builder_home_page_website.png" alt="Homepage Builder — drag and drop grid editor" loading="lazy"/>
-        <figcaption>Homepage Builder — free grid, drag & drop, live preview</figcaption>
+        <img src="/img/Nodyx_grid_builder_home_page_website.png" alt="Homepage Builder, drag and drop grid editor" loading="lazy"/>
+        <figcaption>Homepage Builder, free grid, drag & drop, live preview</figcaption>
       </figure>
       <figure class="ss-fig">
-        <img src="/img/widget_store_nodyx.png" alt="Widget Store — install .zip widgets" loading="lazy"/>
-        <figcaption>Widget Store — install community widgets in one click</figcaption>
+        <img src="/img/widget_store_nodyx.png" alt="Widget Store, install .zip widgets" loading="lazy"/>
+        <figcaption>Widget Store, install community widgets in one click</figcaption>
       </figure>
       <figure class="ss-fig">
         <img src="/img/Nodyx_Moteur_de_recherche_inter_reseau.png" alt="Cross-instance federated search" loading="lazy"/>
-        <figcaption>Cross-instance search — federated FTS across the network</figcaption>
+        <figcaption>Cross-instance search, federated FTS across the network</figcaption>
       </figure>
       <figure class="ss-fig ss-fig--wide">
-        <img src="/img/Nodyx_canvas_alternative_Mural.png" alt="NodyxCanvas — collaborative whiteboard" loading="lazy"/>
-        <figcaption>NodyxCanvas — collaborative whiteboard, 11 tools, CRDT sync, voice-aware cursors</figcaption>
+        <img src="/img/Nodyx_canvas_alternative_Mural.png" alt="NodyxCanvas, collaborative whiteboard" loading="lazy"/>
+        <figcaption>NodyxCanvas, collaborative whiteboard, 11 tools, CRDT sync, voice-aware cursors</figcaption>
       </figure>
     </div>
   </div>
@@ -552,27 +552,27 @@
       <ul class="lp-features">
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Generative banner</strong> — procedural animation seeded from username, unique per user
+          <strong>Generative banner</strong>, procedural animation seeded from username, unique per user
         </li>
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Reputation rings</strong> — concentric SVG arcs tracking posts, replies, reactions, updated live
+          <strong>Reputation rings</strong>, concentric SVG arcs tracking posts, replies, reactions, updated live
         </li>
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Activity heatmap</strong> — 12-week GitHub-style contribution grid
+          <strong>Activity heatmap</strong>, 12-week GitHub-style contribution grid
         </li>
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>XP levels &amp; grades</strong> — sqrt-based progression, custom colors, animated name effects
+          <strong>XP levels &amp; grades</strong>, sqrt-based progression, custom colors, animated name effects
         </li>
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Shareable invite card</strong> — <code style="font-size:0.8em;background:rgba(255,255,255,0.07);padding:0.1em 0.3em">/users/:username/card</code> generates a rich OG image for Discord &amp; social shares
+          <strong>Shareable invite card</strong>, <code style="font-size:0.8em;background:rgba(255,255,255,0.07);padding:0.1em 0.3em">/users/:username/card</code> generates a rich OG image for Discord &amp; social shares
         </li>
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Follow system</strong> — follow members, build your feed, see who resonates with your posts
+          <strong>Follow system</strong>, follow members, build your feed, see who resonates with your posts
         </li>
       </ul>
     </div>
@@ -635,7 +635,7 @@
             <div class="lp-cell" style="opacity: {0.07 + intensity * 0.85}; background: {intensity > 0.7 ? '#818cf8' : intensity > 0.4 ? '#6366f1' : '#3b3f6e'}"></div>
           {/each}
         </div>
-        <div class="lp-heatmap-label">Activity — last 12 weeks</div>
+        <div class="lp-heatmap-label">Activity, last 12 weeks</div>
       </div>
     </div>
 
@@ -652,26 +652,26 @@
       <div class="section-label">REPUTATION SYSTEM</div>
       <h2 class="section-title" style="margin-bottom: 1rem;">A score that actually means something.</h2>
       <p class="rep-intro">
-        Nodyx tracks every meaningful action — forum posts, replies, reactions, chat participation —
+        Nodyx tracks every meaningful action, forum posts, replies, reactions, chat participation,
         and translates them into a transparent, community-owned reputation score.
         No black box, no pay-to-win. Just real contribution.
       </p>
       <ul class="lp-features">
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Public leaderboard</strong> — top contributors ranked by reputation score, visible to all
+          <strong>Public leaderboard</strong>, top contributors ranked by reputation score, visible to all
         </li>
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Detailed breakdown</strong> — posts, replies, reactions, chat, events — each category tracked separately
+          <strong>Detailed breakdown</strong>, posts, replies, reactions, chat, events, each category tracked separately
         </li>
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Animated progress curves</strong> — SVG reputation rings that grow and pulse with your activity
+          <strong>Animated progress curves</strong>, SVG reputation rings that grow and pulse with your activity
         </li>
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Open formula</strong> — the scoring algorithm is in the codebase, auditable, forkable
+          <strong>Open formula</strong>, the scoring algorithm is in the codebase, auditable, forkable
         </li>
       </ul>
       <div class="rep-cta-row">
@@ -684,21 +684,21 @@
     <!-- Reputation rings mockup -->
     <div class="rep-rings-wrap" aria-hidden="true">
       <div class="rep-rings">
-        <!-- Outer ring — Posts -->
+        <!-- Outer ring, Posts -->
         <svg class="rep-ring-svg rep-ring-svg--1" viewBox="0 0 160 160">
           <circle cx="80" cy="80" r="72" fill="none" stroke="rgba(99,102,241,0.1)" stroke-width="6"/>
           <circle cx="80" cy="80" r="72" fill="none" stroke="#6366f1" stroke-width="6"
             stroke-dasharray="452" stroke-dashoffset="113"
             stroke-linecap="round" transform="rotate(-90 80 80)"/>
         </svg>
-        <!-- Mid ring — Replies -->
+        <!-- Mid ring, Replies -->
         <svg class="rep-ring-svg rep-ring-svg--2" viewBox="0 0 160 160">
           <circle cx="80" cy="80" r="58" fill="none" stroke="rgba(139,92,246,0.1)" stroke-width="5"/>
           <circle cx="80" cy="80" r="58" fill="none" stroke="#8b5cf6" stroke-width="5"
             stroke-dasharray="364" stroke-dashoffset="91"
             stroke-linecap="round" transform="rotate(-90 80 80)"/>
         </svg>
-        <!-- Inner ring — Reactions -->
+        <!-- Inner ring, Reactions -->
         <svg class="rep-ring-svg rep-ring-svg--3" viewBox="0 0 160 160">
           <circle cx="80" cy="80" r="44" fill="none" stroke="rgba(6,182,212,0.1)" stroke-width="4"/>
           <circle cx="80" cy="80" r="44" fill="none" stroke="#06b6d4" stroke-width="4"
@@ -774,25 +774,25 @@
       <h2 class="section-title" style="margin-bottom: 1rem;">Your community, in real time.</h2>
       <p class="rep-intro">
         Follow the people you care about. See their posts as they happen.
-        Reply, resonate — that's it. No algorithm deciding what you see, no engagement
+        Reply, resonate, that's it. No algorithm deciding what you see, no engagement
         engineering, no ads.
       </p>
       <ul class="lp-features">
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Chronological, always</strong> — newest first, no ranking, no surprises
+          <strong>Chronological, always</strong>, newest first, no ranking, no surprises
         </li>
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Rich posts</strong> — TipTap editor with formatting, images, links, code blocks
+          <strong>Rich posts</strong>, TipTap editor with formatting, images, links, code blocks
         </li>
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Résonances</strong> — our take on likes, with a pulse animation for popular posts
+          <strong>Résonances</strong>, our take on likes, with a pulse animation for popular posts
         </li>
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Inline thread replies</strong> — expand replies directly in the feed, no page jump
+          <strong>Inline thread replies</strong>, expand replies directly in the feed, no page jump
         </li>
       </ul>
     </div>
@@ -818,7 +818,7 @@
         <span class="e2e-gradient">Only yours.</span>
       </h2>
       <p class="e2e-intro">
-        Every DM is encrypted <strong>in your browser</strong> before it leaves your device —
+        Every DM is encrypted <strong>in your browser</strong> before it leaves your device,
         three independent layers. The server stores only opaque ciphertext it can never read.
       </p>
 
@@ -832,7 +832,7 @@
               <span class="e2e-layer-tag">Key exchange</span>
             </div>
             <p class="e2e-layer-desc">
-              Your private key is generated in the browser and <strong>never leaves it</strong> — stored as a non-extractable CryptoKey. The server only holds your public key.
+              Your private key is generated in the browser and <strong>never leaves it</strong>, stored as a non-extractable CryptoKey. The server only holds your public key.
             </p>
           </div>
         </div>
@@ -856,7 +856,7 @@
               <span class="e2e-layer-tag e2e-layer-tag-green">Unique to each instance</span>
             </div>
             <p class="e2e-layer-desc">
-              A per-instance obfuscation layer on top of AES-GCM — byte-permutation + deterministic PRNG noise. Even if AES were broken, an attacker still needs <strong>this instance's secret</strong>.
+              A per-instance obfuscation layer on top of AES-GCM, byte-permutation + deterministic PRNG noise. Even if AES were broken, an attacker still needs <strong>this instance's secret</strong>.
             </p>
           </div>
         </div>
@@ -1005,7 +1005,7 @@
       <p class="decent-p">
         Every Nodyx instance is independent. No central server, no corporate hub.
         Instances can discover each other via the <strong>global directory</strong>, relay through
-        <strong>nodyx-relay</strong> even behind NAT, and the network keeps running if any single node goes dark —
+        <strong>nodyx-relay</strong> even behind NAT, and the network keeps running if any single node goes dark,
         including ours.
       </p>
       <p class="decent-p">
@@ -1062,7 +1062,7 @@
         <span class="hb-gradient">your grid.</span>
       </h2>
       <p class="hb-intro">
-        Build your community's public face visually — free rows, resizable columns,
+        Build your community's public face visually, free rows, resizable columns,
         live preview. Configure themes, drop widgets, publish instantly.
         Zero code, zero restart.
       </p>
@@ -1070,19 +1070,19 @@
       <ul class="lp-features" style="margin-bottom: 2rem">
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Free Grid Builder</strong> — N columns per row, drag to resize, spans 1–12
+          <strong>Free Grid Builder</strong>, N columns per row, drag to resize, spans 1–12
         </li>
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Live WYSIWYG preview</strong> — real shell, real widgets, changes instantly
+          <strong>Live WYSIWYG preview</strong>, real shell, real widgets, changes instantly
         </li>
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Theme Editor</strong> — colors, font, border-radius, all in one panel
+          <strong>Theme Editor</strong>, colors, font, border-radius, all in one panel
         </li>
         <li>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <strong>Widget SDK</strong> — upload a <code>.zip</code>, runs in Shadow DOM, no rebuild
+          <strong>Widget SDK</strong>, upload a <code>.zip</code>, runs in Shadow DOM, no rebuild
         </li>
       </ul>
 
@@ -1106,7 +1106,7 @@
           </div>
           <div class="hb-sdk-file">
             <span class="hb-sdk-file-name">widget.iife.js</span>
-            <span class="hb-sdk-file-desc">Web Component — Shadow DOM isolated</span>
+            <span class="hb-sdk-file-desc">Web Component, Shadow DOM isolated</span>
           </div>
         </div>
         <a href="/create-widget" class="hb-sdk-cta">
@@ -1135,7 +1135,7 @@
         <!-- Real screenshot of the Grid Builder -->
         <img
           src="/img/Nodyx_grid_builder_home_page_website.png"
-          alt="Grid Builder — drag and drop homepage editor"
+          alt="Grid Builder, drag and drop homepage editor"
           class="hb-real-shot"
           loading="lazy"
         />
@@ -1165,7 +1165,7 @@
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
         </div>
         <div class="mod-face-label">Public Face</div>
-        <div class="mod-face-desc">Your community's website — visible without an account. Hero, news, events, gallery, contact form, sponsors.</div>
+        <div class="mod-face-desc">Your community's website, visible without an account. Hero, news, events, gallery, contact form, sponsors.</div>
         <div class="mod-face-tag">No login required</div>
       </div>
       <div class="mod-face-sep">
@@ -1176,7 +1176,7 @@
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
         </div>
         <div class="mod-face-label">Internal Face</div>
-        <div class="mod-face-desc">The platform your members actually use — forum, chat, voice, wiki, calendar, DMs, tasks.</div>
+        <div class="mod-face-desc">The platform your members actually use, forum, chat, voice, wiki, calendar, DMs, tasks.</div>
         <div class="mod-face-tag">Members only</div>
       </div>
     </div>
@@ -1366,7 +1366,7 @@
   </div>
 
   <div class="footer-bottom">
-    <span>AGPL-3.0 — built in the open, for the people.</span>
+    <span>AGPL-3.0, built in the open, for the people.</span>
     <span>One instance = one community.</span>
   </div>
 </footer>

--- a/nodyx-docs/src/routes/[...slug]/+page.svelte
+++ b/nodyx-docs/src/routes/[...slug]/+page.svelte
@@ -85,7 +85,7 @@
   })
 
   // Scrollspy: highlight the TOC entry matching the section the operator is
-  // currently reading. Approach is deliberately simple — rather than juggling
+  // currently reading. Approach is deliberately simple, rather than juggling
   // IntersectionObserver entries (which leaves "no active section" gaps when
   // the cursor is mid-section between two headings), we walk the heading list
   // on each scroll and pick the LAST one whose top is above the scroll line.
@@ -124,13 +124,13 @@
 </script>
 
 <svelte:head>
-  <title>{data.docTitle} — Nodyx Docs</title>
+  <title>{data.docTitle} · Nodyx Docs</title>
   <meta name="description"        content={data.description} />
   <link rel="canonical"           href="https://nodyx.dev/{data.slug}" />
 
   <!-- Open Graph -->
   <meta property="og:type"        content="article" />
-  <meta property="og:title"       content="{data.docTitle} — Nodyx Docs" />
+  <meta property="og:title"       content="{data.docTitle} · Nodyx Docs" />
   <meta property="og:description" content={data.description} />
   <meta property="og:url"         content="https://nodyx.dev/{data.slug}" />
   <meta property="og:site_name"   content="Nodyx Docs" />
@@ -140,7 +140,7 @@
 
   <!-- Twitter/X card -->
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="{data.docTitle} — Nodyx Docs" />
+  <meta name="twitter:title"       content="{data.docTitle} · Nodyx Docs" />
   <meta name="twitter:description" content={data.description} />
   <meta name="twitter:image"       content="https://nodyx.dev/og-default.svg" />
 
@@ -184,7 +184,7 @@
     {@html data.html}
   </article>
 
-  <!-- TOC (right sidebar) — sticky, with scrollspy active marker -->
+  <!-- TOC (right sidebar), sticky, with scrollspy active marker -->
   {#if data.headings.length > 2}
     <aside class="toc" aria-label="Table of contents">
       <div class="toc-title">On this page</div>


### PR DESCRIPTION
Balayage complet des docs nodyx.dev (17 fichiers docs/en + gabarits/accueil/extrait de recherche de nodyx-docs), plus de 800 tirets cadratins remplacés selon le contexte (: pour les listes, , pour les incises, · pour les titres). App nodyx-docs déjà rebuild + restart, public servi frais (cf-cache DYNAMIC). Un seul tiret gardé dans un commentaire de code non affiché qui explique un bug lié au caractère.