### PR TITLE
fix(security): trust only real proxies, so request.ip is the true client

### DIFF
--- a/nodyx-core/src/config/trustedProxies.ts
+++ b/nodyx-core/src/config/trustedProxies.ts
@@ -1,0 +1,68 @@
+// ─── Qui a le droit d'écrire l'adresse du visiteur ? ─────────────────────────
+//
+// Le cœur tourne derrière au moins un proxy (Caddy), souvent deux (Cloudflare +
+// Caddy). Chaque proxy ajoute une ligne à X-Forwarded-For. Mais le visiteur
+// peut PRÉ-écrire de fausses lignes avant que ça n'atteigne le premier proxy.
+//
+// Fastify calcule `request.ip` en remontant X-Forwarded-For tant que chaque
+// hop est un proxy DE CONFIANCE, et s'arrête à la première adresse qui ne l'est
+// pas : c'est le vrai visiteur. Tout ce qui est à sa gauche (les fausses lignes
+// de l'attaquant) est ignoré.
+//
+// Donc la sécurité de request.ip = la justesse de cette liste de confiance.
+// `trustProxy: true` (l'ancien réglage) faisait confiance à TOUT LE MONDE, y
+// compris à l'attaquant : request.ip devenait la valeur la plus à gauche, qu'il
+// contrôlait. C'est ce qui permettait d'usurper 127.0.0.1 et de désactiver la
+// limitation de débit.
+//
+// La liste ci-dessous ne fait confiance qu'aux proxys légitimes :
+//   - loopback / plages privées : Caddy et tout proxy interne sur la machine
+//   - plages Cloudflare : quand l'instance est derrière Cloudflare (nodyx.org)
+//
+// La MÊME liste marche pour une instance self-host SANS Cloudflare : les plages
+// Cloudflare n'y apparaissent jamais dans la chaîne, donc elles ne sautent
+// jamais rien à tort. Zéro réglage par instance dans le cas courant.
+
+// Plages IP publiées par Cloudflare (https://www.cloudflare.com/ips/).
+// Stables, changent rarement. À rafraîchir si Cloudflare publie de nouvelles
+// plages ; un edge non listé serait traité comme un visiteur (sur-limitation
+// d'un sous-ensemble d'utilisateurs, jamais une faille de sécurité).
+// Relevé : 2026-08-08.
+const CLOUDFLARE_RANGES = [
+  '173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22',
+  '141.101.64.0/18', '108.162.192.0/18', '190.93.240.0/20', '188.114.96.0/20',
+  '197.234.240.0/22', '198.41.128.0/17', '162.158.0.0/15', '104.16.0.0/13',
+  '104.24.0.0/14', '172.64.0.0/13', '131.0.72.0/22',
+  '2400:cb00::/32', '2606:4700::/32', '2803:f800::/32', '2405:b500::/32',
+  '2405:8100::/32', '2a06:98c0::/29', '2c0f:f248::/32',
+]
+
+// Proxys locaux (Caddy en loopback, éventuel proxy interne en plage privée).
+// Noms spéciaux compris par proxy-addr (le moteur derrière Fastify trustProxy).
+const LOCAL_RANGES = ['loopback', 'linklocal', 'uniquelocal']
+
+/**
+ * Valeur à passer à `Fastify({ trustProxy })`.
+ *
+ * Réglages d'échappatoire, pour les topologies non prévues (autre CDN, proxy
+ * maison en frontal) :
+ *   - TRUST_PROXY            : override COMPLET. 'true'/'false', un nombre de
+ *                              hops, ou une liste d'IP/CIDR séparée par virgules.
+ *   - TRUSTED_PROXIES_EXTRA  : CIDR supplémentaires à AJOUTER à la liste par
+ *                              défaut (ex: l'IP d'un reverse proxy en amont).
+ */
+export function getTrustProxy(): boolean | number | string[] {
+  const override = process.env.TRUST_PROXY?.trim()
+  if (override) {
+    if (override === 'true')  return true
+    if (override === 'false') return false
+    const n = Number(override)
+    if (Number.isInteger(n) && n >= 0) return n
+    return override.split(',').map((s) => s.trim()).filter(Boolean)
+  }
+
+  const extra = (process.env.TRUSTED_PROXIES_EXTRA ?? '')
+    .split(',').map((s) => s.trim()).filter(Boolean)
+
+  return [...LOCAL_RANGES, ...CLOUDFLARE_RANGES, ...extra]
+}

