### PR TITLE
fix(responsive): header auth buttons no longer overflow on mobile

### DIFF
--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -967,9 +967,9 @@
 					</div>
 			{:else}
 				<a href="/auth/login"
-				   class="nx-auth-btn flex items-center justify-center h-8 min-w-[5.5rem] px-3 text-xs font-medium rounded-lg transition-all">{tFn('common.login')}</a>
+				   class="nx-auth-btn flex items-center justify-center h-8 px-2.5 sm:min-w-[5.5rem] sm:px-3 text-xs font-medium rounded-lg transition-all whitespace-nowrap">{tFn('common.login')}</a>
 				<a href="/auth/register"
-				   class="nx-auth-btn nx-auth-btn--primary flex items-center justify-center h-8 min-w-[5.5rem] px-3 text-xs font-bold rounded-lg transition-all">{tFn('common.register')}</a>
+				   class="nx-auth-btn nx-auth-btn--primary flex items-center justify-center h-8 px-2.5 sm:min-w-[5.5rem] sm:px-3 text-xs font-bold rounded-lg transition-all whitespace-nowrap">{tFn('common.register')}</a>
 			{/if}
 		</div>
 	</nav>


### PR DESCRIPTION
Deuxième correction du passage responsive, trouvée au navigateur headless une fois la sidebar membres réglée : **51px de débordement horizontal à 375px**, venant du header.

Les boutons d'auth invités (Se connecter / S'inscrire) forçaient chacun `min-w-[5.5rem]` dans un groupe `shrink-0`. Avec le hamburger et le logo de la communauté aussi présents, le groupe dépassait de 51px un écran de 375px, **coupant le bouton S'inscrire**. Le français ("Se connecter" / "S'inscrire") est le pire cas.

## Correctif
Retirer le min-width fixe sur mobile (les boutons se dimensionnent à leur contenu : `px-2.5`, `whitespace-nowrap`), et rétablir `min-w-[5.5rem]` à partir du breakpoint `sm` : rien ne change sur écran large.

## Prouvé (navigateur headless)
Débordement horizontal = **0** à 320px, 375px, en français comme en anglais.

L'orbe décoratif du HeroBanner qui pointait aussi au-delà du bord est clippé par son propre `overflow:hidden`, il ne contribuait pas.

`svelte-check` 0 erreur, `i18n:scan` 0.