### PR TITLE
i18n(grid-renderer): extract GridRenderer edit strings to keys

### DIFF
--- a/nodyx-frontend/src/lib/components/homepage/GridRenderer.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/GridRenderer.svelte
@@ -3,6 +3,9 @@
 	import { DEFAULT_THEME, autoSpanMd, autoSpanSm } from '$lib/types/homepage'
 	import { PLUGIN_REGISTRY } from './plugins'
 	import DynamicWidget from './DynamicWidget.svelte'
+	import { t as i18n } from '$lib/i18n'   // `t` est déjà utilisé pour le thème
+
+	const tFn = $derived($i18n)
 
 	interface Props {
 		layout:           GridLayout
@@ -101,12 +104,12 @@
 				<div class="gr-row-bar">
 					<button
 						class="gr-row-bar-handle"
-						title="Déplacer la ligne"
+						title={tFn('grid_renderer.move_row')}
 						onpointerdown={(e) => onRowDragStart?.(e, row.id)}
-					>⠿ déplacer</button>
+					>{tFn('grid_renderer.drag')}</button>
 					<div class="gr-row-bar-actions">
-						<button class="gr-row-btn" title="Paramètres" onclick={() => onRowSettings?.(row.id)}>⚙</button>
-						<button class="gr-row-btn gr-row-btn--del" title="Supprimer" onclick={() => onRowDelete?.(row.id)}>✕</button>
+						<button class="gr-row-btn" title={tFn('grid_renderer.settings')} onclick={() => onRowSettings?.(row.id)}>⚙</button>
+						<button class="gr-row-btn gr-row-btn--del" title={tFn('grid_renderer.delete')} onclick={() => onRowDelete?.(row.id)}>✕</button>
 					</div>
 				</div>
 			{/if}
@@ -152,7 +155,7 @@
 						<!-- Colonne vide en mode éditeur -->
 						<button class="gr-col-empty-btn" onclick={() => onAddWidget?.(row.id, col.id)}>
 							<span class="gr-col-empty-icon">＋</span>
-							<span class="gr-col-empty-label">Ajouter un widget</span>
+							<span class="gr-col-empty-label">{tFn('grid_renderer.add_widget')}</span>
 							<span class="gr-col-empty-hint">span {col.span}/12</span>
 						</button>
 					{/if}
@@ -161,7 +164,7 @@
 						<!-- Badge edit/supprimer sur le widget -->
 						<div class="gr-col-overlay">
 							<button class="gr-col-overlay-btn" onclick={(e) => { e.stopPropagation(); onColClick?.(row.id, col.id) }}>⚙ Config</button>
-							<button class="gr-col-overlay-btn gr-col-overlay-btn--add" onclick={(e) => { e.stopPropagation(); onAddWidget?.(row.id, col.id) }}>↩ Changer</button>
+							<button class="gr-col-overlay-btn gr-col-overlay-btn--add" onclick={(e) => { e.stopPropagation(); onAddWidget?.(row.id, col.id) }}>{tFn('grid_renderer.change')}</button>
 						</div>
 					{/if}
 
@@ -170,7 +173,7 @@
 						     → hors du flux CSS Grid, n'occupe pas de cellule -->
 						<button
 							class="gr-resize-handle"
-							title="Redimensionner les colonnes"
+							title={tFn('grid_renderer.resize_cols')}
 							onpointerdown={(e) => { e.stopPropagation(); onResizeStart?.(e, row.id, colIdx) }}
 						>◀▶</button>
 					{/if}

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -1944,5 +1944,12 @@
   "media_center.stop": "⏹ Arrêter",
   "media_center.snapshot": "Capture instantanée",
   "media_center.sharing": "{{name}} partage son écran",
-  "media_center.what_share": "Que souhaitez-vous partager ?"
+  "media_center.what_share": "Que souhaitez-vous partager ?",
+  "grid_renderer.move_row": "Déplacer la ligne",
+  "grid_renderer.drag": "⠿ déplacer",
+  "grid_renderer.settings": "Paramètres",
+  "grid_renderer.delete": "Supprimer",
+  "grid_renderer.add_widget": "Ajouter un widget",
+  "grid_renderer.resize_cols": "Redimensionner les colonnes",
+  "grid_renderer.change": "↩ Changer"
 }


### PR DESCRIPTION
Extraction i18n de **GridRenderer** (le renderer de grille homepage, contrôles du mode édition).

- Titres/labels des contrôles (déplacer ligne, paramètres, supprimer, ajouter widget, redimensionner, changer) passés par des clés `grid_renderer.*` via `tFn`.
- **Import i18n aliasé** (`t as i18n`) : `t` est la variable de thème (`const t = $derived({...DEFAULT_THEME...})`).

`i18n:scan` = 0, `npm run i18n:keys` vert, `npm run check` = 0 erreur.