### PR TITLE
ci(i18n): gate public pages at zero hardcoded French

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,10 @@ jobs:
         working-directory: nodyx-frontend
         run: npm run i18n:keys:check
 
+      - name: i18n — aucune chaîne FR en dur sur les pages publiques
+        working-directory: nodyx-frontend
+        run: npm run i18n:public:check
+
       - name: Svelte — typecheck (svelte-check)
         working-directory: nodyx-frontend
         env:

--- a/nodyx-frontend/package.json
+++ b/nodyx-frontend/package.json
@@ -14,7 +14,8 @@
     "i18n:scan": "node scripts/i18n/scan.mjs",
     "i18n:coverage": "node scripts/i18n/coverage.mjs",
     "i18n:keys": "node scripts/i18n/check-keys.mjs",
-    "i18n:keys:check": "node scripts/i18n/check-keys.mjs --check"
+    "i18n:keys:check": "node scripts/i18n/check-keys.mjs --check",
+    "i18n:public:check": "node scripts/i18n/scan.mjs --public --check"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "7.0.1",


### PR DESCRIPTION
## Le capstone du chantier i18n

Toute la **surface publique user-facing** est désormais extraite en i18n : `npm run i18n:scan -- --public` = **0** (parti de ~843 chaînes en dur).

Cette PR **verrouille** cet acquis : nouveau step CI **`i18n:public:check`** (`npm run i18n:scan -- --public --check`) qui **échoue le build** si une chaîne FR en dur réapparaît sur une page publique. Il complète le garde-fou `i18n:keys:check` (clés référencées présentes).

Les pages **admin/studio d'instance** restent hors de ce gate (elles seront extraites dans un lot séparé, puis intégrées).

Vérifs : `npm run i18n:public:check` exit 0 en local ; CI verte.