### PR TITLE
feat(benchmark): bilingual FR/EN voice benchmark

### DIFF
--- a/nodyx-frontend/static/benchmark/bench.js
+++ b/nodyx-frontend/static/benchmark/bench.js
@@ -1,4 +1,4 @@
-/* Nodyx · Benchmark — moteur partagé (graphes, reveal au scroll, thème, nav) */
+/* Nodyx · Benchmark · moteur partagé (graphes, reveal au scroll, thème, nav, langue) */
 (() => {
   "use strict";
   const REDUCED = matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -6,29 +6,104 @@
   const css = v => getComputedStyle(document.documentElement).getPropertyValue(v).trim();
   const el = (t, a = {}) => { const e = document.createElementNS(NS, t); for (const k in a) e.setAttribute(k, a[k]); return e; };
 
+  // ── Langue (fr / en) ───────────────────────────────────────
+  let _lang = "fr";
+  let _page = "";
+  const langCbs = [];
+  function t(fr, en) { return _lang === "en" ? en : fr; }
+  function num(n) { return (+n).toLocaleString(_lang === "en" ? "en-US" : "fr-FR"); }
+  function dec(v, d) { const s = (+v).toFixed(d); return _lang === "en" ? s : s.replace(".", ","); }
+  // Résout un libellé qui peut être une chaîne ou un objet {fr, en}.
+  function tr(v) { return (v && typeof v === "object" && !Array.isArray(v) && "fr" in v) ? (v[_lang] ?? v.fr) : v; }
+
+  function initLang() {
+    let l;
+    try { l = localStorage.getItem("nodyx-bench-lang"); } catch (e) {}
+    if (l !== "fr" && l !== "en") l = (navigator.language || "fr").toLowerCase().startsWith("fr") ? "fr" : "en";
+    _lang = l;
+    const root = document.documentElement;
+    root.setAttribute("data-lang", l);
+    root.setAttribute("lang", l);
+  }
+
+  function ensureLangStyle() {
+    if (document.getElementById("bench-lang-style")) return;
+    const s = document.createElement("style");
+    s.id = "bench-lang-style";
+    s.textContent =
+      ".lang-switch{display:inline-flex;gap:1px;margin-left:6px}" +
+      ".lang-btn{background:none;border:0;cursor:pointer;font-size:1.02rem;line-height:1;padding:4px 5px;border-radius:7px;opacity:.4;filter:grayscale(.55);transition:opacity .15s,filter .15s,background .15s}" +
+      ".lang-btn:hover{opacity:.85;filter:grayscale(0)}" +
+      ".lang-btn[aria-pressed=\"true\"]{opacity:1;filter:grayscale(0);background:rgba(127,127,127,.16)}";
+    document.head.appendChild(s);
+  }
+
+  // Applique la langue au texte du DOM (attributs data-en, data-en-aria, titre).
+  function applyLangText(lang) {
+    document.querySelectorAll("[data-en]").forEach(node => {
+      if (node.dataset.fr == null) node.dataset.fr = node.innerHTML;
+      node.innerHTML = lang === "en" ? node.getAttribute("data-en") : node.dataset.fr;
+    });
+    document.querySelectorAll("[data-en-aria]").forEach(node => {
+      if (node.dataset.frAria == null) node.dataset.frAria = node.getAttribute("aria-label") || "";
+      node.setAttribute("aria-label", lang === "en" ? node.getAttribute("data-en-aria") : node.dataset.frAria);
+    });
+    const b = document.body;
+    if (b && b.dataset.enTitle) {
+      if (b.dataset.frTitle == null) b.dataset.frTitle = document.title;
+      document.title = lang === "en" ? b.dataset.enTitle : b.dataset.frTitle;
+    }
+  }
+
+  // Bascule complète (clic sur un drapeau) : texte + nav + graphes + hooks de page.
+  function applyLang(lang) {
+    if (lang !== "fr" && lang !== "en") return;
+    _lang = lang;
+    const root = document.documentElement;
+    root.setAttribute("data-lang", lang);
+    root.setAttribute("lang", lang);
+    try { localStorage.setItem("nodyx-bench-lang", lang); } catch (e) {}
+    buildNav(_page);
+    applyLangText(lang);
+    langCbs.forEach(fn => { try { fn(lang); } catch (e) {} });
+    redrawAll();
+  }
+
   // ── Navigation (source unique) ─────────────────────────────
   const PAGES = [
-    { id: "pire-cas",        href: "pire-cas.html",        label: "Le pire cas" },
-    { id: "diffusion-audio", href: "diffusion-audio.html", label: "Diffusion audio" },
-    { id: "partage-ecran",   href: "partage-ecran.html",   label: "Partage d'écran" },
-    { id: "technique",       href: "technique.html",       label: "Technique", tech: true },
+    { id: "pire-cas",        href: "pire-cas.html",        label: { fr: "Le pire cas",     en: "Worst case" } },
+    { id: "diffusion-audio", href: "diffusion-audio.html", label: { fr: "Diffusion audio", en: "Audio broadcast" } },
+    { id: "partage-ecran",   href: "partage-ecran.html",   label: { fr: "Partage d'écran", en: "Screen share" } },
+    { id: "technique",       href: "technique.html",       label: { fr: "Technique",       en: "Technical" }, tech: true },
   ];
   function buildNav(current) {
     const mount = document.getElementById("nav-mount");
     if (!mount) return;
+    ensureLangStyle();
     const links = PAGES.map(p => {
       const cur = p.id === current ? ' aria-current="page"' : "";
       const cls = p.tech ? ' class="tech-link"' : "";
-      return `<li${p.tech ? ' class="tech"' : ""}><a href="${p.href}"${cur}${cls}>${p.label}</a></li>`;
+      return `<li${p.tech ? ' class="tech"' : ""}><a href="${p.href}"${cur}${cls}>${tr(p.label)}</a></li>`;
     }).join("");
     mount.className = "nav";
     mount.innerHTML =
       `<div class="nav-in">
         <a class="brand" href="pire-cas.html"><span class="dot"></span> Nodyx · Benchmark</a>
         <ul>${links}</ul>
-        <button class="theme-btn" id="theme" type="button" aria-label="Thème clair/sombre"><span id="theme-ico">◐</span></button>
+        <button class="theme-btn" id="theme" type="button" aria-label="${t("Thème clair/sombre", "Light/dark theme")}"><span id="theme-ico">◐</span></button>
+        <div class="lang-switch" role="group" aria-label="Langue / Language">
+          <button class="lang-btn" data-set-lang="fr" type="button" title="Français" aria-label="Français" aria-pressed="${_lang === "fr"}">🇫🇷</button>
+          <button class="lang-btn" data-set-lang="en" type="button" title="English" aria-label="English" aria-pressed="${_lang === "en"}">🇬🇧</button>
+        </div>
       </div>`;
     initTheme();
+    initLangSwitch();
+  }
+
+  function initLangSwitch() {
+    document.querySelectorAll(".lang-btn").forEach(btn => {
+      btn.addEventListener("click", () => applyLang(btn.dataset.setLang));
+    });
   }
 
   // ── Thème ──────────────────────────────────────────────────
@@ -60,8 +135,8 @@
   // ── Compteurs (chiffres qui montent, au scroll) ────────────
   function animateCount(s) {
     if (s.dataset.done) return; s.dataset.done = "1";
-    const to = parseFloat(s.dataset.count), dec = +(s.dataset.dec || 0);
-    const fmt = v => v.toFixed(dec).replace(".", ",");
+    const to = parseFloat(s.dataset.count), d = +(s.dataset.dec || 0);
+    const fmt = v => dec(v, d);
     if (REDUCED) { s.textContent = fmt(to); return; }
     const t0 = performance.now(), dur = 1300;
     const step = t => { const p = Math.min((t - t0) / dur, 1), e = 1 - Math.pow(1 - p, 3); s.textContent = fmt(to * e); if (p < 1) requestAnimationFrame(step); };
@@ -121,7 +196,7 @@
     if (opts.ref != null) {
       const yy = y(opts.ref);
       svg.appendChild(el("line", { x1: m.l, y1: yy, x2: m.l + pw, y2: yy, class: "refline" }));
-      const rt = el("text", { x: m.l + pw, y: yy - 7, class: "axis-txt", "text-anchor": "end", fill: css("--ink-2") }); rt.textContent = opts.refLabel || ""; svg.appendChild(rt);
+      const rt = el("text", { x: m.l + pw, y: yy - 7, class: "axis-txt", "text-anchor": "end", fill: css("--ink-2") }); rt.textContent = tr(opts.refLabel) || ""; svg.appendChild(rt);
     }
     rows.forEach((d, i) => { if (opts.xevery && !opts.xevery.includes(xkey(d))) return; const t = el("text", { x: x(i), y: H - 12, class: "axis-txt", "text-anchor": "middle" }); t.textContent = xkey(d); svg.appendChild(t); });
     const pts = rows.map((d, i) => [x(i), y(opts.val(d))]);
@@ -134,10 +209,11 @@
     const labelObjs = [];
     (opts.labels || []).forEach(L => {
       const i = rows.findIndex(d => xkey(d) === L.at); if (i < 0) return;
+      const txt = tr(L.text);
       const px = x(i), py = y(opts.val(rows[i])), g = el("g", { style: "transition:opacity .35s" });
-      const tw = L.text.length * 7.6 + 12, lx = Math.min(Math.max(px + L.dx, m.l + tw / 2), m.l + pw - tw / 2 - 2);
+      const tw = txt.length * 7.6 + 12, lx = Math.min(Math.max(px + L.dx, m.l + tw / 2), m.l + pw - tw / 2 - 2);
       g.appendChild(el("rect", { x: lx - tw / 2, y: py + L.dy - 12, width: tw, height: 18, rx: 5, class: "dlabel-bg" }));
-      const tx = el("text", { x: lx, y: py + L.dy + 1, class: "dlabel", "text-anchor": "middle", fill: L.color || opts.stroke }); tx.textContent = L.text; g.appendChild(tx); svg.appendChild(g);
+      const tx = el("text", { x: lx, y: py + L.dy + 1, class: "dlabel", "text-anchor": "middle", fill: L.color || opts.stroke }); tx.textContent = txt; g.appendChild(tx); svg.appendChild(g);
       labelObjs.push({ g, px });
     });
     spec.reveal = e => {
@@ -167,8 +243,13 @@
 
   function redrawAll() { registry.forEach(spec => { build(spec); spec.reveal(1); }); }
 
+  initLang();
+
   window.Bench = {
-    boot(page) { buildNav(page); autoCounters(); autoBars(); },
+    boot(page) { _page = page; buildNav(page); applyLangText(_lang); autoCounters(); autoBars(); },
     chart, counters, onView, css,
+    // Helpers de langue pour les scripts de page (tooltips, tableaux) :
+    t, num, dec, get lang() { return _lang; },
+    onLang(fn) { langCbs.push(fn); },
   };
 })();

--- a/nodyx-frontend/static/benchmark/diffusion-audio.html
+++ b/nodyx-frontend/static/benchmark/diffusion-audio.html
@@ -3,122 +3,122 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Diffusion audio — Nodyx · Banc d'essai vocal</title>
+<title>Diffusion audio · Nodyx · Banc d'essai vocal</title>
 <meta name="description" content="Une personne parle, tout le monde écoute : un seul cœur diffuse à ~8000 personnes, son parfait. Le cas réel. Mesures réelles, auto-hébergé.">
 <meta name="color-scheme" content="light dark">
 <meta property="og:title" content="Diffusion audio : ~8000 personnes écoutent, sur un seul cœur">
 <meta property="og:description" content="Le cas réel du vocal Nodyx : une personne parle, des milliers écoutent. Mesuré sans filtre.">
 <link rel="stylesheet" href="style.css?v=2">
 </head>
-<body data-page="diffusion-audio">
+<body data-page="diffusion-audio" data-en-title="Audio broadcast · Nodyx · Voice benchmark">
 <div id="nav-mount"></div>
 <div class="wrap">
 
   <header class="hero">
     <div class="tapehead">
-      <span class="live">Banc d'essai vocal</span>
-      <span><b>Scénario 02 / 03</b> — le cas réel</span>
-      <span>Forme · <b>1 parle, N écoutent</b></span>
-      <span>Flux · <b>audio</b> (~32 kbit/s)</span>
+      <span class="live" data-en="Voice benchmark">Banc d'essai vocal</span>
+      <span data-en="<b>Scenario 02 / 03</b>: the real case"><b>Scénario 02 / 03</b> : le cas réel</span>
+      <span data-en="Shape · <b>1 talks, N listen</b>">Forme · <b>1 parle, N écoutent</b></span>
+      <span data-en="Stream · <b>audio</b> (~32 kbps)">Flux · <b>audio</b> (~32 kbit/s)</span>
     </div>
-    <h1>Une personne parle, des milliers écoutent.</h1>
-    <p class="lede">Le cas le plus courant : une conférence, une annonce, un town-hall. Une voix, beaucoup
+    <h1 data-en="One person talks, thousands listen.">Une personne parle, des milliers écoutent.</h1>
+    <p class="lede" data-en="The most common case: a conference, an announcement, a town-hall. One voice, many ears. Here the server only has to relay a single stream: capacity changes scale entirely.">Le cas le plus courant : une conférence, une annonce, un town-hall. Une voix, beaucoup
       d'oreilles. Là, le serveur n'a qu'à relayer un flux : la capacité change complètement d'échelle.</p>
 
     <div class="readout">
-      <div class="ro"><span class="ro-v sig">~<span data-count="8000">0</span></span><span class="ro-k">personnes écoutent · par cœur</span></div>
-      <div class="ro"><span class="ro-v"><span data-count="100">0</span><span class="u">%</span></span><span class="ro-k">son parfait · jusqu'à 8000</span></div>
-      <div class="ro"><span class="ro-v">&lt; <span data-count="1">0</span></span><span class="ro-k">cœur utilisé · pour 8000 personnes</span></div>
+      <div class="ro"><span class="ro-v sig">~<span data-count="8000">0</span></span><span class="ro-k" data-en="people listening · per core">personnes écoutent · par cœur</span></div>
+      <div class="ro"><span class="ro-v"><span data-count="100">0</span><span class="u">%</span></span><span class="ro-k" data-en="perfect audio · up to 8000">son parfait · jusqu'à 8000</span></div>
+      <div class="ro"><span class="ro-v">&lt; <span data-count="1">0</span></span><span class="ro-k" data-en="core used · for 8000 people">cœur utilisé · pour 8000 personnes</span></div>
     </div>
 
-    <nav class="scene-nav" aria-label="Scénarios">
-      <a href="pire-cas.html">01 · Le pire cas</a>
-      <a href="diffusion-audio.html" aria-current="page">02 · Diffusion audio</a>
-      <a href="partage-ecran.html">03 · Partage d'écran</a>
+    <nav class="scene-nav" aria-label="Scénarios" data-en-aria="Scenarios">
+      <a href="pire-cas.html" data-en="01 · Worst case">01 · Le pire cas</a>
+      <a href="diffusion-audio.html" aria-current="page" data-en="02 · Audio broadcast">02 · Diffusion audio</a>
+      <a href="partage-ecran.html" data-en="03 · Screen share">03 · Partage d'écran</a>
     </nav>
   </header>
 
   <div class="callout">
-    <span class="cl-badge">80× le pire cas</span>
-    <p>Quand tout le monde parle en même temps (scénario 01), un cœur tient ~100 personnes. Quand
+    <span class="cl-badge" data-en="80× the worst case">80× le pire cas</span>
+    <p data-en="When everyone talks at once (scenario 01), one core holds ~100 people. When <b>only one talks</b> and the others listen, that same core holds <b>~8000</b>: the server relays a single stream instead of crossing them all. That is the real life of a listening room.">Quand tout le monde parle en même temps (scénario 01), un cœur tient ~100 personnes. Quand
       <b>une seule parle</b> et que les autres écoutent, ce même cœur en tient <b>~8000</b> : le serveur ne
       relaie plus qu'un flux au lieu de tous les croiser. C'est ça, la vraie vie d'un salon d'écoute.</p>
   </div>
 
   <section>
     <div class="sec-head">
-      <span class="sec-n">Mesure 01 · un cœur</span>
-      <h2>Un cœur, jusqu'à ~8000 auditeurs</h2>
-      <p>On empile les auditeurs sur une seule diffusion. Le cœur reste tranquille très longtemps : il ne
+      <span class="sec-n" data-en="Measurement 01 · one core">Mesure 01 · un cœur</span>
+      <h2 data-en="One core, up to ~8000 listeners">Un cœur, jusqu'à ~8000 auditeurs</h2>
+      <p data-en="We stack listeners onto a single broadcast. The core stays calm for a very long time: it only saturates around 9000. Below that, not a word lost.">On empile les auditeurs sur une seule diffusion. Le cœur reste tranquille très longtemps : il ne
         sature que vers 9000. En dessous, aucun mot perdu.</p>
     </div>
     <figure>
-      <div class="fig-title"><span class="swatch"></span> Charge d'un cœur selon le nombre d'auditeurs</div>
-      <svg class="chart" id="c-audio" viewBox="0 0 900 320" role="img" aria-label="Charge d'un cœur : 0,03 pour 250 auditeurs, 0,16 pour 1000, 0,57 pour 5000, 0,92 pour 8000 (son parfait), puis saturation vers 10000 (son à 86 %)."></svg>
+      <div class="fig-title" data-en="<span class='swatch'></span> One core's load by number of listeners"><span class="swatch"></span> Charge d'un cœur selon le nombre d'auditeurs</div>
+      <svg class="chart" id="c-audio" viewBox="0 0 900 320" role="img" aria-label="Charge d'un cœur : 0,03 pour 250 auditeurs, 0,16 pour 1000, 0,57 pour 5000, 0,92 pour 8000 (son parfait), puis saturation vers 10000 (son à 86 %)." data-en-aria="One core's load: 0.03 for 250 listeners, 0.16 for 1000, 0.57 for 5000, 0.92 for 8000 (perfect audio), then saturation around 10000 (audio at 86%)."></svg>
     </figure>
   </section>
 
   <section>
     <div class="sec-head">
-      <span class="sec-n">Mesure 02 · la qualité</span>
-      <h2>La qualité ne change pas la capacité</h2>
-      <p>Surprise : que le son soit économe ou studio, un cœur tient toujours ~8000 auditeurs. La cadence
+      <span class="sec-n" data-en="Measurement 02 · quality">Mesure 02 · la qualité</span>
+      <h2 data-en="Quality does not change capacity">La qualité ne change pas la capacité</h2>
+      <p data-en="Surprise: whether the audio is thrifty or studio-grade, one core still holds ~8000 listeners. The packet rate is the same; only the bandwidth per listener rises. Discord runs at ~64 kbps.">Surprise : que le son soit économe ou studio, un cœur tient toujours ~8000 auditeurs. La cadence
         des paquets est la même ; seule la bande passante par auditeur monte. Discord tourne à ~64 kbps.</p>
     </div>
     <div class="table-scroll">
       <table class="data">
-        <thead><tr><th>Qualité</th><th>Débit / auditeur</th><th>Auditeurs / cœur</th><th>Bande passante à 8000</th></tr></thead>
+        <thead><tr><th data-en="Quality">Qualité</th><th data-en="Bitrate / listener">Débit / auditeur</th><th data-en="Listeners / core">Auditeurs / cœur</th><th data-en="Bandwidth at 8000">Bande passante à 8000</th></tr></thead>
         <tbody>
-          <tr><td>Économe</td><td>32 kbps</td><td>~8 000</td><td>256 Mbit/s</td></tr>
-          <tr><td>Standard <span class="tag ok">≈ Discord</span></td><td>64 kbps</td><td>~8 000</td><td>512 Mbit/s</td></tr>
-          <tr><td>Haute</td><td>96 kbps</td><td>~8 000</td><td>768 Mbit/s</td></tr>
+          <tr><td data-en="Thrifty">Économe</td><td>32 kbps</td><td>~8 000</td><td>256 Mbit/s</td></tr>
+          <tr><td data-en="Standard <span class='tag ok'>≈ Discord</span>">Standard <span class="tag ok">≈ Discord</span></td><td>64 kbps</td><td>~8 000</td><td>512 Mbit/s</td></tr>
+          <tr><td data-en="High">Haute</td><td>96 kbps</td><td>~8 000</td><td>768 Mbit/s</td></tr>
           <tr><td>Studio</td><td>128 kbps</td><td>~8 000</td><td>~1 Gbit/s</td></tr>
         </tbody>
       </table>
     </div>
-    <p class="sec-head" style="margin-top:16px;color:var(--ink-3);font-family:var(--mono);font-size:.8rem;">
+    <p class="sec-head" style="margin-top:16px;color:var(--ink-3);font-family:var(--mono);font-size:.8rem;" data-en="Measured: at 8000 listeners, the audio stays perfect from 32 to 128 kbps. At studio quality (128 kbps), 8000 listeners add up to ~1 Gbit/s: that is where the server's connection starts to matter.">
       Mesuré : à 8000 auditeurs, le son reste parfait de 32 à 128 kbps. En studio (128 kbps), 8000 auditeurs
       représentent ~1 Gbit/s : c'est là que la connexion du serveur commence à compter.</p>
   </section>
 
   <section>
     <div class="sec-head">
-      <span class="sec-n">03 · en clair</span>
-      <h2>Concrètement</h2>
-      <p>Ce que ça veut dire pour une annonce ou une conférence.</p>
+      <span class="sec-n" data-en="03 · in plain words">03 · en clair</span>
+      <h2 data-en="In practice">Concrètement</h2>
+      <p data-en="What it means for an announcement or a conference.">Ce que ça veut dire pour une annonce ou une conférence.</p>
     </div>
     <div class="grid2">
       <div class="card">
-        <h3>Une voix, beaucoup d'oreilles</h3>
-        <p>Conférence, town-hall, annonce à la communauté : une personne parle, des milliers suivent en
+        <h3 data-en="One voice, many ears">Une voix, beaucoup d'oreilles</h3>
+        <p data-en="Conference, town-hall, community announcement: one person talks, thousands follow live, on your own server. A single core is more than enough.">Conférence, town-hall, annonce à la communauté : une personne parle, des milliers suivent en
           direct, sur ton propre serveur. Un seul cœur suffit largement.</p>
       </div>
       <div class="card">
-        <h3>Et le réseau, à très grande échelle ?</h3>
-        <p>L'audio est léger (~32 kbit/s par auditeur). À l'échelle de dizaines de milliers, c'est alors
+        <h3 data-en="And the network, at very large scale?">Et le réseau, à très grande échelle ?</h3>
+        <p data-en="Audio is light (~32 kbps per listener). At the scale of tens of thousands, it is your internet connection that caps the total, not the processor. The details are on the technical page.">L'audio est léger (~32 kbit/s par auditeur). À l'échelle de dizaines de milliers, c'est alors
           ta connexion internet qui borne le total, pas le processeur. Le détail est sur la page technique.</p>
       </div>
     </div>
   </section>
 
   <section>
-    <div class="sec-head"><h2>La suite</h2></div>
+    <div class="sec-head"><h2 data-en="What's next">La suite</h2></div>
     <div class="next">
       <a href="partage-ecran.html">
-        <div class="nx-k">Scénario 03 / 03</div>
-        <div class="nx-t">Partage d'écran : là, c'est le réseau qui décide <span class="arr">→</span></div>
+        <div class="nx-k" data-en="Scenario 03 / 03">Scénario 03 / 03</div>
+        <div class="nx-t" data-en="Screen share: here, the network decides <span class='arr'>→</span>">Partage d'écran : là, c'est le réseau qui décide <span class="arr">→</span></div>
       </a>
       <a href="technique.html">
-        <div class="nx-k">Pour les techniciens</div>
-        <div class="nx-t">Chiffres bruts, méthode, par machine <span class="arr">→</span></div>
+        <div class="nx-k" data-en="For the technical crowd">Pour les techniciens</div>
+        <div class="nx-t" data-en="Raw numbers, method, by machine <span class='arr'>→</span>">Chiffres bruts, méthode, par machine <span class="arr">→</span></div>
       </a>
     </div>
   </section>
 
 </div>
-<footer class="site"><div class="wrap">Mesures réelles issues de <a href="https://github.com/Pokled/nodyx">sfu-bench</a> · <a href="https://nodyx.org">Nodyx</a>, vocal souverain auto-hébergé · AGPL-3.0 · <a href="technique.html">reproduire →</a></div></footer>
+<footer class="site"><div class="wrap" data-en="Real measurements from <a href='https://github.com/Pokled/nodyx'>sfu-bench</a> · <a href='https://nodyx.org'>Nodyx</a>, sovereign self-hosted voice · AGPL-3.0 · <a href='technique.html'>reproduce →</a>">Mesures réelles issues de <a href="https://github.com/Pokled/nodyx">sfu-bench</a> · <a href="https://nodyx.org">Nodyx</a>, vocal souverain auto-hébergé · AGPL-3.0 · <a href="technique.html">reproduire →</a></div></footer>
 
-<script src="bench.js?v=2"></script>
+<script src="bench.js?v=3"></script>
 <script>
   const AUDIO = [
     { spec: 250,   cpu: 0.03, health: 100 },
@@ -131,17 +131,17 @@
   ];
   Bench.chart(document.getElementById("c-audio"), {
     rows: AUDIO, xkey: d => d.spec, val: d => d.cpu,
-    max: 1.15, ref: 1.0, refLabel: "limite d'un cœur", ruptureFrom: 6,
+    max: 1.15, ref: 1.0, refLabel: { fr: "limite d'un cœur", en: "one core's limit" }, ruptureFrom: 6,
     yticks: [0, 0.5, 1.0], yfmt: t => t.toFixed(1),
     xevery: [250, 1000, 2000, 5000, 8000, 10000],
     stroke: Bench.css("--signal"), areaFill: Bench.css("--signal-soft"),
     labels: [
-      { at: 8000, text: "8000 · son parfait", dx: -30, dy: 22, color: Bench.css("--signal") },
-      { at: 10000, text: "ça sature", dx: -20, dy: -12, color: Bench.css("--danger") },
+      { at: 8000, text: { fr: "8000 · son parfait", en: "8000 · perfect audio" }, dx: -30, dy: 22, color: Bench.css("--signal") },
+      { at: 10000, text: { fr: "ça sature", en: "it saturates" }, dx: -20, dy: -12, color: Bench.css("--danger") },
     ],
-    tipTitle: d => d.spec.toLocaleString("fr") + " auditeurs",
-    tipVal: d => d.cpu.toFixed(2).replace(".", ",") + " cœur",
-    tipSub: d => (d.health % 1 ? d.health.toFixed(1).replace(".", ",") : d.health) + " % du son",
+    tipTitle: d => Bench.num(d.spec) + Bench.t(" auditeurs", " listeners"),
+    tipVal: d => Bench.dec(d.cpu, 2) + Bench.t(" cœur", " core"),
+    tipSub: d => Bench.dec(d.health, d.health % 1 ? 1 : 0) + Bench.t(" % du son", "% of audio"),
   });
   Bench.boot("diffusion-audio");
 </script>

--- a/nodyx-frontend/static/benchmark/partage-ecran.html
+++ b/nodyx-frontend/static/benchmark/partage-ecran.html
@@ -3,45 +3,45 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Partage d'écran — Nodyx · Banc d'essai vocal</title>
+<title>Partage d'écran · Nodyx · Banc d'essai vocal</title>
 <meta name="description" content="Une personne partage son écran, les autres regardent. Le processeur tient des milliers ; c'est la connexion du serveur qui décide. Capacité par résolution (480p à 4K). Mesures réelles.">
 <meta name="color-scheme" content="light dark">
 <meta property="og:title" content="Partage d'écran : c'est le réseau qui décide, par résolution">
 <meta property="og:description" content="Capacité vidéo du moteur Nodyx, mesurée, du 480p au 4K. Le CPU tient des milliers ; la limite, c'est le débit.">
 <link rel="stylesheet" href="style.css?v=2">
 </head>
-<body data-page="partage-ecran">
+<body data-page="partage-ecran" data-en-title="Screen share · Nodyx · Voice benchmark">
 <div id="nav-mount"></div>
 <div class="wrap">
 
   <header class="hero">
     <div class="tapehead">
-      <span class="live">Banc d'essai vocal</span>
-      <span><b>Scénario 03 / 03</b> — la vidéo</span>
-      <span>Forme · <b>1 partage, N regardent</b></span>
-      <span>Flux · <b>vidéo</b> (480p → 4K)</span>
+      <span class="live" data-en="Voice benchmark">Banc d'essai vocal</span>
+      <span data-en="<b>Scenario 03 / 03</b>: the video"><b>Scénario 03 / 03</b> : la vidéo</span>
+      <span data-en="Shape · <b>1 shares, N watch</b>">Forme · <b>1 partage, N regardent</b></span>
+      <span data-en="Stream · <b>video</b> (480p → 4K)">Flux · <b>vidéo</b> (480p → 4K)</span>
     </div>
-    <h1>Une personne partage, les autres regardent.</h1>
-    <p class="lede">Le partage d'écran, c'est de la vidéo : bien plus lourd que la voix. Et là, une surprise
+    <h1 data-en="One person shares, the others watch.">Une personne partage, les autres regardent.</h1>
+    <p class="lede" data-en="Screen sharing is video: far heavier than voice. And here, a useful surprise: it is not the processor that limits, it is the server's <b>internet connection</b>. So everything depends on the <b>resolution</b>.">Le partage d'écran, c'est de la vidéo : bien plus lourd que la voix. Et là, une surprise
       utile : ce n'est pas le processeur qui limite, c'est la <b>connexion internet</b> du serveur. Donc
       tout dépend de la <b>résolution</b>.</p>
 
     <div class="readout">
-      <div class="ro"><span class="ro-v sig">~<span data-count="400">0</span></span><span class="ro-k">spectateurs en 720p · serveur 1 Gbit/s</span></div>
-      <div class="ro"><span class="ro-v">~<span data-count="220">0</span></span><span class="ro-k">spectateurs en 1080p · serveur 1 Gbit/s</span></div>
-      <div class="ro"><span class="ro-v">× <span data-count="10">0</span></span><span class="ro-k">sur un serveur à 10 Gbit/s</span></div>
+      <div class="ro"><span class="ro-v sig">~<span data-count="400">0</span></span><span class="ro-k" data-en="viewers at 720p · 1 Gbit/s server">spectateurs en 720p · serveur 1 Gbit/s</span></div>
+      <div class="ro"><span class="ro-v">~<span data-count="220">0</span></span><span class="ro-k" data-en="viewers at 1080p · 1 Gbit/s server">spectateurs en 1080p · serveur 1 Gbit/s</span></div>
+      <div class="ro"><span class="ro-v">× <span data-count="10">0</span></span><span class="ro-k" data-en="on a 10 Gbit/s server">sur un serveur à 10 Gbit/s</span></div>
     </div>
 
-    <nav class="scene-nav" aria-label="Scénarios">
-      <a href="pire-cas.html">01 · Le pire cas</a>
-      <a href="diffusion-audio.html">02 · Diffusion audio</a>
-      <a href="partage-ecran.html" aria-current="page">03 · Partage d'écran</a>
+    <nav class="scene-nav" aria-label="Scénarios" data-en-aria="Scenarios">
+      <a href="pire-cas.html" data-en="01 · Worst case">01 · Le pire cas</a>
+      <a href="diffusion-audio.html" data-en="02 · Audio broadcast">02 · Diffusion audio</a>
+      <a href="partage-ecran.html" aria-current="page" data-en="03 · Screen share">03 · Partage d'écran</a>
     </nav>
   </header>
 
   <div class="callout warn">
-    <span class="cl-badge">Le réseau décide</span>
-    <p>En vidéo, le processeur forwarde à des milliers de spectateurs sans transpirer. Le vrai frein, c'est
+    <span class="cl-badge" data-en="The network decides">Le réseau décide</span>
+    <p data-en="In video, the processor forwards to thousands of viewers without breaking a sweat. The real brake is <b>bandwidth</b>: every viewer receives the full stream. The higher the resolution, the bigger the stream, the less room there is. At <b>720p</b> quality (Discord's default), a 1 Gbit/s connection carries ~400 viewers; at 10 Gbit/s, ~4000. <b>Big watch-party? The pipe matters more than the cores.</b>">En vidéo, le processeur forwarde à des milliers de spectateurs sans transpirer. Le vrai frein, c'est
       le <b>débit</b> : chaque spectateur reçoit le flux en entier. Plus la résolution est haute, plus le
       flux est gros, moins il y a de place. À qualité <b>720p</b> (celle de Discord par défaut), une
       connexion à 1 Gbit/s porte ~400 spectateurs ; à 10 Gbit/s, ~4000. <b>Gros watch-party ? Le tuyau
@@ -50,27 +50,27 @@
 
   <section>
     <div class="sec-head">
-      <span class="sec-n">Mesure 01 · le processeur</span>
-      <h2>Le CPU tient, largement</h2>
-      <p>Côté calcul, un seul cœur relaie la vidéo à des milliers de personnes sans forcer (mesuré jusqu'en
+      <span class="sec-n" data-en="Measurement 01 · the processor">Mesure 01 · le processeur</span>
+      <h2 data-en="The CPU holds, easily">Le CPU tient, largement</h2>
+      <p data-en="On the compute side, a single core relays video to thousands of people without straining (measured up to 1080p). The processor is not the wall.">Côté calcul, un seul cœur relaie la vidéo à des milliers de personnes sans forcer (mesuré jusqu'en
         1080p). Le processeur n'est pas le mur.</p>
     </div>
     <figure>
-      <div class="fig-title"><span class="swatch"></span> Charge d'un cœur en 720p (~2,5 Mbit/s), selon le nombre de spectateurs</div>
-      <svg class="chart" id="c-video" viewBox="0 0 900 300" role="img" aria-label="Charge d'un cœur en vidéo 720p : 0,11 pour 200 spectateurs, 0,22 pour 400, 0,47 pour 800, 0,74 pour 2400. Le cœur reste loin de sa limite."></svg>
+      <div class="fig-title" data-en="<span class='swatch'></span> One core's load at 720p (~2.5 Mbit/s), by number of viewers"><span class="swatch"></span> Charge d'un cœur en 720p (~2,5 Mbit/s), selon le nombre de spectateurs</div>
+      <svg class="chart" id="c-video" viewBox="0 0 900 300" role="img" aria-label="Charge d'un cœur en vidéo 720p : 0,11 pour 200 spectateurs, 0,22 pour 400, 0,47 pour 800, 0,74 pour 2400. Le cœur reste loin de sa limite." data-en-aria="One core's load in 720p video: 0.11 for 200 viewers, 0.22 for 400, 0.47 for 800, 0.74 for 2400. The core stays far from its limit."></svg>
     </figure>
   </section>
 
   <section>
     <div class="sec-head">
-      <span class="sec-n">Mesure 02 · le réseau</span>
-      <h2>Ce qui décide vraiment : la résolution</h2>
-      <p>Le nombre de spectateurs dépend directement du débit de chaque flux (donc de la résolution) et de
+      <span class="sec-n" data-en="Measurement 02 · the network">Mesure 02 · le réseau</span>
+      <h2 data-en="What really decides: the resolution">Ce qui décide vraiment : la résolution</h2>
+      <p data-en="The number of viewers depends directly on the bitrate of each stream (so on the resolution) and on the server's connection. Here is the math, for a typical bitrate per resolution.">Le nombre de spectateurs dépend directement du débit de chaque flux (donc de la résolution) et de
         la connexion du serveur. Voici le calcul, pour un débit typique par résolution.</p>
     </div>
     <div class="table-scroll">
       <table class="data">
-        <thead><tr><th>Résolution</th><th>Débit typique</th><th>Serveur 1 Gbit/s</th><th>Serveur 2,5 Gbit/s</th><th>Serveur 10 Gbit/s</th></tr></thead>
+        <thead><tr><th data-en="Resolution">Résolution</th><th data-en="Typical bitrate">Débit typique</th><th data-en="1 Gbit/s server">Serveur 1 Gbit/s</th><th data-en="2.5 Gbit/s server">Serveur 2,5 Gbit/s</th><th data-en="10 Gbit/s server">Serveur 10 Gbit/s</th></tr></thead>
         <tbody>
           <tr><td>480p</td><td>~1 Mbit/s</td><td>~1 000</td><td>~2 500</td><td>~10 000</td></tr>
           <tr><td>720p <span class="tag ok">≈ Discord</span></td><td>~2,5 Mbit/s</td><td>~400</td><td>~1 000</td><td>~4 000</td></tr>
@@ -79,37 +79,37 @@
         </tbody>
       </table>
     </div>
-    <p class="sec-head" style="margin-top:16px;color:var(--ink-3);font-family:var(--mono);font-size:.8rem;">
+    <p class="sec-head" style="margin-top:16px;color:var(--ink-3);font-family:var(--mono);font-size:.8rem;" data-en="Viewers = server bandwidth / stream bitrate. Typical bitrates for a screen share; the real figure varies with content (a still image uses far less than moving video).">
       Spectateurs = débit du serveur / débit du flux. Débits typiques d'un partage d'écran ; le réel varie
       selon le contenu (une image fixe consomme bien moins qu'une vidéo qui bouge).</p>
   </section>
 
   <div class="callout">
-    <span class="cl-badge">Transparence</span>
-    <p>Soyons clairs : le partage d'écran <b>sur ce moteur n'est pas encore en production</b> (il arrive).
+    <span class="cl-badge" data-en="Transparency">Transparence</span>
+    <p data-en="Let's be clear: screen sharing <b>on this engine is not in production yet</b> (it is coming). These numbers measure what the <b>video engine takes as a relay</b>: it is a real capacity, not a promise that 'screen sharing is perfect' today. On-screen smoothness (browser side) is another job, one we test for real, not on the bench.">Soyons clairs : le partage d'écran <b>sur ce moteur n'est pas encore en production</b> (il arrive).
       Ces chiffres mesurent ce que le <b>moteur vidéo encaisse en relais</b> : c'est une capacité réelle,
       pas une promesse que « le partage d'écran est parfait » aujourd'hui. La fluidité à l'écran (côté
       navigateur) est un autre chantier, qu'on teste en vrai, pas au banc d'essai.</p>
   </div>
 
   <section>
-    <div class="sec-head"><h2>La suite</h2></div>
+    <div class="sec-head"><h2 data-en="What's next">La suite</h2></div>
     <div class="next">
       <a href="technique.html">
-        <div class="nx-k">Pour les techniciens</div>
-        <div class="nx-t">Tous les chiffres bruts, la méthode, par machine <span class="arr">→</span></div>
+        <div class="nx-k" data-en="For the technical crowd">Pour les techniciens</div>
+        <div class="nx-t" data-en="All the raw numbers, the method, by machine <span class='arr'>→</span>">Tous les chiffres bruts, la méthode, par machine <span class="arr">→</span></div>
       </a>
       <a href="pire-cas.html">
-        <div class="nx-k">Revenir au début</div>
-        <div class="nx-t">Scénario 01 · le pire cas <span class="arr">→</span></div>
+        <div class="nx-k" data-en="Back to the start">Revenir au début</div>
+        <div class="nx-t" data-en="Scenario 01 · the worst case <span class='arr'>→</span>">Scénario 01 · le pire cas <span class="arr">→</span></div>
       </a>
     </div>
   </section>
 
 </div>
-<footer class="site"><div class="wrap">Mesures réelles issues de <a href="https://github.com/Pokled/nodyx">sfu-bench</a> · <a href="https://nodyx.org">Nodyx</a>, vocal souverain auto-hébergé · AGPL-3.0 · <a href="technique.html">reproduire →</a></div></footer>
+<footer class="site"><div class="wrap" data-en="Real measurements from <a href='https://github.com/Pokled/nodyx'>sfu-bench</a> · <a href='https://nodyx.org'>Nodyx</a>, sovereign self-hosted voice · AGPL-3.0 · <a href='technique.html'>reproduce →</a>">Mesures réelles issues de <a href="https://github.com/Pokled/nodyx">sfu-bench</a> · <a href="https://nodyx.org">Nodyx</a>, vocal souverain auto-hébergé · AGPL-3.0 · <a href="technique.html">reproduire →</a></div></footer>
 
-<script src="bench.js?v=2"></script>
+<script src="bench.js?v=3"></script>
 <script>
   const VIDEO = [
     { spec: 200,  cpu: 0.11 },
@@ -120,14 +120,14 @@
   ];
   Bench.chart(document.getElementById("c-video"), {
     rows: VIDEO, xkey: d => d.spec, val: d => d.cpu,
-    max: 1.05, ref: 1.0, refLabel: "limite d'un cœur",
+    max: 1.05, ref: 1.0, refLabel: { fr: "limite d'un cœur", en: "one core's limit" },
     yticks: [0, 0.5, 1.0], yfmt: t => t.toFixed(1),
     xevery: [200, 400, 800, 1600, 2400],
     stroke: Bench.css("--signal"), areaFill: Bench.css("--signal-soft"),
-    labels: [{ at: 2400, text: "2400 · à peine 0,74 cœur", dx: -50, dy: -14, color: Bench.css("--signal") }],
-    tipTitle: d => d.spec.toLocaleString("fr") + " spectateurs",
-    tipVal: d => d.cpu.toFixed(2).replace(".", ",") + " cœur",
-    tipSub: d => "720p ~2,5 Mbit/s",
+    labels: [{ at: 2400, text: { fr: "2400 · à peine 0,74 cœur", en: "2400 · barely 0.74 core" }, dx: -50, dy: -14, color: Bench.css("--signal") }],
+    tipTitle: d => Bench.num(d.spec) + Bench.t(" spectateurs", " viewers"),
+    tipVal: d => Bench.dec(d.cpu, 2) + Bench.t(" cœur", " core"),
+    tipSub: d => Bench.t("720p ~2,5 Mbit/s", "720p ~2.5 Mbit/s"),
   });
   Bench.boot("partage-ecran");
 </script>

--- a/nodyx-frontend/static/benchmark/pire-cas.html
+++ b/nodyx-frontend/static/benchmark/pire-cas.html
@@ -3,44 +3,44 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Le pire cas — Nodyx · Banc d'essai vocal</title>
+<title>Le pire cas · Nodyx · Banc d'essai vocal</title>
 <meta name="description" content="Le scénario le plus dur : tout le monde parle en même temps. Un serveur Nodyx tient ~600 personnes en vocal. Mesures réelles, auto-hébergé.">
 <meta name="color-scheme" content="light dark">
 <meta property="og:title" content="Le pire cas : ~600 personnes en vocal, tous parlent en même temps">
 <meta property="og:description" content="Le scénario extrême du vocal Nodyx, mesuré sans filtre. Auto-hébergé, AGPL-3.0.">
 <link rel="stylesheet" href="style.css?v=2">
 </head>
-<body data-page="pire-cas">
+<body data-page="pire-cas" data-en-title="Worst case · Nodyx · Voice benchmark">
 <div id="nav-mount"></div>
 <div class="wrap">
 
   <header class="hero">
     <div class="tapehead">
-      <span class="live">Banc d'essai vocal</span>
-      <span><b>Scénario 01 / 03</b> — le cas extrême</span>
-      <span>Machine · <b>1 serveur, 8 cœurs</b></span>
-      <span>Méthode · <b>full-mesh</b> (tous parlent)</span>
+      <span class="live" data-en="Voice benchmark">Banc d'essai vocal</span>
+      <span data-en="<b>Scenario 01 / 03</b>: the extreme case"><b>Scénario 01 / 03</b> : le cas extrême</span>
+      <span data-en="Machine · <b>1 server, 8 cores</b>">Machine · <b>1 serveur, 8 cœurs</b></span>
+      <span data-en="Method · <b>full-mesh</b> (everyone talks)">Méthode · <b>full-mesh</b> (tous parlent)</span>
     </div>
-    <h1>Tout le monde parle en même temps.</h1>
-    <p class="lede">On a pris le scénario le plus dur imaginable pour un serveur vocal, et on a mesuré combien
+    <h1 data-en="Everyone talks at once.">Tout le monde parle en même temps.</h1>
+    <p class="lede" data-en="We took the hardest scenario imaginable for a voice server, and measured how many people it holds without dropping a word. This is the floor: real life is far lighter.">On a pris le scénario le plus dur imaginable pour un serveur vocal, et on a mesuré combien
       de monde il tient sans perdre un mot. C'est le plancher : la vraie vie est bien plus légère.</p>
 
     <div class="readout">
-      <div class="ro"><span class="ro-v sig">~<span data-count="600">0</span></span><span class="ro-k">personnes en vocal · tout le serveur</span></div>
-      <div class="ro"><span class="ro-v"><span data-count="100">0</span></span><span class="ro-k">par pièce · sans perdre un mot</span></div>
-      <div class="ro"><span class="ro-v"><span data-count="6">0</span><span class="u">/ 8</span></span><span class="ro-k">cœurs utilisés · 2 gardés pour le reste</span></div>
+      <div class="ro"><span class="ro-v sig">~<span data-count="600">0</span></span><span class="ro-k" data-en="people in voice · whole server">personnes en vocal · tout le serveur</span></div>
+      <div class="ro"><span class="ro-v"><span data-count="100">0</span></span><span class="ro-k" data-en="per room · without dropping a word">par pièce · sans perdre un mot</span></div>
+      <div class="ro"><span class="ro-v"><span data-count="6">0</span><span class="u">/ 8</span></span><span class="ro-k" data-en="cores used · 2 kept for the rest">cœurs utilisés · 2 gardés pour le reste</span></div>
     </div>
 
-    <nav class="scene-nav" aria-label="Scénarios">
-      <a href="pire-cas.html" aria-current="page">01 · Le pire cas</a>
-      <a href="diffusion-audio.html">02 · Diffusion audio</a>
-      <a href="partage-ecran.html">03 · Partage d'écran</a>
+    <nav class="scene-nav" aria-label="Scénarios" data-en-aria="Scenarios">
+      <a href="pire-cas.html" aria-current="page" data-en="01 · Worst case">01 · Le pire cas</a>
+      <a href="diffusion-audio.html" data-en="02 · Audio broadcast">02 · Diffusion audio</a>
+      <a href="partage-ecran.html" data-en="03 · Screen share">03 · Partage d'écran</a>
     </nav>
   </header>
 
   <div class="callout warn">
-    <span class="cl-badge">Le pire cas imaginable</span>
-    <p>Ici, les 600 personnes <b>parlent ET écoutent tout le monde en même temps</b>, en continu : comme si
+    <span class="cl-badge" data-en="The worst case imaginable">Le pire cas imaginable</span>
+    <p data-en="Here, all 600 people <b>talk AND listen to everyone at the same time</b>, non-stop: as if each one streamed their voice to all the others without ever pausing. In real life, this <b>never happens</b> (in a conversation, one or two people speak at a time). We deliberately picked the <b>hardest scenario there is</b>: the real cases (next scenarios) hold <b>far, far more</b> people.">Ici, les 600 personnes <b>parlent ET écoutent tout le monde en même temps</b>, en continu : comme si
       chacune diffusait sa voix à toutes les autres sans jamais s'arrêter. Dans la vraie vie, ça
       <b>n'arrive jamais</b> (dans une conversation, une ou deux personnes parlent à la fois). On a choisi
       exprès le scénario <b>le plus dur qui soit</b> : les cas réels (scénarios suivants) tiennent
@@ -49,68 +49,68 @@
 
   <section>
     <div class="sec-head">
-      <span class="sec-n">Mesure 01 · une pièce</span>
-      <h2>Jusqu'où tient une seule pièce</h2>
-      <p>Dans une pièce, tout est parfait jusqu'à ~100 personnes. Au-delà, une pièce seule sature : c'est
+      <span class="sec-n" data-en="Measurement 01 · one room">Mesure 01 · une pièce</span>
+      <h2 data-en="How far a single room holds">Jusqu'où tient une seule pièce</h2>
+      <p data-en="In one room, everything is perfect up to ~100 people. Beyond that, a single room saturates: that is when you open more.">Dans une pièce, tout est parfait jusqu'à ~100 personnes. Au-delà, une pièce seule sature : c'est
         là qu'on en ouvre d'autres.</p>
     </div>
     <figure>
-      <div class="fig-title"><span class="swatch"></span> Qualité du son selon le monde dans une pièce</div>
-      <svg class="chart" id="c-cliff" viewBox="0 0 900 320" role="img" aria-label="Qualité du son : parfaite à 100 % jusqu'à 100 personnes dans une pièce, puis chute (68 % à 125, 46 % à 150, 24 % à 200, 9 % à 300)."></svg>
+      <div class="fig-title" data-en="<span class='swatch'></span> Audio quality by number of people in a room"><span class="swatch"></span> Qualité du son selon le monde dans une pièce</div>
+      <svg class="chart" id="c-cliff" viewBox="0 0 900 320" role="img" aria-label="Qualité du son : parfaite à 100 % jusqu'à 100 personnes dans une pièce, puis chute (68 % à 125, 46 % à 150, 24 % à 200, 9 % à 300)." data-en-aria="Audio quality: perfect at 100% up to 100 people in a room, then a drop (68% at 125, 46% at 150, 24% at 200, 9% at 300)."></svg>
     </figure>
   </section>
 
   <section>
     <div class="sec-head">
-      <span class="sec-n">Mesure 02 · le serveur</span>
-      <h2>Et sur tout le serveur : ~600</h2>
-      <p>On ouvre plusieurs pièces ; le serveur les répartit sur ses cœurs, une par cœur. La charge monte
+      <span class="sec-n" data-en="Measurement 02 · the server">Mesure 02 · le serveur</span>
+      <h2 data-en="And across the whole server: ~600">Et sur tout le serveur : ~600</h2>
+      <p data-en="You open several rooms; the server spreads them across its cores, one per core. The load rises straight: every hundred people takes one core.">On ouvre plusieurs pièces ; le serveur les répartit sur ses cœurs, une par cœur. La charge monte
         droit : chaque centaine de personnes prend un cœur.</p>
     </div>
     <figure>
-      <div class="fig-title"><span class="swatch"></span> Charge du serveur selon le nombre de pièces (100 personnes chacune)</div>
-      <svg class="chart" id="c-pool" viewBox="0 0 900 320" role="img" aria-label="Charge du serveur : 1 cœur pour 100 personnes, 2 pour 200, 4 pour 400, 6 cœurs pour 600 personnes. Montée parfaitement linéaire."></svg>
+      <div class="fig-title" data-en="<span class='swatch'></span> Server load by number of rooms (100 people each)"><span class="swatch"></span> Charge du serveur selon le nombre de pièces (100 personnes chacune)</div>
+      <svg class="chart" id="c-pool" viewBox="0 0 900 320" role="img" aria-label="Charge du serveur : 1 cœur pour 100 personnes, 2 pour 200, 4 pour 400, 6 cœurs pour 600 personnes. Montée parfaitement linéaire." data-en-aria="Server load: 1 core for 100 people, 2 for 200, 4 for 400, 6 cores for 600 people. Perfectly linear rise."></svg>
     </figure>
   </section>
 
   <section>
     <div class="sec-head">
-      <span class="sec-n">03 · en clair</span>
-      <h2>Concrètement</h2>
-      <p>Sans le jargon, ce que ça change pour ta communauté.</p>
+      <span class="sec-n" data-en="03 · in plain words">03 · en clair</span>
+      <h2 data-en="In practice">Concrètement</h2>
+      <p data-en="No jargon: what it changes for your community.">Sans le jargon, ce que ça change pour ta communauté.</p>
     </div>
     <div class="grid2">
       <div class="card">
-        <h3>Une pièce = une communauté active</h3>
-        <p>Jusqu'à ~100 personnes qui se parlent dans la même pièce vocale, en même temps, sans qu'un mot
+        <h3 data-en="One room = an active community">Une pièce = une communauté active</h3>
+        <p data-en="Up to ~100 people talking in the same voice room, at the same time, without a word getting lost. That is already more than a busy voice channel.">Jusqu'à ~100 personnes qui se parlent dans la même pièce vocale, en même temps, sans qu'un mot
           se perde. C'est déjà plus qu'un gros vocal bien rempli.</p>
       </div>
       <div class="card">
-        <h3>Le serveur en fait tourner plein</h3>
-        <p>Le serveur répartit les pièces sur ses cœurs : ~600 personnes au total dans ce test extrême,
+        <h3 data-en="The server runs plenty of them">Le serveur en fait tourner plein</h3>
+        <p data-en="The server spreads rooms across its cores: ~600 people total in this extreme test, while keeping 2 cores for the forum, the chat and the rest of the platform.">Le serveur répartit les pièces sur ses cœurs : ~600 personnes au total dans ce test extrême,
           tout en gardant 2 cœurs pour le forum, le chat et le reste de la plateforme.</p>
       </div>
     </div>
   </section>
 
   <section>
-    <div class="sec-head"><h2>La suite</h2></div>
+    <div class="sec-head"><h2 data-en="What's next">La suite</h2></div>
     <div class="next">
       <a href="diffusion-audio.html">
-        <div class="nx-k">Scénario 02 / 03</div>
-        <div class="nx-t">Diffusion audio : une personne parle, des milliers écoutent <span class="arr">→</span></div>
+        <div class="nx-k" data-en="Scenario 02 / 03">Scénario 02 / 03</div>
+        <div class="nx-t" data-en="Audio broadcast: one person talks, thousands listen <span class='arr'>→</span>">Diffusion audio : une personne parle, des milliers écoutent <span class="arr">→</span></div>
       </a>
       <a href="technique.html">
-        <div class="nx-k">Pour les techniciens</div>
-        <div class="nx-t">Chiffres bruts, méthode, par machine <span class="arr">→</span></div>
+        <div class="nx-k" data-en="For the technical crowd">Pour les techniciens</div>
+        <div class="nx-t" data-en="Raw numbers, method, by machine <span class='arr'>→</span>">Chiffres bruts, méthode, par machine <span class="arr">→</span></div>
       </a>
     </div>
   </section>
 
 </div>
-<footer class="site"><div class="wrap">Mesures réelles issues de <a href="https://github.com/Pokled/nodyx">sfu-bench</a> · <a href="https://nodyx.org">Nodyx</a>, vocal souverain auto-hébergé · AGPL-3.0 · <a href="technique.html">reproduire →</a></div></footer>
+<footer class="site"><div class="wrap" data-en="Real measurements from <a href='https://github.com/Pokled/nodyx'>sfu-bench</a> · <a href='https://nodyx.org'>Nodyx</a>, sovereign self-hosted voice · AGPL-3.0 · <a href='technique.html'>reproduce →</a>">Mesures réelles issues de <a href="https://github.com/Pokled/nodyx">sfu-bench</a> · <a href="https://nodyx.org">Nodyx</a>, vocal souverain auto-hébergé · AGPL-3.0 · <a href="technique.html">reproduire →</a></div></footer>
 
-<script src="bench.js?v=2"></script>
+<script src="bench.js?v=3"></script>
 <script>
   const CLIFF = [
     { n: 2,   health: 100,  paths: 2 },
@@ -134,16 +134,16 @@
 
   Bench.chart(document.getElementById("c-cliff"), {
     rows: CLIFF, xkey: d => d.n, val: d => d.health,
-    max: 108, ruptureFrom: 6, yticks: [0, 25, 50, 75, 100], yfmt: t => t + " %",
+    max: 108, ruptureFrom: 6, yticks: [0, 25, 50, 75, 100], yfmt: t => t + Bench.t(" %", "%"),
     xevery: [2, 20, 50, 100, 125, 150, 200, 300],
     stroke: Bench.css("--signal"), areaFill: Bench.css("--signal-soft"),
     labels: [
-      { at: 100, text: "parfait jusqu'à 100", dx: -10, dy: -14, color: Bench.css("--signal") },
-      { at: 150, text: "ça décroche", dx: 6, dy: 24, color: Bench.css("--danger") },
+      { at: 100, text: { fr: "parfait jusqu'à 100", en: "perfect up to 100" }, dx: -10, dy: -14, color: Bench.css("--signal") },
+      { at: 150, text: { fr: "ça décroche", en: "it drops off" }, dx: 6, dy: 24, color: Bench.css("--danger") },
     ],
-    tipTitle: d => d.n + " personnes",
-    tipVal: d => (d.health % 1 ? d.health.toFixed(1).replace(".", ",") : d.health) + " % du son",
-    tipSub: d => "une seule pièce",
+    tipTitle: d => Bench.num(d.n) + Bench.t(" personnes", " people"),
+    tipVal: d => Bench.dec(d.health, d.health % 1 ? 1 : 0) + Bench.t(" % du son", "% of audio"),
+    tipSub: d => Bench.t("une seule pièce", "a single room"),
   });
 
   Bench.chart(document.getElementById("c-pool"), {
@@ -151,10 +151,10 @@
     max: 7, yticks: [0, 2, 4, 6], yfmt: t => t,
     xevery: [1, 2, 4, 6],
     stroke: Bench.css("--signal"), areaFill: Bench.css("--signal-soft"),
-    labels: [{ at: 6, text: "600 personnes · 6 cœurs", dx: -40, dy: -14, color: Bench.css("--signal") }],
-    tipTitle: d => d.total + " personnes",
-    tipVal: d => d.cpu.toFixed(2).replace(".", ",") + " cœurs",
-    tipSub: d => d.rooms + " pièces de 100",
+    labels: [{ at: 6, text: { fr: "600 personnes · 6 cœurs", en: "600 people · 6 cores" }, dx: -40, dy: -14, color: Bench.css("--signal") }],
+    tipTitle: d => Bench.num(d.total) + Bench.t(" personnes", " people"),
+    tipVal: d => Bench.dec(d.cpu, 2) + Bench.t(" cœurs", " cores"),
+    tipSub: d => Bench.t(d.rooms + " pièces de 100", d.rooms + " rooms of 100"),
   });
 
   Bench.boot("pire-cas");

--- a/nodyx-frontend/static/benchmark/technique.html
+++ b/nodyx-frontend/static/benchmark/technique.html
@@ -3,44 +3,44 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Détail technique — Nodyx · Banc d'essai vocal</title>
+<title>Détail technique · Nodyx · Banc d'essai vocal</title>
 <meta name="description" content="Tous les chiffres bruts du banc d'essai vocal Nodyx : full-mesh, diffusion audio, partage d'écran, limites réseau, méthode et machines testées. Sans filtre.">
 <meta name="color-scheme" content="light dark">
 <link rel="stylesheet" href="style.css?v=2">
 </head>
-<body data-page="technique">
+<body data-page="technique" data-en-title="Technical details · Nodyx · Voice benchmark">
 <div id="nav-mount"></div>
 <div class="wrap">
 
   <header class="hero">
     <div class="tapehead">
-      <span class="live">Banc d'essai vocal</span>
-      <span><b>Détail technique</b> — chiffres bruts</span>
-      <span>Outil · <b>sfu-bench</b> (open source)</span>
+      <span class="live" data-en="Voice benchmark">Banc d'essai vocal</span>
+      <span data-en="<b>Technical details</b>: raw numbers"><b>Détail technique</b> : chiffres bruts</span>
+      <span data-en="Tool · <b>sfu-bench</b> (open source)">Outil · <b>sfu-bench</b> (open source)</span>
     </div>
-    <h1>Le détail technique, sans filtre.</h1>
-    <p class="lede">Toutes les mesures brutes, la méthode, et ce qu'on ne cache pas. C'est la partie pour
+    <h1 data-en="The technical details, unfiltered.">Le détail technique, sans filtre.</h1>
+    <p class="lede" data-en="All the raw measurements, the method, and what we don't hide. This is the part for the technical crowd: nothing is tweaked, everything is reproducible.">Toutes les mesures brutes, la méthode, et ce qu'on ne cache pas. C'est la partie pour
       les techniciens : rien n'est arrangé, tout est reproductible.</p>
-    <nav class="scene-nav" aria-label="Scénarios">
-      <a href="pire-cas.html">01 · Le pire cas</a>
-      <a href="diffusion-audio.html">02 · Diffusion audio</a>
-      <a href="partage-ecran.html">03 · Partage d'écran</a>
+    <nav class="scene-nav" aria-label="Scénarios" data-en-aria="Scenarios">
+      <a href="pire-cas.html" data-en="01 · Worst case">01 · Le pire cas</a>
+      <a href="diffusion-audio.html" data-en="02 · Audio broadcast">02 · Diffusion audio</a>
+      <a href="partage-ecran.html" data-en="03 · Screen share">03 · Partage d'écran</a>
     </nav>
   </header>
 
   <section>
     <div class="sec-head">
-      <span class="sec-n">Synthèse</span>
-      <h2>Les trois scénarios d'un coup</h2>
-      <p>La même histoire, résumée : combien de monde selon la forme d'usage, sur un seul serveur 8 cœurs.</p>
+      <span class="sec-n" data-en="Summary">Synthèse</span>
+      <h2 data-en="The three scenarios at a glance">Les trois scénarios d'un coup</h2>
+      <p data-en="The same story, summed up: how many people by usage shape, on a single 8-core server.">La même histoire, résumée : combien de monde selon la forme d'usage, sur un seul serveur 8 cœurs.</p>
     </div>
     <div class="table-scroll">
       <table class="data">
-        <thead><tr><th>Scénario</th><th>Forme</th><th>Capacité (1 serveur, 8 cœurs)</th><th>Limité par</th></tr></thead>
+        <thead><tr><th data-en="Scenario">Scénario</th><th data-en="Shape">Forme</th><th data-en="Capacity (1 server, 8 cores)">Capacité (1 serveur, 8 cœurs)</th><th data-en="Limited by">Limité par</th></tr></thead>
         <tbody>
-          <tr><td>Pire cas</td><td>tous parlent</td><td>~600 personnes</td><td>processeur</td></tr>
-          <tr><td>Diffusion audio</td><td>1 parle, N écoutent</td><td>~8 000 / cœur</td><td>processeur, puis réseau à grande échelle</td></tr>
-          <tr><td>Partage d'écran</td><td>1 partage, N regardent</td><td>~450 (1 Gbit/s) → ~4 500 (10 Gbit/s)</td><td>réseau</td></tr>
+          <tr><td data-en="Worst case">Pire cas</td><td data-en="everyone talks">tous parlent</td><td data-en="~600 people">~600 personnes</td><td data-en="processor">processeur</td></tr>
+          <tr><td data-en="Audio broadcast">Diffusion audio</td><td data-en="1 talks, N listen">1 parle, N écoutent</td><td data-en="~8 000 / core">~8 000 / cœur</td><td data-en="processor, then network at large scale">processeur, puis réseau à grande échelle</td></tr>
+          <tr><td data-en="Screen share">Partage d'écran</td><td data-en="1 shares, N watch">1 partage, N regardent</td><td>~450 (1 Gbit/s) → ~4 500 (10 Gbit/s)</td><td data-en="network">réseau</td></tr>
         </tbody>
       </table>
     </div>
@@ -49,13 +49,13 @@
   <section>
     <div class="sec-head">
       <span class="sec-n">Test 01</span>
-      <h2>Pire cas — full-mesh (tous parlent)</h2>
-      <p>Une pièce, N participants, chacun consomme tous les autres (N×(N-1) chemins). Le son est parfait
+      <h2 data-en="Worst case: full-mesh (everyone talks)">Pire cas : full-mesh (tous parlent)</h2>
+      <p data-en="One room, N participants, each one consumes all the others (N×(N-1) paths). Audio is perfect up to ~100, then drops off.">Une pièce, N participants, chacun consomme tous les autres (N×(N-1) chemins). Le son est parfait
         jusqu'à ~100, puis décroche.</p>
     </div>
     <div class="table-scroll">
       <table class="data" id="t-mesh">
-        <thead><tr><th>Participants</th><th>Chemins</th><th>CPU (cœurs)</th><th>% machine</th><th>RSS (Mo)</th><th>Son</th><th>État</th></tr></thead>
+        <thead><tr><th data-en="Participants">Participants</th><th data-en="Paths">Chemins</th><th data-en="CPU (cores)">CPU (cœurs)</th><th>% machine</th><th data-en="RSS (MB)">RSS (Mo)</th><th data-en="Audio">Son</th><th data-en="State">État</th></tr></thead>
         <tbody></tbody>
       </table>
     </div>
@@ -64,13 +64,13 @@
   <section>
     <div class="sec-head">
       <span class="sec-n">Test 02</span>
-      <h2>Plusieurs pièces réparties sur les cœurs</h2>
-      <p>Des pièces de 100 personnes (full-mesh) réparties une par cœur : la charge monte linéairement,
+      <h2 data-en="Several rooms spread across the cores">Plusieurs pièces réparties sur les cœurs</h2>
+      <p data-en="Rooms of 100 people (full-mesh) spread one per core: the load rises linearly, ~600 people on 6 cores.">Des pièces de 100 personnes (full-mesh) réparties une par cœur : la charge monte linéairement,
         ~600 personnes sur 6 cœurs.</p>
     </div>
     <div class="table-scroll">
       <table class="data" id="t-pool">
-        <thead><tr><th>Pièces</th><th>Total personnes</th><th>CPU (cœurs)</th><th>Son</th><th>État</th></tr></thead>
+        <thead><tr><th data-en="Rooms">Pièces</th><th data-en="Total people">Total personnes</th><th data-en="CPU (cores)">CPU (cœurs)</th><th data-en="Audio">Son</th><th data-en="State">État</th></tr></thead>
         <tbody></tbody>
       </table>
     </div>
@@ -79,22 +79,22 @@
   <section>
     <div class="sec-head">
       <span class="sec-n">Test 03</span>
-      <h2>Diffusion audio (1 parle, N écoutent)</h2>
-      <p>Une seule voix relayée à N auditeurs, sur un cœur. En étoile : N chemins, pas N×(N-1).</p>
+      <h2 data-en="Audio broadcast (1 talks, N listen)">Diffusion audio (1 parle, N écoutent)</h2>
+      <p data-en="A single voice relayed to N listeners, on one core. Star-shaped: N paths, not N×(N-1).">Une seule voix relayée à N auditeurs, sur un cœur. En étoile : N chemins, pas N×(N-1).</p>
     </div>
     <div class="table-scroll">
       <table class="data" id="t-audio">
-        <thead><tr><th>Auditeurs</th><th>CPU (cœurs)</th><th>Son</th><th>État</th></tr></thead>
+        <thead><tr><th data-en="Listeners">Auditeurs</th><th data-en="CPU (cores)">CPU (cœurs)</th><th data-en="Audio">Son</th><th data-en="State">État</th></tr></thead>
         <tbody></tbody>
       </table>
     </div>
     <div class="table-scroll" style="margin-top:16px">
       <table class="data">
-        <thead><tr><th>Qualité audio</th><th>Débit / auditeur</th><th>Auditeurs / cœur</th><th>Bande passante à 8000</th></tr></thead>
+        <thead><tr><th data-en="Audio quality">Qualité audio</th><th data-en="Bitrate / listener">Débit / auditeur</th><th data-en="Listeners / core">Auditeurs / cœur</th><th data-en="Bandwidth at 8000">Bande passante à 8000</th></tr></thead>
         <tbody>
-          <tr><td>Économe</td><td>32 kbps</td><td>~8 000</td><td>256 Mbit/s</td></tr>
+          <tr><td data-en="Thrifty">Économe</td><td>32 kbps</td><td>~8 000</td><td>256 Mbit/s</td></tr>
           <tr><td>Standard (≈ Discord)</td><td>64 kbps</td><td>~8 000</td><td>512 Mbit/s</td></tr>
-          <tr><td>Haute</td><td>96 kbps</td><td>~8 000</td><td>768 Mbit/s</td></tr>
+          <tr><td data-en="High">Haute</td><td>96 kbps</td><td>~8 000</td><td>768 Mbit/s</td></tr>
           <tr><td>Studio</td><td>128 kbps</td><td>~8 000</td><td>~1 Gbit/s</td></tr>
         </tbody>
       </table>
@@ -104,19 +104,19 @@
   <section>
     <div class="sec-head">
       <span class="sec-n">Test 04</span>
-      <h2>Partage d'écran — vidéo</h2>
-      <p>Une diffusion vidéo relayée à N spectateurs. Côté CPU, très léger (mesuré 720p et 1080p) ; c'est le
+      <h2 data-en="Screen share: video">Partage d'écran : vidéo</h2>
+      <p data-en="A video broadcast relayed to N viewers. On the CPU side, very light (measured at 720p and 1080p); it is the <b>network</b> that caps it, by resolution.">Une diffusion vidéo relayée à N spectateurs. Côté CPU, très léger (mesuré 720p et 1080p) ; c'est le
         <b>réseau</b> qui borne, selon la résolution.</p>
     </div>
     <div class="table-scroll">
       <table class="data" id="t-video">
-        <thead><tr><th>Spectateurs (720p)</th><th>CPU (cœurs)</th><th>Son</th></tr></thead>
+        <thead><tr><th data-en="Viewers (720p)">Spectateurs (720p)</th><th data-en="CPU (cores)">CPU (cœurs)</th><th data-en="Audio">Son</th></tr></thead>
         <tbody></tbody>
       </table>
     </div>
     <div class="table-scroll" style="margin-top:16px">
       <table class="data">
-        <thead><tr><th>Résolution</th><th>Débit typique</th><th>1 Gbit/s</th><th>2,5 Gbit/s</th><th>10 Gbit/s</th></tr></thead>
+        <thead><tr><th data-en="Resolution">Résolution</th><th data-en="Typical bitrate">Débit typique</th><th>1 Gbit/s</th><th data-en="2.5 Gbit/s">2,5 Gbit/s</th><th>10 Gbit/s</th></tr></thead>
         <tbody>
           <tr><td>480p</td><td>~1 Mbit/s</td><td>~1 000</td><td>~2 500</td><td>~10 000</td></tr>
           <tr><td>720p (≈ Discord)</td><td>~2,5 Mbit/s</td><td>~400</td><td>~1 000</td><td>~4 000</td></tr>
@@ -130,16 +130,16 @@
   <section>
     <div class="sec-head">
       <span class="sec-n">Machines</span>
-      <h2>Testé sur du vrai matériel</h2>
-      <p>On ne publie que des machines réellement mesurées. Le tableau s'étoffera au fil des tests sur
+      <h2 data-en="Tested on real hardware">Testé sur du vrai matériel</h2>
+      <p data-en="We only publish machines we actually measured. The table will grow as we test more configurations.">On ne publie que des machines réellement mesurées. Le tableau s'étoffera au fil des tests sur
         d'autres configurations.</p>
     </div>
     <div class="table-scroll">
       <table class="data">
-        <thead><tr><th>Machine</th><th>Cœurs</th><th>Pire cas (serveur)</th><th>Audio / cœur</th><th>Vidéo (réseau)</th></tr></thead>
+        <thead><tr><th data-en="Machine">Machine</th><th data-en="Cores">Cœurs</th><th data-en="Worst case (server)">Pire cas (serveur)</th><th data-en="Audio / core">Audio / cœur</th><th data-en="Video (network)">Vidéo (réseau)</th></tr></thead>
         <tbody>
-          <tr><td>VPS Hetzner CPX42</td><td>8</td><td>~600</td><td>~8 000</td><td>débit-dépendant</td></tr>
-          <tr><td colspan="5" style="color:var(--ink-3)">Raspberry, mini-PC, autres VPS — à venir (mesurés, jamais inventés)</td></tr>
+          <tr><td>VPS Hetzner CPX42</td><td>8</td><td>~600</td><td>~8 000</td><td data-en="bandwidth-bound">débit-dépendant</td></tr>
+          <tr><td colspan="5" style="color:var(--ink-3)" data-en="Raspberry, mini-PC, other VPS: coming soon (measured, never invented)">Raspberry, mini-PC, autres VPS : à venir (mesurés, jamais inventés)</td></tr>
         </tbody>
       </table>
     </div>
@@ -147,27 +147,27 @@
 
   <section>
     <div class="sec-head">
-      <span class="sec-n">Méthode & honnêteté</span>
-      <h2>Comment c'est mesuré, et ce qu'on ne cache pas</h2>
+      <span class="sec-n" data-en="Method &amp; honesty">Méthode &amp; honnêteté</span>
+      <h2 data-en="How it's measured, and what we don't hide">Comment c'est mesuré, et ce qu'on ne cache pas</h2>
     </div>
     <div class="grid2">
       <div class="card">
-        <h3>La méthode</h3>
-        <p><b>Outil :</b> <code>sfu-bench</code>, dans le dépôt Nodyx. Participants synthétiques injectant du
+        <h3 data-en="The method">La méthode</h3>
+        <p data-en="<b>Tool:</b> <code>sfu-bench</code>, in the Nodyx repo. Synthetic participants injecting real RTP at real cadence (Opus audio, or a video profile)."><b>Outil :</b> <code>sfu-bench</code>, dans le dépôt Nodyx. Participants synthétiques injectant du
           vrai RTP au rythme réel (audio Opus, ou profil vidéo).</p>
-        <p><b>In-process :</b> le média est injecté directement dans le moteur (sans passer par le réseau)
+        <p data-en="<b>In-process:</b> media is injected straight into the engine (without going through the network) to isolate the cost of <b>relaying</b>. The network limit is therefore <b>calculated</b> separately (bitrate × viewers), not measured on the bench."><b>In-process :</b> le média est injecté directement dans le moteur (sans passer par le réseau)
           pour isoler le coût de <b>relais</b>. La limite réseau est donc <b>calculée</b> à part (débit ×
           spectateurs), pas mesurée au banc.</p>
-        <p><b>Son :</b> paquets reçus / attendus sur une fenêtre de 2 s par palier. <b>Machine :</b> VPS
+        <p data-en="<b>Audio:</b> packets received / expected over a 2 s window per step. <b>Machine:</b> VPS Hetzner CPX42, 8 cores (6 dedicated to media, 2 kept for the rest). Run at low priority."><b>Son :</b> paquets reçus / attendus sur une fenêtre de 2 s par palier. <b>Machine :</b> VPS
           Hetzner CPX42, 8 cœurs (6 dédiés au média, 2 gardés pour le reste). Lancé en basse priorité.</p>
       </div>
       <div class="card">
-        <h3>Ce qu'on ne cache pas</h3>
-        <p><b>Le partage d'écran sur ce moteur n'est pas encore en production</b> (il arrive). Les chiffres
+        <h3 data-en="What we don't hide">Ce qu'on ne cache pas</h3>
+        <p data-en="<b>Screen sharing on this engine is not in production yet</b> (it is coming). The video numbers measure what the engine <b>takes as a relay</b>, not 'screen sharing is perfect'. On-screen smoothness (browser side) is tested for real, not on the bench."><b>Le partage d'écran sur ce moteur n'est pas encore en production</b> (il arrive). Les chiffres
           vidéo mesurent ce que le moteur <b>encaisse en relais</b>, pas « le partage d'écran est parfait ».
           La fluidité à l'écran (côté navigateur) se teste en vrai, pas au banc.</p>
-        <p><b>Le vocal en production aujourd'hui, c'est l'audio.</b></p>
-        <p><b>Pire cas assumé :</b> le full-mesh (tous parlent en même temps) n'arrive jamais en vrai. Les
+        <p data-en="<b>Voice in production today is audio.</b>"><b>Le vocal en production aujourd'hui, c'est l'audio.</b></p>
+        <p data-en="<b>Worst case on purpose:</b> full-mesh (everyone talking at once) never happens in real life. Real cases hold far more people. Nothing is tweaked: the raw measurements are above."><b>Pire cas assumé :</b> le full-mesh (tous parlent en même temps) n'arrive jamais en vrai. Les
           cas réels tiennent bien plus de monde. Rien n'est arrangé : les mesures brutes sont ci-dessus.</p>
       </div>
     </div>
@@ -175,47 +175,61 @@
 
   <section>
     <div class="sec-head">
-      <span class="sec-n">Reproductible</span>
-      <h2>Vérifiez vous-même</h2>
-      <p>Rien n'est une boîte noire. L'outil de mesure est <b>open source</b> (AGPL-3.0). Compilez-le,
+      <span class="sec-n" data-en="Reproducible">Reproductible</span>
+      <h2 data-en="Check for yourself">Vérifiez vous-même</h2>
+      <p data-en="Nothing is a black box. The measurement tool is <b>open source</b> (AGPL-3.0). Compile it, run it, compare: these are exactly the commands that feed these pages.">Rien n'est une boîte noire. L'outil de mesure est <b>open source</b> (AGPL-3.0). Compilez-le,
         lancez-le, comparez : ce sont exactement ces commandes qui alimentent ces pages.</p>
     </div>
     <div class="card">
-      <p><b>Le code</b> — <a href="https://github.com/Pokled/nodyx" style="color:var(--signal)">github.com/Pokled/nodyx</a>,
+      <p data-en="<b>The code</b>: <a href='https://github.com/Pokled/nodyx' style='color:var(--signal)'>github.com/Pokled/nodyx</a>, <code>sfu-bench</code> binary in <code>nodyx-p2p/crates/nodyx-sfu-mediasoup</code>."><b>Le code</b> : <a href="https://github.com/Pokled/nodyx" style="color:var(--signal)">github.com/Pokled/nodyx</a>,
         binaire <code>sfu-bench</code> dans <code>nodyx-p2p/crates/nodyx-sfu-mediasoup</code>.</p>
-      <pre style="font-family:var(--mono);font-size:.82rem;line-height:1.7;background:var(--paper);border:1px solid var(--line);padding:16px 18px;overflow-x:auto;color:var(--ink);margin:6px 0 0;"># compiler
+      <pre style="font-family:var(--mono);font-size:.82rem;line-height:1.7;background:var(--paper);border:1px solid var(--line);padding:16px 18px;overflow-x:auto;color:var(--ink);margin:6px 0 0;" data-en="# build
 cd nodyx-p2p/crates/nodyx-sfu-mediasoup
 cargo build --release --bin sfu-bench
 
-# pire cas — full-mesh (tous parlent)
+# worst case: full-mesh (everyone talks)
+./target/release/sfu-bench 2,5,10,20,50,100,150,300
+
+# several rooms spread across the cores
+SFU_BENCH_WORKERS=6 ./target/release/sfu-bench rooms 100 1,2,4,6
+
+# audio broadcast: 1 talks, N listen
+./target/release/sfu-bench watch 1 250,1000,5000,8000
+
+# screen share 720p (~2.5 Mbit/s): 1 shares, N watch
+SFU_BENCH_PAYLOAD=1250 SFU_BENCH_PACKET_MS=4 ./target/release/sfu-bench watch 1 800,1600"># compiler
+cd nodyx-p2p/crates/nodyx-sfu-mediasoup
+cargo build --release --bin sfu-bench
+
+# pire cas : full-mesh (tous parlent)
 ./target/release/sfu-bench 2,5,10,20,50,100,150,300
 
 # plusieurs pièces réparties sur les cœurs
 SFU_BENCH_WORKERS=6 ./target/release/sfu-bench rooms 100 1,2,4,6
 
-# diffusion audio — 1 parle, N écoutent
+# diffusion audio : 1 parle, N écoutent
 ./target/release/sfu-bench watch 1 250,1000,5000,8000
 
-# partage d'écran 720p (~2,5 Mbit/s) — 1 partage, N regardent
+# partage d'écran 720p (~2,5 Mbit/s) : 1 partage, N regardent
 SFU_BENCH_PAYLOAD=1250 SFU_BENCH_PACKET_MS=4 ./target/release/sfu-bench watch 1 800,1600</pre>
-      <p style="margin-top:14px">Chaque test imprime un tableau lisible <b>et</b> un JSON pour l'archivage.
+      <p style="margin-top:14px" data-en="Each test prints a readable table <b>and</b> a JSON for archival. The numbers on this site come straight out of this tool.">Chaque test imprime un tableau lisible <b>et</b> un JSON pour l'archivage.
         Les chiffres de ce site sortent tels quels de cet outil.</p>
     </div>
   </section>
 
   <section>
-    <div class="sec-head"><h2>Les scénarios</h2></div>
+    <div class="sec-head"><h2 data-en="The scenarios">Les scénarios</h2></div>
     <div class="next">
-      <a href="pire-cas.html"><div class="nx-k">Scénario 01</div><div class="nx-t">Le pire cas <span class="arr">→</span></div></a>
-      <a href="diffusion-audio.html"><div class="nx-k">Scénario 02</div><div class="nx-t">Diffusion audio <span class="arr">→</span></div></a>
-      <a href="partage-ecran.html"><div class="nx-k">Scénario 03</div><div class="nx-t">Partage d'écran <span class="arr">→</span></div></a>
+      <a href="pire-cas.html"><div class="nx-k" data-en="Scenario 01">Scénario 01</div><div class="nx-t" data-en="Worst case <span class='arr'>→</span>">Le pire cas <span class="arr">→</span></div></a>
+      <a href="diffusion-audio.html"><div class="nx-k" data-en="Scenario 02">Scénario 02</div><div class="nx-t" data-en="Audio broadcast <span class='arr'>→</span>">Diffusion audio <span class="arr">→</span></div></a>
+      <a href="partage-ecran.html"><div class="nx-k" data-en="Scenario 03">Scénario 03</div><div class="nx-t" data-en="Screen share <span class='arr'>→</span>">Partage d'écran <span class="arr">→</span></div></a>
     </div>
   </section>
 
 </div>
-<footer class="site"><div class="wrap">Mesures réelles issues de <a href="https://github.com/Pokled/nodyx">sfu-bench</a> · <a href="https://nodyx.org">Nodyx</a>, vocal souverain auto-hébergé · AGPL-3.0</div></footer>
+<footer class="site"><div class="wrap" data-en="Real measurements from <a href='https://github.com/Pokled/nodyx'>sfu-bench</a> · <a href='https://nodyx.org'>Nodyx</a>, sovereign self-hosted voice · AGPL-3.0">Mesures réelles issues de <a href="https://github.com/Pokled/nodyx">sfu-bench</a> · <a href="https://nodyx.org">Nodyx</a>, vocal souverain auto-hébergé · AGPL-3.0</div></footer>
 
-<script src="bench.js?v=2"></script>
+<script src="bench.js?v=3"></script>
 <script>
   const MESH = [
     { n: 2,   paths: 2,     cpu: 0.010, box: 0.1,  rss: 24,  health: 100 },
@@ -246,18 +260,24 @@ SFU_BENCH_PAYLOAD=1250 SFU_BENCH_PACKET_MS=4 ./target/release/sfu-bench watch 1 
     { spec: 200, cpu: 0.11 }, { spec: 400, cpu: 0.22 }, { spec: 800, cpu: 0.47 },
     { spec: 1600, cpu: 0.55 }, { spec: 2400, cpu: 0.74 },
   ];
-  const fr = n => n.toLocaleString("fr");
-  const c2 = v => v.toFixed(2).replace(".", ",");
-  const hp = h => (h % 1 ? h.toFixed(1).replace(".", ",") : h) + " %";
-  const state = h => h >= 99 ? '<span class="tag ok">OK</span>' : h >= 90 ? '<span class="tag warn">tendu</span>' : '<span class="tag crit">rupture</span>';
+  const num = n => Bench.num(n);
+  const c2 = v => Bench.dec(v, 2);
+  const hp = h => Bench.dec(h, h % 1 ? 1 : 0) + Bench.t(" %", "%");
+  const state = h => h >= 99 ? '<span class="tag ok">OK</span>'
+    : h >= 90 ? '<span class="tag warn">' + Bench.t("tendu", "strained") + '</span>'
+    : '<span class="tag crit">' + Bench.t("rupture", "breaking") + '</span>';
   const fill = (id, rows, cells) => {
     const tb = document.querySelector("#" + id + " tbody");
     tb.innerHTML = rows.map(d => "<tr" + (d.health != null && d.health < 99 ? ' class="break"' : "") + ">" + cells(d).map(c => "<td>" + c + "</td>").join("") + "</tr>").join("");
   };
-  fill("t-mesh", MESH, d => [d.n, fr(d.paths), c2(d.cpu), c2(d.box) + " %", fr(d.rss), hp(d.health), state(d.health)]);
-  fill("t-pool", POOL, d => [d.rooms, fr(d.total), c2(d.cpu), hp(d.health), state(d.health)]);
-  fill("t-audio", AUDIO, d => [fr(d.spec), c2(d.cpu), hp(d.health), state(d.health)]);
-  fill("t-video", VIDEO, d => [fr(d.spec), c2(d.cpu), '<span class="tag ok">OK</span>']);
+  function render() {
+    fill("t-mesh", MESH, d => [num(d.n), num(d.paths), c2(d.cpu), c2(d.box) + Bench.t(" %", "%"), num(d.rss), hp(d.health), state(d.health)]);
+    fill("t-pool", POOL, d => [num(d.rooms), num(d.total), c2(d.cpu), hp(d.health), state(d.health)]);
+    fill("t-audio", AUDIO, d => [num(d.spec), c2(d.cpu), hp(d.health), state(d.health)]);
+    fill("t-video", VIDEO, d => [num(d.spec), c2(d.cpu), '<span class="tag ok">OK</span>']);
+  }
+  render();
+  Bench.onLang(render);
 
   Bench.boot("technique");
 </script>


### PR DESCRIPTION
Adds a FR/EN language switch to the voice benchmark (all 4 pages: worst-case, audio broadcast, screen share, technical).

- Language state lives in the shared `bench.js` (flag switch in the nav, `localStorage`, default from the visitor's browser language, persisted across pages).
- Text translated via `data-en` attributes; chart labels and tooltips are language-aware; the technical page's JS-rendered tables re-render on switch.
- Removed the em-dashes from the French copy while here.

Static assets only, no app-code change.