### PR TITLE
fix(profile): translate the Carte button to the shareable card

### DIFF
--- a/nodyx-frontend/scripts/i18n/scan.mjs
+++ b/nodyx-frontend/scripts/i18n/scan.mjs
@@ -29,7 +29,7 @@ const PUBLIC_ONLY = args.has('--public')
 // « membres »…) — c'est l'angle mort qui a laissé passer des chaînes en dur.
 // La wordlist ci-dessous couvre ces cas sans accent (verbes/labels UI courants).
 const ACC = /[àâäéèêëïîôùûüÿçœÀÂÄÉÈÊËÏÎÔÙÛÜŸÇŒ]/
-const FR = /\b([Ss]upprimer|[Aa]nnuler|[Ee]nregistrer|[Mm]odifier|[Aa]jouter|[Ee]nvoyer|[Ff]ermer|[Rr]etour|[Ss]uivant|[Rr]echercher|Aucune?|Nouvelle?|Nouveau|[Cc]harger|[Mm]embres?|Connexion|Inscription|Brouillon|[Pp]ublier|[Cc]hoisir|[Cc]opier|[Pp]artager|[Ee]ffacer|[Ee]nlever|[Oo]uvrir|Bienvenue|Erreur|Chargement|[Rr]ejoindre|[Qq]uitter|[Ss]uivre|[Ss]uivi|[Cc]onnecte[rz]|[Cc]onnecte-toi|[Cc]ontinuer|[Vv]alider|[Cc]ontacte[rz]|[Pp]articiper|[Dd]iffuse|Lancer pour|Attribution)\b/
+const FR = /\b([Ss]upprimer|[Aa]nnuler|[Ee]nregistrer|[Mm]odifier|[Aa]jouter|[Ee]nvoyer|[Ff]ermer|[Rr]etour|[Ss]uivant|[Rr]echercher|Aucune?|Nouvelle?|Nouveau|[Cc]harger|[Mm]embres?|Connexion|Inscription|Brouillon|[Pp]ublier|[Cc]hoisir|[Cc]opier|[Pp]artager|[Ee]ffacer|[Ee]nlever|[Oo]uvrir|Bienvenue|Erreur|Chargement|[Rr]ejoindre|[Qq]uitter|[Ss]uivre|[Ss]uivi|[Cc]onnecte[rz]|[Cc]onnecte-toi|[Cc]ontinuer|[Vv]alider|[Cc]ontacte[rz]|[Pp]articiper|[Dd]iffuse|Lancer pour|Attribution|[Cc]arte)\b/
 // Contractions et pronoms français : quasi impossibles en anglais → forte fiabilité.
 const FR_FUNC = /(\bvous\b|\bvotre\b|\bvos\b|\bcette\b|qu'il|s'agit|d'une|d'un\b|n'est|c'est|l'instant|parlez|Sois le premier)/
 

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -4391,5 +4391,6 @@
   "user_card.stat_xp": "XP points",
   "user_card.stat_days": "Days",
   "user_card.contrib_total": "{{n}} contributions",
-  "user_card.full_profile": "Full profile"
+  "user_card.full_profile": "Full profile",
+  "user.card_btn": "Card"
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -4391,5 +4391,6 @@
   "user_card.stat_xp": "Points XP",
   "user_card.stat_days": "Jours",
   "user_card.contrib_total": "{{n}} contributions",
-  "user_card.full_profile": "Profil complet"
+  "user_card.full_profile": "Profil complet",
+  "user.card_btn": "Carte"
 }

--- a/nodyx-frontend/src/routes/users/[username]/+page.svelte
+++ b/nodyx-frontend/src/routes/users/[username]/+page.svelte
@@ -442,7 +442,7 @@
 							<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
 							</svg>
-							Carte
+							{tFn('user.card_btn')}
 						</a>
 						<a href="/users/me/edit" class="profile-action-btn">
 							<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">


### PR DESCRIPTION
Sur la page profil (`/users/[username]`), le bouton qui mène à la carte partageable affichait « Carte » en dur, même en mode EN (son `title` était pourtant déjà traduit). Mot court sans accent, raté par le scanner.

- Texte extrait vers `user.card_btn` : « Carte » en FR, « Card » en EN
- « Carte » ajouté à la wordlist du scanner : ce cas ne peut plus repasser
- Bouton visible uniquement sur son propre profil (`{#if isOwnProfile}`), vérifié via le code + résolution de la clé

### Garde-fous
- `i18n:scan` (durci) = 0, `keys:check` OK, parité fr/en (4394/4394)
- `npm run check` = 0 erreur