### PR TITLE
i18n(wiki-edit): extract wiki edit page to keys

### DIFF
--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -1886,5 +1886,9 @@
   "reprings.tt_engagement": "Ratio de discussions initiées vs réponses.\nUn engagement de 100 % = vous créez autant que vous participez.",
   "reprings.title": "Réputation",
   "reprings.how_title": "Comment ce score est calculé",
-  "reprings.how_link": "Comment ça marche ?"
+  "reprings.how_link": "Comment ça marche ?",
+  "wiki_edit.meta_title": "Modifier « {{title}} » — Wiki",
+  "wiki_edit.breadcrumb": "Modifier",
+  "wiki_edit.h1": "Modifier la page",
+  "wiki_edit.save": "Enregistrer"
 }

--- a/nodyx-frontend/src/routes/wiki/[slug]/edit/+page.svelte
+++ b/nodyx-frontend/src/routes/wiki/[slug]/edit/+page.svelte
@@ -2,6 +2,9 @@
 	import { enhance } from '$app/forms'
 	import type { PageData, ActionData } from './$types'
 	import NodyxEditor from '$lib/components/editor/NodyxEditor.svelte'
+	import { t } from '$lib/i18n'
+
+	const tFn = $derived($t)
 
 	let { data, form }: { data: PageData; form: ActionData } = $props()
 
@@ -10,7 +13,7 @@
 </script>
 
 <svelte:head>
-	<title>Modifier « {pg?.title} » — Wiki</title>
+	<title>{tFn('wiki_edit.meta_title', { title: pg?.title })}</title>
 </svelte:head>
 
 <div class="max-w-3xl mx-auto py-8 px-4">
@@ -21,10 +24,10 @@
 		<span>/</span>
 		<a href="/wiki/{pg?.slug}" class="hover:text-gray-300 transition-colors truncate max-w-48">{pg?.title}</a>
 		<span>/</span>
-		<span class="text-gray-300">Modifier</span>
+		<span class="text-gray-300">{tFn('wiki_edit.breadcrumb')}</span>
 	</div>
 
-	<h1 class="text-xl font-bold text-white mb-6">Modifier la page</h1>
+	<h1 class="text-xl font-bold text-white mb-6">{tFn('wiki_edit.h1')}</h1>
 
 	{#if form?.error}
 		<div class="mb-4 px-4 py-3 rounded-xl bg-red-900/30 border border-red-500/30 text-red-400 text-sm">
@@ -40,7 +43,7 @@
 		<!-- Title -->
 		<div>
 			<label class="block text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1.5" for="title">
-				Titre *
+				{tFn('wiki_new.title_label')} *
 			</label>
 			<input
 				id="title" name="title" required
@@ -53,12 +56,12 @@
 		<div class="flex gap-3 flex-wrap">
 			<div class="flex-1 min-w-48">
 				<label class="block text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1.5" for="category">
-					Catégorie
+					{tFn('wiki_new.category')}
 				</label>
 				<input
 					id="category" name="category"
 					value={pg?.category ?? ''}
-					placeholder="ex: Règles, Tutoriels, FAQ…"
+					placeholder={tFn('wiki_new.category_ph')}
 					class="w-full bg-gray-900/60 border border-gray-700/60 rounded-xl px-4 py-2.5 text-white text-sm placeholder-gray-600 focus:outline-none focus:border-violet-500/60"
 				/>
 			</div>
@@ -67,7 +70,7 @@
 					<input type="checkbox" name="is_public"
 					       checked={pg?.is_public ?? false}
 					       class="w-4 h-4 rounded border-gray-600 bg-gray-800 accent-violet-500" />
-					<span class="text-sm text-gray-400">Page publique</span>
+					<span class="text-sm text-gray-400">{tFn('wiki_new.public')}</span>
 				</label>
 			</div>
 		</div>
@@ -75,7 +78,7 @@
 		<!-- Excerpt -->
 		<div>
 			<label class="block text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1.5" for="excerpt">
-				Résumé
+				{tFn('wiki_new.summary')}
 			</label>
 			<textarea
 				id="excerpt" name="excerpt" rows="2"
@@ -86,7 +89,7 @@
 		<!-- Content -->
 		<div>
 			<span class="block text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1.5">
-				Contenu
+				{tFn('wiki_new.content_label')}
 			</span>
 			<NodyxEditor name="content" initialContent={pg?.content ?? ''} />
 		</div>
@@ -94,7 +97,7 @@
 		<!-- Submit -->
 		<div class="flex items-center justify-end gap-3 pt-2">
 			<a href="/wiki/{pg?.slug}" class="px-4 py-2 text-sm text-gray-400 hover:text-white transition-colors">
-				Annuler
+				{tFn('wiki_new.cancel')}
 			</a>
 			<button type="submit" disabled={saving}
 			        class="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-violet-600 hover:bg-violet-500 text-white text-sm font-semibold transition-colors disabled:opacity-50">
@@ -104,7 +107,7 @@
 						<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
 					</svg>
 				{/if}
-				Enregistrer
+				{tFn('wiki_edit.save')}
 			</button>
 		</div>
 	</form>


### PR DESCRIPTION
Extraction i18n de la page **édition de page wiki** (`routes/wiki/[slug]/edit`).

- Chaînes propres passées par des clés `wiki_edit.*` + **réutilisation des clés `wiki_new.*`** pour les libellés partagés avec le formulaire de création (Catégorie, Résumé, Titre, Contenu, Page publique, Annuler, placeholder catégorie).
- Titre d'onglet avec interpolation `{{title}}`.

`i18n:scan` = 0, `npm run i18n:keys` vert, `npm run check` = 0 erreur.