### PR TITLE
fix(i18n): translate the remaining hardcoded strings in the app shell

### DIFF
--- a/nodyx-frontend/src/lib/locales/de.json
+++ b/nodyx-frontend/src/lib/locales/de.json
@@ -956,5 +956,15 @@
   "members.guest_count": "{{count}} Mitglieder",
   "members.guest_active": "Aktive Community",
   "members.guest_tagline": "Melde dich an, um zu sehen, wer online ist",
-  "members.guest_aria": "Anmelden, um die Mitglieder zu sehen"
+  "members.guest_aria": "Anmelden, um die Mitglieder zu sehen",
+  "voice.muted_aria": "Mikrofon stummgeschaltet",
+  "voice.deafened_aria": "Kopfhörer aus",
+  "announcement.dismiss": "Ankündigung schließen",
+  "voice.screen_badge": "BILDSCHIRM",
+  "status.modal_title": "Status festlegen",
+  "status.none": "Kein Status",
+  "status.placeholder": "Was du gerade machst…",
+  "common.clear": "Löschen",
+  "presence.joined": "ist beigetreten",
+  "presence.left": "hat verlassen"
 }

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -957,5 +957,15 @@
   "members.guest_count": "{{count}} members",
   "members.guest_active": "Active community",
   "members.guest_tagline": "Sign in to see who is online",
-  "members.guest_aria": "Sign in to see the members"
+  "members.guest_aria": "Sign in to see the members",
+  "voice.muted_aria": "Microphone muted",
+  "voice.deafened_aria": "Deafened",
+  "announcement.dismiss": "Close announcement",
+  "voice.screen_badge": "SCREEN",
+  "status.modal_title": "Set your status",
+  "status.none": "No status",
+  "status.placeholder": "What you're up to…",
+  "common.clear": "Clear",
+  "presence.joined": "joined",
+  "presence.left": "left"
 }

--- a/nodyx-frontend/src/lib/locales/es.json
+++ b/nodyx-frontend/src/lib/locales/es.json
@@ -956,5 +956,15 @@
   "members.guest_count": "{{count}} miembros",
   "members.guest_active": "Comunidad activa",
   "members.guest_tagline": "Inicia sesión para ver quién está en línea",
-  "members.guest_aria": "Inicia sesión para ver los miembros"
+  "members.guest_aria": "Inicia sesión para ver los miembros",
+  "voice.muted_aria": "Micrófono silenciado",
+  "voice.deafened_aria": "Auriculares silenciados",
+  "announcement.dismiss": "Cerrar el anuncio",
+  "voice.screen_badge": "PANTALLA",
+  "status.modal_title": "Define tu estado",
+  "status.none": "Sin estado",
+  "status.placeholder": "Lo que estás haciendo…",
+  "common.clear": "Borrar",
+  "presence.joined": "se unió a",
+  "presence.left": "salió de"
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -957,5 +957,15 @@
   "members.guest_count": "{{count}} membres",
   "members.guest_active": "Communauté active",
   "members.guest_tagline": "Connecte-toi pour voir qui est en ligne",
-  "members.guest_aria": "Se connecter pour voir les membres"
+  "members.guest_aria": "Se connecter pour voir les membres",
+  "voice.muted_aria": "Micro coupé",
+  "voice.deafened_aria": "Écouteurs coupés",
+  "announcement.dismiss": "Fermer l'annonce",
+  "voice.screen_badge": "ÉCRAN",
+  "status.modal_title": "Définir ton statut",
+  "status.none": "Aucun statut",
+  "status.placeholder": "Ce que tu fais…",
+  "common.clear": "Effacer",
+  "presence.joined": "a rejoint",
+  "presence.left": "a quitté"
 }

--- a/nodyx-frontend/src/lib/locales/pt-PT.json
+++ b/nodyx-frontend/src/lib/locales/pt-PT.json
@@ -957,5 +957,15 @@
   "members.guest_count": "{{count}} membros",
   "members.guest_active": "Comunidade ativa",
   "members.guest_tagline": "Inicia sessão para ver quem está online",
-  "members.guest_aria": "Inicia sessão para ver os membros"
+  "members.guest_aria": "Inicia sessão para ver os membros",
+  "voice.muted_aria": "Microfone silenciado",
+  "voice.deafened_aria": "Auscultadores desligados",
+  "announcement.dismiss": "Fechar o anúncio",
+  "voice.screen_badge": "ECRÃ",
+  "status.modal_title": "Define o teu estado",
+  "status.none": "Sem estado",
+  "status.placeholder": "O que estás a fazer…",
+  "common.clear": "Limpar",
+  "presence.joined": "entrou em",
+  "presence.left": "saiu de"
 }

