### PR TITLE
i18n(canvas-left-toolbar): extract CanvasLeftToolbar to keys

### DIFF
--- a/nodyx-frontend/src/lib/components/CanvasLeftToolbar.svelte
+++ b/nodyx-frontend/src/lib/components/CanvasLeftToolbar.svelte
@@ -1,33 +1,36 @@
 <script lang="ts">
 	import type { CanvasTool } from '$lib/canvas'
+	import { t as i18n } from '$lib/i18n'   // `t` = variable de boucle
+
+	const tFn = $derived($i18n)
 
 	let {
 		tool    = $bindable<CanvasTool>('pen'),
 		onClose = () => {},
 	}: { tool: CanvasTool; onClose: () => void } = $props()
 
-	type ToolDef = { id: CanvasTool; label: string; key: string }
+	type ToolDef = { id: CanvasTool; labelKey: string; key: string }
 
 	const groups: ToolDef[][] = [
-		[{ id: 'select', label: 'Sélection', key: 'V' }],
+		[{ id: 'select', labelKey: 'canvas_ltool.select', key: 'V' }],
 		[
-			{ id: 'pen',    label: 'Stylo',      key: 'P' },
-			{ id: 'text',   label: 'Texte',      key: 'T' },
-			{ id: 'sticky', label: 'Post-it',    key: 'N' },
+			{ id: 'pen',    labelKey: 'canvas_ltool.pen',      key: 'P' },
+			{ id: 'text',   labelKey: 'canvas_ltool.text',      key: 'T' },
+			{ id: 'sticky', labelKey: 'canvas_ltool.sticky',    key: 'N' },
 		],
 		[
-			{ id: 'rect',      label: 'Rectangle',  key: 'R' },
-			{ id: 'circle',    label: 'Cercle',     key: 'C' },
-			{ id: 'shape',     label: 'Forme',      key: 'S' },
+			{ id: 'rect',      labelKey: 'canvas_ltool.rect',  key: 'R' },
+			{ id: 'circle',    labelKey: 'canvas_ltool.circle',     key: 'C' },
+			{ id: 'shape',     labelKey: 'canvas_ltool.shape',      key: 'S' },
 		],
 		[
-			{ id: 'arrow',     label: 'Flèche',     key: 'A' },
-			{ id: 'connector', label: 'Connecteur', key: 'X' },
+			{ id: 'arrow',     labelKey: 'canvas_ltool.arrow',     key: 'A' },
+			{ id: 'connector', labelKey: 'canvas_ltool.connector', key: 'X' },
 		],
 		[
-			{ id: 'image',  label: 'Image',      key: 'I' },
-			{ id: 'frame',  label: 'Frame',      key: 'F' },
-			{ id: 'eraser', label: 'Gomme',      key: 'E' },
+			{ id: 'image',  labelKey: 'canvas_ltool.image',      key: 'I' },
+			{ id: 'frame',  labelKey: 'canvas_ltool.frame',      key: 'F' },
+			{ id: 'eraser', labelKey: 'canvas_ltool.eraser',      key: 'E' },
 		],
 	]
 </script>
@@ -43,8 +46,8 @@
 				onclick={() => tool = t.id}
 				class="tool-btn"
 				class:active={tool === t.id}
-				title="{t.label} ({t.key})"
-				aria-label={t.label}
+				title={tFn(t.labelKey) + ' (' + t.key + ')'}
+				aria-label={tFn(t.labelKey)}
 			>
 				{#if t.id === 'select'}
 					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
@@ -114,7 +117,7 @@
 	<div class="sep"></div>
 
 	<!-- Close -->
-	<button class="tool-btn close-btn" onclick={onClose} title="Fermer (Échap)" aria-label="Fermer">
+	<button class="tool-btn close-btn" onclick={onClose} title={tFn('canvas_ltool.close_title')} aria-label={tFn('canvas_ltool.close')}>
 		<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
 			<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
 		</svg>

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -2029,5 +2029,19 @@
   "overlay_playlist.prev": "⏮ Précédent",
   "overlay_playlist.click_start": "▶ Cliquer pour démarrer",
   "overlay_playlist.invalid": "Lien d'overlay invalide ou playlist supprimée.",
-  "overlay_playlist.load_error": "Erreur de chargement."
+  "overlay_playlist.load_error": "Erreur de chargement.",
+  "canvas_ltool.select": "Sélection",
+  "canvas_ltool.pen": "Stylo",
+  "canvas_ltool.text": "Texte",
+  "canvas_ltool.sticky": "Post-it",
+  "canvas_ltool.rect": "Rectangle",
+  "canvas_ltool.circle": "Cercle",
+  "canvas_ltool.shape": "Forme",
+  "canvas_ltool.arrow": "Flèche",
+  "canvas_ltool.connector": "Connecteur",
+  "canvas_ltool.image": "Image",
+  "canvas_ltool.frame": "Frame",
+  "canvas_ltool.eraser": "Gomme",
+  "canvas_ltool.close_title": "Fermer (Échap)",
+  "canvas_ltool.close": "Fermer"
 }


### PR DESCRIPTION
Extraction i18n de **CanvasLeftToolbar** (la barre d'outils gauche du canvas).

- 12 labels d'outils (`groups` → `labelKey`) + titres/aria passés par des clés `canvas_ltool.*` via `tFn` (`title="{...}"` → accolades).
- **Import i18n aliasé** (`t` = variable de boucle).

`i18n:scan` = 0, `npm run i18n:keys` vert, `npm run check` = 0 erreur.