### PR TITLE
fix(responsive): profile uses the available width on large screens

### DIFF
--- a/nodyx-frontend/src/routes/users/[username]/+page.svelte
+++ b/nodyx-frontend/src/routes/users/[username]/+page.svelte
@@ -329,7 +329,7 @@
 
 	<!-- Identity passport — anchored at banner bottom -->
 	<div class="absolute bottom-0 inset-x-0 z-10">
-		<div class="max-w-6xl mx-auto px-6 flex items-end gap-6 pb-6">
+		<div class="max-w-[1600px] mx-auto px-6 flex items-end gap-6 pb-6">
 
 			<!-- Avatar with frame -->
 			<div class="relative shrink-0 translate-y-10" style="width:128px;height:128px;overflow:visible">
@@ -501,7 +501,7 @@
 <!-- ═══════════════════════════════════════════════════════════════
      XP STRIP — full width, cinematic
      ═══════════════════════════════════════════════════════════════ -->
-<div class="max-w-6xl mx-auto px-6 mb-6">
+<div class="max-w-[1600px] mx-auto px-6 mb-6">
 	<div class="profile-xp-strip p-5" style="--accent: {accent}">
 		<div class="flex items-center justify-between mb-3 gap-4 flex-wrap">
 			<div class="flex items-center gap-3">
@@ -541,7 +541,7 @@
 <!-- ═══════════════════════════════════════════════════════════════
      MAIN — 2-column layout
      ═══════════════════════════════════════════════════════════════ -->
-<div class="max-w-6xl mx-auto px-6 pb-16">
+<div class="max-w-[1600px] mx-auto px-6 pb-16">
 	<div class="flex flex-col sm:flex-row gap-5 items-start">
 
 		<!-- ─── LEFT SIDEBAR ─────────────────────────────────────────── -->


### PR DESCRIPTION
Sur grand écran, le profil capait son contenu à `max-w-6xl` (1152px) et le centrait : au-delà, la largeur en trop devenait des **gouttières vides**, et les cartes réputation / stats flottaient étroites, comme une colonne mobile perdue au milieu de l'écran. La marge de 220px ajoutée par #458 pour la sidebar membres accentuait l'effet. C'est le "fullscreen repasse en mode mobile" signalé.

## Correctif
Relever le plafond à **1600px** sur les trois conteneurs de mise en page du profil (hero, barre XP, contenu principal). Le layout borne déjà le contenu entre les deux sidebars : sur un écran de 1920px, le contenu remplit désormais la zone de ~1424px au lieu de 1152 ; le cap ne mord qu'au-delà de ~2100px de viewport, ce qui garde l'ultrawide lisible.

## Prouvé (prévisualisation live)
En injectant le futur cap sur le profil réel à 1920px : la carte réputation et les 4 cartes de stats **remplissent** la ligne, les gouttières se réduisent à une fine marge.

Première page du passage hybride (les tableaux de bord s'élargissent, les pages de lecture gardent un cap confortable). `svelte-check` 0 erreur.