### PR TITLE
i18n(overlay-board): extract board overlay to keys

### DIFF
--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -2020,5 +2020,9 @@
   "overlay_alert.raid": "Raid",
   "overlay_alert.invalid": "Overlay invalide ou révoquée. Génère une nouvelle URL dans Nodyx.",
   "overlay_alert.conn_failed": "Connexion Nodyx impossible.",
-  "overlay_alert.connecting": "Connexion à Nodyx…"
+  "overlay_alert.connecting": "Connexion à Nodyx…",
+  "overlay_board.invalid": "Overlay invalide ou révoquée.",
+  "overlay_board.loading": "Chargement…",
+  "overlay_board.empty": "Pas encore de classement sur cette période.",
+  "overlay_board.recap": "RÉCAP DE STREAM"
 }

--- a/nodyx-frontend/src/routes/overlay/board/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/board/[token]/+page.svelte
@@ -5,6 +5,9 @@
 	import { PUBLIC_API_URL } from '$env/static/public'
 	import { fade, fly, scale } from 'svelte/transition'
 	import { backOut, cubicOut } from 'svelte/easing'
+	import { t } from '$lib/i18n'
+
+	const tFn = $derived($t)
 
 	// Podium top 3 (gold/silver/bronze) + liste rang 4-N en dessous. Avatars
 	// Twitch sur les têtes des podiums. Refresh state toutes les 60s + push
@@ -173,25 +176,25 @@
 
 <div class="overlay-root" class:recap={recapMode}>
 	{#if status === 'invalid'}
-		<div class="status-msg" transition:fade>Overlay invalide ou révoquée.</div>
+		<div class="status-msg" transition:fade>{tFn('overlay_board.invalid')}</div>
 	{:else if status === 'error'}
-		<div class="status-msg" transition:fade>Connexion Nodyx impossible.</div>
+		<div class="status-msg" transition:fade>{tFn('overlay_alert.conn_failed')}</div>
 	{:else if status === 'loading'}
-		<div class="status-msg status-loading" transition:fade>Chargement…</div>
+		<div class="status-msg status-loading" transition:fade>{tFn('overlay_board.loading')}</div>
 	{:else if config && entries.length === 0}
 		<div class="card theme-{config.theme}" style={customStyle()} transition:fade>
 			<header class="title">
 				<h1>{CATEGORY_LABELS[config.category].plural}</h1>
 				<span class="period">{PERIOD_LABELS[config.period]}</span>
 			</header>
-			<div class="empty-msg">Pas encore de classement sur cette période.</div>
+			<div class="empty-msg">{tFn('overlay_board.empty')}</div>
 		</div>
 	{:else if config}
 		<div class="card theme-{config.theme}" style={customStyle()} transition:fade>
 			<header class="title">
 				<h1>{CATEGORY_LABELS[config.category].plural}</h1>
 				<span class="period">{PERIOD_LABELS[config.period]}</span>
-				{#if recapMode}<span class="recap-badge">RÉCAP DE STREAM</span>{/if}
+				{#if recapMode}<span class="recap-badge">{tFn('overlay_board.recap')}</span>{/if}
 			</header>
 
 			<!-- Podium top 3 -->


### PR DESCRIPTION
Extraction i18n de l'**overlay de classement** OBS (`routes/overlay/board/[token]`).

- Messages de statut (invalide, chargement), état vide, badge récap passés par des clés `overlay_board.*` via `tFn` (réutilise `overlay_alert.conn_failed`).

`i18n:scan` = 0, `npm run i18n:keys` vert, `npm run check` = 0 erreur.