### PR TITLE
fix(user-card): translate remaining labels + repair contribution heatmap

### DIFF
--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -4387,5 +4387,9 @@
   "forum.delete_confirm_yes": "Yes, delete",
   "communities.register_intro": "Register it in the directory and get a free subdomain <code class=\"text-indigo-400\">your-name.nodyx.org</code>.",
   "community_page.member_one": "{{n}} member",
-  "community_page.member_many": "{{n}} members"
+  "community_page.member_many": "{{n}} members",
+  "user_card.stat_xp": "XP points",
+  "user_card.stat_days": "Days",
+  "user_card.contrib_total": "{{n}} contributions",
+  "user_card.full_profile": "Full profile"
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -4387,5 +4387,9 @@
   "forum.delete_confirm_yes": "Oui, supprimer",
   "communities.register_intro": "Enregistrez-la dans l'annuaire et recevez un sous-domaine gratuit <code class=\"text-indigo-400\">votre-nom.nodyx.org</code>.",
   "community_page.member_one": "{{n}} membre",
-  "community_page.member_many": "{{n}} membres"
+  "community_page.member_many": "{{n}} membres",
+  "user_card.stat_xp": "Points XP",
+  "user_card.stat_days": "Jours",
+  "user_card.contrib_total": "{{n}} contributions",
+  "user_card.full_profile": "Profil complet"
 }

--- a/nodyx-frontend/src/routes/users/[username]/card/+page.server.ts
+++ b/nodyx-frontend/src/routes/users/[username]/card/+page.server.ts
@@ -11,11 +11,18 @@ export const load: PageServerLoad = async ({ params, fetch, url }) => {
 
 	const profile = await res.json()
 
-	// Activity (last 12 weeks) — best effort
+	// Activity (last 12 weeks), best effort.
+	// L'API renvoie un tableau [{ date, count }] : on le replie en Record<date, count>
+	// pour que la heatmap puisse faire ses lookups par date (sinon toutes les cases à 0).
 	let activity: Record<string, number> = {}
 	try {
 		const ar = await apiFetch(fetch, `/users/${username}/activity`)
-		if (ar.ok) activity = (await ar.json()).activity ?? {}
+		if (ar.ok) {
+			const raw = (await ar.json()).activity ?? []
+			activity = Array.isArray(raw)
+				? Object.fromEntries(raw.map((r: { date: string; count: number }) => [r.date, r.count]))
+				: raw
+		}
 	} catch { /* ignore */ }
 
 	const origin = url.origin

--- a/nodyx-frontend/src/routes/users/[username]/card/+page.svelte
+++ b/nodyx-frontend/src/routes/users/[username]/card/+page.svelte
@@ -239,12 +239,12 @@
 		<div class="stat-sep"></div>
 		<div class="stat-item">
 			<span class="stat-val">{Number(pts).toLocaleString('fr-FR')}</span>
-			<span class="stat-lbl">Points XP</span>
+			<span class="stat-lbl">{tFn('user_card.stat_xp')}</span>
 		</div>
 		<div class="stat-sep"></div>
 		<div class="stat-item">
 			<span class="stat-val">{Math.floor((Date.now() - new Date(profile.created_at).getTime()) / 86400000).toLocaleString('fr-FR')}</span>
-			<span class="stat-lbl">Jours</span>
+			<span class="stat-lbl">{tFn('user_card.stat_days')}</span>
 		</div>
 	</div>
 
@@ -253,7 +253,7 @@
 		<div class="heatmap-header">
 			<span class="heatmap-title">{tFn('user_card.activity')}</span>
 			<span class="heatmap-total">
-				{heatCells.reduce((a, c) => a + c.count, 0)} contributions
+				{tFn('user_card.contrib_total', { n: heatCells.reduce((a, c) => a + c.count, 0) })}
 			</span>
 		</div>
 		<div class="heatmap-grid">
@@ -293,7 +293,7 @@
 					<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
 					<circle cx="12" cy="7" r="4"/>
 				</svg>
-				Profil complet
+				{tFn('user_card.full_profile')}
 			</a>
 
 			<!-- Copy link -->


### PR DESCRIPTION
La carte de profil partageable (`/users/[username]/card`) avait deux bugs, repérés par Jonathan.

### 1. Labels encore en français (même en EN)
`Jours`, `Points XP`, `contributions`, `Profil complet` étaient codés en dur. Le scanner les ratait (mots courts sans accent ou mots anglais ambigus). Extraits vers `user_card.*` (+4 clés fr+en). Vérifié : en EN la carte affiche maintenant Days / XP points / Full profile.

### 2. La heatmap de contributions (façon GitHub) ne marchait pas
Elle était vide pour tout le monde. L'API `/users/:username/activity` renvoie un **tableau** `[{ date, count }]`, mais la page le traitait comme un **objet** `Record<date, count>` et faisait `activity[date]`, qui échouait toujours : toutes les cases restaient à 0 (grises). Corrigé côté serveur en repliant le tableau en objet indexé par date. Vérifié en live : la carte de Pokled affiche « 22 contributions » et les cases s'allument.

### Garde-fous
- `i18n:scan` = 0, `i18n:keys:check` OK, parité fr/en (4393/4393)
- `npm run check` = 0 erreur
- Testé en prod (build local nodyx.org) : heatmap peuplée, labels EN corrects