### PR TITLE
i18n(profile-card): extract ProfileCard attrs to keys

### DIFF
--- a/nodyx-frontend/src/lib/components/ProfileCard.svelte
+++ b/nodyx-frontend/src/lib/components/ProfileCard.svelte
@@ -94,7 +94,7 @@
 			{#if avatarUrl}
 				<img
 					src={avatarUrl}
-					alt="Avatar de {displayName || username}"
+					alt={tFn('profile_card.avatar_alt', { name: displayName || username })}
 					class="w-16 h-16 rounded-full object-cover border border-gray-700"
 				/>
 			{:else}
@@ -143,7 +143,7 @@
 
 		<!-- Tags (max 3) -->
 		{#if visibleTags.length > 0}
-			<ul class="flex flex-wrap justify-center gap-1" aria-label="Tags">
+			<ul class="flex flex-wrap justify-center gap-1" aria-label={tFn('profile_card.tags_aria')}>
 				{#each visibleTags as tag}
 					<li class="text-xs bg-gray-800 text-gray-400 rounded px-1.5 py-0.5">#{tag}</li>
 				{/each}
@@ -169,7 +169,7 @@
 		{#if avatarUrl}
 			<img
 				src={avatarUrl}
-				alt="Avatar de {displayName || username}"
+				alt={tFn('profile_card.avatar_alt', { name: displayName || username })}
 				class="w-20 h-20 rounded-full object-cover border-2 border-gray-600"
 			/>
 		{:else}
@@ -204,7 +204,7 @@
 			</div>
 
 			{#if visibleTags.length > 0}
-				<ul class="flex flex-wrap gap-1.5 mt-1" aria-label="Tags">
+				<ul class="flex flex-wrap gap-1.5 mt-1" aria-label={tFn('profile_card.tags_aria')}>
 					{#each visibleTags as tag}
 						<li class="text-xs bg-gray-800 text-gray-400 rounded px-2 py-0.5">#{tag}</li>
 					{/each}

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -2043,5 +2043,7 @@
   "canvas_ltool.frame": "Frame",
   "canvas_ltool.eraser": "Gomme",
   "canvas_ltool.close_title": "Fermer (Échap)",
-  "canvas_ltool.close": "Fermer"
+  "canvas_ltool.close": "Fermer",
+  "profile_card.avatar_alt": "Avatar de {{name}}",
+  "profile_card.tags_aria": "Tags"
 }


### PR DESCRIPTION
Extraction i18n de **ProfileCard** (la carte de profil, déjà largement i18n).

- `alt` avatar interpolé passé en accolades (`alt={tFn(...)}`), aria « Tags » passés par des clés `profile_card.*` via `tFn`.

`i18n:scan` = 0, `npm run i18n:keys` vert, `npm run check` = 0 erreur.