### PR TITLE
i18n(overlay-playlist): extract playlist overlay to keys

### DIFF
--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -2024,5 +2024,10 @@
   "overlay_board.invalid": "Overlay invalide ou révoquée.",
   "overlay_board.loading": "Chargement…",
   "overlay_board.empty": "Pas encore de classement sur cette période.",
-  "overlay_board.recap": "RÉCAP DE STREAM"
+  "overlay_board.recap": "RÉCAP DE STREAM",
+  "overlay_playlist.next": "⏭ Suivant",
+  "overlay_playlist.prev": "⏮ Précédent",
+  "overlay_playlist.click_start": "▶ Cliquer pour démarrer",
+  "overlay_playlist.invalid": "Lien d'overlay invalide ou playlist supprimée.",
+  "overlay_playlist.load_error": "Erreur de chargement."
 }

--- a/nodyx-frontend/src/routes/overlay/playlist/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/playlist/[token]/+page.svelte
@@ -3,6 +3,9 @@
 	import { browser } from '$app/environment'
 	import { page } from '$app/state'
 	import { PUBLIC_API_URL } from '$env/static/public'
+	import { t } from '$lib/i18n'
+
+	const tFn = $derived($t)
 
 	// ─── Overlay Playlist (OBS browser source) ──────────────────────────────
 	// Lit une playlist du streamer en autoplay loop pour servir de musique
@@ -320,14 +323,14 @@
 			}
 			case 'skip': {
 				advance()
-				flashCmd('⏭ Suivant')
+				flashCmd(tFn('overlay_playlist.next'))
 				break
 			}
 			case 'prev': {
 				if (order.length === 0) break
 				cursor = (cursor - 1 + order.length) % order.length
 				playCurrent()
-				flashCmd('⏮ Précédent')
+				flashCmd(tFn('overlay_playlist.prev'))
 				break
 			}
 			case 'stop': {
@@ -392,18 +395,18 @@
 	<button type="button" onclick={startFromClick}
 		class="fixed inset-0 grid place-items-center bg-black/40 backdrop-blur-sm cursor-pointer">
 		<div class="px-5 py-3 rounded-lg bg-zinc-900/90 border border-zinc-700 text-zinc-100 text-sm font-medium shadow-2xl">
-			▶ Cliquer pour démarrer
+			{tFn('overlay_playlist.click_start')}
 		</div>
 	</button>
 {/if}
 
 {#if status === 'invalid'}
 	<div class="fixed top-3 left-3 px-3 py-1.5 rounded-md bg-rose-950/85 border border-rose-700 text-rose-100 text-xs font-medium">
-		Lien d'overlay invalide ou playlist supprimée.
+		{tFn('overlay_playlist.invalid')}
 	</div>
 {:else if status === 'error'}
 	<div class="fixed top-3 left-3 px-3 py-1.5 rounded-md bg-rose-950/85 border border-rose-700 text-rose-100 text-xs font-medium">
-		Erreur de chargement.
+		{tFn('overlay_playlist.load_error')}
 	</div>
 {:else if status === 'empty'}
 	<div class="fixed top-3 left-3 px-3 py-1.5 rounded-md bg-amber-950/85 border border-amber-700 text-amber-100 text-xs font-medium">


### PR DESCRIPTION
Extraction i18n de l'**overlay playlist** OBS (`routes/overlay/playlist/[token]`).

- Commandes flash (Suivant/Précédent), invite « Cliquer pour démarrer », messages d'erreur passés par des clés `overlay_playlist.*` via `tFn`.

`i18n:scan` = 0, `npm run i18n:keys` vert, `npm run check` = 0 erreur.