### PR TITLE
fix(responsive): members sidebar no longer overlaps content on mobile

### DIFF
--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -2474,7 +2474,11 @@ a.nx-icon-btn[class*="active"],
   width: var(--right-panel-width, 220px);
   background: #0d0d12;
   border-left: 1px solid rgba(255, 255, 255, 0.05);
-  display: flex;
+  /* PAS de `display: flex` ici : ce sélecteur scopé (spécificité + hash Svelte)
+     écrasait le `hidden` de Tailwind et la sidebar restait visible sous 1280px,
+     superposée au contenu sur mobile. On laisse Tailwind piloter l'affichage
+     (`hidden xl:flex` sur l'aside) ; flex-direction ne s'applique que quand
+     Tailwind a mis display:flex à >=1280px. */
   flex-direction: column;
   z-index: 30;
   transition: transform 280ms cubic-bezier(0.34, 1.56, 0.64, 1), width 280ms cubic-bezier(0.34, 1.56, 0.64, 1), opacity 200ms ease-out;


### PR DESCRIPTION
## Le bug

La sidebar membres porte les classes Tailwind `hidden xl:flex` (masquée sous 1280px, visible au-dessus). Mais la règle CSS scopée `.members-c` posait aussi `display: flex`, et **une classe scopée Svelte (avec son hash) l'emporte sur l'utilitaire `.hidden` de Tailwind**. Résultat : `display` restait `flex` à toutes les tailles. Le panneau fixe de 220px restait donc collé à droite sur téléphone, **recouvrant la moitié droite de chaque page**, sans moyen de le fermer (il n'y a pas de bouton membres sur mobile, par design).

## Mesuré, pas supposé

Avec un navigateur headless, **avant** le correctif, à 375px :
- `.members-c` : `display: flex` (devrait être `none`)
- position : `left:155 width:220`, superposée à droite
- **débordement horizontal de la page : 51px**

## Le correctif

Retirer `display: flex` de `.members-c` et laisser Tailwind piloter la visibilité (`hidden xl:flex`). `flex-direction: column` reste et ne s'applique que quand Tailwind met `display:flex` à ≥1280px.

## Prouvé

Navigateur headless, **après** le correctif :

| largeur | sidebar membres | débordement horizontal |
|---|---|---|
| 375px | `none` (masquée) | 0 |
| 768px | `none` (masquée) | 0 |
| 1366px | `flex` (visible) | 0 |

Ça rétablit l'intention d'origine de l'auteur (`hidden xl:flex`), que la règle scopée neutralisait en silence. Première correction du passage responsive.

`svelte-check` 0 erreur, `i18n:scan` 0.