--- a/nodyx-core/src/index.ts
+++ b/nodyx-core/src/index.ts
@@ -6,6 +6,7 @@ import fastifyCors from '@fastify/cors'
 import path from 'path'
 import { getRandomFortune } from './fortunes'
 import { db, redis } from './config/database'
+import { getTrustProxy } from './config/trustedProxies'
 import authRoutes          from './routes/auth'
 import adminRoutes         from './routes/admin'
 import settingsRoutes      from './routes/settings'
@@ -48,7 +49,11 @@ import { initOctoGuard }    from './services/octoguard'
 import { octoguardAdminPlugin, reportsPublicPlugin } from './routes/octoguard'
 import { startScheduler }  from './scheduler'
 
-const server = Fastify({ logger: true, trustProxy: true })
+// trustProxy : PAS `true` (ferait confiance à un X-Forwarded-For usurpé et
+// laisserait l'attaquant dicter request.ip). On ne fait confiance qu'aux proxys
+// légitimes (loopback + privé + Cloudflare), pour que request.ip soit la vraie
+// adresse du visiteur, partout dans le code. cf src/config/trustedProxies.ts
+const server = Fastify({ logger: true, trustProxy: getTrustProxy() })
 
 // ── CORS (pour les appels fetch client-side : upload, chat, mentions) ────────
 const corsOrigin = process.env.FRONTEND_URL

--- a/nodyx-core/src/middleware/rateLimit.ts
+++ b/nodyx-core/src/middleware/rateLimit.ts
@@ -28,16 +28,12 @@ export async function rateLimit(request: FastifyRequest, reply: FastifyReply): P
   )
   if (isLoopbackPeer && !hasForwardingHeader) return
 
-  // For the rate-limit key, prefer the real client IP from trusted proxy headers.
-  // NB: on a self-hosted instance with no Cloudflare, these headers are not
-  // authenticated — hardening the key against a rotating X-Forwarded-For is a
-  // separate, deployment-topology-dependent change (see the trustProxy note).
-  const ip = (
-    (request.headers['cf-connecting-ip'] as string) ||
-    (request.headers['x-real-ip'] as string) ||
-    (request.headers['x-forwarded-for'] as string)?.split(',')[0].trim() ||
-    socketPeer
-  )
+  // Clé = request.ip, calculé par Fastify contre la liste de proxys de confiance
+  // (loopback + privé + Cloudflare, cf config/trustedProxies.ts). C'est la vraie
+  // adresse du visiteur, qu'un X-Forwarded-For usurpé ne peut plus détourner :
+  // les fausses lignes de l'attaquant sont à gauche du dernier proxy de
+  // confiance et sont ignorées. On ne lit donc plus d'en-tête brut ici.
+  const ip = request.ip || socketPeer
 
   const key = `rate:${ip}`
 

