### PR TITLE
i18n: fall back to English before French for partial locales

### DIFF
--- a/nodyx-frontend/src/lib/i18n.ts
+++ b/nodyx-frontend/src/lib/i18n.ts
@@ -147,8 +147,9 @@ export const t = derived(locale, ($locale) => {
   return (key: string, vars?: Record<string, string | number>): string => {
     let str =
       messages[$locale]?.[key] ??
+      messages['en']?.[key] ??   // EN est à 100% de parité : fallback universel avant le FR source
       messages['fr']?.[key] ??
-      key  // fallback = la clé elle-même (jamais de crash)
+      key  // fallback ultime = la clé elle-même (jamais de crash)
 
     if (vars) {
       for (const [k, v] of Object.entries(vars)) {


### PR DESCRIPTION
## Meilleur fallback pour les 5 langues partielles

Retour externe (point #7) validé contre le code. La fonction de traduction (`src/lib/i18n.ts`) retombait directement sur le FR source quand une clé manquait dans la langue active :

```
messages[$locale]?.[key] ?? messages['fr']?.[key] ?? key
```

Avec de/es/ru/pt/vi autour de 20 %, ces utilisateurs voyaient donc du **français** pour la majorité de l'UI. L'anglais étant maintenant à parité complète (100 %), c'est un fallback bien plus universel.

Nouvelle chaîne :
```
messages[$locale]?.[key] ?? messages['en']?.[key] ?? messages['fr']?.[key] ?? key
```

Le FR reste le fallback ultime garanti (c'est la source, toujours complète).

Vérifié : `common.validate` (absent de `de.json`) résout maintenant « Confirm » au lieu de « Valider » pour un utilisateur allemand.

### Garde-fous
- `i18n:scan` = 0, `keys:check` OK, `npm run check` = 0 erreur