### PR TITLE
feat(lang): guest-accessible language picker with SSR locale

### DIFF
--- a/nodyx-frontend/src/app.html
+++ b/nodyx-frontend/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="fr">
+<html lang="%lang%">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />

--- a/nodyx-frontend/src/hooks.server.ts
+++ b/nodyx-frontend/src/hooks.server.ts
@@ -1,4 +1,5 @@
 import type { Handle, HandleFetch } from '@sveltejs/kit';
+import { getLocaleFromAcceptLanguage } from '$lib/i18n';
 
 // Make sure /service-worker.js (and any other SW-like files) are never cached
 // by intermediate CDNs. Default behaviour: Cloudflare cached service-worker.js
@@ -15,7 +16,13 @@ const NO_CACHE_PATHS = new Set([
 ]);
 
 export const handle: Handle = async ({ event, resolve }) => {
-	const response = await resolve(event);
+	const cookieLocale = event.cookies.get('nodyx_locale');
+	const acceptLang = event.request.headers.get('accept-language');
+	const locale = cookieLocale || getLocaleFromAcceptLanguage(acceptLang) || 'fr';
+
+	const response = await resolve(event, {
+		transformPageChunk: ({ html }) => html.replace('%lang%', locale)
+	});
 	if (NO_CACHE_PATHS.has(event.url.pathname)) {
 		response.headers.set('cache-control', 'no-cache, no-store, must-revalidate');
 		response.headers.set('pragma',         'no-cache');

--- a/nodyx-frontend/src/lib/i18n.ts
+++ b/nodyx-frontend/src/lib/i18n.ts
@@ -28,7 +28,7 @@ export const LOCALES: LocaleMeta[] = [
   { code: 'de',    label: 'Deutsch',    flag: '🇩🇪' },
   { code: 'ru',    label: 'Русский',    flag: '🇷🇺' },
   { code: 'pt-PT', label: 'Português',  flag: '🇵🇹' },
-  { code: 'vi',    label: 'Tiếng Việt', flag: '🇻🇳' },
+  { code: 'vi',    label: 'Vietnamese', flag: '🇻🇳' },
 ]
 
 // ── Messages ──────────────────────────────────────────────────────────────────
@@ -48,6 +48,38 @@ const messages: Record<Locale, Record<string, any>> = { fr, en, es, de, ru, 'pt-
 // ── Store locale ──────────────────────────────────────────────────────────────
 
 const STORAGE_KEY = 'nodyx_locale'
+const COOKIE_KEY = 'nodyx_locale'
+
+export function getLocaleFromAcceptLanguage(header: string | null): Locale | undefined {
+  if (!header) return undefined
+  try {
+    const parsed = header
+      .split(',')
+      .map(lang => {
+        const [name, q] = lang.split(';q=')
+        return {
+          code: name.trim().toLowerCase(),
+          weight: q ? parseFloat(q) : 1.0
+        }
+      })
+      .sort((a, b) => b.weight - a.weight)
+
+    for (const lang of parsed) {
+      const code = lang.code
+      const nav = code.slice(0, 2)
+      if (code === 'pt-pt' || (nav === 'pt' && !code.startsWith('pt-br'))) return 'pt-PT'
+      if (nav === 'fr') return 'fr'
+      if (nav === 'es') return 'es'
+      if (nav === 'de') return 'de'
+      if (nav === 'ru') return 'ru'
+      if (nav === 'vi') return 'vi'
+      if (nav === 'en') return 'en'
+    }
+  } catch {
+    // ignore
+  }
+  return undefined
+}
 
 function getInitialLocale(): Locale {
   if (!browser) return 'fr'
@@ -75,8 +107,16 @@ function createLocaleStore() {
       set(getInitialLocale())
     },
     setLocale(locale: Locale) {
-      if (browser) localStorage.setItem(STORAGE_KEY, locale)
+      if (browser) {
+        localStorage.setItem(STORAGE_KEY, locale)
+        // Sync cookie for SSR — avoids flash of default locale
+        document.cookie = `${COOKIE_KEY}=${locale}; path=/; max-age=${60 * 60 * 24 * 365}; samesite=lax`
+      }
       set(locale)
+    },
+    /** Set initial locale from SSR data (cookie) — avoids flash on hydration */
+    setSSR(locale: Locale) {
+      if (LOCALES.some((l) => l.code === locale)) set(locale)
     },
     get current(): Locale {
       return get({ subscribe })

--- a/nodyx-frontend/src/routes/+layout.server.ts
+++ b/nodyx-frontend/src/routes/+layout.server.ts
@@ -2,6 +2,7 @@ import { redirect } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
 import { apiFetch } from '$lib/api';
 import { env } from '$env/dynamic/public';
+import { getLocaleFromAcceptLanguage } from '$lib/i18n';
 
 const DIRECTORY_URL = (env.PUBLIC_DIRECTORY_URL ?? 'https://nodyx.org') + '/api/directory';
 
@@ -50,6 +51,11 @@ function normalizeUrl(url: string | null): string | null {
 
 export const load: LayoutServerLoad = async ({ fetch, cookies, request, url }) => {
 	const token = cookies.get('token');
+	let ssrLocale = cookies.get('nodyx_locale');
+	if (!ssrLocale) {
+		const acceptLang = request.headers.get('accept-language');
+		ssrLocale = getLocaleFromAcceptLanguage(acceptLang) || 'fr';
+	}
 
 	const [infoRes, userRes, directoryJson, announcementRes, modulesRes] = await Promise.all([
 		apiFetch(fetch, '/instance/info'),
@@ -91,7 +97,7 @@ export const load: LayoutServerLoad = async ({ fetch, cookies, request, url }) =
 	}> = (((directoryJson as any)?.instances) ?? []).filter((i: { slug: string }) => i.slug !== currentSlug);
 
 	if (!token || !userRes?.ok) {
-		return { user: null, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount: 0, token: null, networkInstances: [], directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion, themeCss, instanceTheme, instanceEffect };
+		return { user: null, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount: 0, token: null, networkInstances: [], directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion, themeCss, instanceTheme, instanceEffect, ssrLocale };
 	}
 
 	const { user } = await userRes.json();
@@ -121,5 +127,5 @@ export const load: LayoutServerLoad = async ({ fetch, cookies, request, url }) =
 	const linkedSlugs: string[] = user.linked_instances ?? [];
 	const networkInstances = allInstances.filter(i => linkedSlugs.includes(i.slug));
 
-	return { user, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount, token: token || null, appTheme, networkInstances, directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion, themeCss, instanceTheme, instanceEffect };
+	return { user, communityName, communityLogoUrl, communityBannerUrl, memberCount, unreadCount, token: token || null, appTheme, networkInstances, directoryInstances: allInstances, activeAnnouncement, modules, demoMode, nodyxVersion, themeCss, instanceTheme, instanceEffect, ssrLocale };
 };

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import '../app.css';
 	import { onMount } from 'svelte';
-	import { fade } from 'svelte/transition';
+	import { fade, fly } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
 	import type { LayoutData } from './$types';
 	import { page } from '$app/stores';
 	import { browser } from '$app/environment';
@@ -26,7 +27,7 @@
 	import ChannelIcon from '$lib/components/ChannelIcon.svelte';
 	import { get } from 'svelte/store';
 	import { voiceStore, voiceChannelMembersStore, voiceEventsStore, screenShareStore, remoteScreenStore } from '$lib/voice';
-	import { locale, t } from '$lib/i18n';
+	import { locale, t, LOCALES, type Locale } from '$lib/i18n';
 	import { unreadCountsStore, flashChannelIdStore } from '$lib/unreadStore';
 	import { playMention, playDm } from '$lib/sounds';
 	const tFn = $derived($t)
@@ -165,7 +166,11 @@
 	)
 	let showOffline = $state(false)
 
+	// SSR: set locale from cookie/accept-language BEFORE first render — avoids flash of default 'fr'
+	if (data.ssrLocale) locale.setSSR(data.ssrLocale as Locale)
+
 	onMount(async () => {
+		// Sync/initialize locale on the client side (e.g. read user choice from localStorage)
 		locale.init()
 
 		// Register <nodyx-audio-player> custom element (idempotent)
@@ -243,6 +248,45 @@
 
 	// ── User dropdown ──────────────────────────────────────────────────────────
 	let dropdownOpen = $state(false)
+	let langView = $state(false)
+	let langSaved = $state(false)
+	let langSavedTimeout: ReturnType<typeof setTimeout> | undefined
+	// Close the language pane when the route changes — otherwise it stays
+	// mounted over the new page until the user clicks "back".
+	let skipLangReset = false
+	$effect(() => {
+		$page.url.pathname
+		if (skipLangReset) { skipLangReset = false; return }
+		langView = false
+	})
+	function openLang() {
+		skipLangReset = true
+		langView = true
+		goto('/', { noScroll: true })
+	}
+	const currentLocale = $derived($locale)
+	function pickLocale(code: Locale) {
+		locale.setLocale(code)
+		langSaved = true
+		clearTimeout(langSavedTimeout)
+		langSavedTimeout = setTimeout(() => langSaved = false, 2000)
+	}
+
+	// Swipe-to-dismiss for mobile
+	let touchStartY = 0
+	let touchCurrentY = 0
+	function onLangTouchStart(e: TouchEvent) { touchStartY = e.touches[0].clientY }
+	function onLangTouchMove(e: TouchEvent) {
+		touchCurrentY = e.touches[0].clientY
+		const diff = touchCurrentY - touchStartY
+		if (diff > 0) (e.currentTarget as HTMLElement).style.transform = `translateY(${diff}px)`
+	}
+	function onLangTouchEnd() {
+		const diff = touchCurrentY - touchStartY
+		if (diff > 100) langView = false
+		const el = document.querySelector('.lang-view') as HTMLElement
+		if (el) el.style.transform = ''
+	}
 
 	// XP info — formule sqrt identique à ProfileCard / MiniProfileCard / page profil
 	const xpInfo = $derived((() => {
@@ -480,7 +524,11 @@
 			paletteOpen = true
 			return
 		}
-		// Close on Escape only if palette is open (palette handles its own Esc)
+		// Escape closes language pane
+		if (e.key === 'Escape' && langView) {
+			e.preventDefault()
+			langView = false
+		}
 	}
 </script>
 
@@ -611,6 +659,15 @@
 
 		<!-- Right: actions (notifs + DMs + account) -->
 		<div class="flex items-center gap-1 shrink-0 ml-auto lg:ml-0">
+			<!-- Language button (guest + logged-in) -->
+			<button
+				onclick={openLang}
+				class="lang-nav-btn p-2 transition-colors flex items-center gap-1.5 text-gray-500"
+				title={tFn('settings.language.label')}
+				aria-label={tFn('settings.language.label')}>
+				<span class="text-base leading-none">{LOCALES.find(l => l.code === currentLocale)?.flag ?? '🌐'}</span>
+				<svg class="hidden sm:block w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 8l6 6M4 14l6-6 2-3M2 5h12M7 2h1M22 22l-5-10-5 10M14 18h6"/></svg>
+			</button>
 			{#if user}
 				<!-- Notifications -->
 				<a href="/notifications"
@@ -1141,7 +1198,7 @@
 
 		<!-- ── Contenu principal ───────────────────────────────────────────────── -->
 		<div class="flex-1 overflow-hidden">
-		<main class="h-full overflow-y-auto min-w-0 {isBanned ? '' : showChannelSidebar ? 'lg:pl-[292px] xl:mr-[220px]' : 'lg:pl-[72px] xl:mr-[220px]'}" style="padding-bottom: var(--bottom-nav-h)">
+		<main class="{langView ? 'h-[calc(100vh-48px)] overflow-hidden' : 'h-full overflow-y-auto'} min-w-0 {isBanned ? '' : showChannelSidebar ? 'lg:pl-[292px] xl:mr-[220px]' : 'lg:pl-[72px] xl:mr-[220px]'}" style="padding-bottom: var(--bottom-nav-h)">
 
             <!-- ── System announcement banner ─────────────────────────────────── -->
             {#if showAnnouncement && announcement}
@@ -1171,8 +1228,67 @@
             {/if}
 
 
-            <div class="w-full flex-1 flex flex-col {$page.url.pathname === '/' || $page.url.pathname.startsWith('/chat') || $page.url.pathname.startsWith('/admin') || $page.url.pathname.startsWith('/users/') || $page.url.pathname.startsWith('/feed') || $page.url.pathname.startsWith('/settings') || $page.url.pathname.startsWith('/garden') || $page.url.pathname.startsWith('/calendar') || $page.url.pathname.startsWith('/discover') || $page.url.pathname.startsWith('/wiki') || $page.url.pathname.startsWith('/library') || $page.url.pathname.startsWith('/dm') ? '' : ($page.url.pathname.startsWith('/forum') || $page.url.pathname.startsWith('/tasks')) ? 'px-4 sm:px-6 py-8' : 'max-w-5xl mx-auto px-4 py-8'}">
-                {@render children()}
+            <div class="w-full flex-1 flex flex-col {langView ? 'lang-view-wrap h-full' : ($page.url.pathname === '/' || $page.url.pathname.startsWith('/chat') || $page.url.pathname.startsWith('/admin') || $page.url.pathname.startsWith('/users/') || $page.url.pathname.startsWith('/feed') || $page.url.pathname.startsWith('/settings') || $page.url.pathname.startsWith('/garden') || $page.url.pathname.startsWith('/calendar') || $page.url.pathname.startsWith('/discover') || $page.url.pathname.startsWith('/wiki') || $page.url.pathname.startsWith('/library') || $page.url.pathname.startsWith('/dm') ? '' : ($page.url.pathname.startsWith('/forum') || $page.url.pathname.startsWith('/tasks')) ? 'px-4 sm:px-6 py-8' : 'max-w-5xl mx-auto px-4 py-8')}">
+                {#if langView}
+                    <!-- svelte-ignore a11y_no_static_element_interactions -->
+                    <div class="fixed inset-0 bg-black/40 backdrop-blur-sm z-40" onclick={() => langView = false} transition:fade={{ duration: 200 }}></div>
+                    <div
+                        class="lang-view flex flex-col gap-4 w-full h-full min-h-0 p-6 sm:p-8 relative z-41"
+                        role="dialog"
+                        aria-modal="true"
+                        aria-labelledby="lang-title"
+                        aria-describedby="lang-desc"
+                        transition:fly={{ y: 20, duration: 300, easing: cubicOut }}
+                        ontouchstart={onLangTouchStart}
+                        ontouchmove={onLangTouchMove}
+                        ontouchend={onLangTouchEnd}
+                    >
+                        <button onclick={() => langView = false} class="lang-back inline-flex items-center gap-1.5 text-[11px] text-gray-600 shrink-0 bg-transparent border-none cursor-pointer" aria-label={tFn('common.back')}>
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M19 12H5M12 5l-7 7 7 7"/>
+                            </svg>
+                            {tFn('common.back')}
+                        </button>
+                        <div class="flex flex-col gap-4 min-h-0 flex-1">
+                            <div class="flex items-start gap-4 mb-1 shrink-0">
+                                <div class="lang-icon w-12 h-12 rounded-lg flex items-center justify-center shrink-0 border">
+                                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
+                                        <path d="M5 8l6 6M4 14l6-6 2-3M2 5h12M7 2h1M22 22l-5-10-5 10M14 18h6"/>
+                                    </svg>
+                                </div>
+                                <div>
+                                    <h2 id="lang-title" class="lang-title text-xl font-bold text-slate-100 m-0 mb-1 leading-tight">{tFn('settings.language.title')}</h2>
+                                    <p id="lang-desc" class="text-[13px] text-gray-500 leading-relaxed m-0">{tFn('settings.language.desc')}</p>
+                                </div>
+                            </div>
+                            <div class="lang-card rounded-lg p-5 min-h-0 flex flex-col flex-1">
+                                <div class="lang-segments flex flex-col gap-2 overflow-y-auto overflow-x-hidden flex-1 min-h-0 px-2">
+                                    {#each LOCALES as loc}
+                                    <button
+                                        onclick={() => pickLocale(loc.code)}
+                                        class="lang-seg flex items-center gap-4 p-4 rounded-lg border border-white/[0.06] bg-white/[0.02] cursor-pointer w-full relative overflow-hidden shrink-0 text-left {currentLocale === loc.code ? 'active' : ''}"
+                                    >
+                                        <span class="text-[26px] leading-none shrink-0">{loc.flag}</span>
+                                        <span class="flex-1 min-w-0">
+                                            <span class="lang-label text-sm font-semibold text-slate-200 block leading-relaxed">{loc.label}</span>
+                                        </span>
+                                        {#if currentLocale === loc.code}
+                                        <svg class="lang-seg-check w-5 h-5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
+                                        </svg>
+                                        {/if}
+                                    </button>
+                                    {/each}
+                                </div>
+                            </div>
+                            {#if langSaved}
+                            <div class="lang-success mt-3 py-2 px-3 rounded-md text-[13px] font-medium shrink-0 bg-green-400/10 border border-green-400/20 text-green-400">{tFn('settings.language.saved')}</div>
+                            {/if}
+                        </div>
+                    </div>
+                {:else}
+                    {@render children()}
+                {/if}
             </div>
         </main>
 		</div>
@@ -1966,4 +2082,131 @@
 	from { transform: scale(0); opacity: 0; }
 	to   { transform: scale(1); opacity: 1; }
 }
+
+/* ── Language view (state-swapped, no route) ────────────────────────────── */
+.lang-view-wrap {
+    background: rgba(6, 6, 10, 0.85);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    color: #e2e8f0;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+.lang-nav-btn {
+    border-radius: 6px;
+    transition: color 200ms cubic-bezier(0.25, 0.1, 0.25, 1),
+                background 200ms cubic-bezier(0.25, 0.1, 0.25, 1),
+                transform 100ms ease-out;
+}
+.lang-nav-btn:hover {
+    color: #9ca3af !important;
+    background: rgba(255,255,255,0.05);
+}
+.lang-nav-btn:active { transform: scale(0.95); }
+.lang-nav-btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(var(--nx-accent-rgb), 0.4);
+}
+.lang-back {
+    transition: color 200ms cubic-bezier(0.25, 0.1, 0.25, 1),
+                transform 200ms cubic-bezier(0.25, 0.1, 0.25, 1);
+}
+.lang-back:hover { color: #9ca3af; transform: translateX(-2px); }
+.lang-back:active { transform: translateX(0) scale(0.98); }
+.lang-back:focus-visible { outline: none; color: var(--nx-accent-soft); }
+.lang-card {
+    background: rgba(255, 255, 255, 0.03);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid rgba(255,255,255,0.06);
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+}
+.lang-icon {
+    border-color: rgba(var(--nx-accent-rgb), 0.2);
+    background: rgba(var(--nx-accent-rgb), 0.1);
+    color: var(--nx-accent-soft);
+}
+.lang-title {
+    font-family: 'Space Grotesk', sans-serif;
+    letter-spacing: -0.03em;
+}
+.lang-label {
+    font-family: 'Space Grotesk', sans-serif;
+    letter-spacing: -0.005em;
+}
+.lang-segments {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255,255,255,.06) transparent;
+}
+.lang-segments::-webkit-scrollbar { width: 5px; position: absolute; }
+.lang-segments::-webkit-scrollbar-track { background: transparent; }
+.lang-segments::-webkit-scrollbar-thumb { background: rgba(255,255,255,.06); border-radius: 99px; }
+.lang-segments::-webkit-scrollbar-thumb:hover { background: rgba(var(--nx-accent-rgb), 0.4); }
+.lang-seg {
+    transition: all 300ms cubic-bezier(0.25, 0.1, 0.25, 1);
+}
+.lang-seg::before {
+    content: '';
+    position: absolute;
+    left: 0; top: 0; bottom: 0;
+    width: 2px;
+    background: linear-gradient(180deg, var(--nx-accent), var(--nx-accent-2));
+    opacity: 0;
+    transform: translateX(-100%);
+    transition: all 300ms cubic-bezier(0.25, 0.1, 0.25, 1);
+    box-shadow: 0 0 8px var(--nx-accent);
+}
+.lang-seg:hover {
+    border-color: rgba(var(--nx-accent-rgb), 0.2);
+    background: rgba(255,255,255,0.04);
+    padding-left: 24px;
+    transform: scale(1.01);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+.lang-seg:active {
+    transform: scale(0.98);
+    background: rgba(255, 255, 255, 0.05);
+    transition: transform 100ms ease-out, background 100ms ease-out;
+}
+.lang-seg:focus-visible {
+    outline: none;
+    border-color: var(--nx-accent);
+    box-shadow: 0 0 0 3px rgba(var(--nx-accent-rgb), 0.3);
+}
+.lang-seg.active {
+    border-color: rgba(var(--nx-accent-rgb), 0.3);
+    background: rgba(var(--nx-accent-rgb), 0.04);
+    padding-left: 24px;
+}
+.lang-seg.active::before { opacity: 1; transform: translateX(0); }
+.lang-seg.active .text-slate-200 { color: var(--nx-accent-soft); }
+.lang-seg-check {
+    color: var(--nx-accent);
+    transform: scale(0);
+    transition: transform 350ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.lang-seg.active .lang-seg-check { transform: scale(1); }
+.lang-success {
+    animation: lang-success-in 200ms ease-out;
+}
+@keyframes lang-success-in {
+    from { opacity: 0; transform: translateY(-4px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Reduced motion ──────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+    .lang-back,
+    .lang-seg,
+    .lang-seg::before,
+    .lang-seg-check,
+    .lang-success {
+        transition: none !important;
+        animation: none !important;
+        transform: none !important;
+    }
+}
+
+
 </style>

--- a/nodyx-frontend/src/routes/settings/+page.svelte
+++ b/nodyx-frontend/src/routes/settings/+page.svelte
@@ -5,7 +5,7 @@
 
     import { PUBLIC_API_URL, PUBLIC_SIGNET_URL } from '$env/static/public';
     import { tick } from 'svelte';
-    import { t, locale, LOCALES, type Locale } from '$lib/i18n';
+    import { t, locale } from '$lib/i18n';
     import { get } from 'svelte/store';
     import { soundSettings } from '$lib/soundSettings';
     import { streamerNotifSettings, testStreamerNotif, type StreamerEventKey } from '$lib/sounds/streamerNotifSettings';
@@ -45,11 +45,9 @@
     // $t and $locale are legacy store subscriptions; wrapping in $derived ensures
     // Svelte 5's rune dependency tracker re-renders the component on locale change.
     const tFn          = $derived($t)
-    const currentLocale = $derived($locale)
 
     // ── Navigation ────────────────────────────────────────────────────────────
     let activeSection = $state('network')
-    let langSaved     = $state(false)
 
     // ── Twitch link (viewer flow) ─────────────────────────────────────────────
     type TwitchLink = { twitchId: string; twitchLogin: string } | null
@@ -154,12 +152,6 @@
             loadTwitchLink()
         }
     })
-
-    function setLocale(code: Locale) {
-        locale.setLocale(code)
-        langSaved = true
-        setTimeout(() => langSaved = false, 2000)
-    }
 
     // ── Nodyx Signet ──────────────────────────────────────────────────────────
     type SignetDevice = { id: string; label: string; created_at: string; last_used_at: string | null }
@@ -585,16 +577,6 @@
                 {#if !sounds.enabled}
                     <span class="sb-badge-dot" style="background:#6b7280"></span>
                 {/if}
-            </button>
-
-            <button class="sb-item {activeSection === 'language' ? 'active' : ''}"
-                    onclick={() => activeSection = 'language'}>
-                <span class="sb-icon" style="background: rgba(16,185,129,0.12); color: #34d399">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M5 8l6 6M4 14l6-6 2-3M2 5h12M7 2h1M22 22l-5-10-5 10M14 18h6"/>
-                    </svg>
-                </span>
-                <span class="sb-label">{tFn('settings.language.label')}</span>
             </button>
         </nav>
 
@@ -1360,42 +1342,6 @@
         {/if}
 
         <!-- ═══ LANGUE ════════════════════════════════════════════════════════ -->
-        {#if activeSection === 'language'}
-        <div class="s-pane" style="--accent: #34d399; --accent-bg: rgba(16,185,129,0.08); --accent-border: rgba(16,185,129,0.2)">
-            <div class="s-pane-header">
-                <div class="s-pane-icon" style="background: var(--accent-bg); border-color: var(--accent-border); color: var(--accent)">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
-                        <path d="M5 8l6 6M4 14l6-6 2-3M2 5h12M7 2h1M22 22l-5-10-5 10M14 18h6"/>
-                    </svg>
-                </div>
-                <div>
-                    <h2 class="s-pane-title">{tFn('settings.language.title')}</h2>
-                    <p class="s-pane-desc">{tFn('settings.language.desc')}</p>
-                </div>
-            </div>
-
-            <div class="s-card">
-                {#if langSaved}
-                <div class="s-success-banner" style="margin-bottom:16px">{tFn('settings.language.saved')}</div>
-                {/if}
-                <div class="lang-flags">
-                    {#each LOCALES as loc}
-                    <button
-                        onclick={() => setLocale(loc.code)}
-                        class="lang-flag-item {currentLocale === loc.code ? 'active' : ''}"
-                    >
-                        <span class="lang-flag">{loc.flag}</span>
-                        <span class="lang-flag-label">{loc.label}</span>
-                        {#if currentLocale === loc.code}
-                        <span class="lang-flag-active">{tFn('common.current')}</span>
-                        {/if}
-                    </button>
-                    {/each}
-                </div>
-            </div>
-        </div>
-        {/if}
-
     </main>
 </div>
 
@@ -1951,32 +1897,7 @@
 }
 .signet-copy-btn.copied { color: #4ade80; border-color: rgba(74,222,128,0.3); }
 
-/* ── Langue ──────────────────────────────────────────────────────────────── */
-.lang-flags {
-    display: flex;
-    justify-content: center;
-    gap: 16px;
-    padding: 8px 0;
-}
-.lang-flag-item {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 6px;
-    padding: 16px 28px;
-    border-radius: 8px;
-    border: 1px solid rgba(255,255,255,0.06);
-    background: rgba(255,255,255,0.02);
-    cursor: pointer;
-    transition: border-color 0.15s, background 0.15s;
-    color: inherit;
-    font-family: inherit;
-}
-.lang-flag-item:hover { border-color: rgba(255,255,255,0.12); background: rgba(255,255,255,0.04); }
-.lang-flag-item.active { border-color: rgba(16,185,129,0.25); background: rgba(16,185,129,0.05); }
-.lang-flag { font-size: 28px; }
-.lang-flag-label { font-size: 13px; font-weight: 600; color: #6b7280; }
-.lang-flag-active { font-size: 10px; font-weight: 700; color: #34d399; text-transform: uppercase; letter-spacing: 0.08em; }
+
 
 /* ── Sons ────────────────────────────────────────────────────────────────── */
 .sound-volume-wrap {


### PR DESCRIPTION
## Summary
- Move language picker from /settings to a layout pane accessible to guests via the nav bar
- Redesign as segmented cards using the Nodyx brand accent (indigo/violet) instead of off-brand green
- Internal list scroll with fixed header — the page stays put, only the language list scrolls
- Read locale from cookie in hooks.server.ts so SSR renders the right language on first paint — no flash from fr to user's lang

<img width="1876" height="880" alt="screenshot-2026-07-19_01-59-57" src="https://github.com/user-attachments/assets/bfb43bdc-8a09-4910-a8ec-38e12968ed69" />