--- a/nodyx-frontend/src/lib/locales/ru.json
+++ b/nodyx-frontend/src/lib/locales/ru.json
@@ -957,5 +957,15 @@
   "members.guest_count": "{{count}} участников",
   "members.guest_active": "Активное сообщество",
   "members.guest_tagline": "Войдите, чтобы увидеть, кто онлайн",
-  "members.guest_aria": "Войдите, чтобы увидеть участников"
+  "members.guest_aria": "Войдите, чтобы увидеть участников",
+  "voice.muted_aria": "Микрофон выключен",
+  "voice.deafened_aria": "Наушники выключены",
+  "announcement.dismiss": "Закрыть объявление",
+  "voice.screen_badge": "ЭКРАН",
+  "status.modal_title": "Установить статус",
+  "status.none": "Нет статуса",
+  "status.placeholder": "Чем вы заняты…",
+  "common.clear": "Очистить",
+  "presence.joined": "присоединился к",
+  "presence.left": "покинул"
 }

--- a/nodyx-frontend/src/lib/locales/vi.json
+++ b/nodyx-frontend/src/lib/locales/vi.json
@@ -957,5 +957,15 @@
   "members.guest_count": "{{count}} thành viên",
   "members.guest_active": "Cộng đồng đang hoạt động",
   "members.guest_tagline": "Đăng nhập để xem ai đang trực tuyến",
