### PR TITLE
feat(recovery): CLI to regain access to a locked-out owner account

### DIFF
--- a/nodyx-core/package.json
+++ b/nodyx-core/package.json
@@ -9,6 +9,7 @@
     "start": "node dist/index.js",
     "seed": "ts-node src/scripts/seed.ts",
     "seed:reset": "ts-node src/scripts/seed.ts --reset",
+    "recover": "ts-node src/scripts/recover.ts",
     "generate-esy": "ts-node src/scripts/generate-esy.ts",
     "turn": "node turn-server.js",
     "test": "vitest run",

--- a/nodyx-core/src/scripts/recover.ts
+++ b/nodyx-core/src/scripts/recover.ts
@@ -1,0 +1,181 @@
+#!/usr/bin/env ts-node
+// ─── nodyx-recover — reprendre la main sur son instance ──────────────────────
+//
+//   cd <instance>/nodyx-core
+//   npm run recover                      # interactif : choisir un compte, obtenir un lien
+//   npm run recover -- --list            # lister les propriétaires et admins
+//   npm run recover -- --reset <qui>     # lien de réinitialisation pour <username|email>
+//   npm run recover -- --promote <qui>   # promouvoir un compte en propriétaire
+//
+// ─── Le principe ─────────────────────────────────────────────────────────────
+// Pour un auto-hébergement, le point d'ancrage de confiance n'est ni le mot de
+// passe, ni l'e-mail, ni un appareil (tout ça peut être perdu) : c'est L'ACCÈS À
+// LA MACHINE. Qui peut lancer cette commande sur le serveur EST le propriétaire.
+// L'outil ne demande donc aucune authentification en ligne : il s'appuie sur le
+// fait que tu as déjà un shell ici.
+//
+// Il ne démarre PAS l'application (ni Redis, ni Socket.IO). Il se connecte juste
+// à la base, comme le cœur, et génère le MÊME jeton qu'un e-mail « mot de passe
+// oublié » aurait envoyé. Tu ouvres le lien, tu tombes sur le formulaire de
+// réinitialisation habituel. Robuste : marche même quand l'app est cassée.
+
+import * as dotenv from 'dotenv'
+import { Pool } from 'pg'
+import readline from 'node:readline/promises'
+import { stdin as input, stdout as output } from 'node:process'
+import { generateResetToken } from './recoveryToken'
+
+dotenv.config()
+
+const RESET_TTL_SEC = 30 * 60 // 30 min : le temps de passer du terminal au navigateur
+
+const db = new Pool({
+	host:     process.env.DB_HOST,
+	port:     Number(process.env.DB_PORT) || 5432,
+	database: process.env.DB_NAME,
+	user:     process.env.DB_USER,
+	password: process.env.DB_PASSWORD,
+})
+
+const C = {
+	reset: '\x1b[0m', bold: '\x1b[1m', dim: '\x1b[2m',
+	green: '\x1b[32m', cyan: '\x1b[36m', red: '\x1b[31m', yellow: '\x1b[33m',
+}
+const ok   = (s: string) => console.log(`${C.green}✔${C.reset}  ${s}`)
+const info = (s: string) => console.log(`${C.cyan}•${C.reset}  ${s}`)
+const bad  = (s: string) => console.error(`${C.red}✘${C.reset}  ${s}`)
+
+interface Account {
+	id: string
+	username: string
+	email: string | null
+	role: string
+}
+
+// Les rôles vivent dans community_members. On liste les décideurs de l'instance.
+async function listPrivileged(): Promise<Account[]> {
+	const { rows } = await db.query<Account>(
+		`SELECT u.id, u.username, u.email, cm.role
+		   FROM community_members cm
+		   JOIN users u ON u.id = cm.user_id
+		  WHERE cm.role IN ('owner', 'admin')
+		  ORDER BY CASE cm.role WHEN 'owner' THEN 0 ELSE 1 END, u.username`,
+	)
+	return rows
+}
+
+async function findAccount(who: string): Promise<Account | null> {
+	const { rows } = await db.query<Account>(
+		`SELECT u.id, u.username, u.email, COALESCE(cm.role, 'member') AS role
+		   FROM users u
+		   LEFT JOIN community_members cm ON cm.user_id = u.id
+		  WHERE lower(u.username) = lower($1) OR lower(u.email) = lower($1)
+		  LIMIT 1`,
+		[who],
+	)
+	return rows[0] ?? null
+}
+
+function frontendBase(): string {
+	const url = process.env.FRONTEND_URL
+	if (!url) {
+		console.log(`${C.yellow}⚠${C.reset}  FRONTEND_URL absent du .env : je mets un lien relatif, remplace le domaine à la main.`)
+		return ''
+	}
+	return url.replace(/\/$/, '')
+}
+
+// Cœur de l'outil : génère un lien de réinitialisation à usage unique, en
+// réutilisant la table password_resets et donc le flux web existant.
+async function mintResetLink(acc: Account): Promise<void> {
+	const { rawToken, tokenHash, expiresAt } = generateResetToken(RESET_TTL_SEC)
+
+	// Un seul lien actif à la fois, comme le flux « mot de passe oublié ».
+	await db.query(`DELETE FROM password_resets WHERE user_id = $1 AND used_at IS NULL`, [acc.id])
+	await db.query(
+		`INSERT INTO password_resets (user_id, token_hash, expires_at, ip_address, user_agent)
+		 VALUES ($1, $2, $3, 'cli-recovery', 'nodyx-recover')`,
+		[acc.id, tokenHash, expiresAt],
+	)
+
+	const link = `${frontendBase()}/reset-password/${rawToken}`
+	console.log('')
+	ok(`Lien de réinitialisation pour ${C.bold}${acc.username}${C.reset} (${acc.role}) :`)
+	console.log('')
+	console.log(`   ${C.cyan}${link}${C.reset}`)
+	console.log('')
+	info(`Valable 30 minutes, à usage unique. Ouvre-le dans un navigateur.`)
+	info(`Toutes les sessions actives de ce compte seront invalidées au changement.`)
+}
+
+async function promote(acc: Account): Promise<void> {
+	const communityId = (await db.query<{ id: string }>(`SELECT id FROM communities ORDER BY created_at ASC LIMIT 1`)).rows[0]?.id
+	if (!communityId) { bad('Aucune communauté trouvée sur cette instance.'); return }
+
+	await db.query(
+		`INSERT INTO community_members (community_id, user_id, role)
+		 VALUES ($1, $2, 'owner')
+		 ON CONFLICT (community_id, user_id) DO UPDATE SET role = 'owner'`,
+		[communityId, acc.id],
+	)
+	ok(`${C.bold}${acc.username}${C.reset} est maintenant propriétaire de l'instance.`)
+}
+
+async function main(): Promise<void> {
+	const args = process.argv.slice(2)
+	const flag = (name: string) => { const i = args.indexOf(name); return i >= 0 ? args[i + 1] : undefined }
+
+	console.log(`${C.bold}Nodyx — récupération d'accès${C.reset}  ${C.dim}(instance : ${process.env.DB_NAME ?? '?'})${C.reset}\n`)
+
+	if (args.includes('--list')) {
+		const accts = await listPrivileged()
+		if (!accts.length) { bad('Aucun propriétaire ni admin. Utilise --promote <compte> pour en désigner un.'); return }
+		for (const a of accts) info(`${a.role.padEnd(6)}  ${a.username}  ${C.dim}${a.email ?? '(sans email)'}${C.reset}`)
+		return
+	}
+
+	const resetWho   = flag('--reset')
+	const promoteWho = flag('--promote')
+
+	if (promoteWho) {
+		const acc = await findAccount(promoteWho)
+		if (!acc) { bad(`Compte introuvable : ${promoteWho}`); process.exitCode = 1; return }
+		const rl = readline.createInterface({ input, output })
+		const ans = (await rl.question(`Promouvoir ${C.bold}${acc.username}${C.reset} en propriétaire ? [o/N] `)).trim().toLowerCase()
+		rl.close()
+		if (ans === 'o' || ans === 'oui' || ans === 'y') await promote(acc)
+		else info('Annulé.')
+		return
+	}
+
+	if (resetWho) {
+		const acc = await findAccount(resetWho)
+		if (!acc) { bad(`Compte introuvable : ${resetWho}`); process.exitCode = 1; return }
+		await mintResetLink(acc)
+		return
+	}
+
+	// Mode interactif : lister, choisir, générer.
+	const accts = await listPrivileged()
+	if (!accts.length) {
+		bad('Aucun propriétaire ni admin sur cette instance.')
+		info('Pour en désigner un :  npm run recover -- --promote <username|email>')
+		return
+	}
+	console.log('Comptes à privilèges sur cette instance :\n')
+	accts.forEach((a, i) => console.log(`  ${C.bold}[${i + 1}]${C.reset} ${a.role.padEnd(6)}  ${a.username}  ${C.dim}${a.email ?? '(sans email)'}${C.reset}`))
+	console.log('')
+
+	const rl = readline.createInterface({ input, output })
+	const pick = (await rl.question('Réinitialiser lequel ? (numéro, ou Entrée pour annuler) ')).trim()
+	rl.close()
+	if (!pick) { info('Annulé.'); return }
+
+	const idx = Number(pick) - 1
+	if (!Number.isInteger(idx) || idx < 0 || idx >= accts.length) { bad('Choix invalide.'); process.exitCode = 1; return }
+	await mintResetLink(accts[idx])
+}
+
+main()
+	.catch((e) => { bad(`Erreur : ${e instanceof Error ? e.message : String(e)}`); process.exitCode = 1 })
+	.finally(() => db.end())

