### PR TITLE
fix(layout): federated instance icons navigate to their site (regressed in #324)

### DIFF
--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -874,12 +874,9 @@
 
 				<!-- Network instances -->
 				{#each networkInstances as inst}
-					{@const isInstActive = activeCommunityName === inst.name}
-					<a href={inst.url} target="_blank" rel="noopener noreferrer" class="icon net {isInstActive ? 'active' : ''}" data-tip={inst.name} title={inst.name} onclick={(e) => {
-						e.preventDefault();
-						panelCollapsedStore.set(false);
-						activeCommunityNameStore.set(inst.name);
-					}}>
+					<!-- Decentralized: each instance is its own deployment (own design + data). -->
+					<!-- Clicking simply opens that instance's site; we never render a remote instance in place. -->
+					<a href={inst.url} target="_blank" rel="noopener noreferrer" class="icon net" data-tip={inst.name} title={inst.name}>
 						{#if inst.logo_url}
 							<img src={inst.logo_url.startsWith('http') ? inst.logo_url : inst.url.replace(/\/$/, '') + inst.logo_url}
 							     alt={inst.name} class="w-full h-full object-cover" />


### PR DESCRIPTION
**Regression from #324:** clicking a federated instance in the galaxy bar called `e.preventDefault()` and set an "active community" name, swapping the sidebar title in place (and prefixing nav/channel links) while the page stayed on the current instance. The channels/content shown were still the local instance's.

Nodyx is **decentralized**: each instance is its own deployment, with its own design and data, so a remote instance can never be rendered in place. Clicking now simply opens that instance's site (`href={inst.url}`, `target=_blank`). Nothing sets `activeCommunityName` anymore, so the title and links stay local. `npm run check`: 0 errors.