### PR TITLE
ci(i18n): verify translation placeholders stay intact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,10 @@ jobs:
         working-directory: nodyx-frontend
         run: npm run i18n:keys:check
 
+      - name: i18n — placeholders intacts dans chaque traduction
+        working-directory: nodyx-frontend
+        run: npm run i18n:placeholders:check
+
       - name: i18n — aucune chaîne FR en dur (public + admin)
         working-directory: nodyx-frontend
         run: npm run i18n:check

--- a/nodyx-frontend/package.json
+++ b/nodyx-frontend/package.json
@@ -15,6 +15,8 @@
     "i18n:coverage": "node scripts/i18n/coverage.mjs",
     "i18n:keys": "node scripts/i18n/check-keys.mjs",
     "i18n:keys:check": "node scripts/i18n/check-keys.mjs --check",
+    "i18n:placeholders": "node scripts/i18n/check-placeholders.mjs",
+    "i18n:placeholders:check": "node scripts/i18n/check-placeholders.mjs --check --quiet",
     "i18n:public:check": "node scripts/i18n/scan.mjs --public --check",
     "i18n:check": "node scripts/i18n/scan.mjs --check"
   },

--- a/nodyx-frontend/scripts/i18n/README.md
+++ b/nodyx-frontend/scripts/i18n/README.md
@@ -1,13 +1,21 @@
 # i18n tooling
 
-Two small, dependency-free scripts to keep Nodyx fully translatable and catch
-hardcoded strings before they pile up.
+Four small, dependency-free scripts that keep Nodyx fully translatable: they
+catch hardcoded strings, dangling keys, corrupted placeholders, and show what is
+left to translate. All four run in CI.
+
+Contributors: the friendly view of all this is **<https://nodyx.org/translate>**.
+You do not need any of these commands to translate Nodyx.
 
 ## The rule
 
 **Every user-facing string goes through a translation key. Nothing hardcoded.**
 Keys are written in English; strings are authored in French in `fr.json` (the
 source), mirrored to `en.json`, then translated into the other locales.
+
+At runtime a missing key falls back to **English** before French, because
+`en.json` is kept at full parity with the source. A partially translated locale
+therefore shows English, never a surprise French sentence.
 
 ## `npm run i18n:scan`
 
@@ -17,24 +25,61 @@ is a string that was never extracted.
 
 It also flags hardcoded **translatable attributes** (`aria-label`, `title`,
 `placeholder`, `alt`, `data-tip`) with a literal value, in **any** language, so
-English strings from contributors are caught too (the French heuristic misses
-those). An `attr={tFn(...)}` uses braces, not quotes, so it is never flagged.
+English strings from contributors are caught too. An `attr={tFn(...)}` uses
+braces, not quotes, so it is never flagged.
 
 ```bash
 npm run i18n:scan              # count per file + total
 npm run i18n:scan -- --list    # show every offending line
 npm run i18n:scan -- --public  # ignore admin / studio (owner-only) pages
-npm run i18n:scan -- --check   # exit 1 if anything is found (CI gate)
+npm run i18n:check             # exit 1 if anything is found (CI gate)
 ```
 
