### PR TITLE
i18n(overlay-ticker): extract ticker overlay to keys

### DIFF
--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -2054,5 +2054,6 @@
   "dm_conv.encrypted": "🔒 message chiffré",
   "dm_conv.esc": "Échap",
   "overlay_clips.gate_sub": "Clique une fois pour autoriser l'autoplay des clips Twitch. Dans OBS, coche \"Control audio via OBS\" dans les propriétés du Browser Source — l'autoplay marchera direct sans ce gate.",
-  "overlay_clips.bg_tab": "Onglet en arrière-plan : Twitch bloque l'autoplay. Reviens sur cet onglet pour démarrer, OU teste depuis OBS Browser Source (autoplay y marche)."
+  "overlay_clips.bg_tab": "Onglet en arrière-plan : Twitch bloque l'autoplay. Reviens sur cet onglet pour démarrer, OU teste depuis OBS Browser Source (autoplay y marche).",
+  "overlay_ticker.empty": "Aucun event encore. Le ticker se remplira au fil des follows / subs / raids."
 }

--- a/nodyx-frontend/src/routes/overlay/ticker/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/ticker/[token]/+page.svelte
@@ -4,6 +4,9 @@
 	import { browser } from '$app/environment'
 	import { PUBLIC_API_URL } from '$env/static/public'
 	import { fade } from 'svelte/transition'
+	import { t } from '$lib/i18n'
+
+	const tFn = $derived($t)
 
 	// Bandeau défilant en bas d'écran. SVG icons par event type, typographie
 	// hiérarchisée (nom gros, badge eyebrow), drift de couleur subtle du
@@ -246,11 +249,11 @@
 
 <div class="overlay-root">
 	{#if status === 'invalid'}
-		<div class="status-msg" transition:fade>Overlay invalide ou révoquée.</div>
+		<div class="status-msg" transition:fade>{tFn('overlay_board.invalid')}</div>
 	{:else if status === 'error'}
-		<div class="status-msg" transition:fade>Connexion Nodyx impossible.</div>
+		<div class="status-msg" transition:fade>{tFn('overlay_alert.conn_failed')}</div>
 	{:else if status === 'loading'}
-		<div class="status-msg status-loading" transition:fade>Chargement…</div>
+		<div class="status-msg status-loading" transition:fade>{tFn('overlay_board.loading')}</div>
 	{:else if config && tokens.length > 0}
 		<div class="ticker theme-{config.theme}"
 		     style="--scroll-duration: {config.speedSeconds}s; --drift: {driftColor}; {customStyle()}">
@@ -323,7 +326,7 @@
 		</div>
 	{:else if config}
 		<div class="status-msg status-loading" transition:fade>
-			Aucun event encore. Le ticker se remplira au fil des follows / subs / raids.
+			{tFn('overlay_ticker.empty')}
 		</div>
 	{/if}
 </div>


### PR DESCRIPTION
Extraction i18n de l'**overlay ticker** OBS (`routes/overlay/ticker/[token]`).

- Messages de statut (réutilisent `overlay_board.*` / `overlay_alert.*`) + état vide passés par des clés `overlay_ticker.*` via `tFn`.

`i18n:scan` = 0, `npm run i18n:keys` vert, `npm run check` = 0 erreur.