### PR TITLE
i18n(dm): extract DM list strings to keys

### DIFF
--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -2005,5 +2005,8 @@
   "banned.message": "Votre compte a été banni de <span class=\"text-white font-medium\">{{name}}</span>.",
   "banned.logout": "Se déconnecter",
   "chat.gif": "GIF",
-  "chat.more": "Plus…"
+  "chat.more": "Plus…",
+  "dm.keep_typing": "Continue à taper… (encore 1 caractère)",
+  "dm.no_match": "Aucun membre ne correspond à <span class=\"text-gray-300 font-mono\">\"{{query}}\"</span>",
+  "dm.encrypted": "🔒 Message chiffré"
 }

--- a/nodyx-frontend/src/routes/dm/+page.svelte
+++ b/nodyx-frontend/src/routes/dm/+page.svelte
@@ -178,11 +178,11 @@
 						<svg class="w-3 h-3 shrink-0 text-indigo-400/60" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 							<line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
 						</svg>
-						Continue à taper… (encore 1 caractère)
+						{tFn('dm.keep_typing')}
 					</div>
 				{:else if searchQuery.trim().length >= 2 && !searching}
 					<div class="absolute top-full mt-1.5 left-0 right-0 bg-gray-900/95 border border-white/[0.08] rounded-xl shadow-2xl z-20 px-3 py-2.5 text-[11px] text-gray-500">
-						Aucun membre ne correspond à <span class="text-gray-300 font-mono">"{searchQuery.trim()}"</span>
+						{@html tFn('dm.no_match', { query: searchQuery.trim() })}
 					</div>
 				{/if}
 			</div>
@@ -254,7 +254,7 @@
 								<p class="text-[11px] truncate mt-0.5 {conv.unread_count > 0 ? 'text-gray-400 font-medium' : 'text-gray-600'}">
 									{#if conv.last_message_content}
 										{#if conv.last_message_encrypted}
-											<span class="opacity-60">🔒 Message chiffré</span>
+											<span class="opacity-60">{tFn('dm.encrypted')}</span>
 										{:else}
 											{conv.last_message_sender_id === currentUserId ? tFn('dm.you_prefix') : ''}{truncate(conv.last_message_content)}
 										{/if}
@@ -337,11 +337,11 @@
 						<svg class="w-3.5 h-3.5 shrink-0 text-indigo-400/60" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 							<line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
 						</svg>
-						Continue à taper… (encore 1 caractère)
+						{tFn('dm.keep_typing')}
 					</div>
 				{:else if searchQuery.trim().length >= 2 && !searching}
 					<div class="absolute top-full mt-2 left-0 right-0 bg-gray-900/95 border border-white/[0.08] rounded-xl shadow-2xl z-20 px-3 py-3 text-xs text-gray-500">
-						Aucun membre ne correspond à <span class="text-gray-300 font-mono">"{searchQuery.trim()}"</span>
+						{@html tFn('dm.no_match', { query: searchQuery.trim() })}
 					</div>
 				{/if}
 			</div>


### PR DESCRIPTION
Extraction i18n des dernières chaînes de la **liste des DM** (`routes/dm`, déjà largement i18n).

- Indice de saisie, message « aucun membre ne correspond » (avec `<span>` via `{@html}`, interpolé avec la requête), badge « Message chiffré » passés par des clés `dm.*` via `tFn`.

`i18n:scan` = 0, `npm run i18n:keys` vert, `npm run check` = 0 erreur.