-The goal is **0** (public pages first, admin/studio next), then wire
-`--public --check` into CI so it never regresses.
+It sits at **0**, and CI keeps it there for the whole frontend.
+
+Known blind spot: the heuristic looks for accents, a French wordlist, and French
+contractions. A sentence that is French, accent-free, and outside the wordlist
+can still slip through. The scanner is a net, not a proof.
+
+## `npm run i18n:keys`
+
+Verifies that every key referenced in the code actually exists in `fr.json`. A
+missing one renders the raw key on screen (`dm.reply`), and neither
+`svelte-check` nor the build notices.
+
+```bash
+npm run i18n:keys              # list missing keys
+npm run i18n:keys:check        # exit 1 if any is missing (CI gate)
+```
+
+## `npm run i18n:placeholders`
+
+The translator safety net. A translation may change every word, but it must not
+invent something the app is meant to fill in. Checks three things against the
+source:
+
+- `{{var}}` i18n interpolations, replaced at runtime by `tFn(key, vars)`
+- `{token}` single-brace template tokens (OctoGuard welcome messages, alert
+  templates, chat timers), substituted later by the feature itself
+- `<tag>` markup inside strings rendered with `{@html}`, including balance
+
+The rule is asymmetric on purpose. Something **in the translation but not in the
+source** is an error: the call site never passes it, so `{{foo}}` is printed
+literally and an unclosed tag leaks markup. Something **in the source but
+dropped by the translation** is only a warning, because it is usually a language
+choice: French writes `({{n}} non lue{{s}})` with a plural marker that no other
+language needs.
+
+```bash
+npm run i18n:placeholders        # full report, errors and warnings
+npm run i18n:placeholders:check  # exit 1 on errors only (CI gate)
+```
 
 ## `npm run i18n:coverage`
 