--- a/nodyx-core/src/scripts/recoveryToken.ts
+++ b/nodyx-core/src/scripts/recoveryToken.ts
@@ -1,0 +1,32 @@
+import crypto from 'crypto'
+
+// ─── Jeton de réinitialisation, compatible avec /auth/reset-password ─────────
+//
+// L'endpoint POST /api/v1/auth/reset-password/:token attend un jeton dont il
+// recalcule le SHA-256 pour retrouver la ligne password_resets. On génère ici
+// EXACTEMENT le même format (32 octets aléatoires en hex, hash SHA-256), pour
+// que le lien produit par l'outil de récupération soit consommé par le flux web
+// déjà éprouvé, sans rien dupliquer côté serveur.
+//
+// Isolé dans son propre module pour être testable : un test prouve que ce que
+// l'outil génère est bien accepté par l'endpoint réel.
+
+export interface ResetToken {
+	/** À mettre dans l'URL, montré une seule fois. Jamais stocké en clair. */
+	rawToken:  string
+	/** Ce qu'on stocke en base (colonne token_hash). */
+	tokenHash: string
+	expiresAt: Date
+}
+
+export function generateResetToken(ttlSeconds: number): ResetToken {
+	const rawToken  = crypto.randomBytes(32).toString('hex')
+	const tokenHash = crypto.createHash('sha256').update(rawToken).digest('hex')
+	const expiresAt = new Date(Date.now() + ttlSeconds * 1000)
+	return { rawToken, tokenHash, expiresAt }
+}
+
+/** Le hash tel que l'endpoint le recalcule à partir du jeton reçu dans l'URL. */
+export function hashResetToken(rawToken: string): string {
+	return crypto.createHash('sha256').update(rawToken).digest('hex')
+}

