### PR TITLE
fix(deps): @fastify/static 10, and the test that was missing under it

### DIFF
--- a/nodyx-core/package-lock.json
+++ b/nodyx-core/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fastify/cors": "11.2.0",
         "@fastify/multipart": "10.0.0",
-        "@fastify/static": "^9.1.3",
+        "@fastify/static": "^10.1.3",
         "@types/adm-zip": "^0.5.8",
         "@types/pg": "8.20.0",
         "adm-zip": "^0.6.0",
@@ -391,9 +391,9 @@
       }
     },
     "node_modules/@fastify/static": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.3.0.tgz",
-      "integrity": "sha512-9YMYRpCOtMBrqKYWcqiw7ykOrn4D0jogHpJrFS0KGeSuOwzKMM5/mjj7B0CFLVoQ6htqKYw//Zs7APn9DBq05w==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-10.1.3.tgz",
+      "integrity": "sha512-W6jqajYS974XjPjB5hQWoxPM8NKM4+p8YmQT6G5IbCa4uhdWSVadZUv75siy1wEA/3ty8RYdpBydfWeu9AqAqQ==",
       "funding": [
         {
           "type": "github",
@@ -407,8 +407,9 @@
       "license": "MIT",
       "dependencies": {
         "@fastify/accept-negotiator": "^2.0.0",
+        "@fastify/error": "^4.0.0",
         "@fastify/send": "^4.0.0",
-        "content-disposition": "^1.0.1",
+        "content-disposition": "^2.0.1",
         "fastify-plugin": "^6.0.0",
         "fastq": "^1.17.1",
         "glob": "^13.0.0"
@@ -2109,9 +2110,9 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-2.0.1.tgz",
+      "integrity": "sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/nodyx-core/package.json
+++ b/nodyx-core/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@fastify/cors": "11.2.0",
     "@fastify/multipart": "10.0.0",
-    "@fastify/static": "^9.1.3",
+    "@fastify/static": "^10.1.3",
     "@types/adm-zip": "^0.5.8",
     "@types/pg": "8.20.0",
     "adm-zip": "^0.6.0",

--- a/nodyx-core/src/tests/static-uploads.test.ts
+++ b/nodyx-core/src/tests/static-uploads.test.ts
@@ -1,0 +1,89 @@
+// ─── Service des fichiers uploadés (@fastify/static) ────────────────────────
+//
+// `@fastify/static` est enregistré une seule fois, dans index.ts, pour servir
+// `uploads/` sous le préfixe `/uploads/`. Rien ne le testait : une montée de
+// version majeure pouvait donc casser silencieusement TOUS les avatars, images
+// et pièces jointes de l'instance, et seuls les visiteurs s'en seraient rendu
+// compte.
+//
+// Écrit lors du passage de la version 9 à la 10, motivé par un avis de sécurité
+// (contournement d'autorisation par URL non canonique). Le test reproduit
+// exactement la configuration de production, options comprises.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import Fastify, { type FastifyInstance } from 'fastify'
+import fastifyStatic from '@fastify/static'
+
+let app: FastifyInstance
+let root: string
+
+const CONTENU = 'nodyx-avatar-bytes'
+
+beforeAll(async () => {
+	root = mkdtempSync(join(tmpdir(), 'nodyx-uploads-'))
+	mkdirSync(join(root, 'avatars'), { recursive: true })
+	writeFileSync(join(root, 'avatars', 'moi.png'), CONTENU)
+
+	// Un fichier HORS du dossier servi : c'est lui qu'une traversée de chemin
+	// chercherait à atteindre.
+	writeFileSync(join(root, '..', 'nodyx-secret-hors-racine.txt'), 'JAMAIS SERVI')
+
+	app = Fastify({ logger: false })
+	// Configuration identique à celle d'index.ts.
+	await app.register(fastifyStatic, {
+		root,
+		prefix: '/uploads/',
+		decorateReply: false,
+	})
+	await app.ready()
+})
+
+afterAll(async () => {
+	await app?.close()
+	rmSync(root, { recursive: true, force: true })
+	rmSync(join(root, '..', 'nodyx-secret-hors-racine.txt'), { force: true })
+})
+
+describe('/uploads/ sert bien les fichiers', () => {
+	it('renvoie un fichier existant avec son contenu', async () => {
+		const res = await app.inject({ method: 'GET', url: '/uploads/avatars/moi.png' })
+		expect(res.statusCode).toBe(200)
+		expect(res.body).toBe(CONTENU)
+	})
+
+	it('renvoie 404 sur un fichier absent', async () => {
+		const res = await app.inject({ method: 'GET', url: '/uploads/avatars/inexistant.png' })
+		expect(res.statusCode).toBe(404)
+	})
+
+	it("ne sert rien en dehors du préfixe", async () => {
+		const res = await app.inject({ method: 'GET', url: '/avatars/moi.png' })
+		expect(res.statusCode).toBe(404)
+	})
+})
+
+describe('/uploads/ ne laisse pas sortir de sa racine', () => {
+	// Les formes d'échappement classiques, dont celles qui exploitent un
+	// décodage non canonique : c'est la famille visée par l'avis de sécurité
+	// qui a motivé le passage en version 10.
+	const evasions = [
+		'/uploads/../nodyx-secret-hors-racine.txt',
+		'/uploads/..%2Fnodyx-secret-hors-racine.txt',
+		'/uploads/%2e%2e/nodyx-secret-hors-racine.txt',
+		'/uploads/%2e%2e%2fnodyx-secret-hors-racine.txt',
+		'/uploads/..%252Fnodyx-secret-hors-racine.txt',
+		'/uploads/....//nodyx-secret-hors-racine.txt',
+		'/uploads/.%2e/nodyx-secret-hors-racine.txt',
+	]
+
+	for (const url of evasions) {
+		it(`refuse ${url}`, async () => {
+			const res = await app.inject({ method: 'GET', url })
+			expect(res.statusCode).not.toBe(200)
+			expect(res.body).not.toContain('JAMAIS SERVI')
+		})
+	}
+})


### PR DESCRIPTION
La dernière vulnérabilité connue du projet : **contournement d'autorisation par URL non canonique** dans `@fastify/static`. Son correctif est un changement **majeur** (9 vers 10), sur la couche qui sert **tous les avatars, images et pièces jointes** d'une instance. Et rien ne testait cette couche : elle est enregistrée une seule fois dans `index.ts` et jamais exercée. Une mauvaise montée de version aurait cassé tous les fichiers uploadés du site, et seuls les visiteurs l'auraient remarqué.

## D'abord mesurer l'exposition réelle, pas la supposer

`/uploads/` est bien routé publiquement et sert de vrais fichiers depuis internet. Mais il ne porte **aucune autorisation à contourner** : ce dossier est public par conception.

J'ai sondé notre propre serveur avec huit charges de traversée de chemin, en direct sur le cœur et à travers Caddy :

```
../package.json          %2e%2e/package.json      ..%252Fpackage.json
..%2Fpackage.json        %2e%2e%2fpackage.json    ....//package.json
.%2e/package.json        ..;/package.json
```

Toutes refusées, 404 ou 403. **Conclusion honnête : l'exposition réelle était faible.** Ce n'est pas une raison pour laisser la version vulnérable, c'est une raison pour la traiter posément plutôt que dans l'urgence.

## Ensuite écrire le test qui manquait

Il reproduit la configuration de production, options comprises. Il vérifie qu'un vrai fichier est servi avec son contenu, qu'un fichier absent renvoie 404, que rien n'est servi hors du préfixe, et il rejoue les sept formes d'échappement, dont les encodages non canoniques visés par l'avis.

## Enfin prouver que la montée est sans danger

| | résultat |
|---|---|
| le test sur **9.3.0** | 10 tests au vert |
| le test sur **10.1.3** | 10 tests au vert |
| le test **volontairement saboté** | il échoue |

Comportement **identique** entre les deux versions pour notre usage : le majeur ne change rien chez nous. Et le sabotage prouve que le test n'est pas creux.

Les tests de traversée passent aussi en 9.x, ce qui confirme la sonde en production : nous n'avons jamais été exposés à ce vecteur-là.

## Résultat

`npm audit` remonte désormais **zéro vulnérabilité** sur les cinq applications. Suite du cœur : 425 tests.