### PR TITLE
ops: version the deploy scripts, and make deploy-all cover everything

### DIFF
--- a/scripts/deploy-all.sh
+++ b/scripts/deploy-all.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# ─── Nodyx — déploiement de toutes les applications du serveur ───────────────
+#
+# À lancer en root :  sudo /opt/deploy-all.sh
+#
+# Ce script vit DANS le dépôt. La copie de /opt/deploy-all.sh n'est qu'un
+# lanceur : elle fait le `git pull` puis exécute cette version-ci. Sans cette
+# séparation, bash relirait le script pendant que le pull le réécrit sous lui.
+#
+# ─── Pourquoi cette réécriture (2026-08-07) ──────────────────────────────────
+# L'ancienne version couvrait 4 applications sur 9, et se terminait par
+# « ✓ Les deux instances sont à jour » sans avoir rien vérifié. Concrètement :
+#   · demo.nodyx.org n'était jamais déployée (il fallait y penser à la main)
+#   · nodyx.dev, start.nodyx.org et le hub n'étaient JAMAIS redéployés
+#   · un build en échec n'empêchait pas le message de succès
+# Même famille de défaut que le bug pm2-logrotate : une étape qui annonce le
+# succès sans l'avoir constaté. D'où la règle appliquée ici : on ne déclare
+# rien qu'on n'ait vérifié, et on sort en erreur si un point de contrôle tombe.
+#
+# ─── Attention ownership ─────────────────────────────────────────────────────
+# /var/www/nexus appartient à root (source + node_modules + dist). PM2 tourne
+# sous l'utilisateur `nodyx` mais n'a besoin que de LIRE dist/ pour exécuter
+# node : on build donc en root ici, et on redémarre en `nodyx`.
+# /opt/sleemstudio et /opt/demo appartiennent à `nodyx` : tout s'y fait en nodyx.
+
+set -uo pipefail
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[1;33m'; BOLD='\033[1m'; RESET='\033[0m'
+ok()   { echo -e "${GREEN}✔${RESET}  $*"; }
+bad()  { echo -e "${RED}✘${RESET}  $*"; }
+warn() { echo -e "${YELLOW}⚠${RESET}  $*"; }
+head_() { echo -e "\n${BOLD}### $*${RESET}"; }
+
+FAILURES=0
+fail() { bad "$*"; FAILURES=$((FAILURES + 1)); }
+
+git config --global --add safe.directory /var/www/nexus 2>/dev/null || true
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+# build_app <libellé> <répertoire> [utilisateur]
+# Installe et build une app. Toute erreur est comptée, jamais avalée.
+build_app() {
+  local label="$1" dir="$2" as="${3:-root}"
+  local cmd="cd '$dir' && npm ci --no-audit --no-fund && npm run build"
+  local rc=0
+
+  # rc capturé explicitement : lire $? après un bloc if/fi est ambigu, et un
+  # script de déploiement qui se trompe sur un code de retour ment sur son
+  # propre résultat. C'est exactement le défaut qu'on corrige ici.
+  if [[ "$as" == "root" ]]; then
+    bash -c "$cmd" >/dev/null 2>&1 || rc=$?
+  else
+    sudo -u "$as" bash -lc "$cmd" >/dev/null 2>&1 || rc=$?
+  fi
+
+  if [[ $rc -eq 0 ]]; then
+    ok "$label construite"
+    return 0
+  fi
+  fail "$label : BUILD EN ÉCHEC"
+  return 1
+}
+
+# restart_if_built <ok|ko> <nom pm2...>
+# Ne redémarre QUE si tous les builds du groupe ont réussi : redémarrer sur un
+# build à moitié écrit servirait du code cassé aux visiteurs.
+restart_if_built() {
+  local built="$1"; shift
+  if [[ "$built" == "ok" ]]; then
+    restart_app "$@"
+  else
+    warn "redémarrage ignoré ($*) : un build du groupe a échoué, l'ancienne version reste en ligne"
+  fi
+}
+
+# restart_app <nom pm2...>
+restart_app() {
+  sudo -u nodyx pm2 restart "$@" --update-env >/dev/null 2>&1 \
+    && ok "redémarré : $*" \
+    || fail "redémarrage EN ÉCHEC : $*"
+}
+
+# check_url <libellé> <url>
+check_url() {
+  local label="$1" url="$2"
+  local code
+  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "$url" || echo 000)"
+  case "$code" in
+    200|301|302|303) ok "$label répond $code" ;;
+    *)               fail "$label répond $code" ;;
+  esac
+}
+
+# ── 1. Dépôt principal ───────────────────────────────────────────────────────
+head_ "Mise à jour du dépôt principal"
+cd /var/www/nexus || { bad "/var/www/nexus introuvable"; exit 1; }
+if git pull --ff-only; then
+  ok "dépôt à jour sur $(git rev-parse --short HEAD)"
+else
+  bad "git pull impossible, déploiement interrompu"
+  exit 1
+fi
+
+# ── 2. nodyx.org ─────────────────────────────────────────────────────────────
+head_ "nodyx.org (build en root)"
+G=ok
+build_app "nodyx-core"     /var/www/nexus/nodyx-core     || G=ko
+build_app "nodyx-frontend" /var/www/nexus/nodyx-frontend || G=ko
+restart_if_built "$G" nodyx-core nodyx-frontend
+
+# ── 3. Applications satellites (même dépôt, même commit) ─────────────────────
+# Elles vivent dans le dépôt principal : sans redémarrage ici, elles servent
+# indéfiniment le build d'avant, sans que personne ne s'en aperçoive.
+head_ "Satellites : nodyx.dev, start.nodyx.org, hub"
+G=ok
+build_app "nodyx-docs"    /var/www/nexus/nodyx-docs    || G=ko
+build_app "nodyx-hub"     /var/www/nexus/nodyx-hub     || G=ko
+build_app "nodyx-landing" /var/www/nexus/nodyx-landing || G=ko
+restart_if_built "$G" nodyx-docs nodyx-hub nodyx-landing
+
+# ── 4. sleemstudio.nodyx.org (dépôt dédié, build figé sur son domaine) ───────
+head_ "sleemstudio.nodyx.org (build en nodyx)"
+if sudo -u nodyx bash -lc 'cd /opt/sleemstudio && git pull --ff-only' >/dev/null 2>&1; then
+  ok "dépôt sleemstudio à jour"
+  G=ok
+  build_app "sleemstudio-core"     /opt/sleemstudio/nodyx-core     nodyx || G=ko
+  build_app "sleemstudio-frontend" /opt/sleemstudio/nodyx-frontend nodyx || G=ko
+  restart_if_built "$G" sleemstudio-core sleemstudio-frontend
+else
+  fail "git pull sleemstudio en échec, instance NON déployée"
+fi
+
+# ── 5. demo.nodyx.org (oubliée par l'ancien script) ──────────────────────────
+head_ "demo.nodyx.org (build en nodyx)"
+if sudo -u nodyx bash -lc 'cd /opt/demo && git pull --ff-only' >/dev/null 2>&1; then
+  ok "dépôt demo à jour"
+  G=ok
+  build_app "demo-core"     /opt/demo/nodyx-core     nodyx || G=ko
+  build_app "demo-frontend" /opt/demo/nodyx-frontend nodyx || G=ko
+  restart_if_built "$G" demo-core demo-frontend
+else
+  fail "git pull demo en échec, instance NON déployée"
+fi
+
+# ── 6. Vérification : on ne déclare le succès qu'après l'avoir constaté ──────
+head_ "Vérification des services"
+sleep 8
+check_url "nodyx.org"             "https://nodyx.org/"
+check_url "nodyx.org/translate"   "https://nodyx.org/translate"
+check_url "sleemstudio.nodyx.org" "https://sleemstudio.nodyx.org/"
+check_url "demo.nodyx.org"        "https://demo.nodyx.org/"
+check_url "nodyx.dev"             "https://nodyx.dev/"
+check_url "start.nodyx.org"       "https://start.nodyx.org/"
+
+# Toute application PM2 qui ne serait plus en ligne
+BROKEN="$(sudo -u nodyx pm2 jlist 2>/dev/null \
+  | python3 -c "import sys,json;print(' '.join(p['name'] for p in json.load(sys.stdin) if p.get('pm2_env',{}).get('status')!='online'))" 2>/dev/null || echo '')"
+if [[ -n "$BROKEN" ]]; then
+  fail "applications PM2 hors ligne : $BROKEN"
+else
+  ok "toutes les applications PM2 sont en ligne"
+fi
+
+# ── 7. Verdict ───────────────────────────────────────────────────────────────
+echo
+if [[ $FAILURES -eq 0 ]]; then
+  echo -e "${GREEN}${BOLD}✓ Déploiement terminé : 9 applications à jour et vérifiées.${RESET}"
+  exit 0
+else
+  echo -e "${RED}${BOLD}✘ Déploiement terminé avec $FAILURES problème(s). Voir ci-dessus.${RESET}"
+  exit 1
+fi

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -1,0 +1,28 @@
+# Scripts d'exploitation
+
+Ces scripts pilotent le serveur de production. Ils vivaient auparavant
+**uniquement sur le disque du VPS**, hors de tout dépôt : ni relus, ni
+sauvegardés, ni restaurables si la machine disparaissait. Ils sont versionnés
+ici pour la même raison que le reste du code.
+
+| fichier | rôle | installation |
+|---|---|---|
+| `../deploy-all.sh` | déploie et **vérifie** les 9 applications du serveur | exécuté par le lanceur ci-dessous |
+| `opt-deploy-wrapper.sh` | lanceur hors dépôt : fait le `git pull` puis passe la main | `sudo install -m 755 scripts/ops/opt-deploy-wrapper.sh /opt/deploy-all.sh` |
+| `nodyx-demo-reset.sh` | remise à zéro quotidienne de demo.nodyx.org | `sudo install -m 755 scripts/ops/nodyx-demo-reset.sh /usr/local/bin/nodyx-demo-reset` |
+
+## Le principe qui a motivé la réécriture du déploiement
+
+Un script d'exploitation **ne déclare jamais un succès qu'il n'a pas constaté**.
+
+L'ancien `deploy-all.sh` couvrait 4 applications sur 9 et se terminait par
+« ✓ Les deux instances sont à jour », quoi qu'il se soit passé. Trois
+conséquences réelles : `demo.nodyx.org` n'était jamais déployée, `nodyx.dev`,
+`start.nodyx.org` et le hub ne l'étaient jamais non plus, et un build en échec
+n'empêchait pas le message de succès.
+
+C'est le même défaut que le bug `pm2-logrotate` : une étape qui annonce avoir
+réussi sans avoir vérifié. La version actuelle compte ses échecs, ne redémarre
+un groupe que si tous ses builds ont réussi, interroge les six domaines à la
+fin, vérifie qu'aucune application PM2 n'est hors ligne, et **sort en code 1**
+s'il reste le moindre problème.

