### PR TITLE
fix(core): exempter les appels SSR internes du rate-limit (secret partagé)

### DIFF
--- a/nodyx-core/.env.example
+++ b/nodyx-core/.env.example
@@ -39,6 +39,16 @@
 # Si vous le changez plus tard, tout le monde sera déconnecté. À garder secret.
 JWT_SECRET=CHANGEZ_MOI_EN_PRODUCTION_UTILISEZ_UNE_VALEUR_ALEATOIRE_LONGUE
 
+# ── Secret interne frontend <-> core (exemption rate-limit du SSR) ─────────────
+# Le rendu d'une page tire ~8 requêtes vers le core (layout + page). Le frontend
+# les marque avec cet en-tête partagé pour que le core les exempte du rate-limit ;
+# sans quoi un visiteur qui navigue épuise son quota et reçoit des pages vides.
+# Générez-le comme JWT_SECRET, et mettez LA MÊME valeur côté frontend (variable
+# d'environnement PM2 INTERNAL_API_SECRET, ex. dans ecosystem.config.js).
+# Facultatif : si absent, le SSR retombe sur le bypass loopback (l'IP réelle du
+# visiteur n'est alors pas propagée au core pour les bans/inscriptions).
+INTERNAL_API_SECRET=CHANGEZ_MOI_MEME_VALEUR_QUE_LE_FRONTEND
+
 # ── Base de données PostgreSQL ────────────────────────────────────────────────
 # Le coeur de stockage : membres, messages, fils, tout vit ici.
 DB_HOST=localhost

--- a/nodyx-core/src/middleware/rateLimit.ts
+++ b/nodyx-core/src/middleware/rateLimit.ts
@@ -1,12 +1,37 @@
 import { FastifyRequest, FastifyReply } from 'fastify'
+import { timingSafeEqual } from 'crypto'
 import { redis } from '../config/database'
 
 const WINDOW_SECONDS = 60
 const MAX_REQUESTS   = 100
 
