### PR TITLE
feat(core): traduire emails et push selon la langue de l'utilisateur

### DIFF
--- a/nodyx-core/src/i18n/serverStrings.ts
+++ b/nodyx-core/src/i18n/serverStrings.ts
@@ -1,0 +1,146 @@
+// ── i18n backend : le strict nécessaire ─────────────────────────────────────
+//
+// Contrairement à une erreur API (le frontend peut toujours la retraduire, ou
+// afficher son propre message de repli), un email ou une notification push
+// partent définitivement dans la langue choisie ici : une fois envoyés, ils ne
+// sont plus rattrapables. C'est le seul texte que le core doit traduire
+// lui-même — tout le reste (erreurs API, notifications in-app, logs d'audit)
+// reste du texte technique ou du structuré traduit côté frontend.
+//
+// FR + EN seulement, comme le frontend : les autres langues de la communauté
+// (de/es/it/pt/nl) retombent sur EN, cf i18n:parity:check côté nodyx-frontend.
+
+export type ServerLocale = 'fr' | 'en'
+
+const SUPPORTED: readonly ServerLocale[] = ['fr', 'en']
+
+// Résout la langue effective d'un envoi serveur.
+// Ordre : locale de l'utilisateur (si connue et supportée) -> langue de
+// l'instance (si supportée) -> français (comportement historique, zéro
+// régression pour les instances qui n'ont rien configuré).
+export function resolveServerLocale(
+  userLocale?: string | null,
+  instanceLanguage?: string | null
+): ServerLocale {
+  const u = normalize(userLocale)
+  if (u) return u
+  const i = normalize(instanceLanguage)
+  if (i) return i
+  return 'fr'
+}
+
+function normalize(raw?: string | null): ServerLocale | null {
+  if (!raw) return null
+  const short = raw.slice(0, 2).toLowerCase() as ServerLocale
+  return SUPPORTED.includes(short) ? short : null
+}
+
+interface VerifyEmailStrings {
+  subject:      (community: string) => string
+  textBody:     (username: string, community: string, verifyUrl: string) => string
+  htmlTitle:    string
+  htmlGreeting: (username: string) => string
+  htmlIntro:    (community: string) => string
+  htmlCta:      string
+  htmlInfoLabel: string
+  htmlInfoExpiry: string
+  htmlInfoOnce:   string
+  htmlIgnore:     string
+  htmlFallback:   string
+}
+
+interface ResetEmailStrings {
+  subject:        (community: string) => string
+  textBody:       (username: string, community: string, resetUrl: string) => string
+  htmlTitle:      string
+  htmlGreeting:   (username: string) => string
+  htmlIntro:      string
+  htmlCta:        string
+  htmlSecurityLabel: string
+  htmlInfoExpiry:    string
+  htmlInfoOnce:      string
+  htmlInfoSessions:  string
+  htmlIgnore:        string
+  htmlFallback:      string
+}
+
+interface PushStrings {
+  mentionTitle: (username: string) => string
+}
+
+const VERIFY_EMAIL: Record<ServerLocale, VerifyEmailStrings> = {
+  fr: {
+    subject:  (c) => `Confirmez votre adresse email — ${c}`,
+    textBody: (u, c, url) => `Bonjour ${u},\n\nMerci de vous être inscrit sur ${c} !\n\nCliquez sur ce lien pour activer votre compte (valable 24 heures) :\n${url}\n\nSi vous n'êtes pas à l'origine de cette inscription, ignorez cet email.\n\n— L'équipe ${c}`,
+    htmlTitle:    'Confirmez votre adresse email',
+    htmlGreeting: (u) => `Bonjour <strong style="color:#c8c4bc;">${u}</strong>,`,
+    htmlIntro:    (c) => `Merci de rejoindre <strong style="color:#c8c4bc;">${c}</strong> ! Cliquez sur le bouton ci-dessous pour activer votre compte.`,
+    htmlCta:      'Activer mon compte',
+    htmlInfoLabel:  'Informations',
+    htmlInfoExpiry: 'Ce lien expire dans <strong style="color:#c8c4bc;">24 heures</strong>',
+    htmlInfoOnce:   'Il ne peut être utilisé <strong style="color:#c8c4bc;">qu\'une seule fois</strong>',
+    htmlIgnore:     'Si vous n\'êtes pas à l\'origine de cette inscription, ignorez simplement cet email.',
+    htmlFallback:   'Si le bouton ne fonctionne pas, copiez ce lien dans votre navigateur :',
+  },
+  en: {
+    subject:  (c) => `Confirm your email address — ${c}`,
+    textBody: (u, c, url) => `Hi ${u},\n\nThanks for signing up on ${c}!\n\nClick this link to activate your account (valid for 24 hours):\n${url}\n\nIf you didn't sign up for this, just ignore this email.\n\n— The ${c} team`,
+    htmlTitle:    'Confirm your email address',
+    htmlGreeting: (u) => `Hi <strong style="color:#c8c4bc;">${u}</strong>,`,
+    htmlIntro:    (c) => `Thanks for joining <strong style="color:#c8c4bc;">${c}</strong>! Click the button below to activate your account.`,
+    htmlCta:      'Activate my account',
+    htmlInfoLabel:  'Details',
+    htmlInfoExpiry: 'This link expires in <strong style="color:#c8c4bc;">24 hours</strong>',
+    htmlInfoOnce:   'It can only be used <strong style="color:#c8c4bc;">once</strong>',
+    htmlIgnore:     'If you didn\'t sign up for this, just ignore this email.',
+    htmlFallback:   'If the button doesn\'t work, copy this link into your browser:',
+  },
+}
+
+const RESET_EMAIL: Record<ServerLocale, ResetEmailStrings> = {
+  fr: {
+    subject:  (c) => `Réinitialisation de votre mot de passe — ${c}`,
+    textBody: (u, c, url) => `Bonjour ${u},\n\nVous avez demandé la réinitialisation de votre mot de passe sur ${c}.\n\nCliquez sur ce lien pour choisir un nouveau mot de passe (valable 1 heure) :\n${url}\n\nSi vous n'êtes pas à l'origine de cette demande, ignorez simplement cet email — votre mot de passe restera inchangé.\n\nCe lien ne peut être utilisé qu'une seule fois.\n\n— L'équipe ${c}`,
+    htmlTitle:    'Réinitialisation du mot de passe',
+    htmlGreeting: (u) => `Bonjour <strong style="color:#c8c4bc;">${u}</strong>,`,
+    htmlIntro:    'Vous avez demandé la réinitialisation de votre mot de passe. Cliquez sur le bouton ci-dessous pour en choisir un nouveau.',
+    htmlCta:      'Réinitialiser mon mot de passe',
+    htmlSecurityLabel: '🔒 Informations de sécurité',
+    htmlInfoExpiry:    'Ce lien expire dans <strong style="color:#c8c4bc;">1 heure</strong>',
+    htmlInfoOnce:      'Il ne peut être utilisé <strong style="color:#c8c4bc;">qu\'une seule fois</strong>',
+    htmlInfoSessions:  'Toutes vos sessions seront déconnectées après le changement',
+    htmlIgnore:        'Si vous n\'êtes pas à l\'origine de cette demande, ignorez simplement cet email — votre mot de passe restera inchangé.',
+    htmlFallback:      'Si le bouton ne fonctionne pas, copiez ce lien dans votre navigateur :',
+  },
+  en: {
+    subject:  (c) => `Reset your password — ${c}`,
+    textBody: (u, c, url) => `Hi ${u},\n\nYou requested a password reset on ${c}.\n\nClick this link to choose a new password (valid for 1 hour):\n${url}\n\nIf you didn't request this, just ignore this email — your password stays unchanged.\n\nThis link can only be used once.\n\n— The ${c} team`,
+    htmlTitle:    'Password reset',
+    htmlGreeting: (u) => `Hi <strong style="color:#c8c4bc;">${u}</strong>,`,
+    htmlIntro:    'You requested a password reset. Click the button below to choose a new one.',
+    htmlCta:      'Reset my password',
+    htmlSecurityLabel: '🔒 Security details',
+    htmlInfoExpiry:    'This link expires in <strong style="color:#c8c4bc;">1 hour</strong>',
+    htmlInfoOnce:      'It can only be used <strong style="color:#c8c4bc;">once</strong>',
+    htmlInfoSessions:  'All your sessions will be signed out after the change',
+    htmlIgnore:        'If you didn\'t request this, just ignore this email — your password stays unchanged.',
+    htmlFallback:      'If the button doesn\'t work, copy this link into your browser:',
+  },
+}
+
+const PUSH: Record<ServerLocale, PushStrings> = {
+  fr: { mentionTitle: (u) => `@${u} vous a mentionné` },
+  en: { mentionTitle: (u) => `@${u} mentioned you` },
+}
+
+export function verifyEmailStrings(locale: ServerLocale): VerifyEmailStrings {
+  return VERIFY_EMAIL[locale]
+}
+
+export function resetEmailStrings(locale: ServerLocale): ResetEmailStrings {
+  return RESET_EMAIL[locale]
+}
+
+export function pushStrings(locale: ServerLocale): PushStrings {
+  return PUSH[locale]
+}

