### PR TITLE
i18n(layout): re-key strings hardcoded by #324 + scan attributes in any language

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -98,11 +98,11 @@ One merged PR = one star. Typos count. Translations count. Bug reports that turn
         <sub><b>JoeJoeflyn</b></sub>
       </a>
       <br/>
-      <sub>🌟 × 3</sub>
+      <sub>🌟 × 4</sub>
       <br/>
-      <sub><a href="https://github.com/Pokled/nodyx/pull/306">PR #306</a> · <a href="https://github.com/Pokled/nodyx/pull/314">PR #314</a> · <a href="https://github.com/Pokled/nodyx/issues/327">#327</a></sub>
+      <sub><a href="https://github.com/Pokled/nodyx/pull/306">PR #306</a> · <a href="https://github.com/Pokled/nodyx/pull/314">PR #314</a> · <a href="https://github.com/Pokled/nodyx/issues/327">#327</a> · <a href="https://github.com/Pokled/nodyx/pull/324">PR #324</a></sub>
       <br/>
-      <sub><em>Vietnamese translation, guest language picker, SSR crash report</em></sub>
+      <sub><em>Vietnamese, guest language picker, SSR crash report, collapsible members sidebar</em></sub>
       <br/>
       <sub><strong>First Vietnamese contributor 🇻🇳</strong></sub>
     </td>
@@ -172,6 +172,7 @@ Sometimes a contribution isn't a PR. Sometimes it's just being there at exactly 
 
 | Contributor | Contribution | Type | Issue / PR | Fix / polish | Date |
 |---|---|---|---|---|---|
