### PR TITLE
fix(responsive): kill the horizontal scrollbar in the content area

### DIFF
--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -1290,7 +1290,12 @@
 		     AUSSI les <main> imbriqués des pages (profil, settings, admin, dm) et leur
 		     collait un padding-left 276px + margin-right 220px parasites → contenu poussé
 		     au milieu et rétréci. -->
-		<main class="app-shell-main {langView ? 'h-[calc(100vh-48px)] overflow-hidden' : 'h-full overflow-y-auto'} min-w-0 pb-[var(--bottom-nav-h)]"
+		<!-- overflow-x-hidden : zone de contenu d'appli = défilement vertical seul.
+		     `overflow-y-auto` force sinon overflow-x à `auto` (spec CSS), et le
+		     moindre debordement (ex: banniere full-bleed -mx-6 du profil, +24px)
+		     faisait apparaitre une scrollbar horizontale + du contenu glissant
+		     sous les sidebars. On clippe l'horizontal, plus jamais de scrollbar. -->
+		<main class="app-shell-main {langView ? 'h-[calc(100vh-48px)] overflow-hidden' : 'h-full overflow-y-auto overflow-x-hidden'} min-w-0 pb-[var(--bottom-nav-h)]"
 		      class:panel-collapsed={isBanned || !showChannelSidebar || panelCollapsed}
 		      class:members-collapsed={membersCollapsed}>
 


### PR DESCRIPTION
Reproduit **en connecté** au navigateur headless : le `<main>` de contenu (`app-shell-main`) avait un débordement horizontal interne de 24px sur le profil (et jusqu'à ~100px sur le forum), avec une **scrollbar horizontale**, et la faire défiler glissait du contenu sous les sidebars. C'est le "scrollbar toujours présente" signalé.

## Cause
Le main est `overflow-y-auto`. Or, par la spec CSS, quand un axe est `auto` et l'autre `visible`, l'axe visible **calcule aussi `auto`** : `overflow-x` était donc effectivement `auto`. Le moindre débordement horizontal créait alors une scrollbar, et la bannière full-bleed du profil (`-mx-6`, +24px) en est un.

## Correctif
Zone de contenu = **défilement vertical seul**, `overflow-x: hidden` (comportement standard d'un shell d'appli). Les bannières full-bleed sont contenues, les popovers sont déjà portalés hors du main, et les sidebars fixes vivent en dehors : rien de légitime n'est rogné.

## Prouvé
`main.app-shell-main` calcule désormais `overflow-x: hidden`, `scrollWidth == clientWidth`, plus de scrollbar horizontale. `svelte-check` 0 erreur.