### PR TITLE
i18n(batch): final public batch — 11 tFn-less files

### DIFF
--- a/nodyx-frontend/src/lib/components/ActivityHeatmap.svelte
+++ b/nodyx-frontend/src/lib/components/ActivityHeatmap.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+
+	import { t } from '$lib/i18n'
+	const tFn = $derived($t)
 	import { API_URL } from '$lib/api'
 
 	let { username, accent = '#6366f1' }: { username: string; accent?: string } = $props()
@@ -90,8 +93,8 @@
 	function showTip(e: MouseEvent, cell: Cell) {
 		const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
 		const label = cell.count === 0
-			? `Aucune activité — ${fmtDate(cell.date)}`
-			: `${cell.count} contribution${cell.count > 1 ? 's' : ''} — ${fmtDate(cell.date)}`
+			? tFn('heatmap.no_activity', { date: fmtDate(cell.date) })
+			: (cell.count > 1 ? tFn('heatmap.contrib_many', { count: cell.count, date: fmtDate(cell.date) }) : tFn('heatmap.contrib_one', { count: cell.count, date: fmtDate(cell.date) }))
 		tooltip = {
 			text: label,
 			x: rect.left + rect.width / 2,
@@ -127,7 +130,7 @@
 		<!-- Header stats -->
 		<div class="flex items-center justify-between mb-4">
 			<p class="text-xs uppercase tracking-widest font-medium" style="color: var(--p-text-muted)">
-				Activité — 12 derniers mois
+				{tFn('heatmap.title')}
 			</p>
 			<div class="flex items-center gap-4 text-[11px]" style="color: var(--p-text-muted)">
 				<span><strong class="text-white">{data.total}</strong> contributions</span>

--- a/nodyx-frontend/src/lib/components/MaintenanceBanner.svelte
+++ b/nodyx-frontend/src/lib/components/MaintenanceBanner.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+
+	import { t } from '$lib/i18n'
+	const tFn = $derived($t)
 	// Polls /api/v1/instance/maintenance every 15s. When maintenance is active
 	// (set by backup create / restore on the server side), shows a sticky amber
 	// banner so users understand why their writes are temporarily refused.
@@ -54,7 +57,7 @@
 		<span class="maint-banner-text">
 			<strong>{reasonText}</strong>
 			<span class="maint-banner-detail">
-				· les nouvelles inscriptions et publications sont temporairement désactivées. Réessaye dans quelques instants.
+				{tFn('maint.notice')}
 			</span>
 		</span>
 	</div>

--- a/nodyx-frontend/src/lib/components/MemberScreenPreview.svelte
+++ b/nodyx-frontend/src/lib/components/MemberScreenPreview.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+
+	import { t } from '$lib/i18n'
+	const tFn = $derived($t)
     let {
         stream,
         username,
@@ -68,7 +71,7 @@
         <div class="absolute top-2 left-2 flex items-center gap-1 px-1.5 py-0.5"
              style="background: rgba(0,0,0,0.72); border: 1px solid rgba(59,130,246,0.3)">
             <span class="w-1.5 h-1.5 rounded-full bg-blue-400 animate-pulse"></span>
-            <span class="text-[9px] font-bold" style="color: rgb(96,165,250); letter-spacing: 0.08em">ÉCRAN</span>
+            <span class="text-[9px] font-bold" style="color: rgb(96,165,250); letter-spacing: 0.08em">{tFn('msp.screen')}</span>
         </div>
     </div>
 
@@ -84,6 +87,6 @@
             </div>
         {/if}
         <span class="text-[11px] font-semibold text-white truncate flex-1">{username}</span>
-        <span class="text-[9px] font-medium shrink-0" style="color: rgb(75,85,99)">Double-clic → plein écran</span>
+        <span class="text-[9px] font-medium shrink-0" style="color: rgb(75,85,99)">{tFn('msp.dblclick')}</span>
     </div>
 </div>

--- a/nodyx-frontend/src/lib/components/MessageBody.svelte
+++ b/nodyx-frontend/src/lib/components/MessageBody.svelte
@@ -8,6 +8,9 @@
   composants Svelte natifs → XSS-safe par construction.
 -->
 <script lang="ts">
+
+	import { t } from '$lib/i18n'
+	const tFn = $derived($t)
 	import { linkify } from '$lib/linkify'
 	import { requestOpenExternal } from '$lib/stores/externalLinkGuard'
 	import { analyzeUrl } from '$lib/urlAnalysis'
@@ -58,7 +61,7 @@
 				rel="noopener noreferrer nofollow"
 				class="message-body__image-wrap"
 				onclick={(e) => onLinkClick(e, seg.href)}
-				title="Cliquer pour ouvrir"
+				title={tFn('msg.click_open')}
 			>
 				<img src={seg.href} alt="" class="message-body__image" loading="lazy" />
 			</a>

--- a/nodyx-frontend/src/lib/components/NodyxVersionBadge.svelte
+++ b/nodyx-frontend/src/lib/components/NodyxVersionBadge.svelte
@@ -8,6 +8,9 @@
     - showLogo : boolean (défaut true)
 -->
 <script lang="ts">
+
+	import { t } from '$lib/i18n'
+	const tFn = $derived($t)
 	interface Props {
 		version:   string
 		variant?: 'footer' | 'inline' | 'admin'
@@ -31,7 +34,7 @@
 <a
 	href="/about"
 	class="inline-flex items-center {sizeClass} opacity-60 hover:opacity-100 transition-opacity text-zinc-400 hover:text-zinc-200"
-	title="À propos de Nodyx"
+	title={tFn('about.meta_title')}
 >
 	{#if showLogo}
 		<img

--- a/nodyx-frontend/src/lib/components/ReactionTooltip.svelte
+++ b/nodyx-frontend/src/lib/components/ReactionTooltip.svelte
@@ -12,6 +12,9 @@
     apparaît en bas, en gris discret
 -->
 <script lang="ts">
+
+	import { t } from '$lib/i18n'
+	const tFn = $derived($t)
 	interface ReactionUser {
 		username:   string
 		name_color: string | null
@@ -33,7 +36,7 @@
 		const now  = Date.now()
 		const then = new Date(iso).getTime()
 		const sec  = Math.max(0, Math.floor((now - then) / 1000))
-		if (sec < 5)      return 'à l’instant'
+		if (sec < 5)      return tFn('follow.just_now')
 		if (sec < 60)     return `il y a ${sec} s`
 		const min = Math.floor(sec / 60)
 		if (min < 60)     return `il y a ${min} min`

--- a/nodyx-frontend/src/lib/components/homepage/DynamicWidget.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/DynamicWidget.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+
+	import { t } from '$lib/i18n'
+	const tFn = $derived($t)
 	// Charge un widget externe (Web Component) à la volée
 	// Le widget doit s'auto-enregistrer via customElements.define('nodyx-widget-{id}', ...)
 	import { onMount } from 'svelte'
@@ -47,7 +50,7 @@
 				await Promise.race([
 					customElements.whenDefined(tagName),
 					new Promise((_, reject) =>
-						setTimeout(() => reject(new Error(`${tagName} non enregistré après 5s`)), 5000)
+						setTimeout(() => reject(new Error(tFn('dw.not_registered', { tag: tagName }))), 5000)
 					),
 				])
 			}
@@ -69,7 +72,7 @@
 	<div class="w-full flex items-center justify-center py-8 gap-2" style="color:#374151">
 		<div class="w-4 h-4 rounded-full border-2 animate-spin"
 		     style="border-color:rgba(167,139,250,.2); border-top-color:var(--nx-accent-2-soft)"></div>
-		<span class="text-xs">Chargement du widget…</span>
+		<span class="text-xs">{tFn('dw.loading')}</span>
 	</div>
 
 {:else if loadStatus === 'error'}

--- a/nodyx-frontend/src/lib/components/homepage/widgets/AnnouncementBanner.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/AnnouncementBanner.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+
+	import { t } from '$lib/i18n'
+	const tFn = $derived($t)
 	interface Props {
 		config: Record<string, unknown>;
 		instance: Record<string, unknown>;
@@ -38,7 +41,7 @@
 				onclick={() => dismissed = true}
 				class="absolute right-3 top-1/2 -translate-y-1/2 p-1 transition-opacity hover:opacity-80"
 				style="color:#6b7280"
-				aria-label="Fermer"
+				aria-label={tFn('common.close')}
 			>
 				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>

--- a/nodyx-frontend/src/lib/components/widgets/GitHubWidget.svelte
+++ b/nodyx-frontend/src/lib/components/widgets/GitHubWidget.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+
+	import { t } from '$lib/i18n'
+	const tFn = $derived($t)
 	import { API_URL } from '$lib/api'
 
 	interface GhRepo {
@@ -101,7 +104,7 @@
 			<div class="flex items-start gap-3 px-4 py-3 border-b border-gray-700">
 				<img
 					src={data.avatar_url}
-					alt="Avatar GitHub de {data.login}"
+					alt={tFn('gh.avatar_alt', { login: data.login })}
 					class="w-10 h-10 rounded-full border border-gray-600 shrink-0"
 				/>
 				<div class="flex-1 min-w-0">
@@ -121,7 +124,7 @@
 			<!-- Repos (max 3) -->
 			{#if data.pinned_repos.length > 0}
 				<div class="px-4 py-3">
-					<p class="text-xs text-gray-500 uppercase tracking-wider mb-2">Repos récents</p>
+					<p class="text-xs text-gray-500 uppercase tracking-wider mb-2">{tFn('gh.recent_repos')}</p>
 					<ul class="space-y-2">
 						{#each data.pinned_repos as repo}
 							<li>

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -2090,5 +2090,19 @@
   "emoji_picker.cat_nourriture": "Nourriture",
   "emoji_picker.cat_voyage": "Voyage",
   "emoji_picker.cat_objets": "Objets",
-  "emoji_picker.cat_symboles": "Symboles"
+  "emoji_picker.cat_symboles": "Symboles",
+  "heatmap.no_activity": "Aucune activité — {{date}}",
+  "heatmap.contrib_one": "{{count}} contribution — {{date}}",
+  "heatmap.contrib_many": "{{count}} contributions — {{date}}",
+  "heatmap.title": "Activité — 12 derniers mois",
+  "msp.screen": "ÉCRAN",
+  "msp.dblclick": "Double-clic → plein écran",
+  "dw.not_registered": "{{tag}} non enregistré après 5s",
+  "dw.loading": "Chargement du widget…",
+  "gh.avatar_alt": "Avatar GitHub de {{login}}",
+  "gh.recent_repos": "Repos récents",
+  "maint.notice": "· les nouvelles inscriptions et publications sont temporairement désactivées. Réessaye dans quelques instants.",
+  "msg.click_open": "Cliquer pour ouvrir",
+  "canvas_board.connecting": "Connexion au canvas…",
+  "auth.back_login": "Retour à la connexion"
 }

--- a/nodyx-frontend/src/routes/auth/verify-email/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/auth/verify-email/[token]/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+
+	import { t } from '$lib/i18n'
+	const tFn = $derived($t)
 	import type { PageData } from './$types';
 	let { data }: { data: PageData } = $props();
 </script>
@@ -17,7 +20,7 @@
 		<h1 class="text-2xl font-bold text-white mb-3">Lien invalide</h1>
 		<p class="text-gray-400 text-sm mb-6">{data.error}</p>
 		<p class="text-sm text-gray-600">
-			<a href="/auth/login" class="text-indigo-400 hover:text-indigo-300">Retour à la connexion</a>
+			<a href="/auth/login" class="text-indigo-400 hover:text-indigo-300">{tFn('auth.back_login')}</a>
 		</p>
 	{/if}
 </div>

--- a/nodyx-frontend/src/routes/canvas/[boardId]/+page.svelte
+++ b/nodyx-frontend/src/routes/canvas/[boardId]/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+
+	import { t } from '$lib/i18n'
+	const tFn = $derived($t)
 	import { goto } from '$app/navigation'
 	import { socket } from '$lib/socket'
 	import NodyxCanvas from '$lib/components/NodyxCanvas.svelte'
@@ -34,6 +37,6 @@
 	/>
 {:else}
 	<div class="fixed inset-0 z-[9999] flex items-center justify-center bg-[#0a0a10] text-gray-400 text-sm">
-		Connexion au canvas…
+		{tFn('canvas_board.connecting')}
 	</div>
 {/if}


### PR DESCRIPTION
**Dernier lot public** : 11 fichiers qui n'avaient pas encore `tFn` (import ajouté à chacun).

- ActivityHeatmap (tooltips relatifs + titre), MemberScreenPreview (ÉCRAN, double-clic), DynamicWidget (erreur + loading), GitHubWidget (alt avatar + repos récents), MaintenanceBanner (notice), MessageBody (title), NodyxVersionBadge (réutilise `about.meta_title`), ReactionTooltip (réutilise `follow.just_now`), AnnouncementBanner (réutilise `common.close`), verify-email (retour connexion), canvas/[boardId] (connexion).

**Après cette PR, la seule page encore flaggée en public est la page admin `grades`** (les pages admin/studio étant traitées après le public par design).

`i18n:scan --public` = 0 hors admin, `npm run i18n:keys` vert, `npm run check` = 0 erreur.