### PR TITLE
i18n(about): extract About page strings to keys

### DIFF
--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -1835,5 +1835,15 @@
   "table.kick_confirm": "Exclure {{name}} du salon vocal ?",
   "table.invalid_youtube": "Lien YouTube invalide. Exemples : youtube.com/watch?v=... ou youtu.be/...",
   "table.join": "Rejoindre",
-  "table.you": "Vous"
+  "table.you": "Vous",
+  "about.meta_title": "À propos de Nodyx",
+  "about.logo_alt": "Nodyx",
+  "about.tagline": "Plateforme communautaire libre, auto-hébergée et décentralisée. Forum + chat temps réel + vocal, sans GAFAM, sans analytics, sans silos. Une instance = une communauté.",
+  "about.this_release": "Cette release",
+  "about.release_notes": "Voir les notes sur GitHub →",
+  "about.history": "Historique",
+  "about.all_versions": "Toutes les versions →",
+  "about.source_code": "Code source",
+  "about.license_label": "Licence",
+  "about.license": "Nodyx est un logiciel libre publié sous licence AGPL-3.0. Toute modification déployée publiquement doit être partagée sous la même licence. Aucune télémétrie n'est envoyée à un service tiers. Les données de cette instance restent sur le serveur qui l'héberge."
 }

--- a/nodyx-frontend/src/routes/about/+page.svelte
+++ b/nodyx-frontend/src/routes/about/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
 	import type { PageData } from './$types'
+	import { t } from '$lib/i18n'
+
+	const tFn = $derived($t)
+
 	let { data }: { data: PageData & { nodyxVersion?: string } } = $props()
 
 	const version = $derived((data as any).nodyxVersion ?? 'unknown')
@@ -11,7 +15,7 @@
 </script>
 
 <svelte:head>
-	<title>À propos de Nodyx</title>
+	<title>{tFn('about.meta_title')}</title>
 </svelte:head>
 
 <div class="max-w-2xl mx-auto px-6 py-12">
@@ -19,7 +23,7 @@
 	<div class="flex items-center gap-4 mb-8">
 		<img
 			src="/nodyx-octopus.png"
-			alt="Nodyx"
+			alt={tFn('about.logo_alt')}
 			class="h-16 w-16 object-contain"
 		/>
 		<div>
@@ -29,9 +33,7 @@
 	</div>
 
 	<p class="text-zinc-300 leading-relaxed mb-8">
-		Plateforme communautaire libre, auto-hébergée et décentralisée.
-		Forum + chat temps réel + vocal, sans GAFAM, sans analytics, sans silos.
-		Une instance = une communauté.
+		{tFn('about.tagline')}
 	</p>
 
 	<div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-10">
@@ -41,9 +43,9 @@
 			rel="noopener noreferrer"
 			class="block p-4 rounded-lg border border-zinc-800 hover:border-zinc-600 transition-colors bg-zinc-900/40"
 		>
-			<div class="text-xs uppercase tracking-wider text-zinc-500 mb-1">Cette release</div>
+			<div class="text-xs uppercase tracking-wider text-zinc-500 mb-1">{tFn('about.this_release')}</div>
 			<div class="text-sm font-mono text-white">v{version}</div>
-			<div class="text-xs text-zinc-500 mt-2">Voir les notes sur GitHub →</div>
+			<div class="text-xs text-zinc-500 mt-2">{tFn('about.release_notes')}</div>
 		</a>
 
 		<a
@@ -52,9 +54,9 @@
 			rel="noopener noreferrer"
 			class="block p-4 rounded-lg border border-zinc-800 hover:border-zinc-600 transition-colors bg-zinc-900/40"
 		>
-			<div class="text-xs uppercase tracking-wider text-zinc-500 mb-1">Historique</div>
+			<div class="text-xs uppercase tracking-wider text-zinc-500 mb-1">{tFn('about.history')}</div>
 			<div class="text-sm font-mono text-white">CHANGELOG.md</div>
-			<div class="text-xs text-zinc-500 mt-2">Toutes les versions →</div>
+			<div class="text-xs text-zinc-500 mt-2">{tFn('about.all_versions')}</div>
 		</a>
 
 		<a
@@ -63,7 +65,7 @@
 			rel="noopener noreferrer"
 			class="block p-4 rounded-lg border border-zinc-800 hover:border-zinc-600 transition-colors bg-zinc-900/40"
 		>
-			<div class="text-xs uppercase tracking-wider text-zinc-500 mb-1">Code source</div>
+			<div class="text-xs uppercase tracking-wider text-zinc-500 mb-1">{tFn('about.source_code')}</div>
 			<div class="text-sm font-mono text-white">Pokled/Nodyx</div>
 			<div class="text-xs text-zinc-500 mt-2">github.com →</div>
 		</a>
@@ -74,17 +76,14 @@
 			rel="noopener noreferrer"
 			class="block p-4 rounded-lg border border-zinc-800 hover:border-zinc-600 transition-colors bg-zinc-900/40"
 		>
-			<div class="text-xs uppercase tracking-wider text-zinc-500 mb-1">Licence</div>
+			<div class="text-xs uppercase tracking-wider text-zinc-500 mb-1">{tFn('about.license_label')}</div>
 			<div class="text-sm font-mono text-white">{data.licenseName}</div>
 			<div class="text-xs text-zinc-500 mt-2">GNU AGPL v3 →</div>
 		</a>
 	</div>
 
 	<div class="text-xs text-zinc-500 leading-relaxed border-t border-zinc-800 pt-6">
-		Nodyx est un logiciel libre publié sous licence AGPL-3.0. Toute modification
-		déployée publiquement doit être partagée sous la même licence. Aucune télémétrie
-		n'est envoyée à un service tiers. Les données de cette instance restent sur le
-		serveur qui l'héberge.
+		{tFn('about.license')}
 	</div>
 
 </div>


### PR DESCRIPTION
Extraction i18n de la page **À propos** (`routes/about`).

- Titre, tagline, les 4 cartes (release / historique / code source / licence) et la prose de licence AGPL passés par des clés `about.*` via `tFn`.
- Sans-accent inclus : « Cette release », « Historique », « Code source », « Licence », « Toutes les versions ».

`i18n:scan` = 0, `npm run i18n:keys` vert, `npm run check` = 0 erreur.