### PR TITLE
fix(i18n): translate the guest members card (was hardcoded French)

### DIFF
--- a/nodyx-frontend/src/lib/locales/de.json
+++ b/nodyx-frontend/src/lib/locales/de.json
@@ -952,5 +952,9 @@
   "widgets.twitch_open_channel": "Den Kanal {{channel}} auf Twitch öffnen",
   "widgets.open": "Öffnen",
   "widgets.twitch_offline_mid": "ist offline — entdecke",
-  "widgets.twitch_offline_end": "in der Zwischenzeit"
+  "widgets.twitch_offline_end": "in der Zwischenzeit",
+  "members.guest_count": "{{count}} Mitglieder",
+  "members.guest_active": "Aktive Community",
+  "members.guest_tagline": "Melde dich an, um zu sehen, wer online ist",
+  "members.guest_aria": "Anmelden, um die Mitglieder zu sehen"
 }

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -953,5 +953,9 @@
   "widgets.twitch_open_channel": "Open the {{channel}} channel on Twitch",
   "widgets.open": "Open",
   "widgets.twitch_offline_mid": "is offline — check out",
-  "widgets.twitch_offline_end": "in the meantime"
+  "widgets.twitch_offline_end": "in the meantime",
+  "members.guest_count": "{{count}} members",
+  "members.guest_active": "Active community",
+  "members.guest_tagline": "Sign in to see who is online",
+  "members.guest_aria": "Sign in to see the members"
 }

--- a/nodyx-frontend/src/lib/locales/es.json
+++ b/nodyx-frontend/src/lib/locales/es.json
@@ -952,5 +952,9 @@
   "widgets.twitch_open_channel": "Abrir el canal {{channel}} en Twitch",
   "widgets.open": "Abrir",
   "widgets.twitch_offline_mid": "está desconectado — descubre",
-  "widgets.twitch_offline_end": "mientras tanto"
+  "widgets.twitch_offline_end": "mientras tanto",
+  "members.guest_count": "{{count}} miembros",
+  "members.guest_active": "Comunidad activa",
+  "members.guest_tagline": "Inicia sesión para ver quién está en línea",
+  "members.guest_aria": "Inicia sesión para ver los miembros"
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -953,5 +953,9 @@
   "widgets.twitch_open_channel": "Ouvrir la chaîne {{channel}} sur Twitch",
   "widgets.open": "Ouvrir",
   "widgets.twitch_offline_mid": "est offline — découvre",
-  "widgets.twitch_offline_end": "en attendant"
+  "widgets.twitch_offline_end": "en attendant",
+  "members.guest_count": "{{count}} membres",
+  "members.guest_active": "Communauté active",
+  "members.guest_tagline": "Connecte-toi pour voir qui est en ligne",
+  "members.guest_aria": "Se connecter pour voir les membres"
 }

--- a/nodyx-frontend/src/lib/locales/pt-PT.json
+++ b/nodyx-frontend/src/lib/locales/pt-PT.json
@@ -953,5 +953,9 @@
   "widgets.twitch_open_channel": "Abrir o canal {{channel}} no Twitch",
   "widgets.open": "Abrir",
   "widgets.twitch_offline_mid": "está offline — vê",
-  "widgets.twitch_offline_end": "entretanto"
+  "widgets.twitch_offline_end": "entretanto",
+  "members.guest_count": "{{count}} membros",
+  "members.guest_active": "Comunidade ativa",
+  "members.guest_tagline": "Inicia sessão para ver quem está online",
+  "members.guest_aria": "Inicia sessão para ver os membros"
 }

--- a/nodyx-frontend/src/lib/locales/ru.json
+++ b/nodyx-frontend/src/lib/locales/ru.json
@@ -953,5 +953,9 @@
   "widgets.twitch_open_channel": "Открыть канал {{channel}} на Twitch",
   "widgets.open": "Открыть",
   "widgets.twitch_offline_mid": "офлайн — посмотри",
-  "widgets.twitch_offline_end": "пока что"
+  "widgets.twitch_offline_end": "пока что",
+  "members.guest_count": "{{count}} участников",
+  "members.guest_active": "Активное сообщество",
+  "members.guest_tagline": "Войдите, чтобы увидеть, кто онлайн",
+  "members.guest_aria": "Войдите, чтобы увидеть участников"
 }

--- a/nodyx-frontend/src/lib/locales/vi.json
+++ b/nodyx-frontend/src/lib/locales/vi.json
@@ -953,5 +953,9 @@
   "widgets.twitch_open_channel": "Mở {{channel}} trên Twitch",
   "widgets.open": "Mở",
   "widgets.twitch_offline_mid": "ngoại tuyến",
-  "widgets.twitch_offline_end": "— xem trong lúc chờ"
+  "widgets.twitch_offline_end": "— xem trong lúc chờ",
+  "members.guest_count": "{{count}} thành viên",
+  "members.guest_active": "Cộng đồng đang hoạt động",
+  "members.guest_tagline": "Đăng nhập để xem ai đang trực tuyến",
+  "members.guest_aria": "Đăng nhập để xem thành viên"
 }

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -1522,7 +1522,7 @@
 			</div>
 			{:else}
 				<!-- Not logged in — invite card -->
-				<a href="/auth/login" class="guest-members-card" aria-label="Se connecter pour voir les membres">
+				<a href="/auth/login" class="guest-members-card" aria-label={tFn('members.guest_aria')}>
 
 					<!-- Radar animé -->
 					<div class="guest-radar">
@@ -1553,12 +1553,12 @@
 					<div class="guest-live-row">
 						<span class="guest-live-dot"></span>
 						<span class="guest-live-label">
-							{memberCount > 0 ? `${memberCount} membre${memberCount > 1 ? 's' : ''}` : 'Communauté active'}
+							{memberCount > 0 ? tFn('members.guest_count', { count: memberCount }) : tFn('members.guest_active')}
 						</span>
 					</div>
 
 					<!-- Texte -->
-					<p class="guest-tagline">Connecte-toi pour voir<br>qui est en ligne</p>
+					<p class="guest-tagline">{tFn('members.guest_tagline')}</p>
 
 					<!-- CTA -->
 					<div class="guest-cta">
@@ -1567,7 +1567,7 @@
 							<polyline points="10 17 15 12 10 7"/>
 							<line x1="15" y1="12" x2="3" y2="12"/>
 						</svg>
-						Se connecter
+						{tFn('common.login')}
 					</div>
 				</a>
 			{/if}


### PR DESCRIPTION
The members side panel shown to signed-out visitors had hardcoded French strings, so it stayed French whatever language you picked: the member count, the "sign in to see who is online" tagline, the sign-in button, and the card aria-label.

Routed all of them through i18n. Added `members.guest_count`, `members.guest_active`, `members.guest_tagline` and `members.guest_aria` to all 7 locales (fr, en, es, de, ru, pt-PT, vi); the button reuses the existing `common.login`.

Frontend only. `npm run check`: 0 errors.