### PR TITLE
i18n(overlay-alert): extract alert overlay to keys

### DIFF
--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -2012,5 +2012,13 @@
   "notifications.canvas_access_request_label": "demande l'accès en édition à un Canvas",
   "notifications.canvas_access_granted_label": "t'a accordé l'accès en édition à un Canvas",
   "notifications.view": "Voir →",
-  "notifications.mark_read": "Marquer comme lu"
+  "notifications.mark_read": "Marquer comme lu",
+  "overlay_alert.follow": "Nouveau follower",
+  "overlay_alert.subscribe": "Nouvel abonné",
+  "overlay_alert.gift": "Sub offert",
+  "overlay_alert.cheer": "Bits",
+  "overlay_alert.raid": "Raid",
+  "overlay_alert.invalid": "Overlay invalide ou révoquée. Génère une nouvelle URL dans Nodyx.",
+  "overlay_alert.conn_failed": "Connexion Nodyx impossible.",
+  "overlay_alert.connecting": "Connexion à Nodyx…"
 }

--- a/nodyx-frontend/src/routes/overlay/alert/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/alert/[token]/+page.svelte
@@ -6,6 +6,9 @@
 	import { fly, fade, scale } from 'svelte/transition'
 	import { backOut, cubicOut } from 'svelte/easing'
 	import { playAlertSound } from '$lib/sounds/presetSounds'
+	import { t } from '$lib/i18n'
+
+	const tFn = $derived($t)
 
 	// Page transparente conçue pour être collée comme Browser Source dans OBS.
 	// Le token dans l'URL EST l'auth : il bootstrappe la config via REST et
@@ -245,11 +248,11 @@
 	}
 
 	const LABELS: Record<AlertEventKey, string> = {
-		'channel.follow':            'Nouveau follower',
-		'channel.subscribe':         'Nouvel abonné',
-		'channel.subscription.gift': 'Sub offert',
-		'channel.cheer':             'Bits',
-		'channel.raid':              'Raid',
+		'channel.follow':            'overlay_alert.follow',
+		'channel.subscribe':         'overlay_alert.subscribe',
+		'channel.subscription.gift': 'overlay_alert.gift',
+		'channel.cheer':             'overlay_alert.cheer',
+		'channel.raid':              'overlay_alert.raid',
 	}
 
 	// Echappe une string pour la mettre dans une CSS url() ou color : on
@@ -285,21 +288,21 @@
 <div class="overlay-root theme-{config.theme} pos-{config.position}">
 	{#if status === 'invalid'}
 		<div class="status-msg status-error" transition:fade>
-			Overlay invalide ou révoquée. Génère une nouvelle URL dans Nodyx.
+			{tFn('overlay_alert.invalid')}
 		</div>
 	{:else if status === 'error'}
 		<div class="status-msg status-error" transition:fade>
-			Connexion Nodyx impossible.
+			{tFn('overlay_alert.conn_failed')}
 		</div>
 	{:else if status === 'loading'}
 		<div class="status-msg status-info" transition:fade>
-			Connexion à Nodyx…
+			{tFn('overlay_alert.connecting')}
 		</div>
 	{/if}
 
 	{#each alerts as alert (alert.id)}
 		{@const accent  = config.theme === 'custom' && config.customTheme?.accentColor ? config.customTheme.accentColor : ACCENTS[alert.eventType]}
-		{@const label   = LABELS[alert.eventType]}
+		{@const label   = tFn(LABELS[alert.eventType])}
 		{@const iconUrl = config.events[alert.eventType]?.iconUrl ?? null}
 		{@const cstyles = config.theme === 'custom' ? buildCustomStyle(config.customTheme) : ''}
 		<div class="alert-card" style="--accent: {accent}; {cstyles}"


### PR DESCRIPTION
Extraction i18n de l'**overlay d'alerte** OBS (`routes/overlay/alert/[token]`).

- `LABELS` (types d'alerte) convertis en clés résolues via `tFn` à l'usage.
- Messages de statut (overlay invalide, connexion impossible/en cours) passés par des clés `overlay_alert.*`.

`i18n:scan` = 0, `npm run i18n:keys` vert, `npm run check` = 0 erreur.