--- a/scripts/ops/nodyx-demo-reset.sh
+++ b/scripts/ops/nodyx-demo-reset.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Reset quotidien de l'instance demo.nodyx.org
+set -euo pipefail
+# Hash bcrypt du mot de passe des comptes de DÉMONSTRATION. Ce n'est pas un
+# secret : le mot de passe en clair est déjà public dans `nodyx-core/src/
+# scripts/seed.ts`, et ces comptes n'existent que sur demo.nodyx.org, une
+# instance remise à zéro tous les jours.
+HASH='$2b$10$2q70jhn9/.7oJJIgdVL3nOPAZD8QKzGgFE/mNX1R/BjNafEALz6ky'
+
+sudo -u postgres psql -d demo <<SQL
+-- Vider le contenu variable (messages, posts, DMs, notifs, réactions)
+TRUNCATE channel_messages, posts, dm_conversations, dm_messages, dm_participants,
+         notifications, channel_message_reactions, post_reactions, post_thanks,
+         polls, poll_options, poll_votes RESTART IDENTITY CASCADE;
+
+-- Remettre à zéro les threads et les canaux (recréés proprement ensuite)
+DELETE FROM threads;
+DELETE FROM channels;
+
+-- Recréer les 3 canaux texte + 3 canaux vocaux
+INSERT INTO channels (community_id, name, slug, type, position)
+SELECT c.id, v.name, v.slug, v.type, v.pos
+FROM communities c, (VALUES
+  ('général',      'general',      'text',  0),
+  ('random',       'random',       'text',  1),
+  ('présentation', 'presentation', 'text',  2),
+  ('lounge',       'lounge',       'voice', 3),
+  ('gaming',       'gaming',       'voice', 4),
+  ('music',        'music',        'voice', 5)
+) AS v(name, slug, type, pos)
+WHERE c.slug = 'demo';
+
+-- Recréer les utilisateurs demo (garder seulement admin, alice, bob, charlie)
+DELETE FROM users WHERE username NOT IN ('admin','alice','bob','charlie');
+UPDATE users SET email_verified = true,
+                 bio = NULL, avatar = NULL, points = 0;
+
+-- Recréer les messages seed
+INSERT INTO channel_messages (channel_id, author_id, content) VALUES
+  ((SELECT id FROM channels WHERE slug='general'   LIMIT 1), (SELECT id FROM users WHERE username='admin'),   'Bienvenue sur l''instance de démonstration Nodyx ! Connecte-toi avec alice, bob ou charlie — mot de passe : demo1234'),
+  ((SELECT id FROM channels WHERE slug='general'   LIMIT 1), (SELECT id FROM users WHERE username='alice'),   'Salut ! Je découvre Nodyx pour la première fois, c''est vraiment propre.'),
+  ((SELECT id FROM channels WHERE slug='general'   LIMIT 1), (SELECT id FROM users WHERE username='bob'),     'N''hésitez pas à tester le chat, les canaux vocaux et le forum !'),
+  ((SELECT id FROM channels WHERE slug='random'    LIMIT 1), (SELECT id FROM users WHERE username='charlie'), 'Quelqu''un a essayé les réactions sur les messages ?'),
+  ((SELECT id FROM channels WHERE slug='random'    LIMIT 1), (SELECT id FROM users WHERE username='alice'),   'Oui ! Et le canal vocal "lounge" est dispo pour tester l''audio 🎙️'),
+  ((SELECT id FROM channels WHERE slug='presentation' LIMIT 1), (SELECT id FROM users WHERE username='bob'), 'Admin sys dans une asso, je cherche un outil self-hosted open-source pour notre équipe.');
+
+-- Recréer les threads forum seed
+INSERT INTO threads (category_id, author_id, title, slug)
+SELECT c.id, (SELECT id FROM users WHERE username='admin'),
+       'Bienvenue sur la démo Nodyx !', 'bienvenue-sur-la-demo-nodyx'
+FROM categories c LIMIT 1;
+
+INSERT INTO threads (category_id, author_id, title, slug)
+SELECT c.id, (SELECT id FROM users WHERE username='alice'),
+       'Comparatif Nodyx vs Discord — mes premières impressions', 'comparatif-nodyx-vs-discord'
+FROM categories c LIMIT 1;
+
+INSERT INTO posts (thread_id, author_id, content)
+SELECT t.id, (SELECT id FROM users WHERE username='admin'),
+  'Cette instance est là pour explorer Nodyx librement. Mot de passe : demo1234. Réinitialisée chaque nuit à minuit.'
+FROM threads t WHERE slug='bienvenue-sur-la-demo-nodyx';
+
+INSERT INTO posts (thread_id, author_id, content)
+SELECT t.id, (SELECT id FROM users WHERE username='alice'),
+  'Interface propre, très proche de Discord. Forum intégré = grosse différence. Installation en une commande, impressionnant.'
+FROM threads t WHERE slug='comparatif-nodyx-vs-discord';
+SQL
+
+runuser -u nodyx -- env PM2_HOME=/home/nodyx/.pm2 pm2 restart demo-core
+echo "[$(date)] Demo reset OK"

