### PR TITLE
fix(responsive): let the header title truncate so actions never overflow

### DIFF
--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -766,7 +766,10 @@
 		{/if}
 
 		<!-- Mobile: community name logo -->
-		<a href="/" class="lg:hidden shrink-0 font-black text-sm truncate max-w-[140px]"
+		<!-- min-w-0 (pas shrink-0) : sur écran étroit c'est le TITRE qui cède et se
+		     tronque, pas les boutons d'action à droite. Un nom long comme
+		     « Nodyx - Hub Communautaire » débordait sinon de ~25px. -->
+		<a href="/" class="lg:hidden min-w-0 font-black text-sm truncate max-w-[140px]"
 		   style="font-family: 'Space Grotesk', sans-serif; background: linear-gradient(135deg, var(--nx-accent-2-soft), var(--nx-cyan-soft)); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; color: transparent">
 			{communityName}
 		</a>


### PR DESCRIPTION
Après le correctif des boutons d'auth, la prod gardait ~25px de débordement à 375px alors qu'une install par défaut n'en avait pas. La différence : **le nom de la communauté**. Le logo mobile était `shrink-0` avec `max-w-[140px]`, donc un nom long comme « Nodyx - Hub Communautaire » occupait ses 140px pleins à gauche et poussait le groupe de boutons (`shrink-0`) au-delà du bord droit. Un nom court (« Nodyx ») rentrait, d'où le fait que la home par défaut semblait correcte et la vraie non.

Le bon patron : **le titre cède, les actions restent**. Le logo passe de `shrink-0` à `min-w-0` : il peut se rétrécir et se tronquer sous la contrainte, en gardant `max-w-[140px]` comme plafond sur grand écran.

Preuve finale au navigateur headless après déploiement, dans la réponse.