--- a/nodyx-core/src/migrations/110_user_locale.sql
+++ b/nodyx-core/src/migrations/110_user_locale.sql
@@ -1,0 +1,7 @@
+-- Migration 110 — Langue préférée de l'utilisateur.
+-- Sert aux emails transactionnels et aux notifications push : contrairement à une
+-- réponse d'erreur API (rattrapable côté frontend à tout moment), un email ou une
+-- notification OS envoyés en français restent figés une fois partis. NULL = pas
+-- encore renseignée, résolue à la lecture (locale utilisateur -> langue de
+-- l'instance -> français), pas de backfill nécessaire.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS locale VARCHAR(5);

--- a/nodyx-core/src/models/user.ts
+++ b/nodyx-core/src/models/user.ts
@@ -30,6 +30,7 @@ export interface User {
   updated_at:                Date
   email_verified:            boolean
   email_verification_token:  string | null
+  locale:                    string | null
 }
 
 // Password excluded — safe to send to clients

--- a/nodyx-core/src/routes/admin.ts
+++ b/nodyx-core/src/routes/admin.ts
@@ -15,6 +15,7 @@ import { generateCategorySlug } from '../models/community'
 import { io } from '../socket/io'
 import { invalidateUserSessions } from './auth'
 import { isSmtpConfigured, sendPasswordResetEmail } from '../services/emailService'
+import { resolveServerLocale } from '../i18n/serverStrings'
 import { scanBuffer } from '../services/fileScanner'
 import { NODYX_VERSION } from '../utils/version'
 import { randomUUID, createHash, randomBytes } from 'crypto'
@@ -320,8 +321,8 @@ export default async function adminRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const { userId } = request.params as { userId: string }
 
-    const { rows: userRows } = await db.query<{ id: string; username: string; email: string }>(
-      `SELECT id, username, email FROM users WHERE id = $1`,
+    const { rows: userRows } = await db.query<{ id: string; username: string; email: string; locale: string | null }>(
+      `SELECT id, username, email, locale FROM users WHERE id = $1`,
       [userId]
     )
     if (!userRows[0]) return reply.code(404).send({ error: 'User not found' })
@@ -349,7 +350,8 @@ export default async function adminRoutes(app: FastifyInstance) {
     let emailSent = false
     if (isSmtpConfigured()) {
       try {
-        await sendPasswordResetEmail({ to: user.email, username: user.username, resetUrl })
+        const locale = resolveServerLocale(user.locale, process.env.NODYX_COMMUNITY_LANGUAGE)
+        await sendPasswordResetEmail({ to: user.email, username: user.username, resetUrl, locale })
         emailSent = true
       } catch {
         // SMTP configuré mais échec — on retourne quand même le lien
@@ -1012,6 +1014,7 @@ export default async function adminRoutes(app: FastifyInstance) {
         to,
         username: 'Admin',
         resetUrl: `${process.env.FRONTEND_URL ?? 'http://localhost:5173'}/reset-password/test-smtp`,
+        locale: resolveServerLocale(null, process.env.NODYX_COMMUNITY_LANGUAGE),
       })
       return reply.send({ success: true, message: `Email de test envoyé à ${to}` })
     } catch (err: unknown) {

--- a/nodyx-core/src/routes/auth.ts
+++ b/nodyx-core/src/routes/auth.ts
@@ -11,6 +11,7 @@ import { requireAuth } from '../middleware/auth'
 import * as UserModel from '../models/user'
 import { toSelfUser } from '../utils/publicUser'
 import { isSmtpConfigured, sendPasswordResetEmail, sendVerificationEmail } from '../services/emailService'
+import { resolveServerLocale } from '../i18n/serverStrings'
 import { getUserTotp, TOTP_PENDING_TTL } from './totp'
 
 // ── Discord security alerts ───────────────────────────────────────────────────
@@ -229,6 +230,14 @@ export default async function authRoutes(app: FastifyInstance) {
     // Store registration IP
     await db.query(`UPDATE users SET registration_ip = $1::inet WHERE id = $2`, [clientIp, user.id]).catch(() => {})
 
+    // Locale déduite d'Accept-Language à l'inscription (pas encore de préférence
+    // explicite) : sert aux emails/push, retraduisibles nulle part une fois envoyés.
+    const signupLocale = resolveServerLocale(
+      request.headers['accept-language'],
+      process.env.NODYX_COMMUNITY_LANGUAGE
+    )
+    await db.query(`UPDATE users SET locale = $1 WHERE id = $2`, [signupLocale, user.id]).catch(() => {})
+
     // Alerte Discord nouvelle inscription
     sendSecurityAlert({
       title:  '👤 Nouvelle inscription',
@@ -274,7 +283,7 @@ export default async function authRoutes(app: FastifyInstance) {
       )
       const frontendUrl = process.env.FRONTEND_URL ?? 'http://localhost:5173'
       const verifyUrl = `${frontendUrl}/auth/verify-email/${verificationToken}`
-      sendVerificationEmail({ to: email, username, verifyUrl }).catch(() => {})
+      sendVerificationEmail({ to: email, username, verifyUrl, locale: signupLocale }).catch(() => {})
       return reply.code(201).send({ pending_verification: true })
     }
 
@@ -506,7 +515,8 @@ export default async function authRoutes(app: FastifyInstance) {
 
       if (isSmtpConfigured()) {
         try {
-          await sendPasswordResetEmail({ to: user.email, username: user.username, resetUrl })
+          const locale = resolveServerLocale(user.locale, process.env.NODYX_COMMUNITY_LANGUAGE)
+          await sendPasswordResetEmail({ to: user.email, username: user.username, resetUrl, locale })
         } catch (err) {
           request.log.error({ err }, 'Failed to send password reset email')
           // Ne pas exposer l'erreur SMTP à l'utilisateur
@@ -643,7 +653,8 @@ export default async function authRoutes(app: FastifyInstance) {
 
     const frontendUrl = process.env.FRONTEND_URL ?? 'http://localhost:5173'
     const verifyUrl = `${frontendUrl}/auth/verify-email/${verificationToken}`
-    sendVerificationEmail({ to: user.email, username: user.username, verifyUrl }).catch(() => {})
+    const locale = resolveServerLocale(user.locale, process.env.NODYX_COMMUNITY_LANGUAGE)
+    sendVerificationEmail({ to: user.email, username: user.username, verifyUrl, locale }).catch(() => {})
 
     return reply.send({ message: 'Si ce compte existe et n\'est pas vérifié, un email a été envoyé.' })
   })

--- a/nodyx-core/src/routes/users.ts
+++ b/nodyx-core/src/routes/users.ts
@@ -14,6 +14,7 @@ import { io } from '../socket/io'
 import { scanBuffer } from '../services/fileScanner'
 import { scanImageNSFW } from '../services/nsfwScanner'
 import { checkContent } from '../services/contentFilter'
+import { resolveServerLocale } from '../i18n/serverStrings'
 
 const IMAGE_MAX_WIDTH  = 4096
 const IMAGE_MAX_HEIGHT = 4096
@@ -606,6 +607,30 @@ export default async function userRoutes(app: FastifyInstance) {
 
     // Public route: strict whitelist, no email or PII leaks.
     return reply.send({ user: toPublicUser(user) })
+  })
+
+  // PATCH /api/v1/users/me/locale — langue préférée (emails, notifications push)
+  // Contrairement à un texte d'erreur API (le frontend décide toujours de sa propre
+  // langue d'affichage), un email ou un push partent définitivement dans cette
+  // langue une fois envoyés. Le frontend appelle cette route quand l'utilisateur
+  // change de langue (cookie nodyx_locale), pour que le core suive.
+  app.patch('/me/locale', {
+    preHandler: [rateLimit, requireAuth],
+  }, async (request, reply) => {
+    const me = request.user!.userId
+    const { locale } = (request.body ?? {}) as { locale?: string }
+
+    if (!locale || typeof locale !== 'string') {
+      return reply.code(400).send({ error: 'locale required', code: 'BAD_REQUEST' })
+    }
+
+    // Seules fr/en sont réellement traduites côté core ; toute autre valeur
+    // retombe silencieusement sur le résolveur habituel (langue de l'instance,
+    // puis français) — même doctrine que le frontend pour les 5 autres langues.
+    const resolved = resolveServerLocale(locale, null)
+    await db.query(`UPDATE users SET locale = $1 WHERE id = $2`, [resolved, me])
+
+    return reply.send({ ok: true, locale: resolved })
   })
 
   // PATCH /api/v1/users/me/public-key — store user's ECDH public key (E2E DM encryption)

--- a/nodyx-core/src/services/emailService.ts
+++ b/nodyx-core/src/services/emailService.ts
@@ -1,4 +1,5 @@
 import nodemailer from 'nodemailer'
+import { verifyEmailStrings, resetEmailStrings, type ServerLocale } from '../i18n/serverStrings'
 
 // ── SMTP detection ────────────────────────────────────────────────────────────
 // Tous les champs requis doivent être présents pour activer l'envoi email.
@@ -35,26 +36,28 @@ export async function sendVerificationEmail(opts: {
   to:          string
   username:    string
   verifyUrl:   string
+  locale?:     ServerLocale
 }): Promise<void> {
   if (!isSmtpConfigured()) {
     throw new Error('SMTP non configuré sur cette instance')
   }
 
-  const { to, verifyUrl } = opts
+  const { to, verifyUrl, locale = 'fr' } = opts
   const username      = sanitizeHeader(opts.username)
   const communityName = sanitizeHeader(process.env.NODYX_COMMUNITY_NAME ?? 'Nodyx')
   const from = process.env.SMTP_FROM ?? process.env.SMTP_USER!
+  const s = verifyEmailStrings(locale)
 
   const transport = createTransport()
 
   await transport.sendMail({
     from:    `"${communityName}" <${from}>`,
     to,
-    subject: `Confirmez votre adresse email — ${communityName}`,
-    text: `Bonjour ${username},\n\nMerci de vous être inscrit sur ${communityName} !\n\nCliquez sur ce lien pour activer votre compte (valable 24 heures) :\n${verifyUrl}\n\nSi vous n'êtes pas à l'origine de cette inscription, ignorez cet email.\n\n— L'équipe ${communityName}`,
+    subject: s.subject(communityName),
+    text: s.textBody(username, communityName, verifyUrl),
     html: `
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="${locale}">
 <head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
 <body style="margin:0;padding:0;background:#0d0b08;font-family:system-ui,-apple-system,sans-serif;">
   <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#0d0b08;padding:40px 16px;">
@@ -66,36 +69,36 @@ export async function sendVerificationEmail(opts: {
         </td></tr>
 
         <tr><td style="background:#0f0d0a;border-left:1px solid rgba(200,145,74,0.15);border-right:1px solid rgba(200,145,74,0.15);padding:36px 40px;">
-          <p style="margin:0 0 8px;font-size:20px;font-weight:700;color:#f5f0e8;">Confirmez votre adresse email</p>
-          <p style="margin:0 0 24px;font-size:14px;color:#8a8279;">Bonjour <strong style="color:#c8c4bc;">${username}</strong>,</p>
+          <p style="margin:0 0 8px;font-size:20px;font-weight:700;color:#f5f0e8;">${s.htmlTitle}</p>
+          <p style="margin:0 0 24px;font-size:14px;color:#8a8279;">${s.htmlGreeting(username)}</p>
           <p style="margin:0 0 28px;font-size:14px;line-height:1.6;color:#8a8279;">
-            Merci de rejoindre <strong style="color:#c8c4bc;">${communityName}</strong> ! Cliquez sur le bouton ci-dessous pour activer votre compte.
+            ${s.htmlIntro(communityName)}
           </p>
 
           <table role="presentation" cellpadding="0" cellspacing="0" width="100%"><tr><td align="center" style="padding-bottom:28px;">
             <a href="${verifyUrl}"
                style="display:inline-block;background:#c8914a;color:#0d0b08;font-size:15px;font-weight:700;text-decoration:none;padding:14px 36px;border-radius:8px;letter-spacing:0.2px;">
-              Activer mon compte
+              ${s.htmlCta}
             </a>
           </td></tr></table>
 
           <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:rgba(200,145,74,0.06);border:1px solid rgba(200,145,74,0.18);border-radius:8px;margin-bottom:20px;">
             <tr><td style="padding:16px 20px;">
-              <p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#c8914a;text-transform:uppercase;letter-spacing:0.5px;">Informations</p>
+              <p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#c8914a;text-transform:uppercase;letter-spacing:0.5px;">${s.htmlInfoLabel}</p>
               <ul style="margin:0;padding-left:16px;font-size:13px;color:#8a8279;line-height:1.7;">
-                <li>Ce lien expire dans <strong style="color:#c8c4bc;">24 heures</strong></li>
-                <li>Il ne peut être utilisé <strong style="color:#c8c4bc;">qu'une seule fois</strong></li>
+                <li>${s.htmlInfoExpiry}</li>
+                <li>${s.htmlInfoOnce}</li>
               </ul>
             </td></tr>
           </table>
 
           <p style="margin:0;font-size:13px;color:#5a5550;line-height:1.6;">
-            Si vous n'êtes pas à l'origine de cette inscription, ignorez simplement cet email.
+            ${s.htmlIgnore}
           </p>
         </td></tr>
 
         <tr><td style="background:#0a0906;border:1px solid rgba(200,145,74,0.15);border-top:none;border-radius:0 0 12px 12px;padding:20px 40px;text-align:center;">
-          <p style="margin:0 0 8px;font-size:11px;color:#4a4540;">Si le bouton ne fonctionne pas, copiez ce lien dans votre navigateur :</p>
+          <p style="margin:0 0 8px;font-size:11px;color:#4a4540;">${s.htmlFallback}</p>
           <p style="margin:0;font-size:11px;word-break:break-all;"><a href="${verifyUrl}" style="color:#c8914a;text-decoration:none;">${verifyUrl}</a></p>
         </td></tr>
 
@@ -113,26 +116,28 @@ export async function sendPasswordResetEmail(opts: {
   to:       string
   username: string
   resetUrl: string
+  locale?:  ServerLocale
 }): Promise<void> {
   if (!isSmtpConfigured()) {
     throw new Error('SMTP non configuré sur cette instance')
   }
 
-  const { to, resetUrl } = opts
+  const { to, resetUrl, locale = 'fr' } = opts
   const username      = sanitizeHeader(opts.username)
   const communityName = sanitizeHeader(process.env.NODYX_COMMUNITY_NAME ?? 'Nodyx')
   const from = process.env.SMTP_FROM ?? process.env.SMTP_USER!
+  const s = resetEmailStrings(locale)
 
   const transport = createTransport()
 
   await transport.sendMail({
     from:    `"${communityName}" <${from}>`,
     to,
-    subject: `Réinitialisation de votre mot de passe — ${communityName}`,
-    text: `Bonjour ${username},\n\nVous avez demandé la réinitialisation de votre mot de passe sur ${communityName}.\n\nCliquez sur ce lien pour choisir un nouveau mot de passe (valable 1 heure) :\n${resetUrl}\n\nSi vous n'êtes pas à l'origine de cette demande, ignorez simplement cet email — votre mot de passe restera inchangé.\n\nCe lien ne peut être utilisé qu'une seule fois.\n\n— L'équipe ${communityName}`,
+    subject: s.subject(communityName),
+    text: s.textBody(username, communityName, resetUrl),
     html: `
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="${locale}">
 <head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
 <body style="margin:0;padding:0;background:#0d0b08;font-family:system-ui,-apple-system,sans-serif;">
   <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#0d0b08;padding:40px 16px;">
@@ -146,40 +151,40 @@ export async function sendPasswordResetEmail(opts: {
 
         <!-- Corps -->
         <tr><td style="background:#0f0d0a;border-left:1px solid rgba(200,145,74,0.15);border-right:1px solid rgba(200,145,74,0.15);padding:36px 40px;">
-          <p style="margin:0 0 8px;font-size:20px;font-weight:700;color:#f5f0e8;">Réinitialisation du mot de passe</p>
-          <p style="margin:0 0 24px;font-size:14px;color:#8a8279;">Bonjour <strong style="color:#c8c4bc;">${username}</strong>,</p>
+          <p style="margin:0 0 8px;font-size:20px;font-weight:700;color:#f5f0e8;">${s.htmlTitle}</p>
+          <p style="margin:0 0 24px;font-size:14px;color:#8a8279;">${s.htmlGreeting(username)}</p>
           <p style="margin:0 0 28px;font-size:14px;line-height:1.6;color:#8a8279;">
-            Vous avez demandé la réinitialisation de votre mot de passe. Cliquez sur le bouton ci-dessous pour en choisir un nouveau.
+            ${s.htmlIntro}
           </p>
 
           <!-- CTA -->
           <table role="presentation" cellpadding="0" cellspacing="0" width="100%"><tr><td align="center" style="padding-bottom:28px;">
             <a href="${resetUrl}"
                style="display:inline-block;background:#c8914a;color:#0d0b08;font-size:15px;font-weight:700;text-decoration:none;padding:14px 36px;border-radius:8px;letter-spacing:0.2px;">
-              Réinitialiser mon mot de passe
+              ${s.htmlCta}
             </a>
           </td></tr></table>
 
           <!-- Avertissements sécurité -->
           <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:rgba(200,145,74,0.06);border:1px solid rgba(200,145,74,0.18);border-radius:8px;margin-bottom:20px;">
             <tr><td style="padding:16px 20px;">
-              <p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#c8914a;text-transform:uppercase;letter-spacing:0.5px;">🔒 Informations de sécurité</p>
+              <p style="margin:0 0 8px;font-size:12px;font-weight:600;color:#c8914a;text-transform:uppercase;letter-spacing:0.5px;">${s.htmlSecurityLabel}</p>
               <ul style="margin:0;padding-left:16px;font-size:13px;color:#8a8279;line-height:1.7;">
-                <li>Ce lien expire dans <strong style="color:#c8c4bc;">1 heure</strong></li>
-                <li>Il ne peut être utilisé <strong style="color:#c8c4bc;">qu'une seule fois</strong></li>
-                <li>Toutes vos sessions seront déconnectées après le changement</li>
+                <li>${s.htmlInfoExpiry}</li>
+                <li>${s.htmlInfoOnce}</li>
+                <li>${s.htmlInfoSessions}</li>
               </ul>
             </td></tr>
           </table>
 
           <p style="margin:0;font-size:13px;color:#5a5550;line-height:1.6;">
-            Si vous n'êtes pas à l'origine de cette demande, ignorez simplement cet email — votre mot de passe restera inchangé.
+            ${s.htmlIgnore}
           </p>
         </td></tr>
 
         <!-- Pied de page -->
         <tr><td style="background:#0a0906;border:1px solid rgba(200,145,74,0.15);border-top:none;border-radius:0 0 12px 12px;padding:20px 40px;text-align:center;">
-          <p style="margin:0 0 8px;font-size:11px;color:#4a4540;">Si le bouton ne fonctionne pas, copiez ce lien dans votre navigateur :</p>
+          <p style="margin:0 0 8px;font-size:11px;color:#4a4540;">${s.htmlFallback}</p>
           <p style="margin:0;font-size:11px;word-break:break-all;"><a href="${resetUrl}" style="color:#c8914a;text-decoration:none;">${resetUrl}</a></p>
         </td></tr>
 

--- a/nodyx-core/src/socket/index.ts
+++ b/nodyx-core/src/socket/index.ts
@@ -12,6 +12,7 @@ import * as NotificationModel from '../models/notification'
 import { resolveMentions } from '../utils/mentions'
 import { io } from './io'
 import { sendPushToUser } from '../routes/notifications'
+import { resolveServerLocale, pushStrings } from '../i18n/serverStrings'
 import { checkHtmlContent } from '../services/contentFilter'
 import { runPipeline, isOctoGuardEnabled, isUserMuted, tryHandleCommand } from '../services/octoguard'
 
@@ -599,9 +600,16 @@ export function registerSocketIO(server: Server): void {
             // Separate chat-specific mention badge (won't mix with forum notifications)
             io.to(`user:${notifiedUserId}`).emit('chat:mention')
           }
-          // Web Push si l'utilisateur n'est pas connecté en temps réel
+          // Web Push si l'utilisateur n'est pas connecté en temps réel.
+          // Contrairement à une erreur API, un push envoyé n'est plus retraduisible
+          // une fois reçu (le service worker l'affiche tel quel) : on résout la
+          // langue du destinataire, pas celle de l'auteur du message.
+          const { rows: localeRows } = await db.query<{ locale: string | null }>(
+            `SELECT locale FROM users WHERE id = $1`, [notifiedUserId]
+          ).catch(() => ({ rows: [] }))
+          const pushLocale = resolveServerLocale(localeRows[0]?.locale, process.env.NODYX_COMMUNITY_LANGUAGE)
           sendPushToUser(notifiedUserId, {
-            title: `@${username} vous a mentionné`,
+            title: pushStrings(pushLocale).mentionTitle(username),
             body:  sanitized.slice(0, 80),
             type:  'mention',
             tag:   'chat-mention',

--- a/nodyx-core/src/tests/i18n-server-locale.test.ts
+++ b/nodyx-core/src/tests/i18n-server-locale.test.ts
@@ -1,0 +1,94 @@
+// ─── i18n backend : résolution de langue + emails/push traduits ────────────────
+//
+// Contrairement à une erreur API (retraduisible côté frontend à tout moment), un
+// email ou un push partent définitivement dans la langue choisie ici. Ce test
+// prouve : (1) l'ordre de repli exact (user > instance > français), et (2) que
+// les emails générés portent VRAIMENT le bon texte selon la locale — pas juste
+// que la fonction ne plante pas.
+// cf feedback_test_first_critical (module critique = nodyx-core = SANCTUAIRE).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { resolveServerLocale } from '../i18n/serverStrings'
+
+describe('resolveServerLocale — ordre de repli', () => {
+	it('locale utilisateur connue et supportée -> prioritaire', () => {
+		expect(resolveServerLocale('en', 'fr')).toBe('en')
+	})
+
+	it('pas de locale utilisateur -> retombe sur la langue de l\'instance', () => {
+		expect(resolveServerLocale(null, 'en')).toBe('en')
+		expect(resolveServerLocale(undefined, 'en')).toBe('en')
+	})
+
+	it('ni user ni instance supportés -> français par défaut (comportement historique)', () => {
+		expect(resolveServerLocale(null, null)).toBe('fr')
+		expect(resolveServerLocale('de', 'es')).toBe('fr') // aucune des deux traduite côté core
+	})
+
+	it('normalise les tags longs (fr-FR, en-US) sur leur langue primaire', () => {
+		expect(resolveServerLocale('fr-FR', null)).toBe('fr')
+		expect(resolveServerLocale('en-US,en;q=0.9', null)).toBe('en') // en-tête Accept-Language brut
+	})
+
+	it('une locale utilisateur non supportée retombe sur l\'instance, pas sur fr directement', () => {
+		expect(resolveServerLocale('de', 'en')).toBe('en')
+	})
+})
+
+// ── Emails : le texte généré correspond VRAIMENT à la locale demandée ──────────
+
+const { sendMailMock } = vi.hoisted(() => ({ sendMailMock: vi.fn().mockResolvedValue(undefined) }))
+
+vi.mock('nodemailer', () => ({
+	default: { createTransport: () => ({ sendMail: sendMailMock }) },
+}))
+
+describe('emailService — le contenu généré suit la locale demandée', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		process.env.SMTP_HOST = 'smtp.test'
+		process.env.SMTP_USER = 'test'
+		process.env.SMTP_PASS = 'test'
+		process.env.NODYX_COMMUNITY_NAME = 'TestCommunity'
+	})
+
+	it('sendVerificationEmail(locale: "en") produit un sujet et un corps en anglais', async () => {
+		const { sendVerificationEmail } = await import('../services/emailService')
+		await sendVerificationEmail({ to: 'a@b.com', username: 'Bob', verifyUrl: 'https://x/y', locale: 'en' })
+
+		expect(sendMailMock).toHaveBeenCalledTimes(1)
+		const call = sendMailMock.mock.calls[0][0]
+		expect(call.subject).toBe('Confirm your email address — TestCommunity')
+		expect(call.text).toContain('Hi Bob,')
+		expect(call.html).toContain('lang="en"')
+		expect(call.html).toContain('Activate my account')
+	})
+
+	it('sendVerificationEmail sans locale -> français (défaut historique, zéro régression)', async () => {
+		const { sendVerificationEmail } = await import('../services/emailService')
+		await sendVerificationEmail({ to: 'a@b.com', username: 'Bob', verifyUrl: 'https://x/y' })
+
+		const call = sendMailMock.mock.calls[0][0]
+		expect(call.subject).toBe('Confirmez votre adresse email — TestCommunity')
+		expect(call.html).toContain('lang="fr"')
+	})
+
+	it('sendPasswordResetEmail(locale: "en") produit un sujet et un corps en anglais', async () => {
+		const { sendPasswordResetEmail } = await import('../services/emailService')
+		await sendPasswordResetEmail({ to: 'a@b.com', username: 'Bob', resetUrl: 'https://x/y', locale: 'en' })
+
+		const call = sendMailMock.mock.calls[0][0]
+		expect(call.subject).toBe('Reset your password — TestCommunity')
+		expect(call.text).toContain('You requested a password reset')
+		expect(call.html).toContain('Reset my password')
+	})
+
+	it('sendPasswordResetEmail(locale: "fr") produit un sujet et un corps en français', async () => {
+		const { sendPasswordResetEmail } = await import('../services/emailService')
+		await sendPasswordResetEmail({ to: 'a@b.com', username: 'Bob', resetUrl: 'https://x/y', locale: 'fr' })
+
+		const call = sendMailMock.mock.calls[0][0]
+		expect(call.subject).toBe('Réinitialisation de votre mot de passe — TestCommunity')
+		expect(call.html).toContain('Réinitialiser mon mot de passe')
+	})
+})


### PR DESCRIPTION
## Pourquoi

Les emails transactionnels (vérification, reset password) et les notifications push étaient 100% en dur en français, aucune notion de langue utilisateur. Contrairement à une erreur API (rattrapable côté frontend n'importe quand), un email/push envoyé reste figé dans sa langue une fois parti : c'est le seul vrai verrou i18n côté core.

Périmètre volontairement serré (cf CDC validé) : les ~400 messages d'erreur API existants (mélange EN/FR, dette acceptée, admin/edge-case pour l'essentiel) ne sont **pas** retouchés ici — refaire un marathon de retrofit dessus serait répéter l'extraction i18n de juillet-août sur le core.

## Changements

- **Migration 110** : `users.locale` (nullable, pas de backfill — `NULL` résolu à la lecture).
- **`src/i18n/serverStrings.ts`** : dictionnaire FR/EN dédié (vérification, reset, push mention) + `resolveServerLocale()` — ordre de repli locale utilisateur → langue de l'instance → français. Mêmes 2 langues que le frontend ; les 5 autres retombent sur EN.
- **`emailService.ts`** : les 2 templates générent leur contenu depuis le dictionnaire, structure HTML inchangée.
- **`auth.ts`** : locale déduite d'`Accept-Language` à l'inscription et persistée ; réutilisée pour renvoi de vérification et demande de reset.
- **`admin.ts`** : reset-link admin et email de test SMTP résolvent aussi une locale.
- **`socket/index.ts`** : le push de mention lit la locale du **destinataire** (pas de l'auteur du message).
- **`users.ts`** : `PATCH /me/locale` pour que le frontend synchronise le choix de langue vers le core.
- **Nouvelle règle (non rétroactive)** : toute nouvelle réponse d'erreur du core porte un `code` stable en plus de `error`, pour une migration progressive future sans marathon.

## Tests

`resolveServerLocale` (5 cas de repli/normalisation) + intégration email (le sujet/corps générés correspondent vraiment à la locale demandée). Suite complète : 35 fichiers, **460 tests, tous verts**. `tsc` et build propres.