### PR TITLE
i18n(wiki-view): extract wiki page view to keys

### DIFF
--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -1959,5 +1959,14 @@
   "user_card.copy_link": "Copier le lien",
   "user_card.copied": "Copié !",
   "user_card.share": "Partager",
-  "user_card.meta_title": "{{name}} — Carte Nodyx"
+  "user_card.meta_title": "{{name}} — Carte Nodyx",
+  "wiki_view.confirm_delete": "Supprimer définitivement « {{title}} » ?",
+  "wiki_view.edit": "Modifier",
+  "wiki_view.delete": "Supprimer",
+  "wiki_view.created": "Créé le {{date}}",
+  "wiki_view.edited_by": "· Modifié par {{name}}",
+  "wiki_view.back": "Retour au wiki",
+  "wiki_view.unknown_author": "Inconnu",
+  "wiki_view.views_one": "{{count}} vue",
+  "wiki_view.views_many": "{{count}} vues"
 }

--- a/nodyx-frontend/src/routes/wiki/[slug]/+page.svelte
+++ b/nodyx-frontend/src/routes/wiki/[slug]/+page.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import type { PageData } from './$types'
 	import { page } from '$app/stores'
+	import { t } from '$lib/i18n'
+
+	const tFn = $derived($t)
 
 	let { data }: { data: PageData } = $props()
 
@@ -19,7 +22,7 @@
 	}
 
 	async function deletePage() {
-		if (!confirm(`Supprimer définitivement « ${pg.title} » ?`)) return
+		if (!confirm(tFn('wiki_view.confirm_delete', { title: pg.title }))) return
 		const token = $page.data.token as string | null
 		const res = await fetch(`/api/v1/wiki/${pg.slug}`, {
 			method: 'DELETE',
@@ -59,7 +62,7 @@
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
 						      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
 					</svg>
-					Modifier
+					{tFn('wiki_view.edit')}
 				</a>
 				{#if data.user?.role === 'owner' || data.user?.role === 'admin' || data.user?.role === 'moderator'}
 					<button onclick={deletePage}
@@ -68,7 +71,7 @@
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
 							      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
 						</svg>
-						Supprimer
+						{tFn('wiki_view.delete')}
 					</button>
 				{/if}
 			</div>
@@ -85,11 +88,11 @@
 					{(pg?.author_username ?? '?')[0].toUpperCase()}
 				</div>
 			{/if}
-			<span>{pg?.author_username ?? 'Inconnu'}</span>
+			<span>{pg?.author_username ?? tFn('wiki_view.unknown_author')}</span>
 		</div>
-		<span>Créé le {formatDate(pg?.created_at)}</span>
+		<span>{tFn('wiki_view.created', { date: formatDate(pg?.created_at) })}</span>
 		{#if pg?.editor_username && pg.editor_username !== pg.author_username}
-			<span>· Modifié par {pg.editor_username}</span>
+			<span>{tFn('wiki_view.edited_by', { name: pg.editor_username })}</span>
 		{/if}
 		<span class="flex items-center gap-1">
 			<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -98,7 +101,7 @@
 				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
 				      d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
 			</svg>
-			{pg?.views} vue{pg?.views !== 1 ? 's' : ''}
+			{pg?.views !== 1 ? tFn('wiki_view.views_many', { count: pg?.views }) : tFn('wiki_view.views_one', { count: pg?.views })}
 		</span>
 		{#if pg?.is_public}
 			<span class="px-2 py-0.5 rounded-full bg-green-900/30 text-green-500 border border-green-500/20">
@@ -118,7 +121,7 @@
 			<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
 			</svg>
-			Retour au wiki
+			{tFn('wiki_view.back')}
 		</a>
 	</div>
 </div>


### PR DESCRIPTION
Extraction i18n de la **page de lecture wiki** (`routes/wiki/[slug]`).

- Confirmation de suppression (interpolée), boutons Modifier/Supprimer, méta (Créé le, Modifié par), lien retour, fallback « Inconnu », pluriel « vue(s) » passés par des clés `wiki_view.*` via `tFn`.

`i18n:scan` = 0, `npm run i18n:keys` vert, `npm run check` = 0 erreur.