### PR TITLE
fix(i18n): 6 dangling keys shown raw to users + permanent CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,10 @@ jobs:
         working-directory: nodyx-frontend
         run: npm ci
 
+      - name: i18n — clés référencées présentes (pas de clé affichée en brut)
+        working-directory: nodyx-frontend
+        run: npm run i18n:keys:check
+
       - name: Svelte — typecheck (svelte-check)
         working-directory: nodyx-frontend
         env:

--- a/nodyx-frontend/package.json
+++ b/nodyx-frontend/package.json
@@ -12,7 +12,9 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "test": "vitest run",
     "i18n:scan": "node scripts/i18n/scan.mjs",
-    "i18n:coverage": "node scripts/i18n/coverage.mjs"
+    "i18n:coverage": "node scripts/i18n/coverage.mjs",
+    "i18n:keys": "node scripts/i18n/check-keys.mjs",
+    "i18n:keys:check": "node scripts/i18n/check-keys.mjs --check"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "7.0.1",

--- a/nodyx-frontend/scripts/i18n/check-keys.mjs
+++ b/nodyx-frontend/scripts/i18n/check-keys.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Vérifie que toute clé i18n RÉFÉRENCÉE dans le code existe bien dans fr.json.
+//
+// Le scanner (scan.mjs) garantit qu'il ne reste pas de texte FR en dur.
+// Celui-ci garantit l'inverse : qu'aucune clé tFn('x') ne pointe dans le vide.
+// Une clé absente de fr.json s'affiche EN BRUT à l'écran (« dm.reply »), et ni
+// `svelte-check` ni le build ne l'attrapent : c'est un bug runtime invisible en CI.
+//
+//   node scripts/i18n/check-keys.mjs          # liste les clés manquantes
+//   node scripts/i18n/check-keys.mjs --check   # exit 1 si au moins une manque
+//
+// Deux façons de référencer une clé sont couvertes :
+//   1. appel direct  : tFn('x'), $t('x'), translate('x'), get(t)('x')  (tout namespace)
+//   2. littéral clé  : 'namespace.sub' passé via un tableau/champ (labelKey, etc.)
+//      -> limité aux namespaces déjà présents dans fr.json, pour éviter le bruit.
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(HERE, '..', '..')
+const SRC = join(ROOT, 'src')
+const FR = join(SRC, 'lib', 'locales', 'fr.json')
+
+const keys = new Set(Object.keys(JSON.parse(readFileSync(FR, 'utf8'))))
+const namespaces = new Set([...keys].map((k) => k.split('.')[0]))
+
+// Premiers segments qui RESSEMBLENT à un namespace mais n'en sont pas :
+// 'channel.follow' etc. sont des types d'events Twitch (champ `key:`), pas des clés i18n.
+const NOT_I18N = new Set(['channel', 'image', 'video', 'text'])
+
+const KEYISH = /^[a-z][a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_]+)+$/
+const CALL = /(?:tFn|\$t|translate)\(\s*'([^']+)'/g
+const GETT = /get\(\s*t\s*\)\(\s*'([^']+)'/g
+const LITERAL = /['"]([a-z][a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_]+)+)['"]/g
+
+// Un préfixe de concaténation (`tFn('a.b.' + x)`) finit par `.` ou `_` : non vérifiable.
+const isPrefix = (s) => s.endsWith('.') || s.endsWith('_')
+
+function walk(dir) {
+	const out = []
+	for (const e of readdirSync(dir, { withFileTypes: true })) {
+		const p = join(dir, e.name)
+		if (e.isDirectory()) out.push(...walk(p))
+		else if ((e.name.endsWith('.svelte') || e.name.endsWith('.ts')) && !e.name.endsWith('.test.ts')) out.push(p)
+	}
+	return out
+}
+
+const missing = new Map()
+for (const file of walk(SRC)) {
+	const txt = readFileSync(file, 'utf8')
+	const refs = new Set()
+	for (const m of txt.matchAll(CALL)) if (!isPrefix(m[1])) refs.add(m[1])
+	for (const m of txt.matchAll(GETT)) if (!isPrefix(m[1])) refs.add(m[1])
+	for (const m of txt.matchAll(LITERAL)) {
+		const s = m[1]
+		const ns = s.split('.')[0]
+		if (isPrefix(s) || NOT_I18N.has(ns) || !namespaces.has(ns)) continue
+		refs.add(s)
+	}
+	const bad = [...refs].filter((k) => KEYISH.test(k) && !keys.has(k))
+	if (bad.length) missing.set(file.replace(ROOT + '/', ''), bad.sort())
+}
+
+if (missing.size === 0) {
+	console.log('✓ i18n keys: toutes les clés référencées existent dans fr.json')
+	process.exit(0)
+}
+
+let total = 0
+console.log('Clés i18n référencées mais ABSENTES de fr.json (affichées en brut à l\'écran) :\n')
+for (const [file, ks] of [...missing].sort()) {
+	for (const k of ks) { console.log(`  ${file}: ${k}`); total++ }
+}
+console.log(`\n${total} clé(s) manquante(s) dans ${missing.size} fichier(s).`)
+process.exit(process.argv.includes('--check') ? 1 : 0)

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -1427,5 +1427,11 @@
   "canvas.close": "Fermer",
   "canvas.meta_title": "Canvas : mes projets",
   "canvas.heading": "Mes projets Canvas",
-  "canvas.rename_prompt": "Renommer le projet :"
+  "canvas.rename_prompt": "Renommer le projet :",
+  "home.join_community": "Rejoindre la communauté",
+  "dm.reply": "Répondre",
+  "common.add_emoji": "Insérer un emoji",
+  "search.no_results": "Aucun résultat",
+  "page_title.search_results": "Résultats pour « {{q}} »",
+  "pedit.section_social": "Réseaux sociaux"
 }