-  "members.guest_aria": "Đăng nhập để xem thành viên"
+  "members.guest_aria": "Đăng nhập để xem thành viên",
+  "voice.muted_aria": "Micrô đã tắt",
+  "voice.deafened_aria": "Đã tắt tai nghe",
+  "announcement.dismiss": "Đóng thông báo",
+  "voice.screen_badge": "MÀN HÌNH",
+  "status.modal_title": "Đặt trạng thái",
+  "status.none": "Không có trạng thái",
+  "status.placeholder": "Bạn đang làm gì…",
+  "common.clear": "Xóa",
+  "presence.joined": "đã tham gia",
+  "presence.left": "đã rời"
 }

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -1130,14 +1130,14 @@
 										{:else}
 											<div class="flex items-center gap-0.5 shrink-0">
 												{#if m.deafened}
-													<svg class="w-[11px] h-[11px]" aria-label="Écouteurs coupés" style="color:#fb923c" fill="none" stroke="currentColor" stroke-width="2.2" viewBox="0 0 24 24">
+													<svg class="w-[11px] h-[11px]" aria-label={tFn('voice.deafened_aria')} style="color:#fb923c" fill="none" stroke="currentColor" stroke-width="2.2" viewBox="0 0 24 24">
 														<path stroke-linecap="round" d="M3 18v-6a9 9 0 0118 0v6"/>
 														<path stroke-linecap="round" d="M21 19a2 2 0 01-2 2h-1a2 2 0 01-2-2v-3a2 2 0 012-2h3zM3 19a2 2 0 002 2h1a2 2 0 002-2v-3a2 2 0 00-2-2H3z"/>
 														<path stroke-linecap="round" d="M2 2l20 20"/>
 													</svg>
 												{/if}
 												{#if m.muted}
-													<svg class="w-[11px] h-[11px]" aria-label="Micro coupé" style="color:#f87171" fill="none" stroke="currentColor" stroke-width="2.2" viewBox="0 0 24 24">
+													<svg class="w-[11px] h-[11px]" aria-label={tFn('voice.muted_aria')} style="color:#f87171" fill="none" stroke="currentColor" stroke-width="2.2" viewBox="0 0 24 24">
 														<path stroke-linecap="round" d="M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z"/>
 														<path stroke-linecap="round" d="M17 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2"/>
 													</svg>
@@ -1218,7 +1218,7 @@
                     <button
                         onclick={() => announcementDismissed = announcement!.id}
                         class="shrink-0 opacity-60 hover:opacity-100 transition-opacity ml-2"
-                        aria-label="Fermer l'annonce"
+                        aria-label={tFn('announcement.dismiss')}
                     >
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
@@ -1377,7 +1377,7 @@
 											{#if isSharing}
 												<span style="display:inline-flex;align-items:center;gap:3px;font-size:9px;font-weight:700;padding:1px 5px;background:rgba(59,130,246,.12);border:1px solid rgba(59,130,246,.22);color:rgb(96,165,250)">
 													<svg style="width:7px;height:7px;shrink:0" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
-													ÉCRAN
+													{tFn('voice.screen_badge')}
 												</span>
 											{/if}
 											{#if isStreaming}
@@ -1455,7 +1455,7 @@
 											{#if isSharing}
 												<span style="display:inline-flex;align-items:center;gap:3px;font-size:9px;font-weight:700;padding:1px 5px;background:rgba(59,130,246,.12);border:1px solid rgba(59,130,246,.22);color:rgb(96,165,250)">
 													<svg style="width:7px;height:7px" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
-													ÉCRAN
+													{tFn('voice.screen_badge')}
 												</span>
 											{/if}
 											{#if isStreaming}
@@ -1691,12 +1691,12 @@
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div class="bg-gray-900 border border-gray-700 rounded-2xl shadow-2xl w-full max-w-sm mx-4 p-5"
 			onclick={(e) => e.stopPropagation()}>
-			<h2 class="text-sm font-bold text-white mb-4">Définir ton statut</h2>
+			<h2 class="text-sm font-bold text-white mb-4">{tFn('status.modal_title')}</h2>
 
 			<!-- Current status preview -->
 			<div class="flex items-center gap-2.5 mb-4 px-3 py-2 bg-gray-800 rounded-xl border border-gray-700">
 				<span class="text-xl w-8 text-center">{statusEmoji || '😶'}</span>
-				<span class="text-sm text-gray-300 flex-1 truncate">{statusText || 'Aucun statut'}</span>
+				<span class="text-sm text-gray-300 flex-1 truncate">{statusText || tFn('status.none')}</span>
 			</div>
 
 			<!-- Emoji + text inputs -->
@@ -1710,7 +1710,7 @@
 				/>
 				<input
 					type="text"
-					placeholder="Ce que tu fais…"
+					placeholder={tFn('status.placeholder')}
 					bind:value={statusText}
 					maxlength={60}
 					class="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white placeholder-gray-500 outline-none focus:border-indigo-600 transition-colors"
@@ -1733,14 +1733,14 @@
 			<div class="flex gap-2">
 				{#if myStatus}
 					<button onclick={clearStatus} class="px-3 py-2 rounded-lg bg-gray-800 hover:bg-gray-700 text-xs text-gray-400 hover:text-white transition-colors">
-						Effacer
+						{tFn('common.clear')}
 					</button>
 				{/if}
 				<button onclick={() => showStatusModal = false} class="px-3 py-2 rounded-lg bg-gray-800 hover:bg-gray-700 text-xs text-gray-400 hover:text-white transition-colors ml-auto">
-					Annuler
+					{tFn('common.cancel')}
 				</button>
 				<button onclick={saveStatus} class="px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-xs text-white font-medium transition-colors">
-					Enregistrer
+					{tFn('common.save')}
 				</button>
 			</div>
 		</div>
@@ -1766,7 +1766,7 @@
 				{/if}
 				<span class="text-xs whitespace-nowrap">
 					<span class="font-bold" style="color: #e2e8f0">{evt.username}</span>
-					<span style="color: #4b5563"> {evt.action === 'join' ? 'a rejoint' : 'a quitté'} </span>
+					<span style="color: #4b5563"> {evt.action === 'join' ? tFn('presence.joined') : tFn('presence.left')} </span>
 					<span style="color: var(--nx-accent-2-soft)"># {evt.channelName}</span>
 				</span>
 				<div class="w-4 h-4 rounded-full flex items-center justify-center shrink-0"


### PR DESCRIPTION
First batch of the i18n audit (shell first, since it shows on every page).

`+layout.svelte` still had French hardcoded in the persistent chrome:
- Status modal: title, text placeholder, no-status label, clear / cancel / save buttons
- The `SCREEN` badge on members who are sharing
- `muted` / `deafened` aria-labels, and the close-announcement aria-label
- The join / left presence toast

10 new keys added across all 7 locales (`voice.muted_aria`, `voice.deafened_aria`, `voice.screen_badge`, `announcement.dismiss`, `status.modal_title`, `status.none`, `status.placeholder`, `common.clear`, `presence.joined`, `presence.left`); cancel/save reuse existing `common.*`.

fr/en are reviewed. es/de/ru/pt/vi are a solid first pass, flagged for native review (same model as the earlier community translations). Frontend only, `npm run check`: 0 errors.