### PR TITLE
fix(responsive): stop layout offsets leaking into nested <main> elements

### DIFF
--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -1285,7 +1285,12 @@
 
 		<!-- ── Contenu principal ───────────────────────────────────────────────── -->
 		<div class="flex-1 overflow-hidden">
-		<main class="{langView ? 'h-[calc(100vh-48px)] overflow-hidden' : 'h-full overflow-y-auto'} min-w-0 pb-[var(--bottom-nav-h)]"
+		<!-- app-shell-main : marqueur pour scoper les décalages (padding-left rail+sidebar,
+		     margin-right membres) à CE main uniquement. Sans ça, `:global(main.app-shell-main)` frappait
+		     AUSSI les <main> imbriqués des pages (profil, settings, admin, dm) et leur
+		     collait un padding-left 276px + margin-right 220px parasites → contenu poussé
+		     au milieu et rétréci. -->
+		<main class="app-shell-main {langView ? 'h-[calc(100vh-48px)] overflow-hidden' : 'h-full overflow-y-auto'} min-w-0 pb-[var(--bottom-nav-h)]"
 		      class:panel-collapsed={isBanned || !showChannelSidebar || panelCollapsed}
 		      class:members-collapsed={membersCollapsed}>
 
@@ -1864,16 +1869,16 @@
 }
 
 /* ── Main content transition during collapse/expand ──────────────────────── */
-:global(main) {
+:global(main.app-shell-main) {
   transition: padding-left .25s cubic-bezier(.4,0,.2,1), margin-right .25s cubic-bezier(.4,0,.2,1);
 }
 
-.layout-dragging :global(main) {
+.layout-dragging :global(main.app-shell-main) {
   transition: none !important;
 }
 
 @media (min-width: 1024px) {
-  :global(main) {
+  :global(main.app-shell-main) {
     padding-left: calc(56px + var(--left-panel-width, 220px)) !important;
   }
   :global(main.panel-collapsed) {
@@ -1882,7 +1887,7 @@
 }
 
 @media (min-width: 1280px) {
-  :global(main) {
+  :global(main.app-shell-main) {
     margin-right: var(--right-panel-width, 220px) !important;
   }
   :global(main.members-collapsed) {


### PR DESCRIPTION
La vraie cause du "contenu pas en pleine largeur" sur plusieurs pages desktop, et du "fullscreen repasse en mode mobile".

## Le mécanisme

Le layout décale son contenu : `padding-left: calc(56px + sidebar)` et, à ≥1280px, `margin-right: 220px` pour réserver la place de la sidebar membres. Ces règles étaient écrites `:global(main) { ... }`, qui matche **tous** les `<main>` du document, pas seulement celui du layout.

Or plusieurs pages utilisent un `<main>` **imbriqué** pour une colonne de contenu : **profil, settings, admin, admin/octoguard, dm**. Elles héritaient donc d'un `padding-left: 276px` et d'un `margin-right: 220px` parasites.

Sur le profil, ça poussait le contenu de la colonne droite de ~276px vers l'intérieur (le grand vide au milieu) et coupait 220px à droite (l'espace perdu près des membres) : la colonne droite mesurait **928px au lieu des 1148px** qu'elle devrait remplir.

## Le correctif (un seul point)

Marquer le main du layout d'une classe dédiée `app-shell-main` et scoper les trois règles de décalage à `:global(main.app-shell-main)`. Les surcharges de repli (`main.panel-collapsed` / `main.members-collapsed`) ne matchent de toute façon que le main du layout, qui porte désormais aussi `app-shell-main`.

## Prouvé (mesure live)

En neutralisant la fuite sur le profil réel à 1920px : la colonne droite passe de **928px à 1148px** et atteint la sidebar membres, débordement reste **0**. Prévisualisé visuellement : carte réputation, les 4 tuiles de stats, les blocs À propos et GitHub remplissent la largeur.

**Un seul changement, corrige d'un coup toutes les pages à `<main>` imbriqué.** Complète #490 (le cap à 1600px pour l'ultrawide). `svelte-check` 0 erreur.