--- a/nodyx-core/src/tests/recovery-token.test.ts
+++ b/nodyx-core/src/tests/recovery-token.test.ts
@@ -1,0 +1,96 @@
+// ─── Le lien produit par nodyx-recover est-il accepté par le vrai endpoint ? ─
+//
+// L'outil de récupération ne réimplémente pas la réinitialisation : il génère un
+// jeton et le range dans password_resets, puis c'est le flux web habituel
+// (POST /auth/reset-password/:token) qui le consomme. Ce test prouve la
+// COMPATIBILITÉ de bout en bout : on génère un jeton comme l'outil, on simule
+// son stockage, on l'envoie à l'endpoint réel, et le mot de passe change.
+//
+// Si le format du jeton ou du hash divergeait un jour, ce test casse.
+// cf feedback_test_first_critical.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { buildApp } from './helpers/buildApp'
+import { generateResetToken, hashResetToken } from '../scripts/recoveryToken'
+
+const { dbQueryMock } = vi.hoisted(() => ({ dbQueryMock: vi.fn() }))
+
+vi.mock('../config/database', () => ({
+	db:    { query: dbQueryMock },
+	redis: {
+		del: vi.fn(), get: vi.fn().mockResolvedValue(null), set: vi.fn(),
+		smembers: vi.fn().mockResolvedValue([]), keys: vi.fn().mockResolvedValue([]), scan: vi.fn().mockResolvedValue(['0', []]),
+		// le preHandler rateLimit s'exécute sous inject (socket non-loopback) : il faut ses méthodes
+		incr: vi.fn().mockResolvedValue(1), expire: vi.fn().mockResolvedValue(1), ttl: vi.fn().mockResolvedValue(60),
+	},
+}))
+
+import { db } from '../config/database'
+import authRoutes from '../routes/auth'
+
+const USER_ID = '11111111-1111-1111-1111-111111111111'
+
+describe('nodyx-recover : le jeton généré est consommable par /auth/reset-password', () => {
+	// clearAllMocks (pas reset) : on efface l'historique d'appels mais on GARDE
+	// les mockResolvedValue du mock Redis, sinon smembers renverrait undefined et
+	// invalidateUserSessions planterait (500) sans rapport avec ce qu'on teste.
+	beforeEach(() => vi.clearAllMocks())
+
+	it('génère un jeton 256 bits (64 hex) et son hash SHA-256', () => {
+		const t = generateResetToken(1800)
+		expect(t.rawToken).toMatch(/^[0-9a-f]{64}$/)
+		expect(t.tokenHash).toBe(hashResetToken(t.rawToken))
+		expect(t.tokenHash).toMatch(/^[0-9a-f]{64}$/)
+		expect(t.expiresAt.getTime()).toBeGreaterThan(Date.now())
+	})
+
+	it('le lien mène à une réinitialisation qui aboutit (cycle complet)', async () => {
+		// 1. L'outil génère le jeton (ce que fait mintResetLink).
+		const { rawToken, tokenHash } = generateResetToken(1800)
+
+		// 2. On simule la base : l'endpoint fait un UPDATE ... RETURNING user_id
+		//    sur la ligne dont token_hash correspond. On ne rend l'utilisateur QUE
+		//    si le hash reçu == celui que l'outil a rangé. C'est la preuve de compat.
+		let passwordUpdated = false
+		dbQueryMock.mockImplementation((sql: string, params?: unknown[]) => {
+			if (sql.includes('UPDATE password_resets') && sql.includes('RETURNING user_id')) {
+				return Promise.resolve({ rows: params?.[0] === tokenHash ? [{ user_id: USER_ID }] : [] })
+			}
+			if (sql.includes('UPDATE users SET password')) {
+				passwordUpdated = true
+				return Promise.resolve({ rows: [] })
+			}
+			return Promise.resolve({ rows: [] }) // invalidateUserSessions, etc.
+		})
+
+		const app = await buildApp(async (a) => { await a.register(authRoutes, { prefix: '/api/v1/auth' }) })
+		const res = await app.inject({
+			method:  'POST',
+			url:     `/api/v1/auth/reset-password/${rawToken}`,
+			payload: { password: 'un-nouveau-mot-de-passe-solide' },
+		})
+		await app.close()
+
+		expect(res.statusCode).toBe(200)
+		expect(passwordUpdated).toBe(true)
+	})
+
+	it('un jeton FORGÉ (non émis par l\'outil) est refusé', async () => {
+		dbQueryMock.mockImplementation((sql: string) => {
+			if (sql.includes('UPDATE password_resets') && sql.includes('RETURNING user_id')) {
+				return Promise.resolve({ rows: [] }) // aucun hash ne correspond
+			}
+			return Promise.resolve({ rows: [] })
+		})
+
+		const app = await buildApp(async (a) => { await a.register(authRoutes, { prefix: '/api/v1/auth' }) })
+		const res = await app.inject({
+			method:  'POST',
+			url:     '/api/v1/auth/reset-password/' + 'f'.repeat(64),
+			payload: { password: 'peu-importe-le-mot-de-passe' },
+		})
+		await app.close()
+
+		expect(res.statusCode).toBe(400)
+	})
+})

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -11,6 +11,7 @@ ici pour la même raison que le reste du code.
 | `opt-deploy-wrapper.sh` | lanceur hors dépôt : fait le `git pull` puis passe la main | `sudo install -m 755 scripts/ops/opt-deploy-wrapper.sh /opt/deploy-all.sh` |
 | `nodyx-demo-reset.sh` | remise à zéro quotidienne de demo.nodyx.org | `sudo install -m 755 scripts/ops/nodyx-demo-reset.sh /usr/local/bin/nodyx-demo-reset` |
 | `nodyx-backup.sh` | sauvegarde **vérifiée** des 3 bases + uploads | `sudo install -m 755 scripts/ops/nodyx-backup.sh /usr/local/bin/nodyx-backup` |
