### PR TITLE
i18n(batch): TwitchStream, calendar forms, community, feed, profile

### DIFF
--- a/nodyx-frontend/src/lib/components/homepage/widgets/TwitchStream.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/TwitchStream.svelte
@@ -262,7 +262,7 @@
 							<div class="w-8 h-8 rounded-full border-2 animate-spin"
 							     style="border-color:rgba(145,70,255,.2); border-top-color:{accent}"></div>
 							<span class="text-[10px] uppercase tracking-[.18em] font-bold" style="color:#6b7280; font-family:'Space Grotesk',sans-serif">
-								Chargement du stream
+								{tFn('widgets.twitch_loading')}
 							</span>
 						</div>
 					</div>
@@ -272,7 +272,7 @@
 					{#key activeChannel + parentDomain}
 						<iframe
 							src={playerUrl}
-							title="Twitch player — {activeChannel}"
+							title={tFn('widgets.twitch_player_title', { channel: activeChannel })}
 							allowfullscreen
 							allow="autoplay; fullscreen; picture-in-picture"
 							onload={onIframeLoad}
@@ -294,7 +294,7 @@
 						{#key activeChannel + parentDomain}
 							<iframe
 								src={chatUrl}
-								title="Twitch chat — {activeChannel}"
+								title={tFn('widgets.twitch_chat_title', { channel: activeChannel })}
 								class="w-full h-full"
 								style="border:0"
 							></iframe>

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -2063,5 +2063,18 @@
   "overlay_goal.loading": "Chargement de l'état…",
   "overlay_sb.invalid": "Overlay Soundboard : token invalide ou révoqué.",
   "overlay_sb.conn_failed": "Connexion impossible. Vérifie le réseau OBS.",
-  "overlay_sb.ready": "Soundboard prêt"
+  "overlay_sb.ready": "Soundboard prêt",
+  "widgets.twitch_loading": "Chargement du stream",
+  "widgets.twitch_player_title": "Twitch player — {{channel}}",
+  "widgets.twitch_chat_title": "Twitch chat — {{channel}}",
+  "cal_form.tags_ph": "musique, jeux, irl, dev...",
+  "cal_form.location_ph": "Parc de la Villette, Paris — ou https://meet.jit.si/monEvent",
+  "cal_form.url_ph": "https://...",
+  "community_page.meta_desc": "Communauté {{name}} sur Nodyx.",
+  "community_page.no_category": "Aucune catégorie pour l'instant.",
+  "community_page.configure": "Configurer la communauté →",
+  "feed.cancel": "Annuler",
+  "feed.delete": "Supprimer",
+  "user_profile.avatar_alt": "Avatar de {{name}}",
+  "user_profile.soon": "Bientôt disponible"
 }

--- a/nodyx-frontend/src/routes/calendar/[id]/edit/+page.svelte
+++ b/nodyx-frontend/src/routes/calendar/[id]/edit/+page.svelte
@@ -212,7 +212,7 @@
 			<div>
 				<label for="tags" class="block text-sm font-medium text-gray-300 mb-1.5">{tFn('event.field_tags')} <span class="text-gray-600 text-xs font-normal">{tFn('event.tags_hint')}</span></label>
 				<input id="tags" name="tags" type="text" value={ev.tags?.join(', ') ?? ''}
-				       placeholder="musique, jeux, irl, dev..."
+				       placeholder={tFn('cal_form.tags_ph')}
 				       class="w-full bg-gray-800/80 border border-gray-700 rounded-xl px-4 py-3 text-white placeholder-gray-500 text-sm
 				              focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500/40 transition-colors"/>
 			</div>
@@ -235,7 +235,7 @@
 			<div>
 				<label for="location" class="block text-sm font-medium text-gray-300 mb-1.5">Adresse / nom du lieu <span class="text-gray-600 text-xs font-normal">(optionnel)</span></label>
 				<input id="location" name="location" type="text" bind:value={locationText}
-				       placeholder="Parc de la Villette, Paris — ou https://meet.jit.si/monEvent"
+				       placeholder={tFn('cal_form.location_ph')}
 				       class="w-full bg-gray-800/80 border border-gray-700 rounded-xl px-4 py-3 text-white placeholder-gray-500 text-sm
 				              focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500/40 transition-colors"/>
 			</div>
@@ -329,7 +329,7 @@
 						<label for="ticket_url" class="block text-sm font-medium text-gray-300 mb-1.5">Lien d'achat <span class="text-gray-600 text-xs font-normal">(Eventbrite, HelloAsso, etc.)</span></label>
 						<input id="ticket_url" name="ticket_url" type="url"
 						       value={ev.ticket_url ?? ''}
-						       placeholder="https://..."
+						       placeholder={tFn('cal_form.url_ph')}
 						       class="w-full bg-gray-800/80 border border-gray-700 rounded-xl px-4 py-3 text-white placeholder-gray-500 text-sm
 						              focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500/40 transition-colors"/>
 					</div>

--- a/nodyx-frontend/src/routes/calendar/new/+page.svelte
+++ b/nodyx-frontend/src/routes/calendar/new/+page.svelte
@@ -201,7 +201,7 @@
 			<!-- Tags -->
 			<div>
 				<label for="tags" class="block text-sm font-medium text-gray-300 mb-1.5">{tFn('event.field_tags')} <span class="text-gray-600 text-xs font-normal">{tFn('event.tags_hint')}</span></label>
-				<input id="tags" name="tags" type="text" placeholder="musique, jeux, irl, dev..."
+				<input id="tags" name="tags" type="text" placeholder={tFn('cal_form.tags_ph')}
 				       class="w-full bg-gray-800/80 border border-gray-700 rounded-xl px-4 py-3 text-white placeholder-gray-500 text-sm
 				              focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500/40 transition-colors"/>
 			</div>
@@ -223,7 +223,7 @@
 			<div>
 				<label for="location" class="block text-sm font-medium text-gray-300 mb-1.5">Adresse / nom du lieu <span class="text-gray-600 text-xs font-normal">(optionnel)</span></label>
 				<input id="location" name="location" type="text" bind:value={locationText}
-				       placeholder="Parc de la Villette, Paris — ou https://meet.jit.si/monEvent"
+				       placeholder={tFn('cal_form.location_ph')}
 				       class="w-full bg-gray-800/80 border border-gray-700 rounded-xl px-4 py-3 text-white placeholder-gray-500 text-sm
 				              focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500/40 transition-colors"/>
 			</div>
@@ -320,7 +320,7 @@
 					<div>
 						<label for="ticket_url" class="block text-sm font-medium text-gray-300 mb-1.5">Lien d'achat <span class="text-gray-600 text-xs font-normal">(Eventbrite, HelloAsso, etc.)</span></label>
 						<input id="ticket_url" name="ticket_url" type="url"
-						       placeholder="https://..."
+						       placeholder={tFn('cal_form.url_ph')}
 						       class="w-full bg-gray-800/80 border border-gray-700 rounded-xl px-4 py-3 text-white placeholder-gray-500 text-sm
 						              focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500/40 transition-colors"/>
 					</div>

--- a/nodyx-frontend/src/routes/communities/[slug]/+page.svelte
+++ b/nodyx-frontend/src/routes/communities/[slug]/+page.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { enhance } from '$app/forms'
 	import type { PageData } from './$types'
+	import { t } from '$lib/i18n'
+
+	const tFn = $derived($t)
 
 	let { data }: { data: PageData } = $props()
 	const community = $derived(data.community)
@@ -14,7 +17,7 @@
 
 <svelte:head>
 	<title>{community.name} — Nodyx</title>
-	<meta name="description" content={community.description ?? `Communauté ${community.name} sur Nodyx.`} />
+	<meta name="description" content={community.description ?? tFn('community_page.meta_desc', { name: community.name })} />
 	<meta property="og:title" content="{community.name} — Nodyx" />
 	<meta property="og:type" content="website" />
 </svelte:head>
@@ -79,11 +82,11 @@
 <div class="max-w-5xl mx-auto px-4 py-6">
 	{#if categories.length === 0}
 		<div class="text-center py-12 text-gray-500">
-			<p>Aucune catégorie pour l'instant.</p>
+			<p>{tFn('community_page.no_category')}</p>
 			{#if isAdmin}
 				<p class="text-sm mt-2">
 					<a href="/communities/{community.slug}/admin/grades" class="text-indigo-400 hover:text-indigo-300">
-						Configurer la communauté →
+						{tFn('community_page.configure')}
 					</a>
 				</p>
 			{/if}

--- a/nodyx-frontend/src/routes/feed/+page.svelte
+++ b/nodyx-frontend/src/routes/feed/+page.svelte
@@ -479,7 +479,7 @@
 							<span class="composer-char-count" style="color: {charColor}">{charLeft}</span>
 							<div class="composer-actions">
 								<button onclick={() => { composing = false; content = ''; mediaUrl = null; replyTo = null; editorKey++ }} class="composer-cancel">
-									Annuler
+									{tFn('feed.cancel')}
 								</button>
 								<button
 									onclick={submitPost}
@@ -545,7 +545,7 @@
 										<time class="post-time" datetime={post.created_at}>{timeAgo(post.created_at)}</time>
 
 										{#if me?.id === post.author_id || me?.username === post.username}
-											<button onclick={() => deletePost(post.id)} class="post-delete-btn" title="Supprimer">
+											<button onclick={() => deletePost(post.id)} class="post-delete-btn" title={tFn('feed.delete')}>
 												<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 													<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
 												</svg>
@@ -677,7 +677,7 @@
 													<span class="reply-to-tag">↳ @{reply.reply_to_username}</span>
 												{/if}
 												{#if me?.id === reply.author_id || me?.username === reply.username}
-													<button onclick={() => deletePost(reply.id)} class="post-delete-btn" title="Supprimer">
+													<button onclick={() => deletePost(reply.id)} class="post-delete-btn" title={tFn('feed.delete')}>
 														<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 															<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
 														</svg>

--- a/nodyx-frontend/src/routes/users/[username]/+page.svelte
+++ b/nodyx-frontend/src/routes/users/[username]/+page.svelte
@@ -361,7 +361,7 @@
 					<div class="w-full h-full rounded-full overflow-hidden"
 					     style="background: var(--p-accent)">
 						{#if profile.avatar_url}
-							<img src={profile.avatar_url} alt="Avatar de {profile.display_name || profile.username}" class="w-full h-full object-cover" />
+							<img src={profile.avatar_url} alt={tFn('user_profile.avatar_alt', { name: profile.display_name || profile.username })} class="w-full h-full object-cover" />
 						{:else}
 							<div class="w-full h-full flex items-center justify-center text-white text-5xl font-black select-none"
 							     aria-hidden="true">{initials}</div>
@@ -653,12 +653,12 @@
 					</div>
 					<div class="w-10 h-10 flex items-center justify-center text-lg"
 					     style="background: color-mix(in srgb, var(--p-accent) 8%, transparent); border: 1px dashed color-mix(in srgb, var(--p-accent) 20%, transparent)"
-					     title="Bientôt disponible">
+					     title={tFn('user_profile.soon')}>
 						🔒
 					</div>
 					<div class="w-10 h-10 flex items-center justify-center text-lg"
 					     style="background: color-mix(in srgb, var(--p-accent) 8%, transparent); border: 1px dashed color-mix(in srgb, var(--p-accent) 20%, transparent)"
-					     title="Bientôt disponible">
+					     title={tFn('user_profile.soon')}>
 						🔒
 					</div>
 				</div>


### PR DESCRIPTION
Batch d'extraction i18n de **6 petits fichiers** (fichiers distincts, une seule édition `fr.json`) :

- **TwitchStream** : « Chargement du stream » + titres player/chat (interpolés en accolades).
- **Calendrier edit + new** : placeholders partagés (`cal_form.*` : tags, lieu, URL).
- **Page communauté** (`communities/[slug]`) : meta description, « Aucune catégorie », « Configurer » (`tFn` ajouté).
- **Feed** : boutons Annuler / Supprimer.
- **Profil user** : alt avatar interpolé, « Bientôt disponible ».

`i18n:scan` = 0, `npm run i18n:keys` vert, `npm run check` = 0 erreur.