### PR TITLE
i18n(langs): complete the core UI (common + nav) for de, es, pt, ru, vi

### DIFF
--- a/nodyx-frontend/src/lib/locales/de.json
+++ b/nodyx-frontend/src/lib/locales/de.json
@@ -967,5 +967,17 @@
   "common.clear": "Löschen",
   "presence.joined": "ist beigetreten",
   "presence.left": "hat verlassen",
-  "editor.toc": "Automatisches Inhaltsverzeichnis (Anker an den Überschriften)"
+  "editor.toc": "Automatisches Inhaltsverzeichnis (Anker an den Überschriften)",
+  "common.validate": "Bestätigen",
+  "common.pin": "Anheften",
+  "common.unpin": "Lösen",
+  "common.pinned": "Angeheftet",
+  "common.locked": "Gesperrt",
+  "common.featured": "Hervorgehoben",
+  "common.prev_page": "Vorherige Seite",
+  "common.next_page": "Nächste Seite",
+  "nav.docs": "Docs",
+  "common.avatar_alt": "Avatar",
+  "common.logo_alt": "Logo",
+  "common.add_emoji": "Emoji einfügen"
 }

--- a/nodyx-frontend/src/lib/locales/es.json
+++ b/nodyx-frontend/src/lib/locales/es.json
@@ -967,5 +967,17 @@
   "common.clear": "Borrar",
   "presence.joined": "se unió a",
   "presence.left": "salió de",
-  "editor.toc": "Índice automático (anclas en los títulos)"
+  "editor.toc": "Índice automático (anclas en los títulos)",
+  "common.validate": "Confirmar",
+  "common.pin": "Fijar",
+  "common.unpin": "Desfijar",
+  "common.pinned": "Fijado",
+  "common.locked": "Bloqueado",
+  "common.featured": "Destacado",
+  "common.prev_page": "Página anterior",
+  "common.next_page": "Página siguiente",
+  "nav.docs": "Docs",
+  "common.avatar_alt": "Avatar",
+  "common.logo_alt": "Logo",
+  "common.add_emoji": "Insertar un emoji"
 }

--- a/nodyx-frontend/src/lib/locales/pt-PT.json
+++ b/nodyx-frontend/src/lib/locales/pt-PT.json
@@ -967,5 +967,17 @@
   "status.placeholder": "O que estás a fazer…",
   "common.clear": "Limpar",
   "presence.joined": "entrou em",
-  "presence.left": "saiu de"
+  "presence.left": "saiu de",
+  "common.validate": "Confirmar",
+  "common.pin": "Fixar",
+  "common.unpin": "Desafixar",
+  "common.pinned": "Fixado",
+  "common.locked": "Bloqueado",
+  "common.featured": "Em destaque",
+  "common.prev_page": "Página anterior",
+  "common.next_page": "Página seguinte",
+  "nav.docs": "Docs",
+  "common.avatar_alt": "Avatar",
+  "common.logo_alt": "Logótipo",
+  "common.add_emoji": "Inserir um emoji"
 }

--- a/nodyx-frontend/src/lib/locales/ru.json
+++ b/nodyx-frontend/src/lib/locales/ru.json
@@ -967,5 +967,17 @@
   "status.placeholder": "Чем вы заняты…",
   "common.clear": "Очистить",
   "presence.joined": "присоединился к",
-  "presence.left": "покинул"
+  "presence.left": "покинул",
+  "common.validate": "Подтвердить",
+  "common.pin": "Закрепить",
+  "common.unpin": "Открепить",
+  "common.pinned": "Закреплено",
+  "common.locked": "Заблокировано",
+  "common.featured": "Избранное",
+  "common.prev_page": "Предыдущая страница",
+  "common.next_page": "Следующая страница",
+  "nav.docs": "Документация",
+  "common.avatar_alt": "Аватар",
+  "common.logo_alt": "Логотип",
+  "common.add_emoji": "Вставить эмодзи"
 }

--- a/nodyx-frontend/src/lib/locales/vi.json
+++ b/nodyx-frontend/src/lib/locales/vi.json
@@ -967,5 +967,17 @@
   "status.placeholder": "Bạn đang làm gì…",
   "common.clear": "Xóa",
   "presence.joined": "đã tham gia",
-  "presence.left": "đã rời"
+  "presence.left": "đã rời",
+  "common.validate": "Xác nhận",
+  "common.pin": "Ghim",
+  "common.unpin": "Bỏ ghim",
+  "common.pinned": "Đã ghim",
+  "common.locked": "Đã khóa",
+  "common.featured": "Nổi bật",
+  "common.prev_page": "Trang trước",
+  "common.next_page": "Trang sau",
+  "nav.docs": "Tài liệu",
+  "common.avatar_alt": "Ảnh đại diện",
+  "common.logo_alt": "Logo",
+  "common.add_emoji": "Chèn emoji"
 }


### PR DESCRIPTION
## Cœur UI natif dans les 7 langues

Attaque du point #6 (les 5 langues à ~22%). Constat utile : le vrai « 22% » cache une réalité meilleure sur le **cœur**. Les 118 clés vues sur chaque page (`common.*` + `nav.*` : boutons, navigation, labels communs) étaient déjà à **106/118** dans de/es/pt-PT/ru/vi.

Cette PR remplit les 12 dernières (validate, pin/unpin, featured, pagination, docs, avatar/logo alt, insert emoji), donc :

- **cœur UI (common + nav) = 118/118 dans les 7 langues** (fr, en, de, es, pt-PT, ru, vi)

La longue traîne (pages de features : library, cert, event, canvas…) reste servie par le **fallback anglais** (PR #449) jusqu'à Weblate. Un utilisateur allemand voit donc : navigation et boutons en allemand, contenu spécialisé en anglais, jamais de français.

Première passe, relecture par des natifs bienvenue (modèle contributeurs).

### Garde-fous
- `i18n:keys:check` OK
- termes UI standards, pas d'interpolation cassée