### PR TITLE
feat(homepage): make both panels draggable, consistent buttons, improve layout

### DIFF
--- a/nodyx-frontend/src/app.css
+++ b/nodyx-frontend/src/app.css
@@ -19,6 +19,9 @@
 html, body {
   background-color: #06060a;
   overscroll-behavior: none;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
 /* ── Palette de marque (design tokens) ───────────────────────────────────────

--- a/nodyx-frontend/src/lib/components/homepage/GridRenderer.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/GridRenderer.svelte
@@ -415,4 +415,13 @@
 		padding-left:  max(0px, env(safe-area-inset-left));
 		padding-right: max(0px, env(safe-area-inset-right));
 	}
+
+	/* ── F18: Reduced motion — disable edit-mode transitions ── */
+	@media (prefers-reduced-motion: reduce) {
+		.gr-col,
+		.gr-resize-handle,
+		.gr-root :global(*) {
+			transition: none !important;
+		}
+	}
 </style>

--- a/nodyx-frontend/src/lib/components/homepage/widgets/ArticleSlideshow.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/ArticleSlideshow.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte'
+	import { fade } from 'svelte/transition'
+	import { cubicOut } from 'svelte/easing'
 	import { t, locale } from '$lib/i18n'
 
 	const tFn = $derived($t)
@@ -187,9 +189,9 @@
 		<!-- Background image -->
 		{#key slideIndex}
 			{#if slide.imageUrl}
-				<img src={slide.imageUrl} alt="" class="as-bg sfade" />
+				<img src={slide.imageUrl} alt="" class="as-bg" transition:fade={{ duration: 450, easing: cubicOut }} />
 			{:else}
-				<div class="as-bg-fallback sfade"></div>
+				<div class="as-bg-fallback" transition:fade={{ duration: 450, easing: cubicOut }}></div>
 			{/if}
 		{/key}
 
@@ -386,12 +388,15 @@
 		border-radius: 50%;
 		padding: 14px;
 		border: 2px solid rgb(var(--nx-accent-2-rgb) / .5);
-		transition: transform .15s, background .15s;
+		transition: transform .15s cubic-bezier(0.23, 1, 0.32, 1), background .15s;
 		filter: drop-shadow(0 4px 24px rgb(var(--nx-accent-2-rgb) / .4));
 	}
 	.as-play:hover svg {
 		transform: scale(1.08);
 		background: rgb(var(--nx-accent-2-rgb) / .55);
+	}
+	.as-play:active svg {
+		transform: scale(0.95);
 	}
 
 	/* ── Content ────────────────────────────────────────────────────────────── */
@@ -416,7 +421,7 @@
 		height: 1px;
 		width: 2.5rem;
 		background: linear-gradient(to right, var(--nx-accent-2-strong), var(--nx-cyan));
-		flex-shrink: 0;
+		shrink: 0;
 	}
 	.as-cat-text {
 		font-size: 10px;
@@ -492,7 +497,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		flex-shrink: 0;
+		shrink: 0;
 	}
 	.as-avatar img { width: 100%; height: 100%; object-fit: cover; }
 	.as-avatar span { font-size: 11px; font-weight: 700; color: #fff; }
@@ -543,10 +548,11 @@
 		border: none;
 		padding: 0;
 		cursor: pointer;
-		transition: width .3s, opacity .3s;
+		transition: width .3s cubic-bezier(0.23, 1, 0.32, 1), opacity .3s cubic-bezier(0.23, 1, 0.32, 1);
 		width: 16px;
 		opacity: .3;
 	}
+	.as-dot-btn:active { transform: scale(0.97); }
 	.as-dot-btn--active {
 		width: 56px;
 		opacity: 1;
@@ -580,16 +586,8 @@
 		border-color: rgb(var(--nx-accent-2-rgb) / .5);
 		color: var(--nx-accent-2-soft);
 	}
+	.as-arrow:active { transform: scale(0.97); }
 	.as-arrow svg { width: 14px; height: 14px; }
-
-	/* ── Fade animation ─────────────────────────────────────────────────────── */
-	:global(.sfade) {
-		animation: sfade .45s ease;
-	}
-	@keyframes sfade {
-		from { opacity: 0; }
-		to   { opacity: 1; }
-	}
 
 	/* ── Responsive ─────────────────────────────────────────────────────────── */
 	@media (max-width: 639px) {

--- a/nodyx-frontend/src/lib/components/homepage/widgets/TwitchStream.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/TwitchStream.svelte
@@ -277,7 +277,7 @@
 							allow="autoplay; fullscreen; picture-in-picture"
 							onload={onIframeLoad}
 							class="w-full h-full absolute inset-0"
-							style="border:0; opacity:{iframeLoaded ? 1 : 0}; transition:opacity .3s ease"
+							style="border:0; opacity:{iframeLoaded ? 1 : 0}; transition:opacity .3s cubic-bezier(0.23, 1, 0.32, 1)"
 						></iframe>
 					{/key}
 				{/if}
@@ -363,8 +363,11 @@
 		border-color: var(--accent) !important;
 		transform: translateY(-1px);
 	}
+	.twitch-cta:active {
+		transform: translateY(0) scale(0.97);
+	}
 
 	.twitch-cta {
-		transition: all .2s ease;
+		transition: background .2s cubic-bezier(0.16, 1, 0.3, 1), border-color .2s cubic-bezier(0.16, 1, 0.3, 1), transform .2s cubic-bezier(0.16, 1, 0.3, 1);
 	}
 </style>

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -238,17 +238,179 @@
 
 	// ── Galaxy Bar mobile drawer ───────────────────────────────────────────────
 	let gallerySidebarOpen = $state(false)
-	const panelCollapsed = $derived($panelCollapsedStore)
-	const membersCollapsed = $derived($membersCollapsedStore)
+	let panelCollapsed = $state((data as any).panelCollapsed ?? false)
+	let membersCollapsed = $state((data as any).membersCollapsed ?? false)
 
 	function toggleC(velocity: number | MouseEvent = 0) {
 		if (typeof velocity === 'number') {
-			if (velocity > 500) membersCollapsedStore.set(false);
-			else if (velocity < -500) membersCollapsedStore.set(true);
-			else membersCollapsedStore.update(v => !v);
+			if (velocity > 500) membersCollapsed = false;
+			else if (velocity < -500) membersCollapsed = true;
+			else membersCollapsed = !membersCollapsed;
 		} else {
-			membersCollapsedStore.update(v => !v);
+			membersCollapsed = !membersCollapsed;
 		}
+	}
+
+	function toggleL() {
+		panelCollapsed = !panelCollapsed;
+	}
+
+	$effect(() => {
+		panelCollapsedStore.set(panelCollapsed);
+		if (browser) {
+			document.cookie = `nodyx_panel_collapsed=${panelCollapsed}; path=/; max-age=31536000; SameSite=Lax`;
+		}
+	});
+
+	$effect(() => {
+		membersCollapsedStore.set(membersCollapsed);
+		if (browser) {
+			document.cookie = `nodyx_members_collapsed=${membersCollapsed}; path=/; max-age=31536000; SameSite=Lax`;
+		}
+	});
+
+	// ── Panel resizing logic ──────────────────────────────────────────────────
+	let leftPanelWidth = $state((data as any).leftPanelWidth ?? 220);
+	let rightPanelWidth = $state((data as any).rightPanelWidth ?? 220);
+	let isDraggingLeft = $state(false);
+	let isDraggingRight = $state(false);
+	let draggingPastBoundaryLeft = $state(false);
+	let draggingPastBoundaryRight = $state(false);
+
+	let dragStartWidthLeft = 0;
+	let dragStartWidthRight = 0;
+	let leftDragMoved = false;
+	let rightDragMoved = false;
+	// F11: velocity tracking for momentum-based panel snap
+	let dragVelocity = 0;
+	let dragLastX = 0;
+	let dragLastTime = 0;
+
+	let isMounted = $state(false);
+	onMount(() => {
+		isMounted = true;
+	});
+
+	$effect(() => {
+		if (browser) {
+			localStorage.setItem('nodyx_left_panel_width', String(leftPanelWidth));
+			document.cookie = `nodyx_left_panel_width=${leftPanelWidth}; path=/; max-age=31536000; SameSite=Lax`;
+		}
+	});
+
+	$effect(() => {
+		if (browser) {
+			localStorage.setItem('nodyx_right_panel_width', String(rightPanelWidth));
+			document.cookie = `nodyx_right_panel_width=${rightPanelWidth}; path=/; max-age=31536000; SameSite=Lax`;
+		}
+	});
+
+	function startLeftDrag(e: PointerEvent) {
+		if (window.innerWidth < 1024) return;
+		if (e.button !== 0) return;
+		isDraggingLeft = true;
+		leftDragMoved = false;
+		dragStartWidthLeft = leftPanelWidth;
+		dragLastX = e.clientX;
+		dragLastTime = performance.now();
+		dragVelocity = 0;
+		(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+		e.preventDefault();
+	}
+
+	function handleLeftDragMove(e: PointerEvent) {
+		if (!isDraggingLeft) return;
+		leftDragMoved = true;
+		// F11: velocity tracking for momentum snap
+		const now = performance.now();
+		const dt = now - dragLastTime;
+		if (dt > 0) dragVelocity = (e.clientX - dragLastX) / dt;
+		dragLastX = e.clientX;
+		dragLastTime = now;
+		const width = e.clientX - 56;
+		if (width < 130) {
+			draggingPastBoundaryLeft = true;
+			leftPanelWidth = Math.max(0, width);
+		} else {
+			draggingPastBoundaryLeft = false;
+			leftPanelWidth = Math.max(160, Math.min(500, width));
+		}
+	}
+
+	function stopLeftDrag(e: PointerEvent) {
+		if (!isDraggingLeft) return;
+		isDraggingLeft = false;
+		try {
+			(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+		} catch { /* ignore */ }
+
+		if (!leftDragMoved) {
+			toggleL();
+		} else {
+			// F11: use velocity to determine snap target
+			const fastFling = Math.abs(dragVelocity) > 0.5;
+			if (leftPanelWidth < 130 || (fastFling && dragVelocity < 0)) {
+				panelCollapsed = true;
+				leftPanelWidth = 220;
+			} else if (leftPanelWidth < 160) {
+				leftPanelWidth = 160;
+			}
+		}
+		draggingPastBoundaryLeft = false;
+	}
+
+	function startRightDrag(e: PointerEvent) {
+		if (window.innerWidth < 1280) return;
+		if (e.button !== 0) return;
+		isDraggingRight = true;
+		rightDragMoved = false;
+		dragStartWidthRight = rightPanelWidth;
+		dragLastX = e.clientX;
+		dragLastTime = performance.now();
+		dragVelocity = 0;
+		(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+		e.preventDefault();
+	}
+
+	function handleRightDragMove(e: PointerEvent) {
+		if (!isDraggingRight) return;
+		rightDragMoved = true;
+		// F11: velocity tracking
+		const now = performance.now();
+		const dt = now - dragLastTime;
+		if (dt > 0) dragVelocity = (e.clientX - dragLastX) / dt;
+		dragLastX = e.clientX;
+		dragLastTime = now;
+		const width = window.innerWidth - e.clientX;
+		if (width < 130) {
+			draggingPastBoundaryRight = true;
+			rightPanelWidth = Math.max(0, width);
+		} else {
+			draggingPastBoundaryRight = false;
+			rightPanelWidth = Math.max(160, Math.min(500, width));
+		}
+	}
+
+	function stopRightDrag(e: PointerEvent) {
+		if (!isDraggingRight) return;
+		isDraggingRight = false;
+		try {
+			(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+		} catch { /* ignore */ }
+
+		if (!rightDragMoved) {
+			toggleC();
+		} else {
+			// F11: use velocity to determine snap target
+			const fastFling = Math.abs(dragVelocity) > 0.5;
+			if (rightPanelWidth < 130 || (fastFling && dragVelocity > 0)) {
+				membersCollapsed = true;
+				rightPanelWidth = 220;
+			} else if (rightPanelWidth < 160) {
+				rightPanelWidth = 160;
+			}
+		}
+		draggingPastBoundaryRight = false;
 	}
 
 	// Ferme le drawer sur changement de page (navigation SvelteKit)
@@ -294,20 +456,22 @@
 		langSavedTimeout = setTimeout(() => langSaved = false, 2000)
 	}
 
-	// Swipe-to-dismiss for mobile
+	// Swipe-to-dismiss for mobile — F12: spring-feel transition via CSS
 	let touchStartY = 0
 	let touchCurrentY = 0
+	let langDragY = $state(0)
 	function onLangTouchStart(e: TouchEvent) { touchStartY = e.touches[0].clientY }
 	function onLangTouchMove(e: TouchEvent) {
 		touchCurrentY = e.touches[0].clientY
 		const diff = touchCurrentY - touchStartY
-		if (diff > 0) (e.currentTarget as HTMLElement).style.transform = `translateY(${diff}px)`
+		if (diff > 0) langDragY = diff
 	}
 	function onLangTouchEnd() {
 		const diff = touchCurrentY - touchStartY
-		if (diff > 100) langView = false
-		const el = document.querySelector('.lang-view') as HTMLElement
-		if (el) el.style.transform = ''
+		if (diff > 100) {
+			langView = false
+		}
+		langDragY = 0
 	}
 
 	// XP info — formule sqrt identique à ProfileCard / MiniProfileCard / page profil
@@ -670,11 +834,11 @@
 			style="background: rgba(255,255,255,.03); border: 1px solid rgba(255,255,255,.06); cursor: text; text-align: left;"
 			aria-label={tFn('common.command_palette_hint')}
 		>
-			<svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" style="color: #3b3f52; flex-shrink:0">
+			<svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" style="color: #3b3f52; shrink:0">
 				<circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
 			</svg>
 			<span class="flex-1 text-xs truncate" style="color: #3b3f52; font-family: 'Space Grotesk', sans-serif">{tFn('common.search_navigate')}</span>
-			<div style="display:flex;gap:2px;flex-shrink:0">
+			<div style="display:flex;gap:2px;shrink:0">
 				<kbd style="font-size:0.6rem;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.07);padding:0.05rem 0.28rem;color:rgba(255,255,255,.18);font-family:ui-monospace,monospace">Ctrl</kbd>
 				<kbd style="font-size:0.6rem;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.07);padding:0.05rem 0.28rem;color:rgba(255,255,255,.18);font-family:ui-monospace,monospace">K</kbd>
 			</div>
@@ -691,45 +855,48 @@
 				<span class="flex items-center leading-none"><ChannelIcon value={LOCALES.find(l => l.code === currentLocale)?.flagIcon} fallback="🌐" size={18} /></span>
 				<svg class="hidden sm:block w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 8l6 6M4 14l6-6 2-3M2 5h12M7 2h1M22 22l-5-10-5 10M14 18h6"/></svg>
 			</button>
+			<!-- Toggle members sidebar (guest + logged-in, XL only to match sidebar) -->
+			<button type="button"
+			        onclick={toggleC}
+			        class="nx-icon-btn hidden xl:flex items-center justify-center w-8 h-8 rounded-lg transition-all relative"
+			        class:active={!membersCollapsed}
+			        title={tFn('common.members')}
+			        aria-label={tFn('members.toggle_aria')}
+			        aria-expanded={!membersCollapsed}>
+				<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 0 0-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 0 1 5.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 0 1 9.288 0M15 7a3 3 0 1 1-6 0 3 3 0 0 1 6 0zm6 3a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM7 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0z"/>
+				</svg>
+			</button>
 			{#if user}
 				<!-- Notifications -->
 				<a href="/notifications"
-				   class="relative p-2 transition-colors"
-				   style="color: {isActive('/notifications') ? 'var(--nx-accent-2-soft)' : '#6b7280'}"
+				   class="nx-icon-btn relative flex items-center justify-center w-8 h-8 rounded-lg transition-all"
+				   class:active={isActive('/notifications')}
 				   title={tFn('nav.notifications')}>
 					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
 						<path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/>
 					</svg>
 					{#if unreadCount > 0}
-						<span class="absolute top-0.5 right-0.5 min-w-3.5 h-3.5 px-0.5 flex items-center justify-center text-[9px] font-black text-white rounded-full bg-red-500 leading-none">{unreadCount > 9 ? '9+' : unreadCount}</span>
+						<span class="absolute top-0.5 right-0.5 min-w-3.5 h-3.5 px-0.5 flex items-center justify-center text-[9px] font-black text-white rounded-full bg-red-500 leading-none ring-1 ring-[#0a0a0a]">{unreadCount > 9 ? '9+' : unreadCount}</span>
 					{/if}
 				</a>
 				<!-- DMs -->
 				<a href="/dm"
-				   class="relative p-2 transition-colors"
-				   style="color: {isActive('/dm') ? 'var(--nx-accent-2-soft)' : '#6b7280'}"
+				   class="nx-icon-btn relative flex items-center justify-center w-8 h-8 rounded-lg transition-all"
+				   class:active={isActive('/dm')}
 				   title={tFn('nav.dm')}>
 					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
 						<path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-5l-4 4v-4z"/>
 					</svg>
 					{#if dmUnread > 0}
-						<span class="absolute top-0.5 right-0.5 min-w-3.5 h-3.5 px-0.5 flex items-center justify-center text-[9px] font-black text-white rounded-full bg-[var(--nx-accent-2-strong)] leading-none">{dmUnread > 9 ? '9+' : dmUnread}</span>
+						<span class="absolute top-0.5 right-0.5 min-w-3.5 h-3.5 px-0.5 flex items-center justify-center text-[9px] font-black text-white rounded-full bg-[var(--nx-accent-2-strong)] leading-none ring-1 ring-[#0a0a0a]">{dmUnread > 9 ? '9+' : dmUnread}</span>
 					{/if}
 				</a>
-				<!-- Toggle members sidebar -->
-				<button type="button"
-				        onclick={toggleC}
-				        class="p-2 transition-colors relative"
-				        style="color: {!membersCollapsed ? 'var(--nx-accent-2-soft)' : '#6b7280'}; cursor: pointer;"
-				        title={tFn('common.members')}>
-					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-						<path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 0 0-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 0 1 5.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 0 1 9.288 0M15 7a3 3 0 1 1-6 0 3 3 0 0 1 6 0zm6 3a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM7 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0z"/>
-					</svg>
-				</button>
 				{#if user.role === 'owner' || user.role === 'admin'}
 					<a href="/admin"
-					   class="hidden sm:flex items-center px-2.5 h-7 text-[10px] font-black uppercase tracking-wider transition-colors"
-					   style="color: {isActive('/admin') ? 'var(--nx-accent-2-soft)' : '#4b5563'}; border: 1px solid {isActive('/admin') ? 'rgb(var(--nx-accent-2-rgb) / .4)' : 'rgba(255,255,255,.06)'}">{tFn('nav.admin')}</a>
+					   class="nx-admin-pill hidden sm:flex items-center px-2.5 h-7 text-[10px] font-black uppercase tracking-wider rounded-md transition-all"
+					   class:active={isActive('/admin')}
+					   >{tFn('nav.admin')}</a>
 				{/if}
 				<!-- User dropdown -->
 				<div class="relative">
@@ -825,17 +992,18 @@
 					</div>
 			{:else}
 				<a href="/auth/login"
-				   class="px-2.5 h-6 flex items-center text-xs transition-colors"
-				   style="color: #9ca3af; border: 1px solid rgba(255,255,255,.06)">{tFn('common.login')}</a>
+				   class="nx-auth-btn flex items-center justify-center h-8 min-w-[5.5rem] px-3 text-xs font-medium rounded-lg transition-all">{tFn('common.login')}</a>
 				<a href="/auth/register"
-				   class="px-2.5 h-6 flex items-center text-xs font-bold transition-colors"
-				   style="background: var(--nx-accent-2-strong); color: #fff">{tFn('common.register')}</a>
+				   class="nx-auth-btn nx-auth-btn--primary flex items-center justify-center h-8 min-w-[5.5rem] px-3 text-xs font-bold rounded-lg transition-all">{tFn('common.register')}</a>
 			{/if}
 		</div>
 	</nav>
 
 	<!-- ══ BODY ═══════════════════════════════════════════════════════════════ -->
-	<div class="flex flex-1">
+	<div class="flex flex-1"
+	     style="--left-panel-width: {leftPanelWidth}px; --right-panel-width: {rightPanelWidth}px;"
+	     class:layout-dragging={isDraggingLeft || isDraggingRight}
+	     class:layout-loading={!isMounted}>
 
 		<!-- ── Backdrop Channel Sidebar — mobile ──────────────────────────────── -->
 		{#if !isBanned && gallerySidebarOpen}
@@ -856,9 +1024,9 @@
 				<button type="button" class="icon logo {!activeCommunityName ? 'active' : ''}" data-tip={communityName} title={communityName} onclick={() => {
 					if (activeCommunityName) {
 						activeCommunityNameStore.set(null);
-						panelCollapsedStore.set(false);
+						panelCollapsed = false;
 					} else {
-						panelCollapsedStore.update(v => !v);
+						panelCollapsed = !panelCollapsed;
 					}
 				}}>
 					{#if communityLogo}
@@ -908,7 +1076,25 @@
 		       id="variant-a-panel"
 		       role={gallerySidebarOpen ? 'dialog' : undefined}
 		       aria-modal={gallerySidebarOpen ? 'true' : undefined}
-		       aria-label={tFn('nav.community_menu')}>
+		       aria-label={tFn('nav.community_menu')}
+		       style="width: var(--left-panel-width, 220px);"
+		       class:dragging={isDraggingLeft}>
+
+			<button class="edge-handle"
+			        onpointerdown={startLeftDrag}
+			        onpointermove={handleLeftDragMove}
+			        onpointerup={stopLeftDrag}
+			        onclick={(e) => {
+			            if (leftDragMoved) {
+			                e.preventDefault();
+			                e.stopPropagation();
+			            } else {
+			                toggleL();
+			            }
+			        }}
+			        class:dragging-past-boundary={draggingPastBoundaryLeft}
+			        aria-label="Resize community menu"
+			        title="Drag to resize / click to toggle"></button>
 
 			<!-- Panel head -->
 			<div class="panel-head">
@@ -921,7 +1107,7 @@
 					</svg>
 				</a>
 				{/if}
-				<button type="button" class="close" onclick={() => { gallerySidebarOpen = false; panelCollapsedStore.set(true); }} aria-label={tFn('common.close')}>×</button>
+				<button type="button" class="close" onclick={() => { gallerySidebarOpen = false; panelCollapsed = true; }} aria-label={tFn('common.close')}>×</button>
 			</div>
 
 			<!-- Panel scroll: nav + channels together as one block (sketch) -->
@@ -1116,7 +1302,9 @@
 
 		<!-- ── Contenu principal ───────────────────────────────────────────────── -->
 		<div class="flex-1 overflow-hidden">
-		<main class="{langView ? 'h-[calc(100vh-48px)] overflow-hidden' : 'h-full overflow-y-auto'} min-w-0 {isBanned ? '' : showChannelSidebar && !panelCollapsed ? 'lg:pl-[276px]' : 'lg:pl-[56px]'} {membersCollapsed ? 'xl:mr-0' : 'xl:mr-[220px]'} pb-[var(--bottom-nav-h)]">
+		<main class="{langView ? 'h-[calc(100vh-48px)] overflow-hidden' : 'h-full overflow-y-auto'} min-w-0 pb-[var(--bottom-nav-h)]"
+		      class:panel-collapsed={isBanned || !showChannelSidebar || panelCollapsed}
+		      class:members-collapsed={membersCollapsed}>
 
             <!-- ── System announcement banner ─────────────────────────────────── -->
             {#if showAnnouncement && announcement}
@@ -1156,12 +1344,13 @@
                         aria-modal="true"
                         aria-labelledby="lang-title"
                         aria-describedby="lang-desc"
+                        style="transform: translateY({langDragY}px); transition: transform {langDragY > 0 ? 'none' : '0.3s cubic-bezier(0.16, 1, 0.3, 1)'};"
                         transition:fly={{ y: 20, duration: 300, easing: cubicOut }}
                         ontouchstart={onLangTouchStart}
                         ontouchmove={onLangTouchMove}
                         ontouchend={onLangTouchEnd}
                     >
-                        <button onclick={() => langView = false} class="lang-back inline-flex items-center gap-1.5 text-[11px] text-gray-600 shrink-0 bg-transparent border-none cursor-pointer" aria-label={tFn('common.back')}>
+                        <button onclick={() => langView = false} class="lang-back inline-flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider text-gray-400 shrink-0 bg-transparent border border-white/[0.12] rounded-md px-3 py-2 cursor-pointer" aria-label={tFn('common.back')}>
                             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M19 12H5M12 5l-7 7 7 7"/>
                             </svg>
@@ -1211,9 +1400,26 @@
         </main>
 		</div>
 
-		<!-- ── Members Bar (droite) ────────────────────────────────────────── -->
-		<aside class="hidden xl:flex members members-c" class:collapsed={membersCollapsed} id="members-c">
-			<button class="edge-handle" onclick={toggleC} aria-label={tFn('members.toggle_aria')} title={tFn('members.toggle_aria')}></button>
+		<aside class="hidden xl:flex members members-c"
+		       class:collapsed={membersCollapsed}
+		       id="members-c"
+		       style="width: {membersCollapsed ? '0px' : 'var(--right-panel-width, 220px)'};"
+		       class:dragging={isDraggingRight}>
+			<button class="edge-handle"
+			        onpointerdown={startRightDrag}
+			        onpointermove={handleRightDragMove}
+			        onpointerup={stopRightDrag}
+			        onclick={(e) => {
+			            if (rightDragMoved) {
+			                e.preventDefault();
+			                e.stopPropagation();
+			            } else {
+			                toggleC();
+			            }
+			        }}
+			        class:dragging-past-boundary={draggingPastBoundaryRight}
+			        aria-label={tFn('members.toggle_aria')}
+			        title={tFn('members.toggle_aria')}></button>
 			<div class="members-header">
 				<span class="label">{tFn('common.members')}</span>
 				<div class="online-count">
@@ -1677,6 +1883,36 @@
   transition: padding-left .25s cubic-bezier(.4,0,.2,1), margin-right .25s cubic-bezier(.4,0,.2,1);
 }
 
+
+
+.layout-loading,
+.layout-loading * {
+  transition: none !important;
+  animation: none !important;
+}
+
+.layout-dragging :global(main) {
+  transition: none !important;
+}
+
+@media (min-width: 1024px) {
+  :global(main) {
+    padding-left: calc(56px + var(--left-panel-width, 220px)) !important;
+  }
+  :global(main.panel-collapsed) {
+    padding-left: 56px !important;
+  }
+}
+
+@media (min-width: 1280px) {
+  :global(main) {
+    margin-right: var(--right-panel-width, 220px) !important;
+  }
+  :global(main.members-collapsed) {
+    margin-right: 0px !important;
+  }
+}
+
 /* ── Sketch 001: Discord two-tier sidebar — exact sketch CSS, scoped ────── */
 .nodyx-sb .rail {
   position: fixed; top: 48px; bottom: 0; left: 0; width: 56px;
@@ -1689,7 +1925,7 @@
 }
 .nodyx-sb .rail .scroll::-webkit-scrollbar { display: none; }
 .nodyx-sb .rail .icon {
-  width: 32px; height: 32px; border-radius: 6px; flex-shrink: 0; cursor: pointer;
+  width: 32px; height: 32px; border-radius: 6px; shrink: 0; cursor: pointer;
   display: flex; align-items: center; justify-content: center; position: relative;
   transition: all .12s; font-weight: 700; font-size: 12px; font-family: 'JetBrains Mono', monospace;
   text-decoration: none;
@@ -1705,12 +1941,16 @@
 .nodyx-sb .rail .icon.docs:hover { background: #111; color: #818cf8; border-radius: 8px; }
 
 .nodyx-sb .panel {
-  position: fixed; top: 48px; bottom: 0; left: 56px; width: 220px;
+  position: fixed; top: 48px; bottom: 0; left: 56px;
+  width: var(--left-panel-width, 220px);
   background: #0a0a0a; border-right: 1px solid #111;
   z-index: 39; display: flex; flex-direction: column;
-  transform: translateX(0); transition: transform .25s cubic-bezier(.4,0,.2,1);
+  transform: translateX(0); transition: transform .25s cubic-bezier(.4,0,.2,1), width .25s cubic-bezier(.4,0,.2,1);
 }
 .nodyx-sb .panel.collapsed { transform: translateX(-100%); }
+.nodyx-sb .panel.dragging {
+  transition: none !important;
+}
 .nodyx-sb .panel .panel-head {
   padding: 12px 14px; border-bottom: 1px solid #111; display: flex; align-items: center; gap: 8px;
   font-family: 'JetBrains Mono', monospace; font-weight: 700; font-size: 13px; color: #e2e8f0;
@@ -1722,7 +1962,7 @@
 }
 .nodyx-sb .panel .panel-head .close:hover { background: #111; color: #e2e8f0; }
 .nodyx-sb .panel .panel-head .head-icon {
-  flex-shrink: 0; color: #4b5563; cursor: pointer; padding: 4px; border-radius: 4px;
+  shrink: 0; color: #4b5563; cursor: pointer; padding: 4px; border-radius: 4px;
   transition: all .12s; display: flex; align-items: center; justify-content: center;
   text-decoration: none;
 }
@@ -1770,7 +2010,7 @@
 }
 .nodyx-sb .panel .panel-bottom .user-group:hover { background: #111; }
 .nodyx-sb .panel .panel-bottom .user-avatar {
-  width: 32px; height: 32px; border-radius: 6px; flex-shrink: 0;
+  width: 32px; height: 32px; border-radius: 6px; shrink: 0;
   display: flex; align-items: center; justify-content: center;
   font-weight: 700; font-size: 12px; color: #fff; font-family: 'JetBrains Mono', monospace;
   background: linear-gradient(135deg, #6366f1, #3730a3);
@@ -1789,7 +2029,7 @@
   color: #818cf8; text-transform: uppercase; letter-spacing: .1em;
 }
 .nodyx-sb .panel .panel-bottom .quick-icon {
-  flex-shrink: 0; color: #333; cursor: pointer; padding: 6px; border-radius: 4px;
+  shrink: 0; color: #333; cursor: pointer; padding: 6px; border-radius: 4px;
   transition: all .12s; display: flex; align-items: center; justify-content: center;
 }
 .nodyx-sb .panel .panel-bottom .quick-icon:hover { background: #111; color: #818cf8; }
@@ -1836,7 +2076,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	flex-shrink: 0;
+	shrink: 0;
 }
 .guest-radar-ring {
 	position: absolute;
@@ -1919,7 +2159,7 @@
 	background: #4ade80;
 	box-shadow: 0 0 6px rgba(74,222,128,0.6);
 	animation: guest-live-pulse 1.8s ease-in-out infinite;
-	flex-shrink: 0;
+	shrink: 0;
 }
 @keyframes guest-live-pulse {
 	0%, 100% { box-shadow: 0 0 6px rgba(74,222,128,0.6); }
@@ -1982,11 +2222,11 @@
 	text-transform: uppercase; letter-spacing: .16em;
 	color: #374151;
 }
-.lch-sublabel svg { width: 10px; height: 10px; flex-shrink: 0; }
+.lch-sublabel svg { width: 10px; height: 10px; shrink: 0; }
 .lch-sublabel--voice { color: #14532d; margin-top: 4px; }
 .lch-sublabel--voice svg { stroke: #166834; }
 
-.lch-voice-ico { width: 14px; height: 14px; flex-shrink: 0; transition: stroke .15s; }
+.lch-voice-ico { width: 14px; height: 14px; shrink: 0; transition: stroke .15s; }
 
 /* ── Layout channel items — unread glow ──────────────────────────────────── */
 .lch-item {
@@ -2044,7 +2284,7 @@
 }
 
 .lch-badge {
-	flex-shrink: 0;
+	shrink: 0;
 	min-width: 15px;
 	height: 15px;
 	padding: 0 4px;
@@ -2072,6 +2312,74 @@
     min-height: 0;
     overflow: hidden;
 }
+/* ── Top bar icon buttons + auth buttons ─────────────────────────────────── */
+.nx-icon-btn {
+    color: #6b7280;
+    background: transparent;
+    border: 1px solid transparent;
+}
+.nx-icon-btn:hover {
+    color: #d1d5db;
+    background: rgba(255,255,255,0.05);
+    border-color: rgba(255,255,255,0.06);
+}
+.nx-icon-btn:active { transform: scale(0.94); }
+.nx-icon-btn.active {
+    color: var(--nx-accent-2-soft, #818cf8);
+    background: rgba(var(--nx-accent-2-rgb, 99, 102, 241), 0.08);
+    border-color: rgba(var(--nx-accent-2-rgb, 99, 102, 241), 0.2);
+}
+.nx-icon-btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(var(--nx-accent-rgb, 99, 102, 241), 0.4);
+}
+/* Admin pill — uses .nx-icon-btn.active styles */
+a.nx-icon-btn[class*="active"],
+.nx-icon-btn.active {
+    color: var(--nx-accent-2-soft, #818cf8);
+}
+/* Admin pill in top bar */
+.nx-admin-pill {
+    color: #4b5563;
+    background: transparent;
+    border: 1px solid rgba(255,255,255,0.06);
+}
+.nx-admin-pill:hover {
+    color: #d1d5db;
+    background: rgba(255,255,255,0.04);
+    border-color: rgba(255,255,255,0.12);
+}
+.nx-admin-pill.active {
+    color: var(--nx-accent-2-soft, #818cf8);
+    background: rgba(var(--nx-accent-2-rgb, 99, 102, 241), 0.08);
+    border-color: rgba(var(--nx-accent-2-rgb, 99, 102, 241), 0.3);
+}
+/* Auth buttons (Sign in / Register) */
+.nx-auth-btn {
+    color: #9ca3af;
+    background: transparent;
+    border: 1px solid rgba(255,255,255,0.08);
+}
+.nx-auth-btn:hover {
+    color: #f3f4f6;
+    background: rgba(255,255,255,0.05);
+    border-color: rgba(255,255,255,0.14);
+}
+.nx-auth-btn:active { transform: scale(0.97); }
+.nx-auth-btn--primary {
+    color: #fff;
+    background: var(--nx-accent-2-strong, #6366f1);
+    border-color: transparent;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.2), 0 0 12px rgba(var(--nx-accent-2-rgb, 99, 102, 241), 0.25);
+}
+.nx-auth-btn--primary:hover {
+    background: var(--nx-accent-2-strong, #6366f1);
+    filter: brightness(1.1);
+    border-color: transparent;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.25), 0 0 18px rgba(var(--nx-accent-2-rgb, 99, 102, 241), 0.4);
+}
+.nx-auth-btn--primary:active { transform: scale(0.97); }
+
 .lang-nav-btn {
     border-radius: 6px;
     transition: color 200ms cubic-bezier(0.25, 0.1, 0.25, 1),
@@ -2088,12 +2396,11 @@
     box-shadow: 0 0 0 2px rgba(var(--nx-accent-rgb), 0.4);
 }
 .lang-back {
-    transition: color 200ms cubic-bezier(0.25, 0.1, 0.25, 1),
-                transform 200ms cubic-bezier(0.25, 0.1, 0.25, 1);
+    transition: all 200ms cubic-bezier(0.25, 0.1, 0.25, 1);
 }
-.lang-back:hover { color: #9ca3af; transform: translateX(-2px); }
-.lang-back:active { transform: translateX(0) scale(0.98); }
-.lang-back:focus-visible { outline: none; color: var(--nx-accent-soft); }
+.lang-back:hover { color: #fff; border-color: rgba(255,255,255,0.25); }
+.lang-back:active { transform: scale(0.98); }
+.lang-back:focus-visible { outline: none; border-color: var(--nx-accent); }
 .lang-card {
     background: rgba(255, 255, 255, 0.03);
     backdrop-filter: blur(10px);
@@ -2137,11 +2444,8 @@
     box-shadow: 0 0 8px var(--nx-accent);
 }
 .lang-seg:hover {
-    border-color: rgba(var(--nx-accent-rgb), 0.2);
+    border-color: rgba(255,255,255,0.12);
     background: rgba(255,255,255,0.04);
-    padding-left: 24px;
-    transform: scale(1.01);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 .lang-seg:active {
     transform: scale(0.98);
@@ -2154,12 +2458,12 @@
     box-shadow: 0 0 0 3px rgba(var(--nx-accent-rgb), 0.3);
 }
 .lang-seg.active {
-    border-color: rgba(var(--nx-accent-rgb), 0.3);
-    background: rgba(var(--nx-accent-rgb), 0.04);
-    padding-left: 24px;
+    border-color: #4f46e5;
+    background: #4f46e5;
 }
 .lang-seg.active::before { opacity: 1; transform: translateX(0); }
-.lang-seg.active .text-slate-200 { color: var(--nx-accent-soft); }
+.lang-seg.active .text-slate-200 { color: #fff; }
+.lang-seg.active .lang-seg-check { color: #fff; }
 .lang-seg-check {
     color: var(--nx-accent);
     transform: scale(0);
@@ -2193,7 +2497,7 @@
   right: 0;
   top: 48px;
   bottom: 0;
-  width: 220px;
+  width: var(--right-panel-width, 220px);
   background: #0d0d12;
   border-left: 1px solid rgba(255, 255, 255, 0.05);
   display: flex;
@@ -2204,15 +2508,19 @@
   overflow: hidden;
 }
 
+.members-c.dragging {
+  transition: none !important;
+}
+
 .members-c.collapsed {
   width: 0;
   border-left-color: transparent;
   pointer-events: none;
 }
 
+.panel .edge-handle,
 .members-c .edge-handle {
   position: absolute;
-  left: 0;
   top: 0;
   bottom: 0;
   width: 6px;
@@ -2220,16 +2528,33 @@
   z-index: 10;
   background: transparent;
   transition: background-color 120ms ease-out, transform 80ms ease-out;
+  border: none;
+  padding: 0;
 }
+
+.panel .edge-handle {
+  right: 0;
+}
+
+.members-c .edge-handle {
+  left: 0;
+}
+
+.panel .edge-handle:hover,
 .members-c .edge-handle:hover {
   background: rgba(255, 255, 255, 0.05);
 }
+
+.panel .edge-handle:active,
 .members-c .edge-handle:active {
   transform: scaleX(1.1);
 }
+
+.panel .edge-handle.dragging-past-boundary,
 .members-c .edge-handle.dragging-past-boundary {
   transform: scaleX(1.1);
   opacity: 0.7;
+  background: rgba(239, 68, 68, 0.15) !important;
 }
 
 .members-c .members-header {
@@ -2240,7 +2565,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  flex-shrink: 0;
+  shrink: 0;
   overflow: hidden;
 }
 
@@ -2431,7 +2756,7 @@
 
 .members-c .member .avatar-wrap {
   position: relative;
-  flex-shrink: 0;
+  shrink: 0;
 }
 
 .members-c .member .avatar {
@@ -2519,7 +2844,7 @@
   background: rgba(99, 102, 241, 0.25);
   color: var(--nx-accent-2-soft);
   line-height: 1;
-  flex-shrink: 0;
+  shrink: 0;
 }
 
 .members-c .member .status-text {

--- a/nodyx-frontend/src/routes/+page.svelte
+++ b/nodyx-frontend/src/routes/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import { onMount, onDestroy } from 'svelte';
+	import { fade } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
 	import { t } from '$lib/i18n';
 	import WidgetZone from '$lib/components/homepage/WidgetZone.svelte';
 	import GridRenderer from '$lib/components/homepage/GridRenderer.svelte';
@@ -30,6 +32,28 @@
 		return posWidgets(posId).some(w => w.enabled)
 	}
 
+	// Helper: find a widget of a given type across ALL positions (DB-backed config)
+	function findWidget<T = any>(type: string): T | null {
+		for (const pos of hpPositions) {
+			const w = pos.widgets?.find(w => w.widget_type === type && w.enabled)
+			if (w) return (w.config ?? {}) as T
+		}
+		return null
+	}
+
+	// DB-backed Twitch config (from twitch-stream widget in homepage_widgets)
+	const twitchConfig = $derived(findWidget<{ channel?: string; layout?: string; height?: number; show_header?: boolean }>('twitch-stream'))
+	const twitchChannel = $derived(twitchConfig?.channel ?? null)
+
+	// Wifi-signal level (1-4 bars) from a count — used for community stats
+	function signalLevel(n: number): number {
+		if (n <= 0)   return 0
+		if (n < 10)   return 1
+		if (n < 50)   return 2
+		if (n < 200)  return 3
+		return 4
+	}
+
 	function timeAgo(dateStr: string): string {
 		if (!dateStr) return '';
 		const diff = Date.now() - new Date(dateStr).getTime();
@@ -48,11 +72,15 @@
 	let progressPct = $state(0);
 	let slideTimer: ReturnType<typeof setInterval> | null = null;
 	let progressTimer: ReturnType<typeof setInterval> | null = null;
+	let isAnimating = $state(false);
 	const SLIDE_MS = 6000;
 
 	function slideTo(i: number) {
+		if (isAnimating) return;
+		isAnimating = true;
 		slideIndex  = ((i % slideArticles.length) + slideArticles.length) % slideArticles.length;
 		progressPct = 0;
+		setTimeout(() => { isAnimating = false; }, 400);
 	}
 	function slideNext() { slideTo(slideIndex + 1); }
 	function slidePrev() { slideTo(slideIndex - 1); }
@@ -75,8 +103,21 @@
 	const recentThreads   = $derived(threads.slice(0, 5));
 	const featuredThreads = $derived(threads.slice(0, 6));
 	const heroArticle     = $derived(articles[0] ?? null);
-	const restArticles    = $derived(articles.slice(1, 4));
+	const restArticles    = $derived(articles.slice(1, 7));
 	const heroLetter      = $derived(instance.name?.charAt(0).toUpperCase() ?? 'N');
+const categories      = $derived((data as any).categories as any[] ?? []);
+
+	// Social links (hardcoded platform set — consistent across all instances)
+	const SOCIAL_LINKS = [
+		{ type: "discord", color: "#5865f2", path: "M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z" },
+		{ type: "tiktok", color: "#e2e8f0", path: "M12.525.02c1.31-.02 2.61-.01 3.91-.02.08 1.53.63 3.09 1.75 4.17 1.12 1.11 2.7 1.62 4.24 1.79v4.03c-1.44-.05-2.89-.35-4.2-.97-.57-.26-1.1-.59-1.62-.93-.01 2.92.01 5.84-.02 8.75-.08 1.4-.54 2.79-1.35 3.94-1.31 1.92-3.58 3.17-5.91 3.21-1.43.08-2.86-.31-4.08-1.03-2.02-1.19-3.44-3.37-3.65-5.71-.02-.5-.03-1-.01-1.49.18-1.9 1.12-3.72 2.58-4.96 1.66-1.44 3.98-2.13 6.15-1.72.02 1.48-.04 2.96-.04 4.44-.99-.32-2.15-.23-3.02.37-.63.41-1.11 1.04-1.36 1.75-.21.51-.15 1.07-.14 1.61.24 1.64 1.82 3.02 3.5 2.87 1.12-.01 2.19-.66 2.77-1.61.19-.33.4-.67.41-1.06.1-1.79.06-3.57.07-5.36.01-4.03-.01-8.05.02-12.07z" },
+		{ type: "mastodon", color: "#6364ff", path: "M23.268 5.313c-.35-2.578-2.617-4.61-5.304-5.004C17.51.242 15.792 0 11.813 0h-.03c-3.98 0-4.835.242-5.288.309C3.882.692 1.496 2.518.917 5.127.64 6.412.61 7.837.661 9.143c.074 1.874.088 3.745.26 5.611.118 1.24.325 2.47.62 3.68.55 2.237 2.777 4.098 4.96 4.857 2.336.792 4.849.923 7.256.38.265-.061.527-.132.786-.213.585-.184 1.27-.39 1.774-.753a.057.057 0 0 0 .023-.043v-1.809a.052.052 0 0 0-.02-.041.053.053 0 0 0-.046-.01 20.282 20.282 0 0 1-4.709.545c-2.73 0-3.463-1.284-3.674-1.818a5.593 5.593 0 0 1-.319-1.433.053.053 0 0 1 .066-.054c1.517.363 3.072.546 4.632.546.376 0 .75 0 1.125-.01 1.57-.044 3.224-.124 4.768-.422.038-.008.077-.015.11-.024 2.435-.464 4.753-1.92 4.989-5.604.008-.145.03-1.52.03-1.67.002-.512.167-3.63-.024-5.545zm-3.748 9.195h-2.561V8.29c0-1.309-.55-1.976-1.67-1.976-1.23 0-1.846.79-1.846 2.35v3.403h-2.546V8.663c0-1.56-.617-2.35-1.848-2.35-1.112 0-1.668.668-1.67 1.977v6.218H4.822V8.102c0-1.31.337-2.35 1.011-3.12.696-.77 1.608-1.164 2.74-1.164 1.311 0 2.302.5 2.962 1.498l.638 1.06.638-1.06c.66-.999 1.65-1.498 2.96-1.498 1.13 0 2.043.395 2.74 1.164.675.77 1.012 1.81 1.012 3.12z" },
+		{ type: "github", color: "#e2e8f0", path: "M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" },
+		{ type: "steam", color: "#c2c2c2", path: "M11.979 0C5.678 0 .511 4.86.022 11.037l6.432 2.658c.545-.371 1.203-.59 1.912-.59.063 0 .125.004.188.006l2.861-4.142V8.91c0-2.495 2.028-4.524 4.524-4.524 2.494 0 4.524 2.031 4.524 4.527s-2.03 4.525-4.524 4.525h-.105l-4.076 2.911c0 .052.004.105.004.159 0 1.875-1.515 3.396-3.39 3.396-1.635 0-3.016-1.173-3.331-2.718L.436 15.27C1.862 20.307 6.486 24 11.979 24c6.627 0 11.999-5.373 11.999-12S18.605 0 11.979 0zM7.54 18.21l-1.473-.61c.262.543.714.999 1.314 1.25 1.297.539 2.793-.076 3.332-1.375.263-.63.264-1.319.005-1.949s-.75-1.121-1.377-1.383c-.624-.26-1.29-.249-1.878-.03l1.523.63c.956.4 1.409 1.497 1.009 2.455-.397.957-1.497 1.41-2.454 1.012H7.54zm11.415-9.303c0-1.662-1.353-3.015-3.015-3.015-1.665 0-3.015 1.353-3.015 3.015 0 1.665 1.35 3.015 3.015 3.015 1.663 0 3.015-1.35 3.015-3.015zm-5.273-.005c0-1.252 1.013-2.266 2.265-2.266 1.249 0 2.266 1.014 2.266 2.266 0 1.251-1.017 2.265-2.266 2.265-1.252 0-2.265-1.014-2.265-2.265z" },
+		{ type: "facebook", color: "#1877f2", path: "M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" },
+		{ type: "bluesky", color: "#0085ff", path: "M12 10.8c-1.087-2.114-4.046-6.053-6.798-7.995C2.566.944 1.561 1.266.902 1.565.139 1.908 0 3.08 0 3.768c0 .69.378 5.65.624 6.479.815 2.736 3.713 3.66 6.383 3.364.136-.02.275-.039.415-.056-.138.022-.276.04-.415.056-3.912.58-7.387 2.005-2.83 7.078 5.013 5.19 6.87-1.113 7.823-4.308.953 3.195 2.05 9.271 7.733 4.308 4.267-4.308 1.172-6.498-2.74-7.078a8.741 8.741 0 0 1-.415-.056c.14.017.279.036.415.056 2.67.297 5.568-.628 6.383-3.364.246-.828.624-5.79.624-6.478 0-.69-.139-1.861-.902-2.204-.659-.3-1.664-.62-4.3 1.24C16.046 4.748 13.087 8.687 12 10.8z" },
+		{ type: "twitter", color: "#e2e8f0", path: "M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.259 5.631zm-1.161 17.52h1.833L7.084 4.126H5.117z" },
+	];
 </script>
 
 <svelte:head>
@@ -91,87 +132,19 @@
 
 <style>
 	:global(.hp-root) { font-family: 'Inter', sans-serif; }
-	.sg  { font-family: 'Space Grotesk', sans-serif; }
-	/* ── Gradient text ── */
-	.gt {
-		background: linear-gradient(135deg, var(--nx-accent-2-soft) 0%, var(--nx-cyan) 100%);
-		-webkit-background-clip: text; background-clip: text;
-		-webkit-text-fill-color: transparent; color: transparent;
-	}
-	/* ── Decorative letter ── */
-	.deco-letter {
-		font-family: 'Space Grotesk', sans-serif;
-		font-weight: 800;
-		font-size: clamp(140px, 20vw, 280px);
-		line-height: 1;
-		background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .5) 0%, rgb(var(--nx-cyan-rgb) / .2) 50%, transparent 80%);
-		-webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
-		pointer-events: none; user-select: none;
+	/* F1: Global :active press feedback for all interactive elements */
+	:global(.hp-root) button:active,
+	:global(.hp-root) a.nx-press:active {
+		transform: scale(0.97);
+		transition: transform 100ms ease-out;
 	}
 
-	/* ── Glass card ── */
-	.glass {
-		background: rgba(255,255,255,.035);
-		border: 1px solid rgba(255,255,255,.07);
-		backdrop-filter: blur(8px);
-		transition: background .2s, border-color .2s;
-	}
-	.glass:hover { background: rgba(255,255,255,.06); border-color: rgb(var(--nx-accent-2-rgb) / .3); }
-
-	/* ── Module tile ── */
-	.tile { position: relative; overflow: hidden; }
-	.tile::after {
-		content: '';
-		position: absolute; bottom: 0; left: 0; right: 0; height: 2px;
-		background: linear-gradient(90deg, var(--nx-accent-2-strong), var(--nx-cyan));
-		transform: scaleX(0); transform-origin: left;
-		transition: transform .3s ease;
-	}
-	.tile:hover::after { transform: scaleX(1); }
-
-	/* ── Slide cross-fade ── */
-	.sfade { animation: sfade .5s ease forwards; }
-	@keyframes sfade {
-		from { opacity: 0; transform: scale(1.04); }
-		to   { opacity: 1; transform: scale(1); }
-	}
-
-	/* ── Thread hover bar ── */
-	.trow { position: relative; }
-	.trow::before {
-		content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 2px;
-		background: linear-gradient(to bottom, var(--nx-accent-2-strong), var(--nx-cyan));
-		transform: scaleY(0); transform-origin: center;
-		transition: transform .2s ease;
-	}
-	.trow:hover::before { transform: scaleY(1); }
-
-	/* ── Stat glow ── */
-	@keyframes sglow {
-		0%,100% { text-shadow: 0 0 0 rgb(var(--nx-accent-2-rgb) / 0); }
-		50%      { text-shadow: 0 0 20px rgb(var(--nx-accent-2-rgb) / .5); }
-	}
-	.sglow { animation: sglow 4s ease-in-out infinite; }
-
-	/* ── Online pulse ── */
+	/* ── Online pulse (used by twitch live dot) ── */
 	@keyframes opulse {
 		0%   { box-shadow: 0 0 0 0 rgba(74,222,128,.5); }
 		100% { box-shadow: 0 0 0 7px rgba(74,222,128,0); }
 	}
 	.opulse { animation: opulse 2s ease-out infinite; }
-
-	/* ── Noise overlay ── */
-	.noise::after {
-		content: ''; position: absolute; inset: 0; pointer-events: none;
-		background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
-		opacity: .4;
-	}
-
-	/* ── Scanline ── */
-	.scanline::before {
-		content: ''; position: absolute; inset: 0; pointer-events: none;
-		background: repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0,0,0,.04) 2px, rgba(0,0,0,.04) 4px);
-	}
 
 	/* ── Dot grid bg ── */
 	.dotbg {
@@ -183,17 +156,125 @@
 		background-size: 100%, 100%, 28px 28px;
 	}
 
-	/* card accent bottom line on hover */
-	.card-hover {
-		position: relative;
-		transition: border-color .25s;
+	/* ── Bento Dashboard (Linear/Vercel/Raycast aesthetic) ── */
+	.nx-bento {
+		display: grid;
+		grid-template-columns: repeat(12, minmax(0, 1fr));
+		grid-auto-rows: 100px;
 	}
-	.card-hover::after {
-		content: ''; position: absolute; bottom: 0; left: 0; right: 0; height: 1px;
-		background: linear-gradient(90deg, transparent, rgb(var(--nx-accent-2-rgb) / .5), transparent);
-		opacity: 0; transition: opacity .3s;
+	@media (min-width: 640px) { .nx-bento { padding-left: 32px; padding-right: 32px; } }
+	@media (max-width: 900px) { .nx-bento { grid-template-columns: repeat(6, 1fr); } }
+	@media (max-width: 640px) { .nx-bento { grid-template-columns: 1fr; padding: 0 16px; gap: 10px; } }
+
+	/* Featured article (magazine) tile — img hover scale + overlay gradient stay in CSS */
+	.nx-bento-mag img { width: 100%; height: 100%; object-fit: cover; transition: transform .5s cubic-bezier(0.23, 1, 0.32, 1); }
+	.nx-bento-mag:hover img { transform: scale(1.04); }
+	.nx-bento-mag-overlay { position: absolute; inset: 0; background: linear-gradient(to top, rgba(4,4,10,.95) 5%, rgba(4,4,10,.3) 50%, transparent 80%); }
+
+	/* Article grid tile — img hover scale needs parent selector (stays in CSS) */
+	.nx-bento-card:hover .nx-bento-card-cover img { transform: scale(1.05); }
+
+	/* Community tile — signal bars need nth-child (stays in CSS) */
+	.nx-bento-signal { display: flex; align-items: flex-end; gap: 2px; shrink: 0; height: 16px; }
+	.nx-bento-signal-bar {
+		width: 3px; border-radius: 1px; background: rgba(255,255,255,.1);
+		transition: background .2s cubic-bezier(0.23, 1, 0.32, 1);
 	}
-	.card-hover:hover::after { opacity: 1; }
+	.nx-bento-signal-bar:nth-child(1) { height: 25%; }
+	.nx-bento-signal-bar:nth-child(2) { height: 50%; }
+	.nx-bento-signal-bar:nth-child(3) { height: 75%; }
+	.nx-bento-signal-bar:nth-child(4) { height: 100%; }
+	.nx-bento-signal-bar.on { background: currentColor; }
+	.nx-bento-community-thread-title { transition: color .2s cubic-bezier(0.23, 1, 0.32, 1); }
+	.nx-bento-community-thread:hover .nx-bento-community-thread-title { color: var(--nx-accent-2-soft); }
+	/* Ticker tile — animation + mask stay in CSS, rest in Tailwind */
+	.nx-bento-ticker {
+		height: 100%; overflow: hidden; position: relative;
+		mask: linear-gradient(to bottom, transparent 0%, #000 8%, #000 92%, transparent 100%);
+		-webkit-mask: linear-gradient(to bottom, transparent 0%, #000 8%, #000 92%, transparent 100%);
+	}
+	.nx-bento-ticker-track {
+		display: flex; flex-direction: column;
+		animation: nx-bento-tick 30s linear infinite;
+	}
+	.nx-bento-ticker:hover .nx-bento-ticker-track { animation-play-state: paused; }
+	@keyframes nx-bento-tick { from { transform: translateY(0); } to { transform: translateY(-50%); } }
+
+	/* Events tile — only hover effect stays in CSS */
+	.nx-bento-event { transition: border-color .2s cubic-bezier(0.23, 1, 0.32, 1); }
+	.nx-bento-event:hover { border-color: rgba(34,211,238,.25); }
+
+	/* CTA + Social tile — only pseudo-element + custom prop + responsive (rest in Tailwind) */
+	.nx-bento-cta-tile::before {
+		content: ''; position: absolute; top: 0; left: 0; right: 0; height: 1px;
+		background: linear-gradient(90deg, transparent, var(--nx-accent-2-strong), var(--nx-cyan), transparent);
+		pointer-events: none;
+	}
+	.nx-cta-social-link { color: var(--ic, #9ca3af); }
+	@media (max-width: 900px) {
+		.nx-bento-cta-tile { flex-direction: column; }
+		.nx-cta-hero { border-right: none; border-bottom: 1px solid rgba(255,255,255,.06); padding: 16px 20px; }
+		.nx-cta-stats-bar { border-bottom: 1px solid rgba(255,255,255,.06); }
+		.nx-cta-bottom { border-left: none; border-top: 1px solid rgba(255,255,255,.06); flex-wrap: wrap; }
+	}
+	@media (max-width: 900px) {
+		.nx-bento-tile { grid-column: span 6 !important; }
+	}
+	@media (max-width: 640px) {
+		.nx-bento-tile { grid-column: span 1 !important; grid-row: span 4 !important; }
+	}
+
+	/* ── Slideshow hero (bento) — keyframes + complex gradients stay in CSS ── */
+	.nx-slideshow-overlay-l {
+		position: absolute; inset: 0;
+		background: linear-gradient(to right, rgba(4,4,10,.95) 0%, rgba(4,4,10,.6) 40%, transparent 70%);
+	}
+	.nx-slideshow-overlay-b {
+		position: absolute; inset: 0;
+		background: linear-gradient(to top, rgba(4,4,10,.95) 0%, transparent 50%);
+	}
+	.nx-slideshow-glow {
+		position: absolute; top: -100px; right: -100px;
+		width: 400px; height: 400px; border-radius: 50%;
+		background: radial-gradient(circle, rgba(99,102,241,.15) 0%, transparent 70%);
+		pointer-events: none;
+	}
+	.nx-slideshow-cat-line {
+		width: 40px; height: 1px;
+		background: linear-gradient(to right, var(--nx-accent-2-strong), var(--nx-cyan));
+	}
+	.nx-slideshow-progress {
+		position: absolute; inset: 0; height: 100%;
+		background: linear-gradient(to right, var(--nx-accent-2-strong), var(--nx-cyan));
+		width: 0%; transition: width .1s cubic-bezier(0.16, 1, 0.3, 1);
+	}
+
+	/* ── Twitch widget (bento) — only animation + responsive grid stay in CSS ── */
+	.nx-twitch {
+		border: 1px solid rgba(255,255,255,.06); border-radius: 12px;
+		overflow: hidden; background: #0a0a0f;
+		transition: border-color .2s cubic-bezier(0.16, 1, 0.3, 1);
+	}
+	.nx-twitch:hover { border-color: rgba(99,102,241,.2); }
+	.nx-twitch-live-dot {
+		width: 6px; height: 6px; border-radius: 50%; background: #4ade80;
+		animation: opulse 2s ease-out infinite;
+	}
+	.nx-twitch-body {
+		display: grid; grid-template-columns: 3fr 1fr;
+		height: 400px;
+	}
+	@media (max-width: 768px) { .nx-twitch-body { grid-template-columns: 1fr; height: auto; } }
+	@media (max-width: 768px) { .nx-twitch-chat { border-left: none; border-top: 1px solid rgba(255,255,255,.05); height: 300px; } }
+
+	/* ── F6: Reduced motion — disable decorative animations ── */
+	@media (prefers-reduced-motion: reduce) {
+		.opulse,
+		.nx-twitch-live-dot { animation: none; box-shadow: 0 0 0 3px rgba(74,222,128,.5); }
+		.nx-bento-ticker-track { animation: none; transform: none; }
+		.nx-bento-mag img,
+		.nx-bento-card-cover img { transition: none; }
+	}
 
 </style>
 
@@ -216,605 +297,354 @@
      FALLBACK — ancien système positions fixes (tant que pas de grid)
 ══════════════════════════════════════════════════════════════���═════════ -->
 
-<!-- BANNER -->
-{#if hasPos('banner')}
-	<WidgetZone widgets={posWidgets('banner')} {instance} {user} layout="full" {installedWidgets} />
-{/if}
-
 <!-- ═══════════════════════════════════════════════════════════════════
-     HERO — position 'hero' (WidgetZone) ou fallback hardcodé
+     BENTO DASHBOARD — Variant B from sketch 005 (Linear/Vercel/Raycast)
+     Layout: Slideshow → Twitch → Bento (magazine + articles + ticker + community + video + CTA + social)
 ════════════════════════════════════════════════════════════════════════ -->
-{#if hasPos('hero')}
-	<WidgetZone widgets={posWidgets('hero')} {instance} {user} layout="full" {installedWidgets} />
-{:else}
-<!-- Fallback hero hardcodé (tant qu'aucun widget n'est configuré) -->
-<section class="relative overflow-hidden noise" style="background: #0a0a0f; border-bottom: 1px solid rgba(255,255,255,.05); min-height: 220px">
 
-	<!-- Banner bg -->
-	{#if instance.banner_url}
-		<img src={instance.banner_url} alt="" class="absolute inset-0 w-full h-full object-cover" style="opacity:.06" />
-	{/if}
-
-	<!-- Orbs -->
-	<div class="absolute -top-40 -left-20 w-[500px] h-[500px] rounded-full pointer-events-none"
-	     style="background: radial-gradient(circle, rgb(var(--nx-accent-2-rgb) / .14) 0%, transparent 65%)"></div>
-	<div class="absolute -bottom-20 right-0 w-96 h-96 rounded-full pointer-events-none"
-	     style="background: radial-gradient(circle, rgb(var(--nx-cyan-rgb) / .08) 0%, transparent 65%)"></div>
-
-	<!-- Decorative letter -->
-	<div class="deco-letter absolute right-6 top-1/2 -translate-y-1/2 opacity-70 select-none pointer-events-none" aria-hidden="true">{heroLetter}</div>
-
-	<div class="relative z-10 px-8 pt-6 pb-5 flex flex-col gap-4">
-
-		<!-- Identity -->
-		<div class="flex items-center gap-5">
-			{#if instance.logo_url}
-				<img src={instance.logo_url} alt={instance.name}
-				     class="w-12 h-12 object-cover shrink-0" style="outline: 2px solid rgb(var(--nx-accent-2-rgb) / .5); outline-offset: 2px" />
-			{:else}
-				<div class="w-12 h-12 flex items-center justify-center shrink-0 sg text-xl font-black text-white"
-				     style="background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .4), rgb(var(--nx-cyan-rgb) / .15)); border: 1px solid rgb(var(--nx-accent-2-rgb) / .3)">
-					{heroLetter}
-				</div>
-			{/if}
-			<div>
-				<h1 class="sg font-extrabold leading-none mb-1" style="font-size: clamp(1.3rem,2.5vw,1.9rem)">
-					<span class="gt">{instance.name}</span>
-				</h1>
-				{#if instance.description}
-					<p class="text-sm max-w-lg leading-relaxed" style="color: #6b7280">{instance.description}</p>
-				{/if}
-			</div>
-		</div>
-
-		<!-- Stats row -->
-		<div class="flex flex-wrap items-stretch gap-0.5">
-			{#each [
-				{ value: instance.member_count.toLocaleString(), label: tFn('common.members'),  color: 'var(--nx-accent-2-soft)', glow: true },
-				{ value: String(instance.online_count),                  label: tFn('common.online'), color: '#4ade80', online: true },
-				{ value: instance.thread_count.toLocaleString(), label: tFn('common.topics'),   color: 'var(--nx-cyan-soft)', glow: false },
-				{ value: instance.post_count.toLocaleString(),   label: tFn('nav.dm'), color: '#94a3b8', glow: false },
-			] as stat}
-				<div class="flex flex-col items-center justify-center px-6 py-2 gap-0.5"
-				     style="background: rgba(255,255,255,.04); border: 1px solid rgba(255,255,255,.06)">
-					<span class="sg font-black text-xl tabular-nums {stat.glow ? 'sglow' : ''}" style="color: {stat.color}">
-						{#if stat.online}
-							<span class="flex items-center gap-2">
-								<span class="w-2 h-2 rounded-full opulse" style="background:#4ade80"></span>
-								{stat.value}
-							</span>
-						{:else}
-							{stat.value}
-						{/if}
-					</span>
-					<span class="text-[9px] uppercase tracking-[.18em] font-bold" style="color: #374151">{stat.label}</span>
-				</div>
-			{/each}
-
-			<!-- CTA -->
-			<div class="flex items-center gap-2 ml-auto self-center pl-4">
-				{#if data.user && (data.categories?.[0]?.slug ?? data.categories?.[0]?.id)}
-					<a href="/forum/{data.categories?.[0]?.slug ?? data.categories?.[0]?.id}/new"
-					   class="sg px-5 py-2.5 text-sm font-bold uppercase tracking-wider text-white transition-all"
-					   style="background: linear-gradient(135deg, var(--nx-accent-2-strong) 0%, var(--nx-cyan-deep) 100%); border: 1px solid rgb(var(--nx-accent-2-rgb) / .4)">
-						{tFn('common.new_topic')}
-					</a>
-				{:else}
-					<a href="/auth/login"
-					   class="sg px-4 py-2.5 text-sm font-bold uppercase tracking-wider transition-all"
-					   style="color: #9ca3af; border: 1px solid rgba(255,255,255,.1)">
-						{tFn('common.login')}
-					</a>
-					<a href="/auth/register"
-					   class="sg px-5 py-2.5 text-sm font-bold uppercase tracking-wider text-white transition-all"
-					   style="background: linear-gradient(135deg, var(--nx-accent-2-strong) 0%, var(--nx-cyan-deep) 100%); border: 1px solid rgb(var(--nx-accent-2-rgb) / .4)">
-						{tFn('common.join')}
-					</a>
-				{/if}
-			</div>
-		</div>
-	</div>
-</section>
-{/if}
-
-<!-- ═══════════════════════════════════════════════════════════════════
-     STATS-BAR — position 'stats-bar' (WidgetZone) — remplace les stats inline
-════════════════════════════════════════════════════════════════════════ -->
-{#if hasPos('stats-bar')}
-	<div class="flex flex-wrap px-8 py-3 gap-0.5" style="background:#0d0d12; border-bottom:1px solid rgba(255,255,255,.05)">
-		<WidgetZone widgets={posWidgets('stats-bar')} {instance} {user} layout="full" {installedWidgets} />
-	</div>
-{/if}
-
-<!-- ═══════════════════════════════════════════════════════════════════
-     MAIN — position 'main' (WidgetZone) — above main content
-════════════════════════════════════════════════════════════════════════ -->
+<!-- MAIN — position 'main' (WidgetZone) -->
 {#if hasPos('main')}
 	<WidgetZone widgets={posWidgets('main')} {instance} {user} layout="full" {installedWidgets} />
 {/if}
 
-<!-- ═══════════════════════════════════════════════════════════════════
-     MODULES ROW — 4 quick tiles
-════════════════════════════════════════════════════════════════════════ -->
-<div class="grid grid-cols-2 lg:grid-cols-4 gap-px" style="background: rgba(255,255,255,.04); border-bottom: 1px solid rgba(255,255,255,.05)">
-
-	<!-- Tile 1 — Dernière actualité -->
-	{#if heroArticle}
-	<a href="/forum/{heroArticle.categoryId}/{heroArticle.id}"
-	   class="tile glass group flex flex-col gap-2.5 p-5 transition-all duration-200">
-		<div class="flex items-center gap-2">
-			<svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="#a78bfa" stroke-width="2" viewBox="0 0 24 24">
-				<path stroke-linecap="round" stroke-linejoin="round" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10l6 6v8a2 2 0 01-2 2z"/>
-			</svg>
-			<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: var(--nx-accent-2-soft)">{tFn('home.news')}</span>
-		</div>
-		<p class="sg text-sm font-bold leading-snug line-clamp-2 group-hover:text-violet-200 transition-colors" style="color: #e2e8f0">{heroArticle.title}</p>
-		<span class="text-[10px] mt-auto" style="color: #4b5563">{heroArticle.categoryName}</span>
-	</a>
-	{:else}
-	<div class="tile glass flex flex-col gap-2.5 p-5">
-		<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: var(--nx-accent-2-soft)">{tFn('home.news')}</span>
-		{tFn('common.no_article')}
-	</div>
-	{/if}
-
-	<!-- Tile 2 — Dernier thread -->
-	{#if recentThreads[0]}
-	<a href="/forum/{recentThreads[0].category_id}/{recentThreads[0].id}"
-	   class="tile glass group flex flex-col gap-2.5 p-5 transition-all duration-200">
-		<div class="flex items-center gap-2">
-			<svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="#67e8f9" stroke-width="2" viewBox="0 0 24 24">
-				<path stroke-linecap="round" stroke-linejoin="round" d="M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a2 2 0 01-2-2v-6a2 2 0 012-2h8z"/>
-			</svg>
-			<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: var(--nx-cyan-soft)">{tFn('home.forum')}</span>
-		</div>
-		<p class="sg text-sm font-bold leading-snug line-clamp-2 group-hover:text-cyan-200 transition-colors" style="color: #e2e8f0">{recentThreads[0].title}</p>
-		<span class="text-[10px] mt-auto" style="color: #4b5563">{recentThreads[0].category_name}</span>
-	</a>
-	{:else}
-	<a href="/forum" class="tile glass flex flex-col gap-2.5 p-5">
-		<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: var(--nx-cyan-soft)">{tFn('home.forum')}</span>
-		{tFn('home.view_discussions')}
-	</a>
-	{/if}
-
-	<!-- Tile 3 — Membres en ligne -->
-	<div class="tile glass flex flex-col gap-2.5 p-5">
-		<div class="flex items-center gap-2">
-			<span class="w-2 h-2 rounded-full opulse" style="background:#4ade80"></span>
-			<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: #4ade80">{tFn('home.online_members')}</span>
-		</div>
-		<p class="sg font-black text-4xl tabular-nums" style="color: #fff">{instance.online_count}</p>
-		<span class="text-[10px] mt-auto" style="color: #4b5563">{tFn('common.members_total', { count: instance.member_count.toLocaleString() })}</span>
-	</div>
-
-	<!-- Tile 4 — Chat -->
-	<a href="/chat" class="tile glass group flex flex-col gap-2.5 p-5 transition-all duration-200">
-		<div class="flex items-center gap-2">
-			<svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="#fb923c" stroke-width="2" viewBox="0 0 24 24">
-				<path stroke-linecap="round" stroke-linejoin="round" d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/>
-			</svg>
-			<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: #fb923c">{tFn('home.live_chat')}</span>
-		</div>
-		<p class="sg text-sm font-bold group-hover:text-orange-200 transition-colors" style="color: #e2e8f0">{tFn('home.join_channel')}</p>
-		<span class="text-[10px] mt-auto" style="color: #4b5563">{tFn('home.realtime')}</span>
-	</a>
-</div>
-
-<!-- ═══════════════════════════════════════════════════════════════════
-     SLIDESHOW  ×  ACTIVITY FEED
-════════════════════════════════════════════════════════════════════════ -->
-<div class="grid grid-cols-1 lg:grid-cols-[1fr_300px]" style="border-bottom: 1px solid rgba(255,255,255,.05); min-height: 420px">
-
-	<!-- ── Slideshow ── -->
-	<div class="relative overflow-hidden scanline" style="background: #0a0a0f; min-height: 420px; border-right: 1px solid rgba(255,255,255,.05)">
-		{#if slideArticles.length > 0}
-			{@const slide = slideArticles[slideIndex]}
-
-			{#key slideIndex}
-				{#if slide.imageUrl}
-					<img src={slide.imageUrl} alt="" class="sfade absolute inset-0 w-full h-full object-cover" style="opacity:.5" />
+<!-- ══ 1. Slideshow hero (50vh, full-width) ══ -->
+{#if slideArticles.length > 0}
+<section class="py-6 overflow-x-hidden" style="padding-top:24px;">
+	<div class="nx-bento gap-3 mx-auto px-6 box-border" style="grid-auto-rows: auto;">
+		<div style="grid-column: span 12;">
+			<div class="relative w-full h-[50vh] min-h-100 overflow-hidden rounded-xl bg-[#0a0a0f]">
+				{#key slideIndex}
+				{#if slideArticles[slideIndex]?.imageUrl}
+					<img src={slideArticles[slideIndex].imageUrl} alt="" class="absolute inset-0 w-full h-full object-cover opacity-50" transition:fade={{ duration: 400, easing: cubicOut }} />
 				{:else}
-					<div class="sfade absolute inset-0" style="background: linear-gradient(135deg, #12012c 0%, #020c1b 100%)"></div>
+					<div class="absolute inset-0 nx-bg-slide-empty" transition:fade={{ duration: 400, easing: cubicOut }}></div>
 				{/if}
-			{/key}
-
-			<!-- Layered overlays -->
-			<div class="absolute inset-0 pointer-events-none" style="background: linear-gradient(105deg, rgba(5,5,10,.95) 30%, rgba(5,5,10,.5) 70%, transparent 100%)"></div>
-			<div class="absolute inset-0 pointer-events-none" style="background: linear-gradient(to top, rgba(5,5,10,.9) 15%, transparent 60%)"></div>
-
-			<!-- Violet glow bottom-left -->
-			<div class="absolute bottom-0 left-0 w-72 h-48 pointer-events-none"
-			     style="background: radial-gradient(ellipse at bottom left, rgb(var(--nx-accent-2-rgb) / .2), transparent 70%)"></div>
-
-			<div class="relative z-10 h-full flex flex-col justify-end p-8 pb-10">
-				<!-- Category -->
-				{#if slide.categoryName}
-					<div class="flex items-center gap-3 mb-3">
-						<span class="h-px w-10" style="background: linear-gradient(to right, var(--nx-accent-2-strong), var(--nx-cyan))"></span>
-						<span class="sg text-[10px] font-black uppercase tracking-[.22em]" style="color: var(--nx-accent-2-soft)">{slide.categoryName}</span>
+				{/key}
+				<div class="nx-slideshow-overlay-l"></div>
+				<div class="nx-slideshow-overlay-b"></div>
+				<div class="nx-slideshow-glow"></div>
+				<div class="relative z-2 flex flex-col justify-center h-full p-12 max-w-[700px]">
+					<div class="flex items-center gap-3 mb-4">
+						<span class="nx-slideshow-cat-line"></span>
+						<span class="font-mono text-[11px] font-medium uppercase tracking-[0.14em]" style="color: var(--nx-accent-2-soft);">{slideArticles[slideIndex]?.categoryName || tFn('home.news')}</span>
 					</div>
-				{/if}
-
-				<!-- Title -->
-				<h2 class="sg font-extrabold text-white leading-tight line-clamp-3 max-w-2xl mb-3"
-				    style="font-size: clamp(1.3rem, 2.2vw, 1.9rem); text-shadow: 0 2px 30px rgba(0,0,0,.9)">
-					{slide.title}
-				</h2>
-
-				{#if slide.excerpt}
-					<p class="text-sm line-clamp-2 max-w-xl mb-5 leading-relaxed" style="color: #6b7280">{slide.excerpt}</p>
-				{/if}
-
-				<!-- Meta + CTA -->
-				<div class="flex items-center gap-5">
-					<div class="flex items-center gap-2.5">
-						<div class="w-7 h-7 overflow-hidden shrink-0" style="background: rgb(var(--nx-accent-2-rgb) / .3); outline: 1.5px solid rgb(var(--nx-accent-2-rgb) / .4); outline-offset: 1px">
-							{#if slide.authorAvatar}
-								<img src={slide.authorAvatar} alt="" class="w-full h-full object-cover" />
-							{:else}
-								<span class="w-full h-full flex items-center justify-center text-[11px] font-bold text-white">
-									{slide.authorUsername?.charAt(0).toUpperCase() ?? '?'}
-								</span>
-							{/if}
+					<h2 class="font-['Space_Grotesk'] font-extrabold text-[clamp(1.5rem,3vw,2.4rem)] leading-tight text-white m-0 mb-4" style="text-shadow: 0 2px 30px rgba(0,0,0,.9);">{slideArticles[slideIndex]?.title}</h2>
+					{#if slideArticles[slideIndex]?.excerpt}
+						<p class="text-sm text-gray-400 leading-relaxed max-w-[500px] m-0 mb-6">{slideArticles[slideIndex].excerpt}</p>
+					{/if}
+					<div class="flex items-center gap-4 flex-wrap">
+						<div class="flex items-center gap-2.5">
+							<div class="w-8 h-8 rounded-full bg-indigo-500/30 border border-indigo-500/40 flex items-center justify-center text-xs font-bold text-white font-['Space_Grotesk']">{slideArticles[slideIndex]?.authorUsername?.charAt(0).toUpperCase() ?? '?'}</div>
+							<span class="text-[13px] font-semibold" style="color: var(--nx-accent-2-soft);">{slideArticles[slideIndex]?.authorUsername}</span>
+							<span class="text-xs text-gray-500 font-mono">{timeAgo(slideArticles[slideIndex]?.createdAt ?? '')}</span>
 						</div>
-						<span class="text-sm" style="color: #9ca3af">{slide.authorUsername}</span>
-						<span style="color: #374151">·</span>
-						<span class="text-sm" style="color: #6b7280">{timeAgo(slide.createdAt)}</span>
+						<a href="/forum/{slideArticles[slideIndex]?.categoryId}/{slideArticles[slideIndex]?.id}" class="nx-press inline-flex items-center gap-1.5 font-['Space_Grotesk'] text-xs font-bold uppercase tracking-[0.08em] text-white px-4 py-2.25 rounded-md no-underline whitespace-nowrap bg-white/[0.08] backdrop-blur-md border border-white/15 transition-all duration-200 hover:bg-white/15 hover:border-white/30">
+							{tFn('common.read_article')}
+							<svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+						</a>
 					</div>
-					<a href="/forum/{slide.categoryId}/{slide.id}"
-					   class="sg ml-auto group flex items-center gap-2 px-5 py-2.5 text-sm font-bold uppercase tracking-wider text-white transition-all"
-					   style="background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .55), rgb(var(--nx-cyan-rgb) / .25)); border: 1px solid rgb(var(--nx-accent-2-rgb) / .45)">
-						{tFn('common.read_article')}
-						<svg class="w-3.5 h-3.5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
-							<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
-						</svg>
-					</a>
 				</div>
-
-				<!-- Progress bar + nav -->
 				{#if slideArticles.length > 1}
-					<div class="flex items-center gap-3 mt-7">
+				<div class="absolute bottom-8 right-12 flex items-center gap-4 z-3">
+					<div class="flex gap-2">
 						{#each slideArticles as _, i}
-							<button onclick={() => { slideTo(i); startTimers(); }}
-							        class="relative h-px transition-all duration-300 {i === slideIndex ? 'w-14' : 'w-4 opacity-25 hover:opacity-50'}"
-							        style="background: rgba(255,255,255,.15)"
-							        aria-label="Slide {i+1}">
-								{#if i === slideIndex}
-									<span class="absolute top-[-1px] left-0 h-[3px] transition-none"
-									      style="width:{progressPct}%; background: linear-gradient(to right, var(--nx-accent-2-strong), var(--nx-cyan))"></span>
-								{/if}
-							</button>
+						<button class="w-6 h-1 border-0 p-0 bg-white/20 cursor-pointer transition-colors duration-200 relative overflow-hidden {i === slideIndex ? 'bg-white/30' : ''}" onclick={() => slideTo(i)}>
+							{#if i === slideIndex}<span class="nx-slideshow-progress" style="width:{progressPct}%"></span>{/if}
+						</button>
 						{/each}
-						<div class="ml-auto flex gap-1">
-							<button onclick={() => { slidePrev(); startTimers(); }}
-							        class="w-8 h-8 flex items-center justify-center transition-all"
-							        style="border: 1px solid rgba(255,255,255,.08); color: #6b7280"
-							        aria-label={tFn('common.back')}
-							        onmouseenter={e => (e.currentTarget as HTMLElement).style.borderColor='rgb(var(--nx-accent-2-rgb) / .5)'}
-							        onmouseleave={e => (e.currentTarget as HTMLElement).style.borderColor='rgba(255,255,255,.08)'}>
-								<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/></svg>
-							</button>
-							<button onclick={() => { slideNext(); startTimers(); }}
-							        class="w-8 h-8 flex items-center justify-center transition-all"
-							        style="border: 1px solid rgba(255,255,255,.08); color: #6b7280"
-							        aria-label="Suivant"
-							        onmouseenter={e => (e.currentTarget as HTMLElement).style.borderColor='rgb(var(--nx-accent-2-rgb) / .5)'}
-							        onmouseleave={e => (e.currentTarget as HTMLElement).style.borderColor='rgba(255,255,255,.08)'}>
-								<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
-							</button>
-						</div>
 					</div>
-				{/if}
-			</div>
-		{:else}
-			<div class="flex items-center justify-center h-full" style="color: #374151">{tFn('common.no_article')}</div>
-		{/if}
-	</div>
-
-	<!-- ── Activity Feed ── -->
-	<div class="flex flex-col" style="background: #0d0d12">
-		<div class="flex items-center justify-between px-5 py-3.5 shrink-0"
-		     style="border-bottom: 1px solid rgba(255,255,255,.05)">
-			<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: #6b7280">{tFn('home.forum_activity')}</span>
-			<a href="/forum" class="sg text-[10px] font-bold uppercase tracking-wide transition-colors" style="color: #4b5563" onmouseenter={e => (e.target as HTMLElement).style.color='var(--nx-accent-2-soft)'} onmouseleave={e => (e.target as HTMLElement).style.color='#4b5563'}>
-				{tFn('common.view_all')}
-			</a>
-		</div>
-
-		<div class="flex-1 overflow-y-auto" style="divide-color: rgba(255,255,255,.04)">
-			{#each recentThreads as thread, i}
-			<a href="/forum/{thread.category_id}/{thread.id}"
-			   class="trow flex items-start gap-3 px-5 py-4 transition-colors group"
-			   style="border-bottom: 1px solid rgba(255,255,255,.04)"
-			   onmouseenter={e => (e.currentTarget as HTMLElement).style.background='rgba(255,255,255,.025)'}
-			   onmouseleave={e => (e.currentTarget as HTMLElement).style.background='transparent'}>
-				<span class="sg text-[11px] font-black tabular-nums shrink-0 mt-0.5 w-5 text-right"
-				      style="color: {i===0 ? 'var(--nx-accent-2-soft)' : i===1 ? 'var(--nx-cyan-soft)' : '#374151'}">
-					{String(i+1).padStart(2,'0')}
-				</span>
-				<div class="flex-1 min-w-0">
-					<p class="text-xs font-semibold line-clamp-2 leading-snug group-hover:text-white transition-colors" style="color: #d1d5db">
-						{thread.title}
-					</p>
-					<div class="flex items-center gap-2 mt-1.5">
-						<div class="w-4 h-4 overflow-hidden shrink-0" style="background: rgb(var(--nx-accent-2-rgb) / .35)">
-							{#if thread.author_avatar}
-								<img src={thread.author_avatar} alt="" class="w-full h-full object-cover" />
-							{:else}
-								<span class="flex items-center justify-center w-full h-full text-[8px] font-bold text-white">{thread.author_username?.charAt(0).toUpperCase() ?? '?'}</span>
-							{/if}
-						</div>
-						<span class="text-[10px]" style="color: #4b5563">{thread.author_username}</span>
-						<span class="text-[10px] ml-auto" style="color: #374151">{timeAgo(thread.created_at)}</span>
+					<div class="flex gap-1">
+						<button class="w-8 h-8 border border-white/15 bg-black/30 text-white cursor-pointer flex items-center justify-center transition-all duration-200 rounded-md hover:bg-indigo-500/30 hover:border-indigo-500/40" onclick={slidePrev} aria-label="Previous"><svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/></svg></button>
+						<button class="w-8 h-8 border border-white/15 bg-black/30 text-white cursor-pointer flex items-center justify-center transition-all duration-200 rounded-md hover:bg-indigo-500/30 hover:border-indigo-500/40" onclick={slideNext} aria-label="Next"><svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg></button>
 					</div>
 				</div>
-				{#if (thread.post_count ?? 0) > 1}
-					<span class="sg shrink-0 text-[10px] font-bold tabular-nums mt-0.5" style="color: #374151">{thread.post_count}</span>
 				{/if}
-			</a>
-			{:else}
-				<div class="flex items-center justify-center h-24" style="color: #374151; font-size: .75rem">{tFn('common.no_activity')}</div>
-			{/each}
-		</div>
-
-		<div class="px-5 py-3 shrink-0" style="border-top: 1px solid rgba(255,255,255,.05)">
-			<a href="/forum"
-			   class="sg flex items-center justify-center gap-2 w-full py-2.5 text-[10px] font-black uppercase tracking-widest transition-all"
-			   style="color: #6b7280; border: 1px solid rgba(255,255,255,.06)"
-			   onmouseenter={e => { (e.currentTarget as HTMLElement).style.color='var(--nx-accent-2-soft)'; (e.currentTarget as HTMLElement).style.borderColor='rgb(var(--nx-accent-2-rgb) / .25)'; }}
-			   onmouseleave={e => { (e.currentTarget as HTMLElement).style.color='#6b7280'; (e.currentTarget as HTMLElement).style.borderColor='rgba(255,255,255,.06)'; }}>
-				{tFn('home.view_forum')}
-				<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
-			</a>
-		</div>
-	</div>
-</div>
-
-<!-- ═══════════════════════════════════════════════════════════════════
-     SIDEBAR — position 'sidebar' (WidgetZone) — join-card etc.
-════════════════════════════════════════════════════════════════════════ -->
-{#if hasPos('sidebar')}
-	<div class="px-6 py-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
-	     style="border-bottom:1px solid rgba(255,255,255,.05); background:#08080d">
-		<WidgetZone widgets={posWidgets('sidebar')} {instance} {user} layout="grid-3" {installedWidgets} />
-	</div>
-{/if}
-
-<!-- ═══════════════════════════════════════════════════════════════════
-     FORUM THREADS GRID
-════════════════════════════════════════════════════════════════════════ -->
-{#if featuredThreads.length > 0}
-<section class="px-6 py-8" style="border-bottom: 1px solid rgba(255,255,255,.05); background: #08080d">
-
-	<div class="flex items-center gap-4 mb-6">
-		<span class="sg text-[10px] font-black uppercase tracking-[.22em]" style="color: var(--nx-cyan-soft)">{tFn('home.latest_topics')}</span>
-		<div class="flex-1 h-px" style="background: linear-gradient(to right, rgb(var(--nx-cyan-rgb) / .2), transparent)"></div>
-		<a href="/forum" class="sg text-[10px] font-bold uppercase tracking-widest transition-colors" style="color: #4b5563"
-		   onmouseenter={e => (e.target as HTMLElement).style.color='var(--nx-cyan-soft)'} onmouseleave={e => (e.target as HTMLElement).style.color='#4b5563'}>
-			{tFn('common.see_all')}
-		</a>
-	</div>
-
-	<div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
-		{#each featuredThreads as thread}
-		<a href="/forum/{thread.category_id}/{thread.id}"
-		   class="card-hover group flex flex-col p-5 transition-all duration-250"
-		   style="background: #12121a; border: 1px solid rgba(255,255,255,.06)"
-		   onmouseenter={e => (e.currentTarget as HTMLElement).style.borderColor='rgb(var(--nx-accent-2-rgb) / .25)'}
-		   onmouseleave={e => (e.currentTarget as HTMLElement).style.borderColor='rgba(255,255,255,.06)'}>
-
-			<div class="flex items-start justify-between gap-2 mb-4">
-				{#if thread.category_name}
-					<span class="sg text-[9px] font-black uppercase tracking-widest px-2 py-0.5"
-					      style="color: var(--nx-accent-2-soft); background: rgb(var(--nx-accent-2-rgb) / .1); border: 1px solid rgb(var(--nx-accent-2-rgb) / .2)">
-						{thread.category_name}
-					</span>
-				{/if}
-				<div class="flex items-center gap-1 ml-auto shrink-0" style="color: #374151">
-					<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-						<path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
-					</svg>
-					<span class="sg text-[10px] font-bold">{thread.post_count ?? 0}</span>
-				</div>
 			</div>
-
-			<h4 class="sg text-sm font-bold leading-snug line-clamp-3 flex-1 mb-5 group-hover:text-white transition-colors" style="color: #d1d5db">
-				{thread.title}
-			</h4>
-
-			<div class="flex items-center gap-2 pt-4" style="border-top: 1px solid rgba(255,255,255,.05)">
-				<div class="w-6 h-6 overflow-hidden shrink-0" style="background: rgb(var(--nx-accent-2-rgb) / .3); outline: 1px solid rgba(255,255,255,.07)">
-					{#if thread.author_avatar}
-						<img src={thread.author_avatar} alt="" class="w-full h-full object-cover" />
-					{:else}
-						<span class="flex items-center justify-center w-full h-full text-[9px] font-bold text-white">{thread.author_username?.charAt(0).toUpperCase() ?? '?'}</span>
-					{/if}
-				</div>
-				<span class="text-[10px] truncate" style="color: #6b7280">{thread.author_username}</span>
-				<span class="sg text-[10px] ml-auto shrink-0" style="color: #374151">{timeAgo(thread.created_at)}</span>
-			</div>
-		</a>
-		{/each}
+		</div>
 	</div>
 </section>
 {/if}
 
-<!-- ═══════════════════════════════════════════════════════════════════
-     ARTICLES
-════════════════════════════════════════════════════════════════════════ -->
-{#if articles.length > 0}
-<section class="px-6 py-8" style="background: #0a0a0f">
-
-	<div class="flex items-center gap-4 mb-6">
-		<span class="sg text-[10px] font-black uppercase tracking-[.22em]" style="color: var(--nx-accent-2-soft)">{tFn('home.articles')}</span>
-		<div class="flex-1 h-px" style="background: linear-gradient(to right, rgb(var(--nx-accent-2-rgb) / .2), transparent)"></div>
+<!-- ══ 2. Twitch widget (full-width) — DB-backed via twitch-stream widget config ══ -->
+{#if twitchChannel}
+<section class="py-6 overflow-x-hidden" style="padding-top:0;">
+	<div class="nx-bento gap-3 mx-auto px-6 box-border" style="grid-auto-rows: auto;">
+		<div style="grid-column: span 12;">
+			<div class="nx-twitch">
+				<div class="flex items-center gap-2.5 px-5 py-3 border-b border-white/[0.05]">
+					<div class="w-6 h-6 flex items-center justify-center text-[#9146ff]"><svg class="w-5 h-5 fill-current" viewBox="0 0 24 24"><path d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714Z"/></svg></div>
+					<span class="font-['Space_Grotesk'] text-sm font-bold text-white">{twitchChannel}</span>
+					<span class="flex items-center gap-1.5 font-mono text-[10px] font-medium uppercase tracking-[0.1em] text-green-400 bg-green-400/10 border border-green-400/20 px-2 py-0.5 rounded-full"><span class="nx-twitch-live-dot"></span>{tFn('home.live')}</span>
+				</div>
+				<div class="nx-twitch-body">
+					<div class="relative bg-black overflow-hidden">
+						<iframe class="absolute inset-0 w-full h-full border-0" src="https://player.twitch.tv/?channel={twitchChannel}&parent={typeof window !== 'undefined' ? window.location.hostname : 'localhost'}&autoplay=true&muted=true" title="Twitch player — {twitchChannel}" allowfullscreen allow="autoplay; fullscreen; picture-in-picture"></iframe>
+					</div>
+					<div class="nx-twitch-chat relative bg-[#0a0a0f] border-l border-white/[0.05]">
+						<iframe class="absolute inset-0 w-full h-full border-0" src="https://www.twitch.tv/embed/{twitchChannel}/chat?parent={typeof window !== 'undefined' ? window.location.hostname : 'localhost'}&darkpopout" title="Twitch chat — {twitchChannel}"></iframe>
+					</div>
+				</div>
+			</div>
+		</div>
 	</div>
+</section>
+{/if}
 
-	<!-- Hero article -->
-	{#if heroArticle}
-	<a href="/forum/{heroArticle.categoryId}/{heroArticle.id}"
-	   class="card-hover group flex flex-col sm:flex-row overflow-hidden mb-3 transition-all duration-250"
-	   style="background: #12121a; border: 1px solid rgba(255,255,255,.06)"
-	   onmouseenter={e => (e.currentTarget as HTMLElement).style.borderColor='rgb(var(--nx-accent-2-rgb) / .25)'}
-	   onmouseleave={e => (e.currentTarget as HTMLElement).style.borderColor='rgba(255,255,255,.06)'}>
-		<div class="sm:w-64 h-44 sm:h-auto shrink-0 overflow-hidden relative">
+<!-- ══ 3. Bento grid (magazine + articles + ticker + community + video + CTA + social) ══ -->
+<section class="py-6 overflow-x-hidden" style="padding-top:0;">
+	<div class="nx-bento gap-3 mx-auto px-6 box-border">
+
+		<!-- Magazine tile (4 cols × 4 rows) — heroArticle -->
+		{#if heroArticle}
+		<a href="/forum/{heroArticle.categoryId}/{heroArticle.id}" class="nx-bento-mag nx-bento-tile min-w-0 overflow-hidden relative bg-[#0a0a0f] border border-white/[0.06] rounded-xl flex flex-col transition-colors duration-200 hover:border-[rgba(167,139,250,.2)] block no-underline text-inherit" style="grid-column: span 4; grid-row: span 4;">
 			{#if heroArticle.imageUrl}
-				<img src={heroArticle.imageUrl} alt={heroArticle.title}
-				     class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700" style="opacity:.7" />
+				<img src={heroArticle.imageUrl} alt="" />
 			{:else}
-				<div class="w-full h-full flex items-center justify-center" style="background: linear-gradient(135deg, #12012c, #020c1b)">
-					<span class="deco-letter" style="font-size: 5rem">{heroLetter}</span>
-				</div>
+				<div class="absolute inset-0 nx-bg-slide-empty"></div>
 			{/if}
-			<div class="absolute inset-0 hidden sm:block" style="background: linear-gradient(to right, transparent 50%, #12121a 100%)"></div>
-		</div>
-		<div class="flex-1 flex flex-col justify-between p-6">
-			<div>
-				{#if heroArticle.categoryName}
-					<div class="flex items-center gap-2 mb-2">
-						<span class="h-px w-6" style="background: var(--nx-accent-2-strong)"></span>
-						<span class="sg text-[10px] font-black uppercase tracking-[.18em]" style="color: var(--nx-accent-2-soft)">{heroArticle.categoryName}</span>
-					</div>
-				{/if}
-				<h3 class="sg text-xl font-extrabold leading-tight mb-2 group-hover:text-violet-200 transition-colors" style="color: #f1f5f9">{heroArticle.title}</h3>
-				{#if heroArticle.excerpt}
-					<p class="text-sm leading-relaxed line-clamp-2" style="color: #6b7280">{heroArticle.excerpt}</p>
-				{/if}
-			</div>
-			<div class="flex items-center gap-3 mt-4 pt-4" style="border-top: 1px solid rgba(255,255,255,.05)">
-				<span class="text-xs font-semibold" style="color: var(--nx-accent-2-soft)">{heroArticle.authorUsername}</span>
-				<span style="color: #374151">·</span>
-				<span class="text-xs" style="color: #4b5563">{timeAgo(heroArticle.createdAt)}</span>
-				<span class="ml-auto sg text-xs font-bold flex items-center gap-1 group-hover:text-violet-300 transition-colors" style="color: var(--nx-accent-2-soft)">
-					Lire
-					<svg class="w-3 h-3 group-hover:translate-x-0.5 transition-transform" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
-				</span>
-			</div>
-		</div>
-	</a>
-	{/if}
-
-	<!-- Rest articles -->
-	{#if restArticles.length > 0}
-	<div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
-		{#each restArticles as article}
-		<a href="/forum/{article.categoryId}/{article.id}"
-		   class="card-hover group flex gap-4 p-4 transition-all duration-250"
-		   style="background: #12121a; border: 1px solid rgba(255,255,255,.06)"
-		   onmouseenter={e => (e.currentTarget as HTMLElement).style.borderColor='rgb(var(--nx-accent-2-rgb) / .2)'}
-		   onmouseleave={e => (e.currentTarget as HTMLElement).style.borderColor='rgba(255,255,255,.06)'}>
-			{#if article.imageUrl}
-				<img src={article.imageUrl} alt="" class="w-20 h-14 object-cover shrink-0 group-hover:opacity-90 transition-opacity" style="opacity:.7" />
-			{:else}
-				<div class="w-20 h-14 shrink-0 flex items-center justify-center" style="background: rgb(var(--nx-accent-2-rgb) / .08); border: 1px solid rgba(255,255,255,.05)">
-					<span class="sg text-xl font-black" style="color: rgb(var(--nx-accent-2-rgb) / .35)">{heroLetter}</span>
-				</div>
-			{/if}
-			<div class="flex-1 min-w-0 flex flex-col justify-between">
-				<p class="text-xs font-bold line-clamp-2 leading-snug group-hover:text-white transition-colors" style="color: #d1d5db">{article.title}</p>
-				<div class="flex items-center gap-1.5 mt-2">
-					<span class="text-[10px] font-semibold" style="color: var(--nx-accent-2-soft)">{article.authorUsername}</span>
-					<span style="color: #374151">·</span>
-					<span class="text-[10px]" style="color: #4b5563">{timeAgo(article.createdAt)}</span>
-				</div>
+			<div class="nx-bento-mag-overlay"></div>
+			<div class="absolute left-0 right-0 bottom-0 p-6">
+				<span class="inline-block mb-3 font-mono text-[10px] font-medium uppercase tracking-[0.12em] px-2.5 py-1 rounded-full border" style="color: var(--nx-accent-2-soft); background: rgba(99,102,241,.12); border-color: rgba(167,139,250,.2);">{heroArticle.categoryName || tFn('home.news')}</span>
+				<h2 class="font-['Space_Grotesk'] text-lg font-extrabold leading-snug text-white m-0 mb-2 line-clamp-3">{heroArticle.title}</h2>
+				<p class="font-mono text-[10px] text-gray-400">{heroArticle.authorUsername} · {timeAgo(heroArticle.createdAt)}</p>
 			</div>
 		</a>
-		{/each}
-	</div>
-	{/if}
-</section>
-{/if}
-
-<!-- ═══════════════════════════════════════════════════════════════════
-     AGENDA PUBLIC (module events-public)
-════════════════════════════════════════════════════════════════════════ -->
-{#if mods['events-public'] !== false && publicEvents.length > 0}
-<section class="px-6 py-10" style="background: #07070c; border-top: 1px solid rgba(255,255,255,.05)">
-	<div class="max-w-6xl mx-auto">
-		<!-- Header -->
-		<div class="flex items-end justify-between mb-6">
-			<div>
-				<div class="flex items-center gap-2 mb-1">
-					<span class="text-[10px] font-bold tracking-widest uppercase" style="color: var(--nx-cyan)">Agenda</span>
-				</div>
-				<h2 class="text-xl font-bold text-white">Prochains événements</h2>
+		{:else}
+		<div class="min-w-0 overflow-hidden relative bg-white/[0.02] border border-white/[0.06] rounded-xl flex flex-col transition-colors duration-200 hover:border-[rgba(167,139,250,.2)]" style="grid-column: span 4; grid-row: span 4;">
+			<div class="flex items-center gap-2 h-9 px-4 bg-black/20 border-b border-white/[0.05] font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-gray-400 shrink-0"><span class="w-1.5 h-1.5 rounded-full shrink-0 bg-[var(--nx-cyan)]"></span>{tFn('home.news')}</div>
+			<div class="flex items-center justify-center h-full text-center p-8">
+				<span style="font-family:'JetBrains Mono',monospace; font-size:12px; color:#374151; letter-spacing:.1em;">{tFn('common.no_article')}</span>
 			</div>
-			<a href="/calendar" class="flex items-center gap-1.5 text-xs font-medium transition-colors"
-				style="color: var(--nx-cyan)"
-				onmouseenter={e => (e.currentTarget as HTMLElement).style.color='var(--nx-cyan-soft)'}
-				onmouseleave={e => (e.currentTarget as HTMLElement).style.color='var(--nx-cyan)'}>
-				Voir tout
-				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
-					<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
-				</svg>
-			</a>
 		</div>
+		{/if}
 
-		<!-- Cards -->
-		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-			{#each publicEvents as ev}
-				{@const d  = new Date(ev.starts_at)}
-				{@const day = d.toLocaleDateString(instance.language === 'fr' ? 'fr-FR' : 'en-US', { day: 'numeric' })}
-				{@const mon = d.toLocaleDateString(instance.language === 'fr' ? 'fr-FR' : 'en-US', { month: 'short' })}
-				{@const time = ev.is_all_day ? (instance.language === 'fr' ? 'Journée entière' : 'All day') : d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-				<a href="/calendar" class="group relative flex flex-col rounded-2xl overflow-hidden transition-all duration-200"
-					style="background: rgba(255,255,255,.04); border: 1px solid rgba(255,255,255,.07);"
-					onmouseenter={e => { (e.currentTarget as HTMLElement).style.borderColor = 'rgb(var(--nx-cyan-rgb) / .35)'; (e.currentTarget as HTMLElement).style.background = 'rgb(var(--nx-cyan-rgb) / .06)' }}
-					onmouseleave={e => { (e.currentTarget as HTMLElement).style.borderColor = 'rgba(255,255,255,.07)'; (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,.04)' }}>
-
-					<!-- Cover or date block -->
-					{#if ev.cover_url}
-						<div class="h-28 overflow-hidden relative">
-							<img src={ev.cover_url} alt={ev.title} class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"/>
-							<div class="absolute inset-0" style="background: linear-gradient(to top, rgba(0,0,0,.6) 0%, transparent 60%)"></div>
-							<!-- Date badge -->
-							<div class="absolute top-2.5 left-2.5 flex flex-col items-center justify-center w-11 h-11 rounded-xl text-white font-bold"
-								style="background: rgb(var(--nx-cyan-rgb) / .85); backdrop-filter: blur(4px)">
-								<span class="text-base leading-none">{day}</span>
-								<span class="text-[9px] uppercase tracking-wider opacity-90">{mon}</span>
-							</div>
-						</div>
-					{:else}
-						<!-- Date block (no cover) -->
-						<div class="flex items-center gap-3 px-4 pt-4 pb-2">
-							<div class="flex flex-col items-center justify-center w-11 h-11 rounded-xl shrink-0 font-bold text-white"
-								style="background: linear-gradient(135deg, #0891b2, var(--nx-cyan))">
-								<span class="text-base leading-none">{day}</span>
-								<span class="text-[9px] uppercase tracking-wider opacity-90">{mon}</span>
-							</div>
-							<div class="h-px flex-1" style="background: rgb(var(--nx-cyan-rgb) / .2)"></div>
-						</div>
-					{/if}
-
-					<!-- Content -->
-					<div class="flex flex-col flex-1 px-4 {ev.cover_url ? 'pt-3' : 'pt-1'} pb-4 gap-1.5">
-						<p class="text-sm font-semibold text-white leading-snug line-clamp-2 group-hover:text-cyan-300 transition-colors">{ev.title}</p>
-						{#if ev.location}
-							<div class="flex items-center gap-1 text-[11px]" style="color: #6b7280">
-								<svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-									<path stroke-linecap="round" stroke-linejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
-									<path stroke-linecap="round" stroke-linejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
-								</svg>
-								<span class="truncate">{ev.location}</span>
-							</div>
-						{/if}
-						<div class="flex items-center justify-between mt-auto pt-1.5">
-							<span class="text-[10px] font-medium" style="color: var(--nx-cyan)">{time}</span>
-							{#if ev.rsvp_enabled}
-								<span class="text-[10px] px-1.5 py-0.5 rounded-full font-medium"
-									style="background: rgb(var(--nx-cyan-rgb) / .15); color: var(--nx-cyan-soft); border: 1px solid rgb(var(--nx-cyan-rgb) / .25)">
-									RSVP
-								</span>
+		<!-- Article grid tile (8 cols × 4 rows) — restArticles -->
+		{#if restArticles.length > 0}
+		<div class="min-w-0 overflow-hidden relative bg-white/[0.02] border border-white/[0.06] rounded-xl flex flex-col transition-colors duration-200 hover:border-[rgba(167,139,250,.2)]" style="grid-column: span 8; grid-row: span 4;">
+			<div class="flex items-center gap-2 h-9 px-4 bg-black/20 border-b border-white/[0.05] font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-gray-400 shrink-0">
+				<span class="w-1.5 h-1.5 rounded-full shrink-0 bg-[var(--nx-accent-2-strong)]"></span>{tFn('home.articles')}
+				<a href="/forum" class="ml-auto font-mono text-[9px] text-gray-600 no-underline">{tFn('common.view_all')} →</a>
+			</div>
+			<div class="flex-1 min-h-0 overflow-hidden">
+				<div class="grid grid-cols-3 gap-2 p-2.5 h-full overflow-y-auto overflow-x-hidden max-[639px]:grid-cols-2">
+					{#each restArticles as article}
+					<a href="/forum/{article.categoryId}/{article.id}" class="nx-bento-card flex flex-col no-underline text-inherit rounded-lg overflow-hidden bg-white/[0.02] border border-white/[0.05] transition-all duration-200 hover:border-[rgba(167,139,250,.3)] hover:-translate-y-px">
+						<div class="nx-bento-card-cover relative w-full h-20 overflow-hidden bg-[#0a0a0f]">
+							{#if article.imageUrl}
+								<img src={article.imageUrl} alt="" loading="lazy" class="absolute inset-0 w-full h-full object-cover transition-transform duration-300" />
+							{:else}
+								<div class="absolute inset-0 flex items-center justify-center bg-linear-to-br from-indigo-500/[0.08] to-cyan-500/[0.04] font-['Space_Grotesk'] text-[28px] font-black text-[rgba(167,139,250,.2)]">{heroLetter}</div>
 							{/if}
 						</div>
-					</div>
-				</a>
-			{/each}
+						<div class="flex-1 flex flex-col p-2 pb-2.5">
+							<h4 class="font-['Space_Grotesk'] text-xs font-bold leading-snug text-white m-0 mb-1 line-clamp-2">{article.title}</h4>
+							<div class="mt-auto font-mono text-[9px] text-gray-500">
+								<span style="color: var(--nx-accent-2-soft);">{article.authorUsername}</span>
+								<span> · </span>
+								<span>{timeAgo(article.createdAt)}</span>
+							</div>
+						</div>
+					</a>
+					{/each}
+				</div>
+			</div>
 		</div>
+		{/if}
+
+		<!-- Ticker tile (8 cols × 3 rows) — En continu -->
+		{#if recentThreads.length > 0}
+		<div class="min-w-0 overflow-hidden relative bg-white/[0.02] border border-white/[0.06] rounded-xl flex flex-col transition-colors duration-200 hover:border-[rgba(167,139,250,.2)]" style="grid-column: span 8; grid-row: span 3;">
+			<div class="flex items-center gap-2 h-9 px-4 bg-black/20 border-b border-white/[0.05] font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-gray-400 shrink-0">
+				<span class="w-1.5 h-1.5 rounded-full shrink-0 bg-green-400"></span>{tFn('home.en_continu')}
+			</div>
+			<div class="flex-1 min-h-0 overflow-hidden">
+				<div class="nx-bento-ticker">
+					<div class="nx-bento-ticker-track">
+						{#each [...recentThreads, ...recentThreads] as thread}
+						<a href="/forum/{thread.category_id}/{thread.id}" class="flex items-center gap-2.5 px-3 py-2 no-underline text-inherit border-b border-white/[0.04] transition-colors duration-200 hover:bg-indigo-500/[0.06]">
+							<div class="w-8 h-8 shrink-0 rounded-md bg-indigo-500/15 border border-indigo-500/20 flex items-center justify-center font-mono text-[11px] font-bold text-white">{thread.author_username?.charAt(0).toUpperCase() ?? '?'}</div>
+							<div class="flex-1 min-w-0">
+								<p class="text-[11px] font-medium text-slate-200 leading-tight m-0 line-clamp-1">{thread.title}</p>
+								<div class="font-mono text-[8px] text-gray-500 flex items-center gap-1.5">
+									<span class="uppercase tracking-[0.08em]" style="color: var(--nx-accent-2-soft);">{thread.category_name}</span>
+									<span>·</span>
+									<span>{timeAgo(thread.created_at)}</span>
+									<span>·</span>
+									<span>{thread.post_count ?? 0} {tFn('forum.replies_label')}</span>
+								</div>
+							</div>
+						</a>
+						{/each}
+					</div>
+				</div>
+			</div>
+		</div>
+		{/if}
+
+		<!-- Community tile (4 cols × 3 rows) -->
+		<div class="min-w-0 overflow-hidden relative bg-white/[0.02] border border-white/[0.06] rounded-xl flex flex-col transition-colors duration-200 hover:border-[rgba(167,139,250,.2)]" style="grid-column: span 4; grid-row: span 3;">
+			<div class="flex items-center gap-2 h-9 px-4 bg-black/20 border-b border-white/[0.05] font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-gray-400 shrink-0">
+				<span class="w-1.5 h-1.5 rounded-full shrink-0 bg-[var(--nx-accent-2-strong)]"></span>{tFn('home.community_title')}
+			</div>
+			<div class="flex-1 min-h-0 overflow-hidden">
+				<div class="p-2.5 flex flex-col h-full overflow-hidden gap-1.5">
+					<div class="flex flex-col">
+						<div class="nx-bento-community-stat flex items-center justify-between py-1 border-b border-white/[0.05] last:border-b-0">
+							<div class="flex items-baseline gap-2 min-w-0">
+								<span class="font-['Space_Grotesk'] font-black text-base leading-none tabular-nums" style="color: var(--nx-accent-2-soft);">{instance.member_count.toLocaleString()}</span>
+								<span class="font-mono text-[8px] uppercase tracking-[0.1em] text-gray-500">{tFn('common.members')}</span>
+							</div>
+							<div class="nx-bento-signal" style="color: var(--nx-accent-2-soft);">
+								{#each Array(4) as _, i}
+									<span class="nx-bento-signal-bar" class:on={i < signalLevel(instance.member_count)}></span>
+								{/each}
+							</div>
+						</div>
+						<div class="nx-bento-community-stat flex items-center justify-between py-1 border-b border-white/[0.05] last:border-b-0">
+							<div class="flex items-baseline gap-2 min-w-0">
+								<span class="font-['Space_Grotesk'] font-black text-base leading-none tabular-nums" style="color:#4ade80;">{instance.online_count}</span>
+								<span class="font-mono text-[8px] uppercase tracking-[0.1em] text-gray-500">{tFn('common.online')}</span>
+							</div>
+							<div class="nx-bento-signal" style="color:#4ade80;">
+								{#each Array(4) as _, i}
+									<span class="nx-bento-signal-bar" class:on={i < signalLevel(instance.online_count)}></span>
+								{/each}
+							</div>
+						</div>
+						<div class="nx-bento-community-stat flex items-center justify-between py-1 border-b border-white/[0.05] last:border-b-0">
+							<div class="flex items-baseline gap-2 min-w-0">
+								<span class="font-['Space_Grotesk'] font-black text-base leading-none tabular-nums" style="color: var(--nx-cyan-soft);">{instance.thread_count.toLocaleString()}</span>
+								<span class="font-mono text-[8px] uppercase tracking-[0.1em] text-gray-500">{tFn('common.topics')}</span>
+							</div>
+							<div class="nx-bento-signal" style="color: var(--nx-cyan-soft);">
+								{#each Array(4) as _, i}
+									<span class="nx-bento-signal-bar" class:on={i < signalLevel(instance.thread_count)}></span>
+								{/each}
+							</div>
+						</div>
+					</div>
+					<div class="flex flex-col gap-0 flex-1 min-h-0 overflow-hidden">
+						{#each recentThreads.slice(0, 3) as thread}
+						<a href="/forum/{thread.category_id}/{thread.id}" class="nx-bento-community-thread flex flex-col gap-px py-1 no-underline text-inherit border-b border-white/[0.04] last:border-b-0">
+							<span class="nx-bento-community-thread-title text-[11px] font-medium text-slate-200 leading-tight whitespace-nowrap overflow-hidden text-ellipsis transition-colors duration-200">{thread.title}</span>
+							<span class="font-mono text-[8px] uppercase tracking-[0.08em]" style="color: var(--nx-accent-2-soft);">{thread.category_name}</span>
+						</a>
+						{:else}
+							<span style="font-size:11px; color:#374151; padding:8px 0;">{tFn('common.no_activity')}</span>
+						{/each}
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<!-- CTA + Social tile (full-width horizontal bar) -->
+		<div class="nx-bento-cta-tile min-w-0 overflow-hidden relative bg-[#0a0a0f] border border-white/[0.08] rounded-xl flex flex-row items-stretch" style="grid-column: span 12; grid-row: span 1;">
+			<!-- Left: hero identity -->
+			<div class="nx-cta-hero relative z-2 flex items-center gap-3.5 px-6 shrink-0 border-r border-white/[0.06]">
+				{#if instance.logo_url}
+					<img src={instance.logo_url} alt={instance.name} class="w-11 h-11 shrink-0 rounded-2.5 object-cover" />
+				{:else}
+					<div class="w-11 h-11 shrink-0 rounded-2.5 flex items-center justify-center font-['Space_Grotesk'] font-black text-[22px] text-white bg-linear-to-br from-[var(--nx-accent-2-strong)] to-[var(--nx-cyan-deep)]">{heroLetter}</div>
+				{/if}
+				<div class="min-w-0">
+					<h3 class="font-['Space_Grotesk'] text-base font-extrabold text-white m-0 leading-tight whitespace-nowrap">{instance.name}</h3>
+					<p class="text-[10px] text-gray-500 mt-0.5 leading-tight whitespace-nowrap">{tFn('home.cta_sub')}</p>
+				</div>
+			</div>
+
+			<!-- Middle: stats bar -->
+			<div class="nx-cta-stats-bar relative z-2 flex flex-1 min-w-0">
+				<div class="nx-cta-stat-cell flex-1 flex items-center justify-center gap-2.5 px-4 min-w-0">
+					<div class="flex flex-col gap-px min-w-0">
+						<span class="font-['Space_Grotesk'] font-black text-xl leading-none tabular-nums" style="color: var(--nx-accent-2-soft);">{instance.member_count.toLocaleString()}</span>
+						<span class="font-mono text-[8px] uppercase tracking-[0.1em] text-gray-500">{tFn('common.members')}</span>
+					</div>
+					<div class="nx-bento-signal" style="color: var(--nx-accent-2-soft);">
+						{#each Array(4) as _, i}<span class="nx-bento-signal-bar" class:on={i < signalLevel(instance.member_count)}></span>{/each}
+					</div>
+				</div>
+				<div class="nx-cta-stat-cell flex-1 flex items-center justify-center gap-2.5 px-4 min-w-0 border-l border-white/[0.06]">
+					<div class="flex flex-col gap-px min-w-0">
+						<span class="font-['Space_Grotesk'] font-black text-xl leading-none tabular-nums" style="color:#4ade80;">{instance.online_count}</span>
+						<span class="font-mono text-[8px] uppercase tracking-[0.1em] text-gray-500">{tFn('common.online')}</span>
+					</div>
+					<div class="nx-bento-signal" style="color:#4ade80;">
+						{#each Array(4) as _, i}<span class="nx-bento-signal-bar" class:on={i < signalLevel(instance.online_count)}></span>{/each}
+					</div>
+				</div>
+				<div class="nx-cta-stat-cell flex-1 flex items-center justify-center gap-2.5 px-4 min-w-0 border-l border-white/[0.06]">
+					<div class="flex flex-col gap-px min-w-0">
+						<span class="font-['Space_Grotesk'] font-black text-xl leading-none tabular-nums" style="color: var(--nx-cyan-soft);">{instance.thread_count.toLocaleString()}</span>
+						<span class="font-mono text-[8px] uppercase tracking-[0.1em] text-gray-500">{tFn('common.topics')}</span>
+					</div>
+					<div class="nx-bento-signal" style="color: var(--nx-cyan-soft);">
+						{#each Array(4) as _, i}<span class="nx-bento-signal-bar" class:on={i < signalLevel(instance.thread_count)}></span>{/each}
+					</div>
+				</div>
+				<div class="nx-cta-stat-cell flex-1 flex items-center justify-center gap-2.5 px-4 min-w-0 border-l border-white/[0.06]">
+					<div class="flex flex-col gap-px min-w-0">
+						<span class="font-['Space_Grotesk'] font-black text-xl leading-none tabular-nums" style="color:#fbbf24;">{instance.post_count?.toLocaleString() ?? 0}</span>
+						<span class="font-mono text-[8px] uppercase tracking-[0.1em] text-gray-500">{tFn('common.posts')}</span>
+					</div>
+					<div class="nx-bento-signal" style="color:#fbbf24;">
+						{#each Array(4) as _, i}<span class="nx-bento-signal-bar" class:on={i < signalLevel(instance.post_count ?? 0)}></span>{/each}
+					</div>
+				</div>
+			</div>
+
+			<!-- Right: actions + social -->
+			<div class="nx-cta-bottom relative z-2 flex items-center shrink-0 border-l border-white/[0.06]">
+				<div class="flex items-center gap-2 px-5">
+					{#if data.user}
+						<a href="/chat" class="nx-press font-['Space_Grotesk'] font-bold text-xs uppercase tracking-[0.08em] no-underline px-[18px] py-2.25 rounded-md flex items-center justify-center gap-1.5 whitespace-nowrap cursor-pointer transition-all duration-200 text-white bg-indigo-600 border border-indigo-600 hover:bg-indigo-700 hover:border-indigo-700">
+							{tFn('home.join_chat')}
+							<svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+						</a>
+					{:else}
+						<a href="/auth/login" class="nx-press font-['Space_Grotesk'] font-bold text-xs uppercase tracking-[0.08em] no-underline px-[18px] py-2.25 rounded-md flex items-center justify-center gap-1.5 whitespace-nowrap cursor-pointer transition-all duration-200 text-gray-400 bg-transparent border border-white/[0.12] hover:text-white hover:border-white/25">{tFn('common.login')}</a>
+						<a href="/auth/register" class="nx-press font-['Space_Grotesk'] font-bold text-xs uppercase tracking-[0.08em] no-underline px-[18px] py-2.25 rounded-md flex items-center justify-center gap-1.5 whitespace-nowrap cursor-pointer transition-all duration-200 text-white bg-indigo-600 border border-indigo-600 hover:bg-indigo-700 hover:border-indigo-700">
+							{tFn('common.join')}
+							<svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+						</a>
+					{/if}
+				</div>
+				<div class="flex items-center gap-1 px-4 border-l border-white/[0.06] h-full">
+					{#each SOCIAL_LINKS as s}
+					<a href="#" class="nx-press nx-cta-social-link flex items-center justify-center w-8 h-8 rounded-md no-underline transition-all duration-150 hover:bg-white/[0.06] hover:-translate-y-px" style="--ic: {s.color}" title={s.type}>
+						<svg class="w-4 h-4 fill-current" viewBox="0 0 24 24"><path d={s.path}/></svg>
+					</a>
+					{/each}
+				</div>
+			</div>
+		</div>
+
+		<!-- Events tile (12 cols × 2 rows) — publicEvents -->
+		{#if publicEvents.length > 0}
+		<div class="min-w-0 overflow-hidden relative bg-white/[0.02] border border-white/[0.06] rounded-xl flex flex-col transition-colors duration-200 hover:border-[rgba(167,139,250,.2)]" style="grid-column: span 12; grid-row: span 2;">
+			<div class="flex items-center gap-2 h-9 px-4 bg-black/20 border-b border-white/[0.05] font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-gray-400 shrink-0">
+				<span class="w-1.5 h-1.5 rounded-full shrink-0 bg-[var(--nx-cyan)]"></span>{tFn('home.events')}
+			</div>
+			<div class="flex-1 min-h-0 overflow-hidden">
+				<div class="flex flex-col gap-1.5 p-2.5 h-full overflow-y-auto overflow-x-hidden" style="flex-direction: row; flex-wrap: wrap; align-content: center;">
+					{#each publicEvents.slice(0, 6) as ev}
+					<a href="/calendar/{ev.id}" class="nx-bento-event flex items-center gap-2.5 px-2.5 py-2 no-underline text-inherit rounded-md bg-white/[0.02] border border-white/[0.05] transition-colors duration-200" style="flex: 1 1 200px; min-width: 200px;">
+						<div class="flex flex-col items-center justify-center w-10 h-10 shrink-0 rounded-lg bg-linear-to-br from-cyan-600 to-[var(--nx-cyan)] font-['Space_Grotesk'] font-extrabold text-white">
+							<span class="text-base leading-none">{new Date(ev.start_date).getDate()}</span>
+							<span class="text-[8px] uppercase tracking-[0.1em] opacity-90">{new Date(ev.start_date).toLocaleDateString(undefined, { month: 'short' })}</span>
+						</div>
+						<div class="flex-1 min-w-0">
+							<span class="text-xs font-semibold text-slate-200 leading-tight whitespace-nowrap overflow-hidden text-ellipsis block">{ev.title}</span>
+							<span class="font-mono text-[9px]" style="color: var(--nx-cyan-soft);">{new Date(ev.start_date).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}</span>
+						</div>
+					</a>
+					{/each}
+				</div>
+			</div>
+		</div>
+		{/if}
+
 	</div>
 </section>
-{/if}
 
 <!-- ═══════════════════════════════════════════════════════════════════
      WIDE-1 / WIDE-2 — positions (WidgetZone)


### PR DESCRIPTION
## Summary
- Both sidebar panels now draggable with velocity-based momentum snap
- Consistent :active press feedback (scale 0.97) across all buttons/links
- Replace CSS keyframe slideshow fade with interruptible Svelte transitions
- Custom cubic-bezier easing curves instead of generic ease
- prefers-reduced-motion support for decorative animations
- Spring-feel transition for language view dismiss
- Font smoothing + text-rendering optimization
- Fix missing fill/stroke on slideshow nav arrow SVGs
- Article cards: content fills card, author/time pinned to bottom (no empty space)

https://github.com/user-attachments/assets/48356a12-cbca-4549-90b4-aa18e791ab3d
