### PR TITLE
fix(ssr): guard localStorage with browser, not typeof (Node 22.4+ crash)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -98,11 +98,11 @@ One merged PR = one star. Typos count. Translations count. Bug reports that turn
         <sub><b>JoeJoeflyn</b></sub>
       </a>
       <br/>
-      <sub>🌟 × 2</sub>
+      <sub>🌟 × 3</sub>
       <br/>
-      <sub><a href="https://github.com/Pokled/nodyx/pull/306">PR #306</a> · <a href="https://github.com/Pokled/nodyx/pull/314">PR #314</a></sub>
+      <sub><a href="https://github.com/Pokled/nodyx/pull/306">PR #306</a> · <a href="https://github.com/Pokled/nodyx/pull/314">PR #314</a> · <a href="https://github.com/Pokled/nodyx/issues/327">#327</a></sub>
       <br/>
-      <sub><em>Vietnamese (vi) translation + guest-accessible language picker</em></sub>
+      <sub><em>Vietnamese translation, guest language picker, SSR crash report</em></sub>
       <br/>
       <sub><strong>First Vietnamese contributor 🇻🇳</strong></sub>
     </td>
@@ -172,6 +172,7 @@ Sometimes a contribution isn't a PR. Sometimes it's just being there at exactly 
 
 | Contributor | Contribution | Type | Issue / PR | Fix / polish | Date |
 |---|---|---|---|---|---|