--- a/scripts/ops/opt-deploy-wrapper.sh
+++ b/scripts/ops/opt-deploy-wrapper.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# ─── Lanceur à installer en /opt/deploy-all.sh ───────────────────────────────
+#
+#   sudo install -m 755 scripts/ops/opt-deploy-wrapper.sh /opt/deploy-all.sh
+#
+# Pourquoi un lanceur séparé plutôt qu'un lien symbolique vers le dépôt :
+# bash lit un script au fur et à mesure de son exécution. Si le fichier en
+# cours d'exécution est réécrit par un `git pull` qu'il lance lui-même, la
+# suite est lue dans le nouveau contenu, à un décalage arbitraire. Ce lanceur
+# vit HORS du dépôt, fait le pull, puis passe la main par `exec` : le script
+# métier est donc lu une seule fois, déjà à jour.
+set -euo pipefail
+
+REPO=/var/www/nexus
+git config --global --add safe.directory "$REPO" 2>/dev/null || true
+
+cd "$REPO"
+git pull --ff-only
+
+exec bash "$REPO/scripts/deploy-all.sh" "$@"


### PR DESCRIPTION
Les deux scripts qui pilotent ce serveur **n'existaient que sur le disque du VPS**. Ni relus, ni sauvegardés, ni restaurables si la machine disparaissait. C'est le même mode de défaillance que les deux commits retrouvés orphelins plus tôt aujourd'hui.