### PR DESCRIPTION
## Le bug (pré-existant, trouvé en vérifiant l'extraction i18n)

Six clés étaient référencées via `tFn()` / `$t()` mais **n'existaient dans aucun fichier de locale**. Comme `t()` retombe sur la clé elle-même quand elle manque, l'utilisateur voyait la **clé brute** à l'écran :

| Fichier | Clé | Rendu utilisateur |
|---|---|---|
| `homepage/widgets/JoinCard` | `home.join_community` | « home.join_community » |
| `dm/[id]` | `dm.reply` | « dm.reply » (title) |
| `dm/[id]` | `common.add_emoji` | « common.add_emoji » (title) |
| `dm/[id]` | `search.no_results` | « search.no_results » |
| `search` | `page_title.search_results` | « page_title.search_results » (titre d'onglet) |
| `users/me/edit` | `pedit.section_social` | « pedit.section_social » |

Les `?? 'Répondre'` de secours dans le code étaient **morts** : `t()` ne renvoie jamais `null`, donc le `??` ne se déclenchait pas. Ni `svelte-check` ni le build n'attrapent ça : c'est invisible en CI.

## Le fix
Ajout des 6 clés à `fr.json`, **valeurs sourcées depuis le code lui-même** (les fallbacks morts + un commentaire « ROW 2: Réseaux sociaux »). **Aucun `.svelte` modifié** : ces fichiers référençaient déjà les clés, il ne manquait que les entrées.

## Le garde-fou (pour que ça ne repasse jamais)
`scripts/i18n/check-keys.mjs` : vérifie que **toute clé référencée** (appels `tFn/$t/get(t)` + littéraux passés en tableau, ex. `labelKey`) existe dans `fr.json`. Gère les faux positifs (events Twitch `key: 'channel.follow'`, préfixes de concaténation). Câblé en CI via `npm run i18n:keys:check` (exit 1 si une clé manque).

## Vérifs
- `npm run i18n:keys:check` : **0 clé manquante**.
- `npm run check` : **0 erreur**.
- Les 8 PRs d'extraction i18n de ce sprint ont été re-vérifiées : **aucune clé manquante** (y compris les clés en tableau de `reputation`).