+// Appel interne de confiance : le SSR du frontend rend une page en tirant ~8
+// requêtes core (layout + page), et injecte le X-Forwarded-For du visiteur pour
+// alimenter bans/inscriptions. Comptées au nom du visiteur, ces ~8 requêtes/page
+// épuisent son quota en ~12 pages -> 429 -> le loader SSR renvoie une page vide
+// (incident cyclique du 2026-08-08). On exempte donc les appels qui portent un
+// secret partagé connu du seul frontend. C'est LA frontière : un client externe
+// passe par Caddy et ne connaît pas le secret. Fail-closed : pas de secret
+// configuré = pas de bypass (l'ancien bypass loopback ci-dessous prend le relais).
+function isTrustedInternalCall(request: FastifyRequest): boolean {
+  const secret = process.env.INTERNAL_API_SECRET
+  if (!secret) return false
+  const provided = request.headers['x-nodyx-internal']
+  if (typeof provided !== 'string' || provided.length === 0) return false
+  const a = Buffer.from(provided)
+  const b = Buffer.from(secret)
+  // timingSafeEqual exige des tampons de même taille. Court-circuiter sur la
+  // longueur ne fuit rien d'exploitable : la longueur du secret n'est pas secrète.
+  return a.length === b.length && timingSafeEqual(a, b)
+}
+
 // ── Middleware ───────────────────────────────────────────────
 
 export async function rateLimit(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+  // Appels internes du frontend (SSR), authentifiés par secret partagé : exemptés.
+  // Sans cette exemption, un visiteur qui navigue casse le site (429 en cascade).
+  if (isTrustedInternalCall(request)) return
+
   // Bypass ONLY genuine internal traffic: SvelteKit SSR calling the core
   // directly over loopback. That path adds no forwarding header, while Caddy
   // adds one to every proxied external request. So "loopback socket AND no

--- a/nodyx-core/src/tests/rate-limit-internal.test.ts
+++ b/nodyx-core/src/tests/rate-limit-internal.test.ts
@@ -1,0 +1,118 @@
+// ─── Le rate-limit exempte-t-il les appels internes du frontend, et EUX SEULS ? ─
+//
+// Contexte : le SSR du frontend rend une page en tirant ~8 requêtes core, en
+// injectant le X-Forwarded-For du visiteur (pour bans/inscriptions). Sans
+// exemption, ces requêtes sont comptées au nom du visiteur : ~12 pages épuisent
+// son quota -> 429 -> pages vides en cascade (incident cyclique du 2026-08-08).
+//
+// La frontière est un secret partagé (INTERNAL_API_SECRET) que seul le frontend
+// connaît. Ce test prouve les quatre propriétés qui rendent le correctif sûr :
+//   1. bon secret            -> exempté (redis jamais touché)
+//   2. secret forgé          -> rate-limité comme n'importe quel externe
+//   3. aucun secret configuré-> l'en-tête est ignoré (fail-closed)
+//   4. longueur invalide     -> pas de crash timingSafeEqual, pas de bypass
+// cf feedback_test_first_critical.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { incrMock, expireMock, ttlMock } = vi.hoisted(() => ({
+	incrMock:   vi.fn(),
+	expireMock: vi.fn(),
+	ttlMock:    vi.fn(),
+}))
+
+vi.mock('../config/database', () => ({
+	redis: { incr: incrMock, expire: expireMock, ttl: ttlMock },
+	db:    { query: vi.fn() },
+}))
+
+import { rateLimit } from '../middleware/rateLimit'
+
+const SECRET = 'a'.repeat(64)
+
+// Stubs minimalistes de FastifyRequest / FastifyReply : le middleware ne lit que
+// headers, socket.remoteAddress, ip côté requête, et pose code/header/send côté
+// réponse. Pas besoin d'un serveur Fastify complet pour un test d'unité.
+function makeReq(headers: Record<string, string>, socketPeer = '127.0.0.1', ip?: string) {
+	return {
+		headers,
+		socket: { remoteAddress: socketPeer },
+		ip: ip ?? socketPeer,
+	} as any
+}
+
+function makeReply() {
+	const r: any = {
+		statusCode: 200,
+		sentHeaders: {} as Record<string, string>,
+		header(k: string, v: string) { this.sentHeaders[k] = v; return this },
+		code(c: number) { this.statusCode = c; return this },
+		send(payload: any) { this.payload = payload; return this },
+	}
+	return r
+}
+
+describe('rateLimit — exemption des appels internes SSR (secret partagé)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		incrMock.mockResolvedValue(1)
+		expireMock.mockResolvedValue(1)
+		ttlMock.mockResolvedValue(60)
+	})
+	afterEach(() => { delete process.env.INTERNAL_API_SECRET })
+
+	it('bon secret interne -> exempté, redis jamais touché', async () => {
+		process.env.INTERNAL_API_SECRET = SECRET
+		const req = makeReq({ 'x-nodyx-internal': SECRET, 'x-forwarded-for': '203.0.113.9' }, '127.0.0.1', '203.0.113.9')
+		const reply = makeReply()
+		await rateLimit(req, reply)
+		expect(incrMock).not.toHaveBeenCalled()
+		expect(reply.statusCode).toBe(200)
+	})
+
+	it('bon secret : même compteur déjà au plafond, jamais de 429', async () => {
+		process.env.INTERNAL_API_SECRET = SECRET
+		incrMock.mockResolvedValue(999_999) // le plafond serait largement dépassé...
+		const req = makeReq({ 'x-nodyx-internal': SECRET, 'x-forwarded-for': '203.0.113.9' }, '127.0.0.1', '203.0.113.9')
+		const reply = makeReply()
+		await rateLimit(req, reply)
+		expect(reply.statusCode).toBe(200)   // ...mais on a court-circuité avant l'incr
+		expect(incrMock).not.toHaveBeenCalled()
+	})
+
+	it('secret interne FORGÉ -> pas de bypass, rate-limité comme un externe', async () => {
+		process.env.INTERNAL_API_SECRET = SECRET
+		incrMock.mockResolvedValue(101) // au-dessus du plafond (100)
+		const req = makeReq({ 'x-nodyx-internal': 'b'.repeat(64), 'x-forwarded-for': '203.0.113.9' }, '127.0.0.1', '203.0.113.9')
+		const reply = makeReply()
+		await rateLimit(req, reply)
+		expect(incrMock).toHaveBeenCalled()
+		expect(reply.statusCode).toBe(429)
+	})
+
+	it('aucun secret configuré -> en-tête interne ignoré (fail-closed) + XFF présent => compté', async () => {
+		delete process.env.INTERNAL_API_SECRET
+		incrMock.mockResolvedValue(101)
+		const req = makeReq({ 'x-nodyx-internal': SECRET, 'x-forwarded-for': '203.0.113.9' }, '127.0.0.1', '203.0.113.9')
+		const reply = makeReply()
+		await rateLimit(req, reply)
+		expect(reply.statusCode).toBe(429)
+	})
+
+	it('en-tête de longueur invalide -> pas de crash timingSafeEqual, pas de bypass', async () => {
+		process.env.INTERNAL_API_SECRET = SECRET
+		incrMock.mockResolvedValue(101)
+		const req = makeReq({ 'x-nodyx-internal': 'court', 'x-forwarded-for': '203.0.113.9' }, '127.0.0.1', '203.0.113.9')
+		const reply = makeReply()
+		await rateLimit(req, reply)
+		expect(reply.statusCode).toBe(429)
+	})
+
+	it('appel loopback pur (aucun en-tête) -> bypass loopback conservé (dégradation gracieuse)', async () => {
+		const req = makeReq({}, '127.0.0.1', '127.0.0.1')
+		const reply = makeReply()
+		await rateLimit(req, reply)
+		expect(incrMock).not.toHaveBeenCalled()
+		expect(reply.statusCode).toBe(200)
+	})
+})

