### PR TITLE
fix(lang): validate SSR locale before it reaches the page (polish #314)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -91,6 +91,21 @@ One merged PR = one star. Typos count. Translations count. Bug reports that turn
       <br/>
       <sub><strong>First Czech contributor 🇨🇿</strong></sub>
     </td>
+    <td align="center" width="200">
+      <a href="https://github.com/JoeJoeflyn">
+        <img src="https://github.com/JoeJoeflyn.png?size=120" width="120" height="120" style="border-radius:50%;" alt="JoeJoeflyn"/>
+        <br/>
+        <sub><b>JoeJoeflyn</b></sub>
+      </a>
+      <br/>
+      <sub>🌟 × 2</sub>
+      <br/>
+      <sub><a href="https://github.com/Pokled/nodyx/pull/306">PR #306</a> · <a href="https://github.com/Pokled/nodyx/pull/314">PR #314</a></sub>
+      <br/>
+      <sub><em>Vietnamese (vi) translation + guest-accessible language picker</em></sub>
+      <br/>
+      <sub><strong>First Vietnamese contributor 🇻🇳</strong></sub>
+    </td>
   </tr>
 </table>
 
@@ -128,21 +143,6 @@ One merged PR = one star. Typos count. Translations count. Bug reports that turn
       <br/>
       <sub><strong>First dual-stack hunter 🌐</strong></sub>
     </td>
-    <td align="center" width="200">
-      <a href="https://github.com/JoeJoeflyn">
-        <img src="https://github.com/JoeJoeflyn.png?size=120" width="120" height="120" style="border-radius:50%;" alt="JoeJoeflyn"/>
-        <br/>
-        <sub><b>JoeJoeflyn</b></sub>
-      </a>
-      <br/>
-      <sub>🌟 × 1</sub>
-      <br/>
-      <sub><a href="https://github.com/Pokled/nodyx/pull/306">PR #306</a></sub>
-      <br/>
-      <sub><em>Vietnamese (vi) full translation, 955 strings</em></sub>
-      <br/>
-      <sub><strong>First Vietnamese contributor 🇻🇳</strong></sub>
-    </td>
   </tr>
 </table>
 
@@ -172,6 +172,7 @@ Sometimes a contribution isn't a PR. Sometimes it's just being there at exactly 
 
 | Contributor | Contribution | Type | Issue / PR | Fix / polish | Date |
 |---|---|---|---|---|---|
+| [@JoeJoeflyn](https://github.com/JoeJoeflyn) | Moved the language picker out of `/settings` into a guest-accessible layout pane, and read the locale from a cookie in `hooks.server.ts` so SSR paints the right language on first load (no flash from `fr`), auto-detecting the browser's `Accept-Language`. | `feat(lang)` | [#314](https://github.com/Pokled/nodyx/pull/314) | [`c5c3822`](https://github.com/Pokled/nodyx/commit/c5c3822), polish below | 2026-07-19 |
 | [@JoeJoeflyn](https://github.com/JoeJoeflyn) | Vietnamese (vi) translation: 955 strings, full key + placeholder parity with `en.json`, wired into the locale switch (label, flag, navigator detection). Restored 5 dropped interpolation variables and reverted a placeholder URL on review. | `feat(i18n)` | [#306](https://github.com/Pokled/nodyx/pull/306) | [`bc31f37`](https://github.com/Pokled/nodyx/commit/bc31f37) | 2026-07-18 |
 | [@schlaggi](https://github.com/schlaggi) | Reported one-click installer false-positive DNS mismatch on dual-stack machines: `getent hosts` returns mixed-family (A or AAAA depending on `/etc/nsswitch.conf`), then the script compared the resolved IPv6 against the locally-detected IPv4 → bogus "mismatch", Let's Encrypt step refused to proceed. Fix: family-aware resolution via `getent ahostsv4` / `ahostsv6` + optional public IPv6 detection. | `bug(installer)` | [#29](https://github.com/Pokled/nodyx/issues/29) | _to fill on merge_ | 2026-05-18 |
 | [@naranco66](https://github.com/naranco66) | Full Spanish translation of the documentation: 9 documents, ~3000 lines, line-by-line native review (Spain). Includes thoughtful linguistic decisions (`"plataformas herméticas"` over literal `"silos privados"`, gender agreement on `"condenadas"`, sslip.io explanation for a Hispanic audience less familiar with the service). | `docs(es)` | [#28](https://github.com/Pokled/nodyx/pull/28) | [`0a6d74d`](https://github.com/Pokled/nodyx/commit/0a6d74d) | 2026-05-17 |
@@ -220,6 +221,16 @@ Caught during production testing after merge. Not visible in async review.
 - Now supports every canvas element type correctly: pen paths, sticky notes, shapes, arrows, connectors, frames
 
 **This is exactly why we merge-then-polish: some bugs only surface when real hands touch real pixels, and some only when CI runs the type checker.** Three polish passes on one PR is not a failure, it's the system working. The contributor still gets the star, the feature ships, the codebase stays clean. Everyone wins.
+
+### PR [#314](https://github.com/Pokled/nodyx/pull/314) · @JoeJoeflyn · `feat(lang): guest-accessible language picker`
+
+**Original PR:** merged as-is. A genuinely good idea: the picker leaves `/settings` for a layout pane a guest can reach from the nav, the locale is read from a cookie in `hooks.server.ts` so SSR paints the right language on the first byte (no flash from `fr`), and it auto-detects the browser's `Accept-Language`. Frontend only, CI green.
+
+**Polish (same cleanup PR):** `fix(lang): validate the SSR locale before it reaches the page`
+- The `nodyx_locale` cookie was injected raw into `<html lang="%lang%">`. A cookie is attacker-settable, and in the `*.nodyx.org` multi-instance model a sibling subdomain can set a `Domain=.nodyx.org` cookie, so a crafted value could break out of the attribute and run script (XSS). The cookie now only counts if it matches a locale we actually ship (`isKnownLocale`), otherwise we fall back to `Accept-Language`, then `fr`. Same guard added in `+layout.server.ts`.
+- Restored the native `Tiếng Việt` label (the PR had switched it to the English `Vietnamese`, while every other locale carries its own name).
+
+Landed after the merge but before the feature was deployed, so production never served the unvalidated attribute. The idea and the feature are entirely his; we just tightened the one line that touched untrusted input.
 
 ---
 

--- a/nodyx-frontend/src/hooks.server.ts
+++ b/nodyx-frontend/src/hooks.server.ts
@@ -1,5 +1,5 @@
 import type { Handle, HandleFetch } from '@sveltejs/kit';
-import { getLocaleFromAcceptLanguage } from '$lib/i18n';
+import { getLocaleFromAcceptLanguage, isKnownLocale } from '$lib/i18n';
 
 // Make sure /service-worker.js (and any other SW-like files) are never cached
 // by intermediate CDNs. Default behaviour: Cloudflare cached service-worker.js
@@ -18,7 +18,10 @@ const NO_CACHE_PATHS = new Set([
 export const handle: Handle = async ({ event, resolve }) => {
 	const cookieLocale = event.cookies.get('nodyx_locale');
 	const acceptLang = event.request.headers.get('accept-language');
-	const locale = cookieLocale || getLocaleFromAcceptLanguage(acceptLang) || 'fr';
+	// The cookie is attacker-settable (and cross-instance via a *.nodyx.org subdomain),
+	// and `locale` is injected raw into <html lang="%lang%">. Only accept a locale we
+	// actually ship, otherwise a crafted cookie could break out of the attribute (XSS).
+	const locale = (isKnownLocale(cookieLocale) ? cookieLocale : getLocaleFromAcceptLanguage(acceptLang)) || 'fr';
 
 	const response = await resolve(event, {
 		transformPageChunk: ({ html }) => html.replace('%lang%', locale)

--- a/nodyx-frontend/src/lib/i18n.ts
+++ b/nodyx-frontend/src/lib/i18n.ts
@@ -28,7 +28,7 @@ export const LOCALES: LocaleMeta[] = [
   { code: 'de',    label: 'Deutsch',    flag: '🇩🇪' },
   { code: 'ru',    label: 'Русский',    flag: '🇷🇺' },
   { code: 'pt-PT', label: 'Português',  flag: '🇵🇹' },
-  { code: 'vi',    label: 'Vietnamese', flag: '🇻🇳' },
+  { code: 'vi',    label: 'Tiếng Việt', flag: '🇻🇳' },
 ]
 
 // ── Messages ──────────────────────────────────────────────────────────────────
@@ -79,6 +79,14 @@ export function getLocaleFromAcceptLanguage(header: string | null): Locale | und
     // ignore
   }
   return undefined
+}
+
+/**
+ * True only if `code` is a locale we actually ship. Server-safe guard: the SSR
+ * cookie is attacker-settable, so never trust it before it clears this check.
+ */
+export function isKnownLocale(code: string | null | undefined): code is Locale {
+  return !!code && LOCALES.some((l) => l.code === code)
 }
 
 function getInitialLocale(): Locale {

--- a/nodyx-frontend/src/routes/+layout.server.ts
+++ b/nodyx-frontend/src/routes/+layout.server.ts
@@ -2,7 +2,7 @@ import { redirect } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
 import { apiFetch } from '$lib/api';
 import { env } from '$env/dynamic/public';
-import { getLocaleFromAcceptLanguage } from '$lib/i18n';
+import { getLocaleFromAcceptLanguage, isKnownLocale } from '$lib/i18n';
 
 const DIRECTORY_URL = (env.PUBLIC_DIRECTORY_URL ?? 'https://nodyx.org') + '/api/directory';
 
@@ -51,11 +51,8 @@ function normalizeUrl(url: string | null): string | null {
 
 export const load: LayoutServerLoad = async ({ fetch, cookies, request, url }) => {
 	const token = cookies.get('token');
-	let ssrLocale = cookies.get('nodyx_locale');
-	if (!ssrLocale) {
-		const acceptLang = request.headers.get('accept-language');
-		ssrLocale = getLocaleFromAcceptLanguage(acceptLang) || 'fr';
-	}
+	const cookieLocale = cookies.get('nodyx_locale');
+	const ssrLocale = (isKnownLocale(cookieLocale) ? cookieLocale : getLocaleFromAcceptLanguage(request.headers.get('accept-language'))) || 'fr';
 
 	const [infoRes, userRes, directoryJson, announcementRes, modulesRes] = await Promise.all([
 		apiFetch(fetch, '/instance/info'),


### PR DESCRIPTION
Polish behind @JoeJoeflyn's #314 (guest-accessible language picker), landed before deploy so production never served the unvalidated version.

**Security fix.** The `nodyx_locale` cookie was injected raw into `<html lang="%lang%">` through `transformPageChunk` in `hooks.server.ts`. A cookie is attacker-settable, and in the `*.nodyx.org` multi-instance model a sibling subdomain can set a `Domain=.nodyx.org` cookie, so a crafted value could break out of the attribute and run script (XSS). The cookie now only counts if it matches a locale we ship (new `isKnownLocale` guard), otherwise we fall back to `Accept-Language` then `fr`. Same guard added in `+layout.server.ts`.

**Also:** restored the native `Tiếng Việt` label (the PR had switched it to `Vietnamese`, off-pattern from the other native names).

**Credit:** @JoeJoeflyn moves to Regulars (2 stars), with the fix documented in the Polish Trail. The feature and the idea are entirely his.

Frontend only. `npm run check`: 0 errors.