### PR TITLE
fix(auth): drop username-shape bot heuristic that rejected real humans

### DIFF
--- a/nodyx-core/src/routes/auth.ts
+++ b/nodyx-core/src/routes/auth.ts
@@ -122,13 +122,6 @@ const RegisterBody = z.object({
   form_t:   z.coerce.number().int().positive().optional(),
 })
 
-// Username manifestement bot : 10 caractères strictement [a-z] sans aucun
-// tiret/underscore/chiffre. Aucun humain ne nomme son compte 'dfjqexemtj'.
-// On match strict pour éviter de bloquer 'alicebob42' (chiffres) ou
-// 'jean_doe' (underscore). Si un humain veut vraiment ce pattern, qu'il
-// ajoute juste une lettre majuscule ou un chiffre.
-const BOT_USERNAME_RE = /^[a-z]{10}$/
-
 const ANTI_BOT_REJECT = {
   code: 'AUTOMATED_SIGNUP_DETECTED',
   // On reste générique côté message pour ne pas donner d'info à l'attaquant
@@ -185,11 +178,10 @@ export default async function authRoutes(app: FastifyInstance) {
         return reply.code(403).send(ANTI_BOT_REJECT)
       }
     }
-    // Couche 5 : pattern username random — 10 chars strict [a-z]
-    if (BOT_USERNAME_RE.test(username)) {
-      recordBotAttempt('bot_username_pattern', {})
-      return reply.code(403).send(ANTI_BOT_REJECT)
-    }
+    // Note : pas de rejet sur la FORME du username. Une heuristique de type
+    // /^[a-z]{10}$/ recalait des pseudos parfaitement humains (alexandria,
+    // strawberry, lapersonne...) pour ~0 bot que le honeypot ne prend pas déjà.
+    // Le honeypot (couche 1) + le timing (couche 2) portent la défense.
 
     const clientIp = clientIpEarly
 

--- a/nodyx-core/src/tests/auth.test.ts
+++ b/nodyx-core/src/tests/auth.test.ts
@@ -152,6 +152,46 @@ describe('POST /api/v1/auth/register', () => {
 
     expect(res.statusCode).toBe(400)
   })
+
+  // ── Anti-bot : le honeypot (couche 1) + le timing (couche 2) portent la
+  // défense. On NE rejette PLUS sur la FORME du username : /^[a-z]{10}$/
+  // recalait des humains (alexandria, strawberry, lapersonne...). Régression. ──
+  it('accepts a legit 10-letter lowercase username (no longer a bot signal)', async () => {
+    vi.mocked(UserModel.findByEmail).mockResolvedValueOnce(null)
+    vi.mocked(UserModel.findByUsername).mockResolvedValueOnce(null)
+    vi.mocked(UserModel.create).mockResolvedValueOnce(FAKE_PUBLIC_USER)
+
+    const res = await app.inject({
+      method: 'POST',
+      url:    '/api/v1/auth/register',
+      // Avant le fix : 403 AUTOMATED_SIGNUP_DETECTED (10 lettres [a-z]).
+      payload: { username: 'alexandria', email: 'alex@nodyx.dev', password: 'password123' },
+    })
+
+    expect(res.statusCode).toBe(201)
+  })
+
+  it('still rejects a bot that fills the hidden honeypot field', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url:    '/api/v1/auth/register',
+      payload: { username: 'realhuman', email: 'h@nodyx.dev', password: 'password123', website: 'http://spam.example' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(JSON.parse(res.body).code).toBe('AUTOMATED_SIGNUP_DETECTED')
+  })
+
+  it('still rejects a submit that arrives too fast (< 2s after form mount)', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url:    '/api/v1/auth/register',
+      payload: { username: 'speedy', email: 's@nodyx.dev', password: 'password123', form_t: Date.now() },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(JSON.parse(res.body).code).toBe('AUTOMATED_SIGNUP_DETECTED')
+  })
 })
 
 describe('POST /api/v1/auth/login', () => {


### PR DESCRIPTION
## Le problème (trouvé par Jonathan)

Le handler d'inscription avait une couche anti-bot qui jugeait la **forme du username** :

```ts
const BOT_USERNAME_RE = /^[a-z]{10}$/
if (BOT_USERNAME_RE.test(username)) { /* 403 AUTOMATED_SIGNUP_DETECTED */ }
```

→ **tout pseudo de pile 10 lettres minuscules** était refusé comme « inscription automatisée », avec un message générique (l'utilisateur ne savait jamais pourquoi).

## Preuve

Sur 25 mots/prénoms/pseudos réels de 10 lettres minuscules, **24 rejetés** : `alexandria`, `california`, `strawberry`, `programmer`, `watermelon`, `basketball`... et **`lapersonne`** (le pote de sleemstudio).

En prod (`bot_signup_attempts`) : cette couche n'a bloqué que **2 tentatives**, les deux **`pavelblack`** (un humain plausible qui a réessayé puis abandonné), contre **1615** pour le honeypot. Elle ne rattrapait quasiment aucun bot que les autres couches ne prenaient pas déjà, et faisait du dégât collatéral silencieux.

## Le fix

Retrait de `BOT_USERNAME_RE` et du bloc de rejet. Le **honeypot** (couche 1, champ caché `website`) et le **time-to-fill** (couche 2, < 2s) portent la défense (et marchent : 1615 bots chopés, vraies IP).

## Tests (`auth.test.ts`, +3)

- `alexandria` (10 lettres) → **201** (avant : 403). Régression verrouillée.
- honeypot rempli → **403** `AUTOMATED_SIGNUP_DETECTED` (couche 1 intacte).
- submit < 2s → **403** (couche 2 intacte).

**Suite core complète : 404 tests verts, build tsc OK.**

nodyx-core = SANCTUAIRE : correctif validé par le propriétaire avant application.