### PR TITLE
chore(installer): use npm ci for reproducible installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -972,7 +972,7 @@ _nodyx_upgrade() {
 
   info "$(t backend_rebuild)"
   cd "${dir}/nodyx-core"
-  npm install --no-fund --no-audit --silent || die "$(t npm_install_backend_fail)"
+  npm ci --no-fund --no-audit --silent || die "$(t npm_install_backend_fail)"
   npm run build || die "$(t backend_build_fail)"
   ok "$(t backend_built)"
 
@@ -985,7 +985,7 @@ _nodyx_upgrade() {
   elif [[ "$_RB_RAM_MB" -lt 8000 ]]; then export NODE_OPTIONS="--max-old-space-size=2048"
   else                                    export NODE_OPTIONS="--max-old-space-size=4096"
   fi
-  npm install --no-fund --no-audit --silent || die "$(t npm_install_frontend_fail)"
+  npm ci --no-fund --no-audit --silent || die "$(t npm_install_frontend_fail)"
   npm run build || die "$(t frontend_build_fail)"
   unset NODE_OPTIONS
   ok "$(t frontend_built)"
@@ -2477,7 +2477,7 @@ SFUCORE
 fi
 
 cd "${NODYX_DIR}/nodyx-core"
-run_bg "$(t backend_npm_install_label)" npm install --no-fund --no-audit \
+run_bg "$(t backend_npm_install_label)" npm ci --no-fund --no-audit \
   || die "$(t backend_npm_install_fail2)"
 run_bg "$(t backend_compile_label)" npm run build \
   || die "$(t backend_build_fail2)"
@@ -2506,7 +2506,7 @@ PUBLIC_TURN_CREDENTIAL=
 FEENV
 
 cd "${NODYX_DIR}/nodyx-frontend"
-run_bg "$(t front_npm_install_label)" npm install --no-fund --no-audit \
+run_bg "$(t front_npm_install_label)" npm ci --no-fund --no-audit \
   || die "$(t front_npm_install_fail2)"
 
 # On ARM64: ensure native Rollup binary is present
@@ -3067,13 +3067,13 @@ git -C "$NODYX_DIR" pull --ff-only || die "git pull échoué. Vérifie ta connex
 
 info "Rebuild backend..."
 cd "${NODYX_DIR}/nodyx-core"
-npm install --no-fund --no-audit --silent
+npm ci --no-fund --no-audit --silent
 npm run build || die "Build backend échoué."
 ok "Backend compilé"
 
 info "Rebuild frontend..."
 cd "${NODYX_DIR}/nodyx-frontend"
-npm install --no-fund --no-audit --silent
+npm ci --no-fund --no-audit --silent
 npm run build || die "Build frontend échoué."
 ok "Frontend compilé"
 

--- a/install_tunnel.sh
+++ b/install_tunnel.sh
@@ -829,13 +829,13 @@ _nodyx_upgrade() {
 
   info "$(t backend_rebuild)"
   cd "${NODYX_DIR}/nodyx-core"
-  run_bg "npm install (backend)" npm install --no-fund --no-audit
+  run_bg "npm install (backend)" npm ci --no-fund --no-audit
   run_bg "npm run build (backend)" npm run build
   ok "$(t backend_built)"
 
   info "$(t frontend_rebuild)"
   cd "${NODYX_DIR}/nodyx-frontend"
-  run_bg "npm install (frontend)" npm install --no-fund --no-audit
+  run_bg "npm install (frontend)" npm ci --no-fund --no-audit
   run_bg "npm run build (frontend)" npm run build
   ok "$(t frontend_built)"
 
@@ -1355,7 +1355,7 @@ COREENV
 )
 
 cd "${NODYX_DIR}/nodyx-core"
-run_bg "npm install (backend)" npm install --no-fund --no-audit \
+run_bg "npm install (backend)" npm ci --no-fund --no-audit \
   || die "Backend npm install failed."
 run_bg "TypeScript compile (backend)" npm run build \
   || die "Backend build failed."
@@ -1394,7 +1394,7 @@ FEENV
 )
 
 cd "${NODYX_DIR}/nodyx-frontend"
-run_bg "npm install (frontend)" npm install --no-fund --no-audit \
+run_bg "npm install (frontend)" npm ci --no-fund --no-audit \
   || die "Frontend npm install failed."
 run_bg "SvelteKit build (2-5 min on ARM)" npm run build \
   || die "Frontend build failed."
@@ -1824,13 +1824,13 @@ fi
 
 info "Rebuild backend..."
 cd "${NODYX_DIR}/nodyx-core"
-npm install --no-fund --no-audit --silent
+npm ci --no-fund --no-audit --silent
 npm run build || die "Backend build failed."
 ok "Backend compiled"
 
 info "Rebuild frontend..."
 cd "${NODYX_DIR}/nodyx-frontend"
-npm install --no-fund --no-audit --silent
+npm ci --no-fund --no-audit --silent
 npm run build || die "Frontend build failed."
 ok "Frontend compiled"
 


### PR DESCRIPTION
**Why:** the installers ran `npm install`, which honors `package.json` ranges rather than the lockfile. So the ~10 caret-pinned core deps (`fastify: ^5.9.0`, `adm-zip: ^0.6.0`, `nodemailer`, `music-metadata`, ...) drifted to the latest compatible version on every new install, ignoring the committed `package-lock.json`. A silent breaking change in any of them would break a fresh self-hosted install while existing instances kept running. (This is exactly the argon2-0.45-style trap, except argon2 is exact-pinned so it dodges it.)

**Fix:** switch the **12 project installs** (backend + frontend, across the fresh / update / repair paths in both `install.sh` and `install_tunnel.sh`) from `npm install` to `npm ci`, which installs the exact lockfile versions that CI validates. Reproducible, and faster.

**Safety checks:** lockfiles verified in sync (`npm ci --dry-run` passes on core + frontend); only the project installs changed; `npm install -g pm2` and the ARM64 `@rollup/... --no-save` fallback are untouched; `bash -n` passes on both scripts. `npm ci` also handles per-platform optional deps more reliably than `npm install` (the bug the ARM64 fallback works around).