+| [@JoeJoeflyn](https://github.com/JoeJoeflyn) | Reported the SSR 500 on Node 22.4+ / 25+: the new global `localStorage` proxy makes `typeof localStorage === 'undefined'` return false while its methods still throw, breaking the guard in `voiceSettings.ts` and 4 other files. Pinpointed the exact lines and the upstream Node issue. | `bug(ssr)` | [#327](https://github.com/Pokled/nodyx/issues/327) | browser-guard fix (this PR) | 2026-07-20 |
 | [@JoeJoeflyn](https://github.com/JoeJoeflyn) | Moved the language picker out of `/settings` into a guest-accessible layout pane, and read the locale from a cookie in `hooks.server.ts` so SSR paints the right language on first load (no flash from `fr`), auto-detecting the browser's `Accept-Language`. | `feat(lang)` | [#314](https://github.com/Pokled/nodyx/pull/314) | [`c5c3822`](https://github.com/Pokled/nodyx/commit/c5c3822), polish below | 2026-07-19 |
 | [@JoeJoeflyn](https://github.com/JoeJoeflyn) | Vietnamese (vi) translation: 955 strings, full key + placeholder parity with `en.json`, wired into the locale switch (label, flag, navigator detection). Restored 5 dropped interpolation variables and reverted a placeholder URL on review. | `feat(i18n)` | [#306](https://github.com/Pokled/nodyx/pull/306) | [`bc31f37`](https://github.com/Pokled/nodyx/commit/bc31f37) | 2026-07-18 |
 | [@schlaggi](https://github.com/schlaggi) | Reported one-click installer false-positive DNS mismatch on dual-stack machines: `getent hosts` returns mixed-family (A or AAAA depending on `/etc/nsswitch.conf`), then the script compared the resolved IPv6 against the locally-detected IPv4 → bogus "mismatch", Let's Encrypt step refused to proceed. Fix: family-aware resolution via `getent ahostsv4` / `ahostsv6` + optional public IPv6 detection. | `bug(installer)` | [#29](https://github.com/Pokled/nodyx/issues/29) | _to fill on merge_ | 2026-05-18 |

--- a/nodyx-frontend/src/lib/components/StageView.svelte
+++ b/nodyx-frontend/src/lib/components/StageView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { onDestroy } from 'svelte'
+    import { browser } from '$app/environment'
     import {
         localScreenStore,
         remoteScreenStore,
@@ -21,10 +22,10 @@
     // chercher un bouton. Une flèche le replie (et le rouvre). Le choix est
     // mémorisé : on ne le rouvre pas de force à celui qui l'a replié.
     let showChat = $state(
-        typeof localStorage === 'undefined' || localStorage.getItem('nodyx:stage:chat') !== '0',
+        !browser || localStorage.getItem('nodyx:stage:chat') !== '0',
     )
     $effect(() => {
-        if (typeof localStorage !== 'undefined') {
+        if (browser) {
             localStorage.setItem('nodyx:stage:chat', showChat ? '1' : '0')
         }
     })

--- a/nodyx-frontend/src/lib/components/VoiceRoom.svelte
+++ b/nodyx-frontend/src/lib/components/VoiceRoom.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import Table        from '$lib/components/Table.svelte';
 	import NodyxCanvas  from '$lib/components/NodyxCanvas.svelte';
 	import VoiceJukebox from '$lib/components/VoiceJukebox.svelte';
@@ -42,10 +43,10 @@
 	// fil de discussion que pour les canaux TEXTE (`{:else}` côté +page.svelte).
 	// On l'ajoute ici, à droite, OUVERT par défaut et repliable d'une flèche.
 	let showChatPanel = $state(
-		typeof localStorage === 'undefined' || localStorage.getItem('nodyx:voice:chat') !== '0',
+		!browser || localStorage.getItem('nodyx:voice:chat') !== '0',
 	);
 	$effect(() => {
-		if (typeof localStorage !== 'undefined') {
+		if (browser) {
 			localStorage.setItem('nodyx:voice:chat', showChatPanel ? '1' : '0');
 		}
 	});

--- a/nodyx-frontend/src/lib/emojiUsage.ts
+++ b/nodyx-frontend/src/lib/emojiUsage.ts
@@ -6,18 +6,19 @@
  * Clé = un emoji unicode ('🔥') OU un shortcode custom (':rat:').
  */
 import { writable } from 'svelte/store'
+import { browser } from '$app/environment'
 
 const KEY = 'nodyx:emojiUsage'
 
 function load(): Record<string, number> {
-	if (typeof localStorage === 'undefined') return {}
+	if (!browser) return {}
 	try { return JSON.parse(localStorage.getItem(KEY) || '{}') } catch { return {} }
 }
 
 export const emojiUsageStore = writable<Record<string, number>>(load())
 
 export function bumpEmoji(emoji: string): void {
-	if (typeof localStorage === 'undefined' || !emoji) return
+	if (!browser || !emoji) return
 	emojiUsageStore.update(u => {
 		const next = { ...u, [emoji]: (u[emoji] || 0) + 1 }
 		try { localStorage.setItem(KEY, JSON.stringify(next)) } catch { /* quota */ }

--- a/nodyx-frontend/src/lib/jukebox.ts
+++ b/nodyx-frontend/src/lib/jukebox.ts
@@ -6,6 +6,7 @@
  *              peers apply position + elapsed time drift on receive
  */
 import { writable, get } from 'svelte/store'
+import { browser } from '$app/environment'
 import type { Socket } from 'socket.io-client'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -47,12 +48,12 @@ export const jukeboxStore = writable<JukeboxState>({ ..._INIT })
 
 // Per-user volume + mute — localStorage-backed, never broadcast
 function _lsNum(key: string, def: number) {
-  if (typeof localStorage === 'undefined') return def
+  if (!browser) return def
   const v = localStorage.getItem(key)
   return v !== null ? +v : def
 }
 function _lsBool(key: string, def: boolean) {
-  if (typeof localStorage === 'undefined') return def
+  if (!browser) return def
   const v = localStorage.getItem(key)
   return v !== null ? v === '1' : def
 }
@@ -178,7 +179,7 @@ export async function mountYTPlayer(containerId: string): Promise<void> {
 export function jukeboxSetVolume(v: number): void {
   const vol = Math.max(0, Math.min(100, Math.round(v)))
   jukeboxVolume.set(vol)
-  if (typeof localStorage !== 'undefined') localStorage.setItem('jb_vol', String(vol))
+  if (browser) localStorage.setItem('jb_vol', String(vol))
   if (!_ytPlayer || !_ytReady) return
   _ytPlayer.setVolume(vol)
   if (vol === 0) _ytPlayer.mute()
@@ -188,7 +189,7 @@ export function jukeboxSetVolume(v: number): void {
 export function jukeboxToggleMute(): void {
   const muted = !get(jukeboxMuted)
   jukeboxMuted.set(muted)
-  if (typeof localStorage !== 'undefined') localStorage.setItem('jb_muted', muted ? '1' : '0')
+  if (browser) localStorage.setItem('jb_muted', muted ? '1' : '0')
   if (!_ytPlayer || !_ytReady) return
   if (muted) _ytPlayer.mute()
   else { _ytPlayer.unMute(); _ytPlayer.setVolume(get(jukeboxVolume)) }

--- a/nodyx-frontend/src/lib/voiceSettings.ts
+++ b/nodyx-frontend/src/lib/voiceSettings.ts
@@ -2,6 +2,7 @@
  * Nodyx Voice Settings — store persisté dans localStorage
  */
 import { writable } from 'svelte/store'
+import { browser } from '$app/environment'
 
 export interface VoiceSettings {
   /** Gain micro 0.1–2.0 (1.0 = nominal, 2.0 = boost ×2)  */
@@ -45,7 +46,7 @@ const DEFAULTS: VoiceSettings = {
 }
 
 function _load(): VoiceSettings {
-  if (typeof localStorage === 'undefined') return { ...DEFAULTS }
+  if (!browser) return { ...DEFAULTS }
   try {
     const raw = localStorage.getItem('nodyx:voiceSettings')
     if (!raw) return { ...DEFAULTS }
@@ -59,7 +60,7 @@ export const voiceSettingsStore = writable<VoiceSettings>(_load())
 
 // Persist every change
 voiceSettingsStore.subscribe(v => {
-  if (typeof localStorage !== 'undefined') {
+  if (browser) {
     localStorage.setItem('nodyx:voiceSettings', JSON.stringify(v))
   }
 })
@@ -70,7 +71,7 @@ voiceSettingsStore.subscribe(v => {
 const PEER_VOL_KEY = 'nodyx:peerVolumes'
 
 export function loadPeerVolumes(): Record<string, number> {
-  if (typeof localStorage === 'undefined') return {}
+  if (!browser) return {}
   try { return JSON.parse(localStorage.getItem(PEER_VOL_KEY) || '{}') } catch { return {} }
 }
 
@@ -80,7 +81,7 @@ export function getPeerVolume(userId: string): number {
 }
 
 export function savePeerVolume(userId: string, volume: number): void {
-  if (typeof localStorage === 'undefined' || !userId) return
+  if (!browser || !userId) return
   const all = loadPeerVolumes()
   all[userId] = volume
   try { localStorage.setItem(PEER_VOL_KEY, JSON.stringify(all)) } catch { /* quota */ }


### PR DESCRIPTION
Fixes #327 (thanks @JoeJoeflyn for the report and the exact root cause).

**Bug:** Node 22.4+ / 25+ exposes a global `localStorage` proxy. `typeof localStorage === 'undefined'` then returns `false` during SSR, but the methods still throw, so `localStorage.setItem` crashes the render (500 on every request when web storage is on). See nodejs/node#60303.

**Fix:** replace the `typeof localStorage` guard with SvelteKit's `browser` flag from `$app/environment` (the canonical SSR guard, immune to Node's global) across the 5 files that had it: `voiceSettings.ts`, `jukebox.ts`, `emojiUsage.ts`, `VoiceRoom.svelte`, `StageView.svelte`.

Prod was not crashing (it runs without `--experimental-webstorage`), but contributors on recent Node could not run `npm run dev`. @JoeJoeflyn moves to 3 stars for the report. `npm run check`: 0 errors.