### PR TITLE
chore(i18n): scan + coverage tooling, and key parity to 100%

### DIFF
--- a/nodyx-frontend/package.json
+++ b/nodyx-frontend/package.json
@@ -10,7 +10,9 @@
     "prepare": "svelte-kit sync || echo ''",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "test": "vitest run"
+    "test": "vitest run",
+    "i18n:scan": "node scripts/i18n/scan.mjs",
+    "i18n:coverage": "node scripts/i18n/coverage.mjs"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "7.0.1",

--- a/nodyx-frontend/scripts/i18n/README.md
+++ b/nodyx-frontend/scripts/i18n/README.md
@@ -1,0 +1,50 @@
+# i18n tooling
+
+Two small, dependency-free scripts to keep Nodyx fully translatable and catch
+hardcoded strings before they pile up.
+
+## The rule
+
+**Every user-facing string goes through a translation key. Nothing hardcoded.**
+Keys are written in English; strings are authored in French in `fr.json` (the
+source), mirrored to `en.json`, then translated into the other locales.
+
+## `npm run i18n:scan`
+
+Finds French text still living in Svelte markup **outside** an i18n call
+(`tFn(...)` / `$t(...)`). Since keys are English, any French left in a template
+is a string that was never extracted.
+
+```bash
+npm run i18n:scan              # count per file + total
+npm run i18n:scan -- --list    # show every offending line
+npm run i18n:scan -- --public  # ignore admin / studio (owner-only) pages
+npm run i18n:scan -- --check   # exit 1 if anything is found (CI gate)
+```
+
+The goal is **0** (public pages first, admin/studio next), then wire
+`--public --check` into CI so it never regresses.
+
+## `npm run i18n:coverage`
+
+Shows, per locale, how many keys are present vs missing. A missing key falls
+back to French at runtime, so coverage is the "what is left to translate"
+surface.
+
+```bash
+npm run i18n:coverage                 # coverage table
+npm run i18n:coverage -- --emit de    # print { key: source } missing in `de`
+```
+
+## Translating a language (contributors welcome)
+
+You do **not** need to hunt through the code. Everything is already extracted
+into keys:
+
+1. Pick your language (e.g. `de`) and run
+   `npm run i18n:coverage -- --emit de > de.todo.json`.
+2. Translate the **values** in that file (keep the keys and any `{{placeholders}}`).
+3. Merge them into `src/lib/locales/de.json` and open a PR.
+
+One merged translation PR earns a star on the Nodyx Stars wall. A native speaker
+sanity-checking existing wording counts too.

--- a/nodyx-frontend/scripts/i18n/coverage.mjs
+++ b/nodyx-frontend/scripts/i18n/coverage.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * i18n coverage / parity report.
+ *
+ * The canonical key set is the union of every locale file. For each locale it
+ * reports how many keys are present vs missing (a missing key falls back to fr
+ * at runtime, so it silently shows French). This is the "what is left to
+ * translate, per language" surface for contributors.
+ *
+ *   node scripts/i18n/coverage.mjs             coverage table
+ *   node scripts/i18n/coverage.mjs --emit de   print { key: source } for the keys
+ *                                              missing in `de`, ready to translate
+ *   node scripts/i18n/coverage.mjs --check     exit 1 if any locale is incomplete
+ */
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const DIR = join(HERE, '..', '..', 'src', 'lib', 'locales')
+const SOURCE = 'fr' // strings are authored in French
+
+const data = {}
+for (const f of readdirSync(DIR).filter((f) => f.endsWith('.json'))) {
+  data[f.replace('.json', '')] = JSON.parse(readFileSync(join(DIR, f), 'utf8'))
+}
+
+const canonical = new Set()
+for (const d of Object.values(data)) for (const k of Object.keys(d)) canonical.add(k)
+const total = canonical.size
+const src = data[SOURCE] ?? {}
+
+const argv = process.argv.slice(2)
+const emit = argv.includes('--emit') ? argv[argv.indexOf('--emit') + 1] : null
+const check = argv.includes('--check')
+
+if (emit) {
+  if (!data[emit]) { console.error(`Unknown locale: ${emit}`); process.exit(2) }
+  const have = new Set(Object.keys(data[emit]))
+  const stub = {}
+  for (const k of canonical) if (!have.has(k)) stub[k] = src[k] ?? data.en?.[k] ?? ''
+  console.log(JSON.stringify(stub, null, 2))
+  process.exit(0)
+}
+
+console.log(`Canonical keys: ${total}  (source: ${SOURCE})\n`)
+console.log('locale    keys   missing   coverage')
+console.log('-------   ----   -------   --------')
+let incomplete = 0
+for (const loc of Object.keys(data).sort()) {
+  const have = Object.keys(data[loc]).length
+  const missing = total - have
+  if (missing > 0) incomplete++
+  const pct = ((have / total) * 100).toFixed(1)
+  console.log(`${loc.padEnd(7)}  ${String(have).padStart(4)}   ${String(missing).padStart(6)}    ${pct.padStart(6)}%`)
+}
+console.log(`\nTip: node scripts/i18n/coverage.mjs --emit <locale>  ->  keys left to translate.`)
+if (check && incomplete > 0) process.exit(1)

