### PR TITLE
ci(i18n): extend hardcoded-French gate to the whole frontend (public + admin)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,9 @@ jobs:
         working-directory: nodyx-frontend
         run: npm run i18n:keys:check
 
-      - name: i18n — aucune chaîne FR en dur sur les pages publiques
+      - name: i18n — aucune chaîne FR en dur (public + admin)
         working-directory: nodyx-frontend
-        run: npm run i18n:public:check
+        run: npm run i18n:check
 
       - name: Svelte — typecheck (svelte-check)
         working-directory: nodyx-frontend

--- a/nodyx-frontend/package.json
+++ b/nodyx-frontend/package.json
@@ -15,7 +15,8 @@
     "i18n:coverage": "node scripts/i18n/coverage.mjs",
     "i18n:keys": "node scripts/i18n/check-keys.mjs",
     "i18n:keys:check": "node scripts/i18n/check-keys.mjs --check",
-    "i18n:public:check": "node scripts/i18n/scan.mjs --public --check"
+    "i18n:public:check": "node scripts/i18n/scan.mjs --public --check",
+    "i18n:check": "node scripts/i18n/scan.mjs --check"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "7.0.1",


### PR DESCRIPTION
## Verrouiller toute la surface i18n contre les régressions

L'extraction admin/studio est terminée (`i18n:scan` = **0** globalement, cf #443). La gate CI passe donc de **public-only** à **globale**.

### Changement
- Nouveau script `i18n:check` = `scan --check` (scanne public **et** admin, exit 1 si une chaîne FR en dur est trouvée)
- L'étape CI `i18n — aucune chaîne FR en dur` utilise maintenant `i18n:check` au lieu de `i18n:public:check`
- `i18n:public:check` conservé (utile en local pour cibler le public)

### Effet
Toute chaîne user-facing en dur (public **ou** admin) fait désormais échouer le build. Plus aucune régression possible sur l'ensemble du frontend.

Vérifié en local : `npm run i18n:check` = 0, exit 0.