### PR TITLE
i18n(dm-conversation): extract DM conversation strings to keys

### DIFF
--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -2049,5 +2049,8 @@
   "hero.live_aria": "Stream en direct",
   "hero.upcoming_event": "Événement à venir",
   "hero.overflow_aria": "{{n}} autres membres en ligne",
-  "hero.join_to_see": "Rejoindre pour voir qui est là"
+  "hero.join_to_see": "Rejoindre pour voir qui est là",
+  "dm_conv.added": "{{by}} a ajouté {{user}} à la conversation",
+  "dm_conv.encrypted": "🔒 message chiffré",
+  "dm_conv.esc": "Échap"
 }

--- a/nodyx-frontend/src/routes/dm/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/dm/[id]/+page.svelte
@@ -373,7 +373,7 @@
 			sender_username: '',
 			sender_avatar: null,
 			sender_name_color: null,
-			content: `${invited_by} a ajouté ${user.username} à la conversation`,
+			content: tFn('dm_conv.added', { by: invited_by, user: user.username }),
 			created_at: new Date().toISOString(),
 			deleted_at: null,
 			_systemMessage: true,
@@ -897,7 +897,7 @@
 	function replyPreview(msg: DmMessage): string {
 		if (msg.is_encrypted) {
 			if (msg._decrypted) return msg._decrypted.slice(0, 120)
-			return '🔒 message chiffré'
+			return tFn('dm_conv.encrypted')
 		}
 		return (msg.content || '').slice(0, 120)
 	}
@@ -1590,7 +1590,7 @@
 									></textarea>
 									<div class="flex gap-1.5 mt-1.5">
 										<button onclick={saveEdit} class="text-[10px] px-2 py-0.5 rounded-md bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">{tFn('dm.enter')}</button>
-										<button onclick={cancelEdit} class="text-[10px] px-2 py-0.5 rounded-md bg-white/[0.06] hover:bg-white/[0.10] text-gray-400 transition-colors">Échap</button>
+										<button onclick={cancelEdit} class="text-[10px] px-2 py-0.5 rounded-md bg-white/[0.06] hover:bg-white/[0.10] text-gray-400 transition-colors">{tFn('dm_conv.esc')}</button>
 									</div>
 								{:else}
 									<!-- Quote inline si ce message est une réponse à un autre -->
@@ -1600,7 +1600,7 @@
 											<div class="dm-quote-content">
 												<div class="dm-quote-author">{msg.reply_snapshot.sender_username}</div>
 												<div class="dm-quote-preview">
-													{msg.reply_snapshot.is_encrypted ? '🔒 message chiffré' : msg.reply_snapshot.content}
+													{msg.reply_snapshot.is_encrypted ? tFn('dm_conv.encrypted') : msg.reply_snapshot.content}
 												</div>
 											</div>
 										</div>


### PR DESCRIPTION
Extraction des dernières chaînes de la **conversation DM** (`routes/dm/[id]`, déjà largement i18n).

- Message système d'ajout à la conversation (interpolé), badge « message chiffré », bouton « Échap » passés par des clés `dm_conv.*` via `tFn`.

`i18n:scan` = 0, `npm run i18n:keys` vert, `npm run check` = 0 erreur.