-Shows, per locale, how many keys are present vs missing. A missing key falls
-back to French at runtime, so coverage is the "what is left to translate"
-surface.
+Shows, per locale, how many keys are present vs missing. This is the "what is
+left to translate" surface, and the same numbers power
+<https://nodyx.org/translate>.
 
 ```bash
 npm run i18n:coverage                 # coverage table
@@ -44,11 +89,18 @@ npm run i18n:coverage -- --emit de    # print { key: source } missing in `de`
 ## Translating a language (contributors welcome)
 
 You do **not** need to hunt through the code. Everything is already extracted
-into keys:
+into keys, and the whole interface is one flat JSON file per language.
+
+The easy path: open <https://nodyx.org/translate>, click your language, edit on
+GitHub, open a pull request. CI runs the placeholder check on it, so you cannot
+break the app by translating.
+
+The command-line path:
 
 1. Pick your language (e.g. `de`) and run
    `npm run i18n:coverage -- --emit de > de.todo.json`.
-2. Translate the **values** in that file (keep the keys and any `{{placeholders}}`).
+2. Translate the **values** in that file, keeping the keys and every
+   `{{placeholder}}` untouched.
 3. Merge them into `src/lib/locales/de.json` and open a PR.
 
 One merged translation PR earns a star on the Nodyx Stars wall. A native speaker

--- a/nodyx-frontend/scripts/i18n/check-placeholders.mjs
+++ b/nodyx-frontend/scripts/i18n/check-placeholders.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * i18n placeholder integrity checker (the translator safety net).
+ *
+ * A translation may change every word. It may NOT invent something the app is
+ * supposed to fill in. This compares each locale against the source (fr).
+ *
+ * What is checked
+ *   1. `{{var}}`   i18n interpolation, replaced at runtime by `tFn(key, vars)`
+ *   2. `{var}`     single-brace template tokens (OctoGuard welcome messages,
+ *                  alert templates, chat timers). NOT i18n variables: the
+ *                  feature substitutes them later, so translating
+ *                  `{userMention}` silently breaks that feature
+ *   3. `<tag>`     markup inside strings rendered with `{@html}`
+ *
+ * The rule is deliberately ASYMMETRIC, because the two directions are not the
+ * same kind of problem:
+ *
+ *   ERROR  something in the translation that the source does not have.
+ *          The call site only passes the source's variables, so an invented
+ *          `{{foo}}` is printed literally on screen. An invented or unclosed
+ *          tag leaks raw markup. Both are guaranteed breakage.
+ *
+ *   WARN   something in the source that the translation drops. Usually a
+ *          legitimate language choice: fr `({{n}} non lue{{s}})` carries a
+ *          plural marker `{{s}}` that no other language needs. Worth seeing,
+ *          never worth blocking a contributor's pull request over.
+ *
+ * This is the check Weblate would have run for us. We chose not to host
+ * Weblate, so the repo carries the net itself and every translation PR gets
+ * verified in CI.
+ *
+ *   node scripts/i18n/check-placeholders.mjs           full report
+ *   node scripts/i18n/check-placeholders.mjs --check   exit 1 on any ERROR
+ *   node scripts/i18n/check-placeholders.mjs --quiet   hide warnings
+ */
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const DIR = join(HERE, '..', '..', 'src', 'lib', 'locales')
+const SOURCE = 'fr' // strings are authored in French
+
+const args = new Set(process.argv.slice(2))
+const CHECK = args.has('--check')
+const QUIET = args.has('--quiet')
+
+// Tags that never carry a closing tag, so they must not count as unbalanced.
+const VOID_TAGS = new Set(['br', 'hr', 'img', 'input', 'meta', 'link', 'source', 'wbr'])
+
+const locales = {}
+for (const f of readdirSync(DIR).filter((f) => f.endsWith('.json'))) {
+  locales[f.replace('.json', '')] = JSON.parse(readFileSync(join(DIR, f), 'utf8'))
+}
+
+const src = locales[SOURCE]
+if (!src) {
+  console.error(`Source locale ${SOURCE}.json not found in ${DIR}`)
+  process.exit(2)
+}
+
+function parts(str) {
+  // Blank out `{{...}}` before hunting single braces, otherwise every `{{n}}`
+  // would also register as a `{n}`.
+  const singles = str.replace(/\{\{[^}]*\}\}/g, (m) => ' '.repeat(m.length))
+  const tags = [...str.matchAll(/<\s*(\/?)\s*([a-zA-Z][a-zA-Z0-9]*)/g)]
+    .map((m) => ({ closing: m[1] === '/', name: m[2].toLowerCase() }))
+
+  const balance = new Map()
+  for (const t of tags) {
+    if (VOID_TAGS.has(t.name)) continue
+    balance.set(t.name, (balance.get(t.name) ?? 0) + (t.closing ? -1 : 1))
+  }
+
+  return {
+    vars:   new Set([...str.matchAll(/\{\{\s*(\w+)\s*\}\}/g)].map((m) => m[1])),
+    tokens: new Set([...singles.matchAll(/\{\s*(\w+)\s*\}/g)].map((m) => m[1])),
+    tags:   new Set(tags.map((t) => t.name)),
+    balance,
+  }
+}
+
+const KINDS = [
+  ['vars',   '{{var}}'],
+  ['tokens', '{token}'],
+  ['tags',   '<tag>'],
+]
+
+let errors = 0
+let warnings = 0
+const report = []
+
+for (const loc of Object.keys(locales).sort()) {
+  if (loc === SOURCE) continue
+  const dict = locales[loc]
+  const rows = []
+
+  for (const [key, srcVal] of Object.entries(src)) {
+    const val = dict[key]
+    // A missing key is coverage, not corruption: coverage.mjs owns that.
+    if (typeof srcVal !== 'string' || typeof val !== 'string') continue
+
+    const a = parts(srcVal)
+    const b = parts(val)
+
+    for (const [kind, label] of KINDS) {
+      const invented = [...b[kind]].filter((x) => !a[kind].has(x))
+      const dropped  = [...a[kind]].filter((x) => !b[kind].has(x))
+      if (invented.length) rows.push({ lvl: 'ERROR', key, label, detail: `not in source: ${invented.join(', ')}` })
+      if (dropped.length)  rows.push({ lvl: 'warn',  key, label, detail: `dropped: ${dropped.join(', ')}` })
+    }
+
+    // An unclosed tag leaks markup even when the tag name itself exists in the
+    // source, so balance is checked on its own.
+    for (const [name, delta] of b.balance) {
+      if (delta !== (a.balance.get(name) ?? 0)) {
+        rows.push({ lvl: 'ERROR', key, label: '<tag>', detail: `<${name}> is not closed the way the source closes it` })
+      }
+    }
+  }
+
+  errors   += rows.filter((r) => r.lvl === 'ERROR').length
+  warnings += rows.filter((r) => r.lvl === 'warn').length
+  report.push({ loc, rows })
+}
+
+for (const { loc, rows } of report) {
+  const errs = rows.filter((r) => r.lvl === 'ERROR')
+  const warns = rows.filter((r) => r.lvl === 'warn')
+  const shown = QUIET ? errs : rows
+
+  if (!errs.length && (QUIET || !warns.length)) {
+    console.log(`  ${loc.padEnd(7)} ok`)
+    continue
+  }
+  console.log(`  ${loc.padEnd(7)} ${errs.length} error(s), ${warns.length} warning(s)`)
+  for (const r of shown) {
+    console.log(`      ${r.lvl === 'ERROR' ? 'ERROR' : 'warn '}  ${r.key}  [${r.label}]  ${r.detail}`)
+  }
+}
+
+const checked = Object.keys(locales).length - 1
+console.log(
+  errors === 0
+    ? `\n✓ placeholders: ${checked} locale(s) invent nothing the app cannot fill (${warnings} warning(s)).`
+    : `\n${errors} placeholder error(s) across ${checked} locale(s).`,
+)
+
+if (CHECK && errors > 0) process.exit(1)


### PR DESCRIPTION
En abandonnant Weblate, on perd son contrôle automatique des placeholders. Ce filet-là, le dépôt doit le porter lui-même : sans lui, la première PR de traduction d'un contributeur peut afficher `{{name}}` en clair à l'écran ou laisser une balise ouverte, et rien ne l'attraperait.

## Ce qui est vérifié

Pour chaque langue, contre la source `fr` :

- **`{{var}}`** les interpolations i18n, remplacées à l'exécution par `tFn(key, vars)`
- **`{token}`** les variables de gabarit à simple accolade (messages de bienvenue OctoGuard, templates d'alerte, timers du chat). Ce ne sont **pas** des variables i18n : c'est la fonctionnalité qui les substitue plus tard, donc traduire `{userMention}` la casse silencieusement
- **`<tag>`** le balisage dans les chaînes rendues via `{@html}`, équilibre compris

## La règle est asymétrique, volontairement

**Erreur** : quelque chose présent dans la traduction mais absent de la source. Le site d'appel ne passe que les variables de la source, donc un `{{foo}}` inventé s'affiche littéralement, et une balise inventée ou non fermée laisse fuir du markup. C'est de la casse garantie.

**Avertissement** : quelque chose que la traduction abandonne. C'est presque toujours un choix de langue légitime. Le français écrit `({{n}} non lue{{s}})` avec un marqueur de pluriel dont aucune autre langue n'a besoin. Ça mérite d'être vu, jamais de bloquer la PR d'un contributeur.

C'est d'ailleurs ce cas précis qui m'a fait corriger la sémantique : la première version, symétrique, criait au loup sur les 6 langues.

## Preuve

Le validateur passe sur les locales actuelles, mais « ça passe » ne prouve rien. J'ai donc corrompu une locale de quatre façons, en la restaurant à l'identique après chaque essai :

| cas | résultat |
|---|---|
| variable inventée `{{oups}}` | `exit=1`, `not in source: oups` |
| jeton de gabarit traduit `{benutzerErwaehnung}` | `exit=1`, `not in source: benutzerErwaehnung` |
| balise non fermée `<b>` | `exit=1`, `<b> is not closed the way the source closes it` |
| balise inventée `<script>` | `exit=1`, `not in source: script` |

État actuel : 0 erreur, 6 avertissements (le `{{s}}` du pluriel français).

## Aussi

Le README de l'outillage i18n était périmé sur trois points : il annonçait deux scripts alors qu'il y en a quatre, décrivait un repli d'exécution vers le français alors que c'est l'anglais depuis #449, et présentait la CI comme un chantier à venir alors qu'elle est en place. Réécrit, avec le chemin simple pour les contributeurs (nodyx.org/translate).