### PR TITLE
fix(security): rate limiting could be disabled with a spoofed header

### DIFF
--- a/nodyx-core/src/middleware/rateLimit.ts
+++ b/nodyx-core/src/middleware/rateLimit.ts
@@ -7,22 +7,36 @@ const MAX_REQUESTS   = 100
 // ── Middleware ───────────────────────────────────────────────
 
 export async function rateLimit(request: FastifyRequest, reply: FastifyReply): Promise<void> {
-  // Bypass only on actual loopback TCP connections (SvelteKit SSR → core).
-  // We intentionally use request.ip (socket-level) and NOT any header here,
-  // so an attacker cannot spoof X-Real-IP: 127.0.0.1 to escape rate limiting.
-  const socketIp = request.ip ?? ''
-  if (
-    socketIp === '127.0.0.1' ||
-    socketIp === '::1'        ||
-    socketIp === '::ffff:127.0.0.1'
-  ) return
+  // Bypass ONLY genuine internal traffic: SvelteKit SSR calling the core
+  // directly over loopback. That path adds no forwarding header, while Caddy
+  // adds one to every proxied external request. So "loopback socket AND no
+  // forwarding header" is the only combination an external attacker cannot
+  // reproduce, and it is what we key the bypass on.
+  //
+  // The previous version checked `request.ip`, believing it socket-level. It is
+  // NOT: under Fastify `trustProxy: true`, request.ip is derived from
+  // X-Forwarded-For, so `X-Forwarded-For: 127.0.0.1` made request.ip loopback
+  // and disabled rate limiting entirely. We now read the true TCP peer from the
+  // socket, which a header cannot forge.
+  const socketPeer = request.socket?.remoteAddress ?? ''
+  const isLoopbackPeer =
+    socketPeer === '127.0.0.1' || socketPeer === '::1' || socketPeer === '::ffff:127.0.0.1'
+  const hasForwardingHeader = !!(
+    request.headers['x-forwarded-for'] ||
+    request.headers['x-real-ip'] ||
+    request.headers['cf-connecting-ip']
+  )
+  if (isLoopbackPeer && !hasForwardingHeader) return
 
-  // For the rate-limit key, prefer the real client IP from trusted proxy headers
+  // For the rate-limit key, prefer the real client IP from trusted proxy headers.
+  // NB: on a self-hosted instance with no Cloudflare, these headers are not
+  // authenticated — hardening the key against a rotating X-Forwarded-For is a
+  // separate, deployment-topology-dependent change (see the trustProxy note).
   const ip = (
     (request.headers['cf-connecting-ip'] as string) ||
     (request.headers['x-real-ip'] as string) ||
     (request.headers['x-forwarded-for'] as string)?.split(',')[0].trim() ||
-    socketIp
+    socketPeer
   )
 
   const key = `rate:${ip}`

--- a/nodyx-core/src/tests/ratelimit-bypass.test.ts
+++ b/nodyx-core/src/tests/ratelimit-bypass.test.ts
@@ -1,0 +1,97 @@
+// ─── Le contournement du limiteur de débit par X-Forwarded-For ──────────────
+//
+// Le cœur tourne derrière Caddy avec Fastify `trustProxy: true`. Dans ce mode,
+// `request.ip` n'est PAS l'adresse du socket : elle est dérivée de l'en-tête
+// X-Forwarded-For, dont un attaquant contrôle la valeur la plus à gauche.
+//
+// L'ancien limiteur passait outre sur `request.ip === '127.0.0.1'`, en croyant
+// tester le socket. Un attaquant externe envoyant `X-Forwarded-For: 127.0.0.1`
+// désactivait donc TOUTE la limitation de débit : brute-force login sans borne,
+// spam d'inscription, bombardement d'e-mails de réinitialisation.
+//
+// Le vrai discriminant du trafic interne (SSR SvelteKit → cœur) est : socket en
+// loopback ET aucun en-tête de forwarding. Caddy ajoute toujours un en-tête de
+// forwarding au trafic externe, que l'attaquant ne peut pas supprimer.
+//
+// Ces tests échouent sur le code d'avant le correctif. cf feedback_test_first_critical.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { incrMock, expireMock, ttlMock } = vi.hoisted(() => ({
+  incrMock:   vi.fn(),
+  expireMock: vi.fn().mockResolvedValue(1),
+  ttlMock:    vi.fn().mockResolvedValue(60),
+}))
+
+vi.mock('../config/database', () => ({
+  redis: { incr: incrMock, expire: expireMock, ttl: ttlMock },
+}))
+
+import { rateLimit } from '../middleware/rateLimit'
+
+// Fabrique une requête Fastify minimale : le socket porte le VRAI pair TCP
+// (toujours loopback derrière Caddy), les en-têtes portent ce que l'appelant
+// a envoyé.
+function makeReq(opts: { peer?: string; headers?: Record<string, string> }) {
+  return {
+    socket:  { remoteAddress: opts.peer ?? '127.0.0.1' },
+    headers: opts.headers ?? {},
+    // Piège : request.ip est dérivé de XFF sous trustProxy. On le renseigne
+    // comme Fastify le ferait (valeur la plus à gauche), pour prouver que le
+    // limiteur ne s'y fie PLUS.
+    ip: (opts.headers?.['x-forwarded-for']?.split(',')[0].trim()) ?? opts.peer ?? '127.0.0.1',
+  } as any
+}
+
+function makeReply() {
+  const r: any = { code: vi.fn(() => r), send: vi.fn(() => r), header: vi.fn(() => r) }
+  return r
+}
+
+describe('rateLimit — contournement par en-tête', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    incrMock.mockResolvedValue(1) // sous la limite par défaut
+  })
+
+  it('laisse passer le vrai trafic interne SSR (socket loopback, aucun en-tête)', async () => {
+    const reply = makeReply()
+    await rateLimit(makeReq({ peer: '127.0.0.1', headers: {} }), reply)
+    // Aucun compteur touché = bypass legitime
+    expect(incrMock).not.toHaveBeenCalled()
+  })
+
+  it("N'est PAS contourné par X-Forwarded-For: 127.0.0.1 (l'exploit)", async () => {
+    const reply = makeReply()
+    // Ce que le cœur reçoit d'un attaquant passé par Caddy : sa valeur usurpée
+    // à gauche, le vrai IP ajouté par Caddy à droite.
+    await rateLimit(makeReq({ peer: '127.0.0.1', headers: { 'x-forwarded-for': '127.0.0.1, 203.0.113.9' } }), reply)
+    // Le limiteur DOIT s'appliquer : le compteur est incrémenté.
+    expect(incrMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("N'est PAS contourné par X-Forwarded-For: ::1", async () => {
+    const reply = makeReply()
+    await rateLimit(makeReq({ peer: '127.0.0.1', headers: { 'x-forwarded-for': '::1, 203.0.113.9' } }), reply)
+    expect(incrMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("N'est PAS contourné par X-Real-IP: 127.0.0.1", async () => {
+    const reply = makeReply()
+    await rateLimit(makeReq({ peer: '127.0.0.1', headers: { 'x-real-ip': '127.0.0.1' } }), reply)
+    expect(incrMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("N'est PAS contourné par CF-Connecting-IP: 127.0.0.1", async () => {
+    const reply = makeReply()
+    await rateLimit(makeReq({ peer: '127.0.0.1', headers: { 'cf-connecting-ip': '127.0.0.1' } }), reply)
+    expect(incrMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('applique bien la limite à un client externe normal', async () => {
+    const reply = makeReply()
+    incrMock.mockResolvedValue(101) // au-dessus de la limite
+    await rateLimit(makeReq({ peer: '127.0.0.1', headers: { 'x-forwarded-for': '203.0.113.9' } }), reply)
+    expect(reply.code).toHaveBeenCalledWith(429)
+  })
+})


### PR DESCRIPTION
## La faille

Le limiteur de débit général passait outre le trafic loopback en testant `request.ip`, en le croyant « socket-level ». Sous Fastify `trustProxy: true`, il ne l'est pas : `request.ip` est **dérivé de `X-Forwarded-For`**, dont le client contrôle la valeur la plus à gauche.

Un attaquant externe envoyant `X-Forwarded-For: 127.0.0.1` rendait donc `request.ip` égal à loopback et **désactivait entièrement la limitation de débit**, sur toutes les routes qu'elle protège : brute-force sur `/login`, inscription en masse, bombardement d'e-mails de réinitialisation. **Toute instance Nodyx est concernée, pas seulement nodyx.org.**

## Prouvé de bout en bout

Sondé contre le cœur en fonctionnement, en reproduisant exactement ce qu'il reçoit une fois que Caddy a ajouté le vrai IP à droite :

| en-tête reçu par le cœur | résultat |
|---|---|
| `X-Forwarded-For: 203.0.113.9` (client normal) | **LIMITÉ** |
| `X-Forwarded-For: 127.0.0.1, 203.0.113.9` (attaquant) | **NON LIMITÉ** |
| `X-Forwarded-For: ::1, 203.0.113.9` (attaquant) | **NON LIMITÉ** |

## Le correctif

Le contournement exige désormais que **le vrai pair TCP du socket soit loopback ET qu'aucun en-tête de forwarding ne soit présent**. Le SSR SvelteKit appelle le cœur directement en loopback sans un tel en-tête ; Caddy en ajoute un à chaque requête proxifiée, et un attaquant ne peut pas le supprimer. Les deux se séparent donc proprement, et le test lit le **socket**, qu'un en-tête ne peut pas forger.

Racine du problème confirmée aussi côté infra : **la config Caddy live n'écrase pas `X-Forwarded-For`** (elle l'ajoute), contrairement au Caddyfile disque, c'est le piège live ≠ disque du `CLAUDE.md`.

## Preuve

Six tests, dont **quatre échouent sur le code d'avant**. Suite complète du cœur : **431 tests au vert**, `tsc` propre.

## Ce qui n'est PAS corrigé ici, et qui demande ta décision

La **clé** du limiteur, et les limiteurs stricts login/register/forgot, dérivent encore l'IP client d'en-têtes **non authentifiés** sur une instance auto-hébergée sans Cloudflare. Un `X-Forwarded-For` qui tourne peut donc y créer des seaux neufs à volonté.

Le correctif propre : configurer `trustProxy` au **nombre réel de sauts de confiance** selon le déploiement (Caddy seul, ou Cloudflare + Caddy), puis lire `request.ip` une seule fois partout. Ça touche tout le traitement d'IP (honeypot, annuaire, bannissements), donc c'est un changement à part, avec sa propre preuve, et il te revient de trancher la topologie canonique.