+| `nodyx-recover.sh` (via `src/scripts/recover.ts`) | reprendre la main sur un compte owner/admin perdu | `sudo install -m 755 scripts/ops/nodyx-recover-wrapper.sh /usr/local/bin/nodyx-recover` |
 | `nodyx-backup.{timer,service}` | la déclenche chaque nuit | `sudo install -m 644 scripts/ops/nodyx-backup.{timer,service} /etc/systemd/system/ && sudo systemctl daemon-reload && sudo systemctl enable --now nodyx-backup.timer` |
 
 ## Le principe qui a motivé la réécriture du déploiement
@@ -69,3 +70,33 @@ Les archives restent **sur la même machine que les données**. Elles protègent
 d'une bêtise (suppression, migration ratée, restauration à blanc), pas de la
 perte du serveur. Une copie hors-site reste à mettre en place, et elle demande
 un choix de destination et des accès.
+
+
+## Récupération d'accès (compte owner perdu)
+
+Le scénario : l'owner a perdu son mot de passe ET son e-mail (le lien de
+réinitialisation par mail ne sert donc à rien). Sur un auto-hébergement, le seul
+point d'ancrage de confiance qui survit à ça est **l'accès à la machine** : qui
+peut lancer une commande sur le serveur EST le propriétaire.
+
+`nodyx-recover` ne demande donc aucune authentification en ligne, ne démarre pas
+l'application (ni Redis, ni Socket.IO), se connecte juste à la base, et génère le
+**même jeton** qu'un e-mail « mot de passe oublié » aurait envoyé. On obtient un
+lien à ouvrir dans un navigateur : le formulaire de réinitialisation habituel
+fait le reste.
+
+```bash
+sudo nodyx-recover                 # interactif : liste les owners/admins, génère un lien
+sudo nodyx-recover --list          # juste lister
+sudo nodyx-recover --reset <qui>   # lien direct pour un username ou email
+sudo nodyx-recover --promote <qui> # désigner un owner (cas « plus aucun owner »)
+# autre instance :
+NODYX_DIR=/opt/sleemstudio sudo -E nodyx-recover
+```
+
+**Pourquoi pas Nodyx Signet ?** Signet est une méthode d'authentification (un
+appareil). La récupération sert précisément quand les moyens d'auth sont perdus,
+y compris l'appareil : on ne bâtit pas le frein de secours avec la pièce qui peut
+manquer. Le secours doit dépendre du minimum de pièces et être le plus robuste ;
+l'accès machine l'est. Une fois Signet prouvé stable, il pourra devenir un
+facteur EN PLUS, jamais l'ancrage unique.