--- a/nodyx-frontend/src/hooks.server.ts
+++ b/nodyx-frontend/src/hooks.server.ts
@@ -1,4 +1,5 @@
 import type { Handle, HandleFetch } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
 import { getLocaleFromAcceptLanguage, isKnownLocale } from '$lib/i18n';
 
 // Make sure /service-worker.js (and any other SW-like files) are never cached
@@ -61,9 +62,23 @@ export const handleFetch: HandleFetch = ({ event, request, fetch }) => {
 		return fetch(new Request(url, { method: request.method, headers }));
 	}
 
-	// Forward real client IP for SSR calls to the internal backend (127.0.0.1 or localhost)
+	// Appels internes vers le backend (127.0.0.1 / localhost).
+	//
+	// Le rendu d'une page tire ~8 requêtes core (layout + page). Si on forwarde le
+	// X-Forwarded-For du visiteur SANS marquer l'appel comme interne, le core les
+	// compte au nom du visiteur : ~12 pages suffisent à épuiser son quota, le core
+	// répond 429 et le SSR renvoie des pages vides (incident cyclique du 2026-08-08).
+	//
+	// Avec INTERNAL_API_SECRET configuré : on forwarde le vrai IP (pour bans /
+	// inscriptions) ET on marque l'appel comme interne -> le core l'exempte du
+	// rate-limit. Sans secret : on n'ajoute rien, l'appel reste loopback pur et le
+	// core le bypasse via sa règle loopback (dégradation gracieuse, l'IP visiteur
+	// n'est alors pas propagée).
 	if (url.includes('127.0.0.1') || url.includes('localhost')) {
-		headers.set('x-forwarded-for', event.getClientAddress());
+		if (env.INTERNAL_API_SECRET) {
+			headers.set('x-forwarded-for', event.getClientAddress());
+			headers.set('x-nodyx-internal', env.INTERNAL_API_SECRET);
+		}
 		return fetch(new Request(request, { headers }));
 	}
 


### PR DESCRIPTION
## Symptôme

503/500 récurrents et **cycliques** en naviguant sur nodyx.org : pages qui « perdent tout » (contenu vide, il faut rafraîchir plusieurs fois), et numéro de version qui devient **« Vunknown »**.

## Cause racine (prouvée en prod)

Le rendu d'une page tire **~8 requêtes** vers le core (le layout en fait ~6, la page ~2-3). `hooks.server.ts` (handleFetch) injecte le `X-Forwarded-For` du visiteur sur ces appels internes (pour tracer bans/inscriptions). Depuis le durcissement du rate-limiter, ces requêtes internes sont **comptées au nom de l'IP du visiteur** : ~12 pages suffisent à épuiser le quota de 100/min, le core répond **429**, et le loader SSR transforme ça en `error(500)` → **page vide**. Au bout de 60 s la fenêtre se vide → ça remarche → cyclique.

Le **« Vunknown »** est la même cause : quand `/instance/info` prend un 429, `infoJson` est `null` et `nodyxVersion = infoJson?.version ?? 'unknown'`.

Mesure d'un burst de 40 pages profil (avant correctif) : le core a répondu **127× 200 / 103× 429**.

## Correctif

Le frontend marque ses appels internes avec un secret partagé `x-nodyx-internal` que le core reconnaît pour les **exempter du rate-limit** :

- **core** (`rateLimit.ts`) : bypass si le secret est valide, en comparaison **constant-time** et **fail-closed** (pas de secret configuré = pas de bypass). Le `X-Forwarded-For` continue d'alimenter bans/inscriptions.
- **frontend** (`hooks.server.ts`) : ajoute le secret + le XFF sur les appels loopback si `INTERNAL_API_SECRET` est présent ; sinon n'ajoute rien → retombe sur le bypass loopback existant (**dégradation gracieuse**, aucune instance ne casse).
- La frontière est le secret : un client externe passe par Caddy et ne le connaît pas → il reste rate-limité normalement.

## Config requise

`INTERNAL_API_SECRET` (même valeur des deux côtés) : côté core via `.env` (dotenv), côté frontend via l'env PM2 (`ecosystem.config.js`, gitignored). Documenté dans `.env.example`. **Facultatif** grâce à la dégradation gracieuse.

## Tests

6 cas Vitest (`rate-limit-internal.test.ts`) : bypass au bon secret, rate-limit au secret forgé, fail-closed sans secret, robustesse à une longueur invalide (pas de crash `timingSafeEqual`), bypass loopback conservé.

## Vérifié en prod (nodyx.org)

Après déploiement : burst de 50 pages profil en local = **50/50 en 200** (avant : falaise à 15), 40/40 via le domaine public, version affichée **v2.11.0**, sweep de 40 requêtes mixtes = **zéro 500**.