### PR TITLE
i18n(wiki-new): extract new wiki page form to keys

### DIFF
--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -1801,5 +1801,20 @@
   "pedit.url_ph": "https://…",
   "pedit.label_ph": "Label",
   "pedit.avatar_section": "Avatar",
-  "pedit.customize": "Personnaliser"
+  "pedit.customize": "Personnaliser",
+  "wiki_new.meta_title": "Nouvelle page — Wiki",
+  "wiki_new.breadcrumb": "Nouvelle page",
+  "wiki_new.h1": "Créer une page wiki",
+  "wiki_new.title_ph": "Titre de la page",
+  "wiki_new.category": "Catégorie",
+  "wiki_new.category_ph": "ex: Règles, Tutoriels, FAQ…",
+  "wiki_new.summary": "Résumé",
+  "wiki_new.summary_hint": "(affiché dans la liste)",
+  "wiki_new.summary_ph": "Une phrase décrivant le contenu de la page…",
+  "wiki_new.content_ph": "Rédigez le contenu de la page…",
+  "wiki_new.cancel": "Annuler",
+  "wiki_new.publish": "Publier la page",
+  "wiki_new.title_label": "Titre",
+  "wiki_new.public": "Page publique",
+  "wiki_new.content_label": "Contenu"
 }

--- a/nodyx-frontend/src/routes/wiki/new/+page.svelte
+++ b/nodyx-frontend/src/routes/wiki/new/+page.svelte
@@ -2,6 +2,9 @@
 	import { enhance } from '$app/forms'
 	import type { ActionData } from './$types'
 	import NodyxEditor from '$lib/components/editor/NodyxEditor.svelte'
+	import { t } from '$lib/i18n'
+
+	const tFn = $derived($t)
 
 	let { form }: { form: ActionData } = $props()
 
@@ -9,7 +12,7 @@
 </script>
 
 <svelte:head>
-	<title>Nouvelle page — Wiki</title>
+	<title>{tFn('wiki_new.meta_title')}</title>
 </svelte:head>
 
 <div class="max-w-3xl mx-auto py-8 px-4">
@@ -18,10 +21,10 @@
 	<div class="flex items-center gap-2 text-sm text-gray-500 mb-6">
 		<a href="/wiki" class="hover:text-gray-300 transition-colors">Wiki</a>
 		<span>/</span>
-		<span class="text-gray-300">Nouvelle page</span>
+		<span class="text-gray-300">{tFn('wiki_new.breadcrumb')}</span>
 	</div>
 
-	<h1 class="text-xl font-bold text-white mb-6">Créer une page wiki</h1>
+	<h1 class="text-xl font-bold text-white mb-6">{tFn('wiki_new.h1')}</h1>
 
 	{#if form?.error}
 		<div class="mb-4 px-4 py-3 rounded-xl bg-red-900/30 border border-red-500/30 text-red-400 text-sm">
@@ -37,11 +40,11 @@
 		<!-- Title -->
 		<div>
 			<label class="block text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1.5" for="title">
-				Titre *
+				{tFn('wiki_new.title_label')} *
 			</label>
 			<input
 				id="title" name="title" required
-				placeholder="Titre de la page"
+				placeholder={tFn('wiki_new.title_ph')}
 				class="w-full bg-gray-900/60 border border-gray-700/60 rounded-xl px-4 py-2.5 text-white text-sm placeholder-gray-600 focus:outline-none focus:border-violet-500/60"
 			/>
 		</div>
@@ -50,11 +53,11 @@
 		<div class="flex gap-3 flex-wrap">
 			<div class="flex-1 min-w-48">
 				<label class="block text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1.5" for="category">
-					Catégorie
+					{tFn('wiki_new.category')}
 				</label>
 				<input
 					id="category" name="category"
-					placeholder="ex: Règles, Tutoriels, FAQ…"
+					placeholder={tFn('wiki_new.category_ph')}
 					class="w-full bg-gray-900/60 border border-gray-700/60 rounded-xl px-4 py-2.5 text-white text-sm placeholder-gray-600 focus:outline-none focus:border-violet-500/60"
 				/>
 			</div>
@@ -62,7 +65,7 @@
 				<label class="flex items-center gap-2.5 cursor-pointer select-none">
 					<input type="checkbox" name="is_public"
 					       class="w-4 h-4 rounded border-gray-600 bg-gray-800 accent-violet-500" />
-					<span class="text-sm text-gray-400">Page publique</span>
+					<span class="text-sm text-gray-400">{tFn('wiki_new.public')}</span>
 				</label>
 			</div>
 		</div>
@@ -70,11 +73,11 @@
 		<!-- Excerpt -->
 		<div>
 			<label class="block text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1.5" for="excerpt">
-				Résumé <span class="text-gray-600 font-normal normal-case">(affiché dans la liste)</span>
+				{tFn('wiki_new.summary')} <span class="text-gray-600 font-normal normal-case">{tFn('wiki_new.summary_hint')}</span>
 			</label>
 			<textarea
 				id="excerpt" name="excerpt" rows="2"
-				placeholder="Une phrase décrivant le contenu de la page…"
+				placeholder={tFn('wiki_new.summary_ph')}
 				class="w-full bg-gray-900/60 border border-gray-700/60 rounded-xl px-4 py-2.5 text-white text-sm placeholder-gray-600 focus:outline-none focus:border-violet-500/60 resize-none"
 			></textarea>
 		</div>
@@ -82,15 +85,15 @@
 		<!-- Content (NodyxEditor) -->
 		<div>
 			<span class="block text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1.5">
-				Contenu
+				{tFn('wiki_new.content_label')}
 			</span>
-			<NodyxEditor name="content" placeholder="Rédigez le contenu de la page…" />
+			<NodyxEditor name="content" placeholder={tFn('wiki_new.content_ph')} />
 		</div>
 
 		<!-- Submit -->
 		<div class="flex items-center justify-end gap-3 pt-2">
 			<a href="/wiki" class="px-4 py-2 text-sm text-gray-400 hover:text-white transition-colors">
-				Annuler
+				{tFn('wiki_new.cancel')}
 			</a>
 			<button type="submit" disabled={saving}
 			        class="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-violet-600 hover:bg-violet-500 text-white text-sm font-semibold transition-colors disabled:opacity-50">
@@ -100,7 +103,7 @@
 						<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
 					</svg>
 				{/if}
-				Publier la page
+				{tFn('wiki_new.publish')}
 			</button>
 		</div>
 	</form>


### PR DESCRIPTION
Extraction i18n du formulaire de **création de page wiki** (`routes/wiki/new`).

- Titres, labels, placeholders, boutons passés par des clés `wiki_new.*` via `tFn`.
- Sans-accent inclus : « Titre », « Page publique », « Contenu ».

`i18n:scan` = 0, `npm run i18n:keys` vert, `npm run check` = 0 erreur.