## Ce que faisait l'ancien deploy-all

Il couvrait **4 applications sur 9**, et se terminait par « ✓ Les deux instances sont à jour » quoi qu'il arrive. Trois conséquences réelles, pas théoriques :

- **`demo.nodyx.org` n'était jamais déployée** par lui. Il fallait y penser à la main, et je l'ai fait quatre fois aujourd'hui sans réaliser que c'était une rustine.
- **`nodyx.dev`, `start.nodyx.org` et le hub n'étaient jamais redéployés du tout.** Ils vivent dans le même dépôt : sans redémarrage, ils servaient indéfiniment un build d'avant.
- **Un build en échec n'empêchait pas le message de succès.**

C'est le défaut `pm2-logrotate` une deuxième fois : une étape qui annonce un succès qu'elle n'a jamais constaté.

## Ce que fait la nouvelle version

- couvre les **9 applications**
- **ne redémarre un groupe que si tous ses builds ont réussi** : redémarrer sur un build à moitié écrit servirait du code cassé aux visiteurs
- interroge les **six domaines** à la fin
- vérifie qu'**aucune application PM2 n'est hors ligne**
- **sort en code 1** s'il reste le moindre problème, et dit lequel

## Le lanceur, et pourquoi il reste hors du dépôt

`/opt/deploy-all.sh` devient un lanceur de six lignes. Ce n'est pas de la timidité : **bash lit un script au fur et à mesure qu'il l'exécute**. Un script qui se `git pull` lui-même voit la suite de son propre corps lue dans le nouveau contenu, à un décalage arbitraire. Le lanceur vit donc hors du dépôt, fait le pull, puis passe la main avec `exec`, de sorte que le script métier est lu une seule fois, déjà à jour.

## Aussi

`nodyx-demo-reset` est versionné également. Le hash bcrypt qu'il contient n'est pas un secret : c'est celui des comptes de démonstration, dont le mot de passe en clair est déjà public dans `seed.ts`, sur une instance remise à zéro chaque jour. Un commentaire le dit désormais, pour que personne ne le prenne un jour pour une fuite.

## À faire après le merge

```bash
sudo install -m 755 scripts/ops/opt-deploy-wrapper.sh /opt/deploy-all.sh
```

Puis le prochain `sudo /opt/deploy-all.sh` sera le premier à tout couvrir et à tout vérifier.