--- a/scripts/ops/nodyx-recover-wrapper.sh
+++ b/scripts/ops/nodyx-recover-wrapper.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# ─── Lanceur global : sudo nodyx-recover [--list|--reset X|--promote X] ───────
+#
+#   sudo install -m 755 scripts/ops/nodyx-recover-wrapper.sh /usr/local/bin/nodyx-recover
+#
+# Reprendre la main sur une instance quand tout est perdu (mot de passe + email).
+# Le point d'ancrage de confiance = l'accès à cette machine. Aucune auth en ligne.
+#
+# Par défaut : instance principale (/var/www/nexus). Pour une autre instance :
+#   NODYX_DIR=/opt/sleemstudio sudo -E nodyx-recover
+set -euo pipefail
+DIR="${NODYX_DIR:-/var/www/nexus}/nodyx-core"
+[ -d "$DIR" ] || { echo "Instance introuvable : $DIR" >&2; exit 1; }
+cd "$DIR"
+exec npm run --silent recover -- "$@"


### PR DESCRIPTION
Un auto-hébergeur qui perd son mot de passe **et** son e-mail n'avait aucun moyen de revenir : le lien de réinitialisation par mail est inutile, et il ne restait que l'écriture d'un hash bcrypt à la main dans SQL. Ce trou est comblé.

