### PR TITLE
i18n(overlays): extract goal/soundboard/timer overlays to keys

### DIFF
--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -2059,5 +2059,9 @@
   "status.back": "← Retour au fil",
   "status.reshared": "🔁 <a href=\"/users/{{username}}\">{{name}}</a> a repartagé",
   "status.reply_to": "En réponse à <strong>@{{name}}</strong>",
-  "status.cancel": "annuler"
+  "status.cancel": "annuler",
+  "overlay_goal.loading": "Chargement de l'état…",
+  "overlay_sb.invalid": "Overlay Soundboard : token invalide ou révoqué.",
+  "overlay_sb.conn_failed": "Connexion impossible. Vérifie le réseau OBS.",
+  "overlay_sb.ready": "Soundboard prêt"
 }

--- a/nodyx-frontend/src/routes/overlay/goal/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/goal/[token]/+page.svelte
@@ -4,6 +4,9 @@
 	import { browser } from '$app/environment'
 	import { PUBLIC_API_URL } from '$env/static/public'
 	import { fade } from 'svelte/transition'
+	import { t } from '$lib/i18n'
+
+	const tFn = $derived($t)
 
 	// Goal bar : barre de progression vers un objectif (followers, subs cette
 	// session, bits cette session, ou valeur custom). Polling 30s du backend
@@ -112,11 +115,11 @@
 
 <div class="overlay-root">
 	{#if status === 'invalid'}
-		<div class="status-msg" transition:fade>Overlay invalide ou révoquée.</div>
+		<div class="status-msg" transition:fade>{tFn('overlay_board.invalid')}</div>
 	{:else if status === 'error'}
-		<div class="status-msg" transition:fade>Connexion Nodyx impossible.</div>
+		<div class="status-msg" transition:fade>{tFn('overlay_alert.conn_failed')}</div>
 	{:else if status === 'loading'}
-		<div class="status-msg loading" transition:fade>Chargement de l'état…</div>
+		<div class="status-msg loading" transition:fade>{tFn('overlay_goal.loading')}</div>
 	{:else if goalState}
 		{@const accent = goalState.accent}
 		{@const themeCls = `theme-${goalState.theme}`}

--- a/nodyx-frontend/src/routes/overlay/soundboard/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/soundboard/[token]/+page.svelte
@@ -3,6 +3,9 @@
 	import { browser } from '$app/environment'
 	import { page } from '$app/state'
 	import { PUBLIC_API_URL } from '$env/static/public'
+	import { t } from '$lib/i18n'
+
+	const tFn = $derived($t)
 
 	// ─── Overlay Soundboard (OBS browser source) ────────────────────────────
 	// Reçoit les events audio:play/stop/pause depuis le socket /overlay (room
@@ -338,18 +341,18 @@
 <div class="fixed inset-0 pointer-events-none">
 	{#if status === 'invalid'}
 		<div class="absolute top-4 left-4 px-3 py-2 bg-rose-950/90 text-rose-100 text-xs rounded border border-rose-500/60 pointer-events-auto">
-			Overlay Soundboard : token invalide ou révoqué.
+			{tFn('overlay_sb.invalid')}
 		</div>
 	{:else if status === 'error'}
 		<div class="absolute top-4 left-4 px-3 py-2 bg-amber-950/90 text-amber-100 text-xs rounded border border-amber-500/60 pointer-events-auto">
-			Connexion impossible. Vérifie le réseau OBS.
+			{tFn('overlay_sb.conn_failed')}
 		</div>
 	{:else if status === 'ready' && showReadyBadge && !nowPlaying}
 		<!-- Badge éphémère au boot pour confirmer la connexion en preview navigateur.
 		     Disparaît après 6s pour ne pas polluer le stream en prod OBS. -->
 		<div class="absolute top-6 left-1/2 -translate-x-1/2 px-4 py-2 bg-zinc-950/85 backdrop-blur-md border border-emerald-500/50 rounded-full shadow-2xl flex items-center gap-2 text-xs pointer-events-none animate-fade-out">
 			<span class="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse"></span>
-			<span class="text-zinc-100 font-medium">Soundboard prêt</span>
+			<span class="text-zinc-100 font-medium">{tFn('overlay_sb.ready')}</span>
 			<span class="text-zinc-500">— appuie sur un bouton 🎵 de ton Stream Deck</span>
 		</div>
 	{/if}

--- a/nodyx-frontend/src/routes/overlay/timer/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/timer/[token]/+page.svelte
@@ -4,6 +4,9 @@
 	import { browser } from '$app/environment'
 	import { PUBLIC_API_URL } from '$env/static/public'
 	import { fade } from 'svelte/transition'
+	import { t } from '$lib/i18n'
+
+	const tFn = $derived($t)
 
 	// Stream timer overlay : affiche le temps écoulé depuis le started_at de
 	// la session en cours. Bootstrap l'état + config via REST, tick local
@@ -173,11 +176,11 @@
 <div class="overlay-root pos-{config.position}">
 	{#if status === 'invalid'}
 		<div class="status-msg status-error" transition:fade>
-			Overlay invalide ou révoquée.
+			{tFn('overlay_board.invalid')}
 		</div>
 	{:else if status === 'error'}
 		<div class="status-msg status-error" transition:fade>
-			Connexion Nodyx impossible.
+			{tFn('overlay_alert.conn_failed')}
 		</div>
 	{:else if status === 'ready' && isLive}
 		<div class="timer-card theme-{config.theme}" style={customStyle()} transition:fade>


### PR DESCRIPTION
Extraction i18n des **3 derniers overlays OBS** (goal, soundboard, timer) en une PR (fichiers distincts).

- `goal` et `timer` réutilisent `overlay_board.invalid` / `overlay_alert.conn_failed` ; `goal` ajoute `overlay_goal.loading`.
- `soundboard` : ses propres clés `overlay_sb.*` (token invalide, connexion, prêt).

`i18n:scan` = 0, `npm run i18n:keys` vert, `npm run check` = 0 erreur.