### PR TITLE
ci: run the frontend tests, and cover the four apps that had none

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         working-directory: nodyx-core
         run: npx tsc --noEmit
 
-      - name: Vitest — 181 tests attendus
+      - name: Vitest — suite complète
         working-directory: nodyx-core
         # Valeur factice, requise par le bootstrap backend qui refuse de
         # démarrer sans JWT_SECRET >= 32 chars. La prod utilise son propre
@@ -91,6 +91,10 @@ jobs:
       - name: i18n — aucune chaîne FR en dur (public + admin)
         working-directory: nodyx-frontend
         run: npm run i18n:check
+
+      - name: Vitest — tests frontend
+        working-directory: nodyx-frontend
+        run: npm test
 
       - name: Svelte — typecheck (svelte-check)
         working-directory: nodyx-frontend
@@ -147,3 +151,39 @@ jobs:
       - name: cargo test --workspace
         working-directory: nodyx-p2p
         run: cargo test --workspace
+
+  # ── 4. Applications satellites — typecheck + build ────────────────────────
+  # nodyx.dev (docs), start.nodyx.org (landing), le hub et l'authenticator sont
+  # DÉPLOYÉS mais n'avaient aucune CI : un build cassé pouvait partir en prod
+  # sans que rien ne l'arrête. Constaté le 2026-08-07, quand des modifications
+  # de landing et docs sont passées sans qu'aucun job ne les construise.
+  check-satellites:
+    name: "${{ matrix.app }} — typecheck + build"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false   # un satellite cassé ne doit pas masquer l'état des autres
+      matrix:
+        app: [nodyx-docs, nodyx-hub, nodyx-landing, nodyx-authenticator]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: ${{ matrix.app }}/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ${{ matrix.app }}
+        run: npm ci
+
+      - name: Svelte — typecheck (svelte-check)
+        working-directory: ${{ matrix.app }}
+        run: npm run check
+
+      - name: Vite — build production
+        working-directory: ${{ matrix.app }}
+        run: npm run build

--- a/nodyx-docs/package-lock.json
+++ b/nodyx-docs/package-lock.json
@@ -16,6 +16,7 @@
         "@sveltejs/adapter-node": "^5.5.4",
         "@sveltejs/kit": "^2.63.0",
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
+        "@types/node": "^22.20.1",
         "svelte": "^5.56.1",
         "svelte-check": "^4.0.0",
         "typescript": "^5.0.0",
@@ -1095,6 +1096,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -1768,6 +1779,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.5",

--- a/nodyx-docs/package.json
+++ b/nodyx-docs/package.json
@@ -6,7 +6,8 @@
     "dev": "vite dev --port 5175",
     "build": "vite build",
     "start": "node build/index.js",
-    "check": "svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "prepare": "svelte-kit sync || echo ''"
   },
   "dependencies": {
     "highlight.js": "^11.10.0",
@@ -17,6 +18,7 @@
     "@sveltejs/adapter-node": "^5.5.4",
     "@sveltejs/kit": "^2.63.0",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
+    "@types/node": "^22.20.1",
     "svelte": "^5.56.1",
     "svelte-check": "^4.0.0",
     "typescript": "^5.0.0",

--- a/nodyx-docs/src/routes/+page.svelte
+++ b/nodyx-docs/src/routes/+page.svelte
@@ -25,7 +25,11 @@
 
     let W = 0, H = 0, raf = 0
 
-    function resize() {
+    // Fonction flechee, pas une declaration : une `function` est hoistee, donc
+    // TypeScript considere qu'elle pourrait s'executer AVANT le `if (!canvas)
+    // return` ci-dessus et refuse d'appliquer le narrowing. Le garde existait
+    // deja, c'est seulement l'analyse statique qui ne pouvait pas le voir.
+    const resize = () => {
       const rect = canvas.getBoundingClientRect()
       W = canvas.width  = rect.width  * devicePixelRatio
       H = canvas.height = rect.height * devicePixelRatio

--- a/nodyx-hub/package.json
+++ b/nodyx-hub/package.json
@@ -7,7 +7,8 @@
     "dev": "vite dev --port 7777",
     "build": "vite build",
     "preview": "node build/index.js",
-    "check": "svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "prepare": "svelte-kit sync || echo ''"
   },
   "dependencies": {
     "@types/leaflet": "^1.9.21",

--- a/nodyx-landing/package.json
+++ b/nodyx-landing/package.json
@@ -7,7 +7,8 @@
     "dev": "vite dev --port 5177 --host 127.0.0.1",
     "build": "vite build",
     "start": "node build/index.js",
-    "check": "svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "prepare": "svelte-kit sync || echo ''"
   },
   "devDependencies": {
     "@sveltejs/adapter-node": "5.5.4",


### PR DESCRIPTION
Deux trous trouvés en auditant ce que la CI protège **réellement**, par opposition à ce qu'on croyait. Et en les bouchant, la CI a immédiatement trouvé autre chose.

## 1. Les tests du frontend ne tournaient jamais

`nodyx-frontend` a 20 tests. Le job faisait le typecheck et le build, mais aucun test. Une régression y passait sans bruit. Ils tournent maintenant.

## 2. Quatre applications déployées, zéro filet

`nodyx-docs` (nodyx.dev), `nodyx-hub`, `nodyx-landing` (start.nodyx.org) et `nodyx-authenticator` sont en production et n'avaient **aucune** CI.

Ce n'est pas une hypothèse : **aujourd'hui même**, des modifications de `nodyx-landing` et `nodyx-docs` sont parties en production sans qu'aucun job ne les ait jamais construites. Ça s'est bien passé parce que je les ai bâties à la main. Sinon, personne n'aurait rien vu.

Matrice typecheck + build, avec `fail-fast: false` pour qu'un satellite cassé ne masque pas l'état des autres.

## 3. Ce que l'allumage de la CI a révélé aussitôt

Trois des quatre ont échoué au premier run, et pour une raison qui vaut le détour : **`npm run check` ne fonctionnait pas du tout dans ces applications**, sur n'importe quel clone propre. Leur script appelait `svelte-check` directement, sans le `svelte-kit sync` qui génère le `tsconfig.json` qu'il lit, et sans script `prepare`. La commande échouait instantanément : personne, ni en CI ni en local, ne pouvait les vérifier.

Elles suivent maintenant le modèle des deux applications qui marchaient déjà (`nodyx-frontend` et `nodyx-authenticator`).

Et une fois le contrôle réellement en marche, **`nodyx-docs` s'est révélé porter 7 erreurs de type invisibles depuis toujours** :

- l'application lit du markdown sur le disque (`fs`, `path`, `process`) sans `@types/node`
- trois `canvas is possibly null` dans l'animation de la page d'accueil. Le garde existait bien à l'exécution ; `resize` était une déclaration `function`, donc hoistée, et TypeScript supposait qu'elle pouvait s'exécuter avant le garde. Une fonction fléchée déclarée après le garde résout ça sans toucher au comportement.

## 4. Un libellé qui mentait

L'étape des tests du cœur s'appelait « Vitest, 181 tests attendus » alors que la suite en compte 415. Ce n'était pas une assertion, juste un nom, mais un nom faux finit par se croire.

## Résultat

Les 7 jobs passent, dont les 4 nouveaux.