+| [@JoeJoeflyn](https://github.com/JoeJoeflyn) | Collapsible members sidebar with a spring/swipe toggle and a shared collapse store, plus an SSR fetch of the channel list so channels show on first paint. Tidied inline styles into Tailwind along the way. | `feat(ui)` | [#324](https://github.com/Pokled/nodyx/pull/324) | [`1142b2e`](https://github.com/Pokled/nodyx/commit/1142b2e) + i18n polish below | 2026-07-20 |
 | [@JoeJoeflyn](https://github.com/JoeJoeflyn) | Reported the SSR 500 on Node 22.4+ / 25+: the new global `localStorage` proxy makes `typeof localStorage === 'undefined'` return false while its methods still throw, breaking the guard in `voiceSettings.ts` and 4 other files. Pinpointed the exact lines and the upstream Node issue. | `bug(ssr)` | [#327](https://github.com/Pokled/nodyx/issues/327) | browser-guard fix (this PR) | 2026-07-20 |
 | [@JoeJoeflyn](https://github.com/JoeJoeflyn) | Moved the language picker out of `/settings` into a guest-accessible layout pane, and read the locale from a cookie in `hooks.server.ts` so SSR paints the right language on first load (no flash from `fr`), auto-detecting the browser's `Accept-Language`. | `feat(lang)` | [#314](https://github.com/Pokled/nodyx/pull/314) | [`c5c3822`](https://github.com/Pokled/nodyx/commit/c5c3822), polish below | 2026-07-19 |
 | [@JoeJoeflyn](https://github.com/JoeJoeflyn) | Vietnamese (vi) translation: 955 strings, full key + placeholder parity with `en.json`, wired into the locale switch (label, flag, navigator detection). Restored 5 dropped interpolation variables and reverted a placeholder URL on review. | `feat(i18n)` | [#306](https://github.com/Pokled/nodyx/pull/306) | [`bc31f37`](https://github.com/Pokled/nodyx/commit/bc31f37) | 2026-07-18 |
@@ -232,6 +233,16 @@ Caught during production testing after merge. Not visible in async review.
 - Restored the native `Tiếng Việt` label (the PR had switched it to the English `Vietnamese`, while every other locale carries its own name).
 
 Landed after the merge but before the feature was deployed, so production never served the unvalidated attribute. The idea and the feature are entirely his; we just tightened the one line that touched untrusted input.
+
+### PR [#324](https://github.com/Pokled/nodyx/pull/324) · @JoeJoeflyn · `feat: collapsible members sidebar`
+
+**Original PR:** merged as-is. Genuinely nice work: the members sidebar collapses with a spring/swipe toggle (the handler cleanly tells a numeric swipe velocity from a click), a shared collapse store, and an SSR fetch of the channel list so channels appear on first paint instead of after hydration. Inline styles tidied into Tailwind.
+
+**Polish (same cleanup PR):** `i18n(layout): re-key the strings the refactor hardcoded`
+- The CSS cleanup re-hardcoded a handful of strings that were already keyed: the `SCREEN` sharing badge (back to `voice.screen_badge`), and the new controls shipped with hardcoded English attributes (`aria-label="Close"`, `title="Settings"`, `"Toggle members sidebar"`, `alt="Avatar"`/`"Logo"`, ...). Routed back through i18n (reusing `common.close`, `nav.settings` / `nav.admin` / `nav.documentation`, plus new `nav.docs`, `members.toggle_aria`, `common.avatar_alt`, `common.logo_alt`), French source filled, new keys handed to the translation surface.
+- His PR also revealed a gap: our scanner only caught French, so it missed a contributor's English strings. Extended `i18n:scan` to flag hardcoded **translatable attributes** (`aria-label`, `title`, `placeholder`, `alt`, `data-tip`) in any language. It immediately surfaced ~130 more previously invisible strings across the app.
+
+The feature and the idea are entirely his. Everything we build must be translatable, contributor PRs included, so this is exactly the merge-then-polish loop doing its job.
 
 ---
 

--- a/nodyx-frontend/scripts/i18n/README.md
+++ b/nodyx-frontend/scripts/i18n/README.md
@@ -15,6 +15,11 @@ Finds French text still living in Svelte markup **outside** an i18n call
 (`tFn(...)` / `$t(...)`). Since keys are English, any French left in a template
 is a string that was never extracted.
 
+It also flags hardcoded **translatable attributes** (`aria-label`, `title`,
+`placeholder`, `alt`, `data-tip`) with a literal value, in **any** language, so
+English strings from contributors are caught too (the French heuristic misses
+those). An `attr={tFn(...)}` uses braces, not quotes, so it is never flagged.
+
 ```bash
 npm run i18n:scan              # count per file + total
 npm run i18n:scan -- --list    # show every offending line

--- a/nodyx-frontend/scripts/i18n/scan.mjs
+++ b/nodyx-frontend/scripts/i18n/scan.mjs
@@ -53,6 +53,12 @@ const clean = (txt) => txt
   .map((l) => l.replace(/(?<!:)\/\/.*$/, (m) => ' '.repeat(m.length)))
   .join('\n')
 
+// Hardcoded translatable attributes, in ANY language (catches English too, which
+// the French heuristic misses). A literal value holding a letter is user-facing.
+// `attr={tFn(...)}` uses braces, not quotes, so it is never matched here.
+const ATTR = /(?:aria-label|title|placeholder|alt|data-tip)="([^"]*)"/g
+const LETTER = /[A-Za-zÀ-ÖØ-öø-ÿ]/
+
 const files = walk(SRC).sort()
 let total = 0
 const perFile = []
@@ -60,10 +66,15 @@ for (const f of files) {
   if (PUBLIC_ONLY && isAdmin(f)) continue
   const hits = []
   clean(readFileSync(f, 'utf8')).split('\n').forEach((l, i) => {
-    if (l.includes('tFn(') || l.includes('$t(')) return
     const s = l.trim()
     if (!s || s.startsWith('//') || s.startsWith('*') || s.startsWith('import ') || s.startsWith('console.')) return
-    if (ACC.test(l) || FR.test(l)) hits.push({ n: i + 1, s: s.slice(0, 100) })
+    // (a) a translatable attribute holding hardcoded literal text (any language)
+    let attrHit = false
+    ATTR.lastIndex = 0
+    for (let m; (m = ATTR.exec(l)); ) { if (LETTER.test(m[1])) { attrHit = true; break } }
+    // (b) French text sitting outside an i18n call
+    const frHit = !l.includes('tFn(') && !l.includes('$t(') && (ACC.test(l) || FR.test(l))
+    if (attrHit || frHit) hits.push({ n: i + 1, s: s.slice(0, 100) })
   })
   if (hits.length) { perFile.push({ f: relative(SRC, f), hits }); total += hits.length }
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -1083,5 +1083,9 @@
   "event.title_placeholder": "Concert, game jam, réunion mensuelle...",
   "event.creating": "Création...",
   "event.create_event": "Créer l'événement",
-  "event.gps_display_hint": "(pour afficher la carte)"
+  "event.gps_display_hint": "(pour afficher la carte)",
+  "nav.docs": "Docs",
+  "members.toggle_aria": "Afficher ou masquer les membres",
+  "common.avatar_alt": "Avatar",
+  "common.logo_alt": "Logo"
 }

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -739,7 +739,7 @@
 					        aria-haspopup="true" aria-expanded={dropdownOpen}>
 						<div class="relative shrink-0">
 							{#if user.avatar}
-								<img src={user.avatar} alt="Avatar" class="w-6 h-6 object-cover" style="outline: 1px solid rgba(255,255,255,.15)" />
+								<img src={user.avatar} alt={tFn('common.avatar_alt')} class="w-6 h-6 object-cover" style="outline: 1px solid rgba(255,255,255,.15)" />
 							{:else}
 								<div class="w-6 h-6 flex items-center justify-center text-xs font-bold text-white select-none" style="background: linear-gradient(135deg, var(--nx-accent-2-strong), var(--nx-cyan-deep))">{user.username.charAt(0).toUpperCase()}</div>
 							{/if}
@@ -755,7 +755,7 @@
 								<div class="px-4 pt-4 pb-3 bg-gray-800/50">
 									<div class="flex items-center gap-3">
 										{#if user.avatar}
-											<img src={user.avatar} alt="Avatar" class="w-12 h-12 rounded-full object-cover border-2 border-gray-600 shrink-0" />
+											<img src={user.avatar} alt={tFn('common.avatar_alt')} class="w-12 h-12 rounded-full object-cover border-2 border-gray-600 shrink-0" />
 										{:else}
 											<div class="w-12 h-12 rounded-full bg-indigo-700 flex items-center justify-center text-white text-xl font-bold border-2 border-gray-600 shrink-0 select-none">{user.username.charAt(0).toUpperCase()}</div>
 										{/if}
@@ -862,7 +862,7 @@
 					}
 				}}>
 					{#if communityLogo}
-						<img src={communityLogo} alt="Logo" class="w-full h-full object-cover" />
+						<img src={communityLogo} alt={tFn('common.logo_alt')} class="w-full h-full object-cover" />
 					{:else}
 						{communityName.charAt(0).toUpperCase()}
 					{/if}
@@ -895,7 +895,7 @@
 			</div>
 
 			<!-- Docs: pinned at bottom -->
-			<a href="https://nodyx.dev" target="_blank" rel="noopener" class="icon docs" data-tip="Docs" title="Documentation">
+			<a href="https://nodyx.dev" target="_blank" rel="noopener" class="icon docs" data-tip={tFn('nav.docs')} title={tFn('nav.documentation')}>
 				<svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
 				</svg>
@@ -917,14 +917,14 @@
 			<div class="panel-head">
 				<span class="community-name" id="variant-a-community">{displayCommunityName}</span>
 				{#if user?.role === 'owner' || user?.role === 'admin'}
-				<a href="/admin" title="Administration" class="head-icon text-gray-600">
+				<a href="/admin" title={tFn('nav.admin')} class="head-icon text-gray-600">
 					<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
 						<circle cx="12" cy="12" r="3"/>
 						<path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
 					</svg>
 				</a>
 				{/if}
-				<button type="button" class="close" onclick={() => { gallerySidebarOpen = false; panelCollapsedStore.set(true); }} aria-label="Close">×</button>
+				<button type="button" class="close" onclick={() => { gallerySidebarOpen = false; panelCollapsedStore.set(true); }} aria-label={tFn('common.close')}>×</button>
 			</div>
 
 			<!-- Panel scroll: nav + channels together as one block (sketch) -->
@@ -1104,7 +1104,7 @@
 						<div class="user-role">Owner</div>
 					</div>
 				</div>
-				<a class="quick-icon" title="Settings" href="/settings">
+				<a class="quick-icon" title={tFn('nav.settings')} href="/settings">
 					<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 						<circle cx="12" cy="12" r="3"/>
 						<path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
@@ -1217,7 +1217,7 @@
 
 		<!-- ── Members Bar (droite) ────────────────────────────────────────── -->
 		<aside class="hidden xl:flex members members-c" class:collapsed={membersCollapsed} id="members-c">
-			<button class="edge-handle" onclick={toggleC} aria-label="Toggle members sidebar" title="Show members"></button>
+			<button class="edge-handle" onclick={toggleC} aria-label={tFn('members.toggle_aria')} title={tFn('members.toggle_aria')}></button>
 			<div class="members-header">
 				<span class="label">{tFn('common.members')}</span>
 				<div class="online-count">
@@ -1276,7 +1276,7 @@
 									{#if isSharing || isStreaming}
 										<div class="status-text flex items-center gap-1">
 											{#if isSharing}
-												<span class="text-[9px] font-bold px-1 py-px bg-blue-500/10 border border-blue-500/20 text-blue-400">SCREEN</span>
+												<span class="text-[9px] font-bold px-1 py-px bg-blue-500/10 border border-blue-500/20 text-blue-400">{tFn('voice.screen_badge')}</span>
 											{/if}
 											{#if isStreaming}
 												<span class="text-[9px] font-bold px-1 py-px bg-red-500/10 border border-red-500/20 text-red-400">LIVE</span>
@@ -1337,7 +1337,7 @@
 									{#if isSharing || isStreaming}
 										<div class="status-text flex items-center gap-1">
 											{#if isSharing}
-												<span class="text-[9px] font-bold px-1 py-px bg-blue-500/10 border border-blue-500/20 text-blue-400">SCREEN</span>
+												<span class="text-[9px] font-bold px-1 py-px bg-blue-500/10 border border-blue-500/20 text-blue-400">{tFn('voice.screen_badge')}</span>
 											{/if}
 											{#if isStreaming}
 												<span class="text-[9px] font-bold px-1 py-px bg-red-500/10 border border-red-500/20 text-red-400">LIVE</span>


### PR DESCRIPTION
Polish behind @JoeJoeflyn's collapsible members sidebar (#324), merge-then-polish.

**Re-i18n:** the CSS cleanup re-hardcoded the `SCREEN` badge and the new controls came with hardcoded English attributes. Routed them back through i18n (reused `common.close`, `nav.settings`/`nav.admin`/`nav.documentation`; new `nav.docs`, `members.toggle_aria`, `common.avatar_alt`, `common.logo_alt`), French source filled, new keys handed to the translation surface.

**Scanner extended:** his PR revealed that `i18n:scan` only caught French, so it missed a contributor's English strings. It now flags hardcoded **translatable attributes** (`aria-label`, `title`, `placeholder`, `alt`, `data-tip`) in **any** language. That immediately surfaced ~130 more previously invisible strings across the app (a more honest baseline).

@JoeJoeflyn is at 4 stars, with the write-up in the Polish Trail. `npm run check`: 0 errors.