### PR TITLE
chore(deps): never auto-bump argon2 (manual review only)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,17 @@ updates:
       core-minor-patch:
         applies-to: version-updates
         update-types: ["minor", "patch"]
+    # ── argon2 : JAMAIS de bump automatique ─────────────────────────────────
+    # argon2 hache les mots de passe. Après l'incident de sécurité de mars 2026,
+    # on ne laisse aucun bot toucher cette brique à l'aveugle : on la met à jour
+    # À LA MAIN, avec revue, et uniquement pour une raison de sécurité réelle.
+    # Déclencheur concret : argon2 0.45.0 a RETIRÉ le type `Options` (rupture
+    # silencieuse, même pas dans les release notes) qui a cassé le build du core,
+    # pour zéro bénéfice (juste README/Solaris/abandon Node 18-20). cf PR #329.
+    # La version reste épinglée exacte dans package.json ; cet `ignore` empêche
+    # Dependabot de re-proposer le bump dans le groupe.
+    ignore:
+      - dependency-name: "argon2"
 
   # ── 2. nodyx-frontend (npm) ─────────────────────────────────────────────
   - package-ecosystem: "npm"


### PR DESCRIPTION
Follow-up to #329. **argon2 hashes passwords**, so after the March 2026 security incident we do not let Dependabot bump it blindly. It gets manual, reviewed updates only, and only for a real security reason.

**Why now:** argon2 0.45.0 silently removed the `Options` type (not documented in the release notes), which broke the core build (`user.ts`) for zero benefit (just README / Solaris / dropping Node 18-20 support). So #329 fails CI on core.

**This PR** adds `argon2` to the Dependabot `ignore` list for `/nodyx-core`, with a comment explaining the reasoning, so the `core-minor-patch` group re-opens **without argon2** and we still get the good bumps (the `sanitize-html` security patch, `fastify`, `re2`). The version stays exact-pinned in `package.json`, and installs are now lockfile-exact via `npm ci` (#334).