--- a/nodyx-frontend/scripts/i18n/scan.mjs
+++ b/nodyx-frontend/scripts/i18n/scan.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * i18n hardcoded-string scanner (the guardrail).
+ *
+ * Flags French text living in Svelte markup OUTSIDE an i18n call (`tFn(` / `$t(`).
+ * Rationale: translation keys are written in English, so any French left in a
+ * template is, by construction, a string that was never extracted. Getting this
+ * to 0 (and keeping it there via CI) is how we guarantee "nothing hardcoded".
+ *
+ *   node scripts/i18n/scan.mjs            summary per file + total
+ *   node scripts/i18n/scan.mjs --list     also print every offending line
+ *   node scripts/i18n/scan.mjs --public   ignore admin / studio (owner-only) pages
+ *   node scripts/i18n/scan.mjs --check    exit 1 if anything is found (CI gate)
+ */
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, dirname, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const SRC = join(HERE, '..', '..', 'src')
+
+const args = new Set(process.argv.slice(2))
+const LIST = args.has('--list')
+const CHECK = args.has('--check')
+const PUBLIC_ONLY = args.has('--public')
+
+// French signal: accented letters, or a common French UI word.
+const ACC = /[àâäéèêëïîôùûüÿçœÀÂÄÉÈÊËÏÎÔÙÛÜŸÇŒ]/
+const FR = /\b(Supprimer|Annuler|Enregistrer|Modifier|Ajouter|Envoyer|Fermer|Retour|Suivant|Rechercher|Aucune?|Nouvelle?|Nouveau|Charger|Membres?|Voir|Connexion|Inscription|Brouillon|Publier|Choisir|Copier|Partager|Effacer|Enlever|Ouvrir|Bienvenue|Attention|Erreur|Chargement)\b/
+
+const isAdmin = (p) =>
+  p.includes('/routes/admin/') || p.includes('/components/admin/') ||
+  /(streamer-hub|\/obs\/|StreamControl|StudioEngagement|RewardsManager|PlaylistSidebar|SoundLibrary|ChatTimers|ChatCommands|DeckEditor|OverlayManager|AlertBox)/.test(p)
+
+function walk(dir, out = []) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name)
+    if (e.isDirectory()) walk(p, out)
+    else if (e.name.endsWith('.svelte')) out.push(p)
+  }
+  return out
+}
+
+// Blank out comments/styles but KEEP newlines, so line numbers stay accurate.
+const blank = (m) => m.replace(/[^\n]/g, ' ')
+const clean = (txt) => txt
+  .replace(/<style[\s\S]*?<\/style>/g, blank)
+  .replace(/<!--[\s\S]*?-->/g, blank)
+  .replace(/\/\*[\s\S]*?\*\//g, blank)
+
+const files = walk(SRC).sort()
+let total = 0
+const perFile = []
+for (const f of files) {
+  if (PUBLIC_ONLY && isAdmin(f)) continue
+  const hits = []
+  clean(readFileSync(f, 'utf8')).split('\n').forEach((l, i) => {
+    if (l.includes('tFn(') || l.includes('$t(')) return
+    const s = l.trim()
+    if (!s || s.startsWith('//') || s.startsWith('*') || s.startsWith('import ') || s.startsWith('console.')) return
+    if (ACC.test(l) || FR.test(l)) hits.push({ n: i + 1, s: s.slice(0, 100) })
+  })
+  if (hits.length) { perFile.push({ f: relative(SRC, f), hits }); total += hits.length }
+}
+
+perFile.sort((a, b) => b.hits.length - a.hits.length)
+for (const { f, hits } of perFile) {
+  console.log(`${String(hits.length).padStart(4)}  ${f}`)
+  if (LIST) for (const h of hits) console.log(`        ${h.n}: ${h.s}`)
+}
+console.log(`\n${total} hardcoded French string(s) in ${perFile.length} file(s)${PUBLIC_ONLY ? ' (public only)' : ''}.`)
+if (CHECK && total > 0) process.exit(1)

--- a/nodyx-frontend/src/lib/locales/de.json
+++ b/nodyx-frontend/src/lib/locales/de.json
@@ -966,5 +966,6 @@
   "status.placeholder": "Was du gerade machst…",
   "common.clear": "Löschen",
   "presence.joined": "ist beigetreten",
-  "presence.left": "hat verlassen"
+  "presence.left": "hat verlassen",
+  "editor.toc": "Automatisches Inhaltsverzeichnis (Anker an den Überschriften)"
 }

--- a/nodyx-frontend/src/lib/locales/es.json
+++ b/nodyx-frontend/src/lib/locales/es.json
@@ -966,5 +966,6 @@
   "status.placeholder": "Lo que estás haciendo…",
   "common.clear": "Borrar",
   "presence.joined": "se unió a",
-  "presence.left": "salió de"
+  "presence.left": "salió de",
+  "editor.toc": "Índice automático (anclas en los títulos)"
 }


### PR DESCRIPTION
Foundation for the i18n cleanup, so we extract strings **once** and never chase the same ones twice.

**`npm run i18n:scan`** finds French text hardcoded in Svelte markup (outside `tFn`/`$t`). It is the guardrail: the goal is 0, then `--public --check` becomes a CI gate so nothing regresses. Current baseline: **2122** hardcoded strings (891 on public pages, the rest admin/studio).

**`npm run i18n:coverage`** reports missing keys per locale and can emit ready-to-translate stubs (`--emit <locale>`), so a contributor never has to dig through code, just fills values.

Also translated the single key (`editor.toc`) that es and de were missing: **all 7 locales are now at 100%** on the existing 969 keys.

Docs in `scripts/i18n/README.md`. No dependency, frontend-only.