### PR TITLE
fix(deploy): keep nodyx-hub's SQLite dir writable so it survives a redeploy

### DIFF
--- a/scripts/deploy-all.sh
+++ b/scripts/deploy-all.sh
@@ -117,6 +117,18 @@ G=ok
 build_app "nodyx-docs"    /var/www/nexus/nodyx-docs    || G=ko
 build_app "nodyx-hub"     /var/www/nexus/nodyx-hub     || G=ko
 build_app "nodyx-landing" /var/www/nexus/nodyx-landing || G=ko
+
+# nodyx-hub écrit une base SQLite (hub.db) DANS son dossier, et tourne en `nodyx`.
+# SQLite en mode WAL recrée hub.db-wal/-shm au démarrage : il lui faut donc un
+# dossier inscriptible par nodyx. Le build ci-dessus tourne en root et laisse le
+# dossier root:root → au restart, le hub tombait en « readonly database » (500).
+# On rend le dossier + la base inscriptibles par le groupe nodyx AVANT le restart.
+if [[ -d /var/www/nexus/nodyx-hub ]]; then
+  chgrp nodyx /var/www/nexus/nodyx-hub && chmod 775 /var/www/nexus/nodyx-hub
+  chown nodyx:nodyx /var/www/nexus/nodyx-hub/hub.db* 2>/dev/null || true
+  ok "nodyx-hub : dossier de données inscriptible par nodyx (SQLite WAL)"
+fi
+
 restart_if_built "$G" nodyx-docs nodyx-hub nodyx-landing
 
 # ── 4. sleemstudio.nodyx.org (dépôt dédié, build figé sur son domaine) ───────


### PR DESCRIPTION
Déployer olympus.nodyx.org (nodyx-hub) s'est mis à renvoyer des **500** avec `SqliteError: attempt to write a readonly database`.

## Cause

`nodyx-hub` garde une base **SQLite** (`hub.db`) **dans son propre dossier** et tourne sous l'utilisateur `nodyx`. En mode WAL, SQLite recrée `hub.db-wal`/`-shm` au démarrage, ce qui exige un dossier **inscriptible par nodyx**. Or `deploy-all` build le hub **en root** et laisse le dossier `root:root` : au redémarrage post-build, le hub ne pouvait plus créer les fichiers WAL → base en lecture seule → 500 sur toute écriture, connexion comprise.

L'ancien script de déploiement ne rebuildait jamais le hub, donc les fichiers WAL créés à l'installation persistaient et le problème restait caché. Le nouveau script le rebuild et le redémarre, ce qui l'a fait surgir.

## Correctif

Avant de redémarrer les satellites, rendre le dossier du hub et `hub.db*` inscriptibles par le groupe `nodyx`.

## Prouvé en production

Après le `chgrp`/`chmod` et un redémarrage : `hub.db-wal`/`-shm` sont recréés par nodyx, **3 écritures de test → 0 erreur readonly**, et `POST /auth/login` renvoie **403** (rejet normal) au lieu de 500.

Le service est déjà rétabli manuellement ; ce commit garantit que le prochain déploiement ne le recasse pas.