## Le principe

Sur un auto-hébergement, le point d'ancrage de confiance n'est ni le mot de passe, ni l'e-mail, ni un appareil (tout ça peut être perdu) : c'est **l'accès à la machine**. Qui peut lancer une commande sur le serveur EST le propriétaire.

`nodyx-recover` ne demande donc **aucune authentification en ligne**, ne démarre pas l'application (ni Redis, ni Socket.IO), se connecte juste à la base comme le cœur, et génère le **même jeton** qu'un e-mail « mot de passe oublié » aurait envoyé. On obtient un lien, on l'ouvre dans un navigateur, et le formulaire de réinitialisation déjà éprouvé fait le reste.

```
sudo nodyx-recover                    interactif : choisir un owner/admin, obtenir un lien
sudo nodyx-recover --list             lister owners et admins
sudo nodyx-recover --reset <qui>      lien direct (username ou email)
sudo nodyx-recover --promote <qui>    désigner un owner (cas « plus aucun owner »)
```

## Pourquoi pas Nodyx Signet (comme tu l'avais proposé)

Signet est une méthode d'**authentification** (un appareil). La récupération sert **précisément** quand les moyens d'auth sont perdus, l'appareil compris. On ne bâtit pas le frein de secours avec la pièce qui peut manquer. Le secours doit dépendre du minimum de pièces et être le plus robuste : l'accès machine l'est, un flux d'appareil tout neuf non. Une fois Signet prouvé stable, il pourra devenir un facteur **en plus**, jamais l'ancrage unique.

## Preuve

Logique de jeton isolée dans `recoveryToken.ts` pour être testable. Trois tests prouvent le cycle complet :

- le jeton généré est bien 256 bits hex, et son SHA-256 est exactement ce que l'endpoint recalcule
- un lien forgé **comme le fait l'outil** est accepté par le **vrai** `POST /auth/reset-password` et change le mot de passe
- un jeton forgé au hasard est refusé (400)

Vérifié **en vrai** en lecture seule contre la base de prod : `--list` affiche correctement le propriétaire et les admins.

Suite complète du cœur : **445 tests**, `tsc` propre, build propre.

## SANCTUAIRE

Core-adjacent (nouveau script + réutilisation de la table `password_resets`, sans toucher aux routes existantes). Je ne merge et ne déploie pas sans ton go.