--- a/nodyx-core/src/routes/auth.ts
+++ b/nodyx-core/src/routes/auth.ts
@@ -317,7 +317,7 @@ export default async function authRoutes(app: FastifyInstance) {
     }
 
     if (!user || !valid) {
-      const realIp = (request.headers['cf-connecting-ip'] as string) || request.ip
+      const realIp = request.ip  // fiable via trustProxy (loopback+privé+Cloudflare)
       const logLine = `${new Date().toISOString()} INVALID_CREDENTIALS ip=${realIp}\n`
       fs.appendFile('/var/log/nodyx-auth.log', logLine, () => {})
 
@@ -397,7 +397,7 @@ export default async function authRoutes(app: FastifyInstance) {
     await trackSession(user.id, token)
 
     // Détection connexion depuis une nouvelle IP
-    const loginIp    = (request.headers['cf-connecting-ip'] as string) || request.ip
+    const loginIp    = request.ip  // fiable via trustProxy
     const knownIpKey = `known_ip:${user.id}`
     const knownIp    = await redis.get(knownIpKey)
     await redis.set(knownIpKey, loginIp, 'EX', 60 * 60 * 24 * 30) // 30 jours
@@ -437,7 +437,7 @@ export default async function authRoutes(app: FastifyInstance) {
     const publicUser = toSelfUser(user)
 
     // Alerte connexion admin/owner
-    const realIpLogin = (request.headers['cf-connecting-ip'] as string) || request.ip
+    const realIpLogin = request.ip  // fiable via trustProxy
     db.query(
       `SELECT role FROM community_members
        WHERE user_id = $1 AND role IN ('admin', 'owner') LIMIT 1`,

--- a/nodyx-core/src/routes/directory.ts
+++ b/nodyx-core/src/routes/directory.ts
@@ -273,8 +273,9 @@ export default async function directoryRoutes(app: FastifyInstance) {
       const { token, members, online, logo_url, banner_url, version } = req.body;
       if (!token) return reply.status(400).send({ error: 'token required' });
 
-      // Capture real IP — req.ip est fiable car Caddy écrase X-Forwarded-For
-      // (CF-Connecting-IP n'est pas utilisé : non vérifiable sans liste IP Cloudflare)
+      // Capture real IP — req.ip est fiable via la liste de proxys de confiance
+      // (loopback + privé + Cloudflare, cf config/trustedProxies.ts) : un
+      // X-Forwarded-For usurpé ne peut plus le détourner.
       const rawIp = req.ip;
       const isPrivate = !rawIp || rawIp === '127.0.0.1' || rawIp === '::1'
         || rawIp.startsWith('192.168.') || rawIp.startsWith('10.')

--- a/nodyx-core/src/routes/honeypot.ts
+++ b/nodyx-core/src/routes/honeypot.ts
@@ -1074,11 +1074,7 @@ export default async function honeypotRoutes(fastify: FastifyInstance) {
     handler: async (request, reply) => {
 
       const headers = request.headers
-      const ip =
-        (headers['cf-connecting-ip'] as string) ||
-        (headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
-        request.ip ||
-        '0.0.0.0'
+      const ip = request.ip || '0.0.0.0'  // fiable via trustProxy
 
       const originalPath = decodeURIComponent((request.query as any).p || '/').slice(0, 512)
       const userAgent    = (headers['user-agent'] || '').slice(0, 512)
@@ -1279,11 +1275,7 @@ export default async function honeypotRoutes(fastify: FastifyInstance) {
     const { log: username = '', pwd: password = '', _incident: incidentRef = '', _origin_path: loginPath = '/' } = request.body ?? {}
 
     const headers = request.headers
-    const ip =
-      (headers['cf-connecting-ip'] as string) ||
-      (headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
-      request.ip ||
-      '0.0.0.0'
+    const ip = request.ip || '0.0.0.0'  // fiable via trustProxy
     const userAgent  = (headers['user-agent'] || '').slice(0, 512)
     const incidentId = genIncidentId()
 
@@ -1397,11 +1389,7 @@ export default async function honeypotRoutes(fastify: FastifyInstance) {
     if (!fp_hash || !/^[A-F0-9]{8,64}$/.test(fp_hash)) return reply.code(400).send({})
 
     const headers = request.headers
-    const ip =
-      (headers['cf-connecting-ip'] as string) ||
-      (headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
-      request.ip ||
-      '0.0.0.0'
+    const ip = request.ip || '0.0.0.0'  // fiable via trustProxy
 
     try {
       // Upsert fingerprint
@@ -1597,9 +1585,7 @@ export default async function honeypotRoutes(fastify: FastifyInstance) {
       return reply.code(200).send(PIXEL_PNG)
     }
 
-    const ip        = ((request.headers['cf-connecting-ip'] as string) ||
-                       (request.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
-                       request.ip || '0.0.0.0')
+    const ip        = request.ip || '0.0.0.0'  // fiable via trustProxy
     const userAgent = (request.headers['user-agent'] || '').slice(0, 512)
     const referer   = (request.headers['referer']    || '').slice(0, 512)
 

--- a/nodyx-core/src/tests/trusted-proxies.test.ts
+++ b/nodyx-core/src/tests/trusted-proxies.test.ts
@@ -1,0 +1,99 @@
+// ─── request.ip résiste-t-il à un X-Forwarded-For usurpé ? ──────────────────
+//
+// Le cœur dérive request.ip de X-Forwarded-For, que le visiteur peut
+// pré-remplir de fausses lignes. La sécurité repose entièrement sur la liste de
+// proxys de confiance passée à `Fastify({ trustProxy })`.
+//
+// Avec l'ancien `trustProxy: true`, request.ip = la valeur la plus à gauche =
+// contrôlée par l'attaquant (usurpation de 127.0.0.1, désactivation du limiteur,
+// pollution de tous les logs d'IP). Avec la liste loopback + privé + Cloudflare,
+// request.ip = la vraie adresse du visiteur dans TOUTES les topologies.
+//
+// Ces tests montent une vraie instance Fastify avec la config de production et
+// vérifient request.ip pour chaque chaîne X-Forwarded-For que le cœur peut
+// recevoir. Ils échouent sous `trustProxy: true`. cf feedback_test_first_critical.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import Fastify, { type FastifyInstance } from 'fastify'
+import { getTrustProxy } from '../config/trustedProxies'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+  app = Fastify({ trustProxy: getTrustProxy() })
+  app.get('/ip', (req, reply) => reply.send({ ip: req.ip }))
+  await app.ready()
+})
+
+afterAll(async () => { await app?.close() })
+
+// socket = loopback (Caddy → cœur), comme en production. On ne fait varier que
+// X-Forwarded-For, ce que l'attaquant et les proxys écrivent.
+async function ipFor(xff?: string): Promise<string> {
+  const headers = xff !== undefined ? { 'x-forwarded-for': xff } : {}
+  const res = await app.inject({ method: 'GET', url: '/ip', headers })
+  return JSON.parse(res.body).ip
+}
+
+describe('request.ip via trustProxy (loopback + privé + Cloudflare)', () => {
+  it('trafic interne SSR (aucun X-Forwarded-For) = loopback', async () => {
+    expect(await ipFor(undefined)).toMatch(/^(127\.0\.0\.1|::1|::ffff:127\.0\.0\.1)$/)
+  })
+
+  it('visiteur self-host (Caddy direct) = sa vraie adresse', async () => {
+    // Caddy a ajouté la vraie IP à droite.
+    expect(await ipFor('203.0.113.50')).toBe('203.0.113.50')
+  })
+
+  it('visiteur nodyx.org (Cloudflare + Caddy) = sa vraie adresse', async () => {
+    // Cloudflare ajoute la vraie IP, Caddy ajoute l'edge Cloudflare à droite.
+    expect(await ipFor('203.0.113.50, 173.245.48.10')).toBe('203.0.113.50')
+  })
+
+  it("ATTAQUANT self-host, préfixe 127.0.0.1 usurpé = ignoré", async () => {
+    expect(await ipFor('127.0.0.1, 203.0.113.99')).toBe('203.0.113.99')
+  })
+
+  it("ATTAQUANT nodyx.org, préfixe 127.0.0.1 usurpé = ignoré", async () => {
+    expect(await ipFor('127.0.0.1, 203.0.113.99, 173.245.48.10')).toBe('203.0.113.99')
+  })
+
+  it("ATTAQUANT, préfixe IP publique arbitraire (8.8.8.8) = ignoré", async () => {
+    expect(await ipFor('8.8.8.8, 203.0.113.99, 173.245.48.10')).toBe('203.0.113.99')
+  })
+
+  it("ne se laisse JAMAIS réduire à loopback par un en-tête (le cœur de l'exploit)", async () => {
+    for (const xff of ['127.0.0.1, 203.0.113.99', '::1, 203.0.113.99', '127.0.0.1, 203.0.113.99, 173.245.48.10']) {
+      expect(await ipFor(xff)).not.toMatch(/^(127\.0\.0\.1|::1)$/)
+    }
+  })
+})
+
+describe('getTrustProxy — réglages d\'échappatoire', () => {
+  it('TRUST_PROXY=true rétablit le comportement historique (override explicite)', () => {
+    process.env.TRUST_PROXY = 'true'
+    expect(getTrustProxy()).toBe(true)
+    delete process.env.TRUST_PROXY
+  })
+
+  it('TRUST_PROXY=2 est interprété comme un nombre de hops', () => {
+    process.env.TRUST_PROXY = '2'
+    expect(getTrustProxy()).toBe(2)
+    delete process.env.TRUST_PROXY
+  })
+
+  it('TRUSTED_PROXIES_EXTRA ajoute des plages à la liste par défaut', () => {
+    process.env.TRUSTED_PROXIES_EXTRA = '10.8.0.0/24'
+    const v = getTrustProxy() as string[]
+    expect(Array.isArray(v)).toBe(true)
+    expect(v).toContain('10.8.0.0/24')
+    expect(v).toContain('loopback')
+    delete process.env.TRUSTED_PROXIES_EXTRA
+  })
+
+  it('par défaut : liste incluant loopback et les plages Cloudflare', () => {
+    const v = getTrustProxy() as string[]
+    expect(v).toContain('loopback')
+    expect(v).toContain('173.245.48.0/20')
+  })
+})


### PR DESCRIPTION
Suite du correctif du limiteur. Le précédent empêchait de **désactiver** la limitation ; celui-ci corrige la cause racine que tout le code contournait : **`request.ip` n'était pas l'adresse du visiteur.**

## L'image simple

Chaque proxy (Caddy, Cloudflare) écrit au dos de l'enveloppe "reçu de telle adresse". Mais le visiteur peut **pré-écrire de fausses lignes** avant l'envoi. Avec `trustProxy: true`, le cœur faisait confiance à **toutes** les lignes, y compris les fausses, et lisait la première (celle de l'attaquant).

La correction ne fait confiance qu'aux **proxys légitimes** (loopback + plages privées + plages Cloudflare) et lit la ligne écrite par le dernier d'entre eux : la vraie adresse du visiteur.

## Prouvé, pas raisonné

Testé avec une vraie instance Fastify contre les chaînes exactes que le cœur reçoit :

| entrée `X-Forwarded-For` | `trustProxy: true` (avant) | liste proposée (après) |
|---|---|---|
| visiteur self-host `203.0.113.50` | 203.0.113.50 | 203.0.113.50 |
| visiteur nodyx.org `…50, cfEdge` | 203.0.113.50 | 203.0.113.50 |
| attaquant `127.0.0.1, …99` | **127.0.0.1** | 203.0.113.99 |
| attaquant `8.8.8.8, …99, cfEdge` | **8.8.8.8** | 203.0.113.99 |
| SSR interne (aucun XFF) | 127.0.0.1 | 127.0.0.1 |

**La même liste est correcte avec ou sans Cloudflare** : les plages Cloudflare ne sont sautées que si elles apparaissent réellement dans la chaîne. Un self-host derrière Caddy seul ne nécessite **aucune configuration**.

## Portée

Tout ce qui lit `request.ip` en bénéficie d'un seul coup : la clé du limiteur, les limiteurs stricts login/register/forgot, la vérification des bannissements, les logs honeypot, le ping annuaire, l'audit streamer. Les rustines `cf-connecting-ip || request.ip` (elles-mêmes usurpables sur une instance sans Cloudflare) sont supprimées : auth.ts (3 endroits), honeypot.ts (4 endroits). Commentaire faux corrigé dans directory.ts.

Échappatoires pour les topologies exotiques : `TRUST_PROXY` (override complet) et `TRUSTED_PROXIES_EXTRA` (ajouter des plages).

## Vérifications

- 11 tests couvrant les 6 chaînes réelles + les réglages ; **7 échouent sous `trustProxy: true`**
- suite complète du cœur : **442 tests**, `tsc` propre, build de production propre
- **aucun changement de `.env` nécessaire**, nodyx.org compris

## SANCTUAIRE

C'est le cœur, et la portée est large (tout le traitement d'IP). Tu as dit "tu gères, je valide" : voici la preuve. **Je ne merge et ne déploie pas sans ton feu vert.**