### PR TITLE
fix(layout): drop leftover sketch mockup + restore version badge (#324 review)

### DIFF
--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -1094,13 +1094,12 @@
 			</div>
 			{:else}
 			<div class="panel-bottom">
-				<div class="user-group cursor-pointer" onclick={() => alert('Opens edit/status modal')}>
-					<div class="user-avatar">A<span class="status"></span></div>
+				<a href="/auth/login" class="user-group">
+					<div class="user-avatar">?<span class="status"></span></div>
 					<div class="flex-1 min-w-0">
-						<div class="user-name">alice</div>
-						<div class="user-role">Owner</div>
+						<div class="user-name">{tFn('common.login')}</div>
 					</div>
-				</div>
+				</a>
 				<a class="quick-icon" title={tFn('nav.settings')} href="/settings">
 					<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 						<circle cx="12" cy="12" r="3"/>
@@ -1422,6 +1421,7 @@
 					</div>
 				</a>
 			{/if}
+			<NodyxVersionBadge version={data.nodyxVersion ?? 'unknown'} variant="footer" />
 		</aside>
 
 	</div>


### PR DESCRIPTION
Proactive review of the #324 rewrite. Two leftovers found and fixed:

1. **Mockup leaked to prod:** the logged-out branch of the channel panel rendered a hardcoded user (`alice` / `Owner`) with `onclick={() => alert('Opens edit/status modal')}`. A guest saw a fake user and a JS alert. Replaced with a real Sign in link (`common.login`).
2. **Version badge:** `NodyxVersionBadge` was imported but no longer rendered. Restored at the bottom of the members sidebar.

Everything else in the rewrite (members list, search, notifications, announcement bar, status modal, voice, community banner) verified intact. `npm run check`: 0 errors.