### PR TITLE
fix(core): PATCH /me/locale doit retomber sur la langue de l'instance

### DIFF
--- a/nodyx-core/src/models/user.ts
+++ b/nodyx-core/src/models/user.ts
@@ -40,7 +40,7 @@ export type PublicUser = Omit<User, 'password'>
 
 export async function findById(id: string): Promise<PublicUser | null> {
   const { rows } = await db.query<PublicUser>(
-    `SELECT id, username, email, avatar, bio, points, created_at, updated_at, linked_instances
+    `SELECT id, username, email, avatar, bio, points, created_at, updated_at, linked_instances, locale
      FROM users WHERE id = $1`,
     [id]
   )
@@ -57,7 +57,7 @@ export async function findByEmail(email: string): Promise<User | null> {
 
 export async function findByUsername(username: string): Promise<PublicUser | null> {
   const { rows } = await db.query<PublicUser>(
-    `SELECT id, username, email, avatar, bio, points, created_at, updated_at
+    `SELECT id, username, email, avatar, bio, points, created_at, updated_at, locale
      FROM users WHERE username = $1`,
     [username]
   )

--- a/nodyx-core/src/routes/users.ts
+++ b/nodyx-core/src/routes/users.ts
@@ -627,7 +627,7 @@ export default async function userRoutes(app: FastifyInstance) {
     // Seules fr/en sont réellement traduites côté core ; toute autre valeur
     // retombe silencieusement sur le résolveur habituel (langue de l'instance,
     // puis français) — même doctrine que le frontend pour les 5 autres langues.
-    const resolved = resolveServerLocale(locale, null)
+    const resolved = resolveServerLocale(locale, process.env.NODYX_COMMUNITY_LANGUAGE)
     await db.query(`UPDATE users SET locale = $1 WHERE id = $2`, [resolved, me])
 
     return reply.send({ ok: true, locale: resolved })

--- a/nodyx-core/src/tests/users.test.ts
+++ b/nodyx-core/src/tests/users.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import jwt from 'jsonwebtoken'
 import { buildApp } from './helpers/buildApp'
 
@@ -144,6 +144,71 @@ describe('PATCH /api/v1/users/me/profile', () => {
     const avatarSync = calls.find(c => (c[0] as string).includes('UPDATE users SET avatar'))
     expect(avatarSync).toBeDefined()
   })
+})
+
+// ── Tests — PATCH /me/locale ────────────────────────────────────
+//
+// Prouve le repli exact quand l'utilisateur envoie une locale non supportée
+// par le core (ex: 'de', supportée côté frontend mais pas dans le dictionnaire
+// serveur) : elle doit retomber sur la langue de l'INSTANCE, jamais directement
+// sur 'fr' en ignorant l'instance — sinon un utilisateur allemand sur une
+// instance anglophone recevrait des emails en français.
+
+describe('PATCH /api/v1/users/me/locale', () => {
+	let app: Awaited<ReturnType<typeof buildApp>>
+	const ORIGINAL_LANG = process.env.NODYX_COMMUNITY_LANGUAGE
+
+	beforeEach(async () => {
+		vi.clearAllMocks()
+		vi.mocked(redis.exists).mockImplementation((key: string) => Promise.resolve(key.startsWith('banned:') ? 0 : 1))
+		vi.mocked(db.query).mockResolvedValue({ rows: [], rowCount: 1 } as any)
+		app = await buildApp(a => a.register(userRoutes, { prefix: '/api/v1/users' }))
+	})
+
+	afterEach(() => {
+		if (ORIGINAL_LANG === undefined) delete process.env.NODYX_COMMUNITY_LANGUAGE
+		else process.env.NODYX_COMMUNITY_LANGUAGE = ORIGINAL_LANG
+	})
+
+	it('returns 401 without auth token', async () => {
+		const res = await app.inject({ method: 'PATCH', url: '/api/v1/users/me/locale', payload: { locale: 'en' } })
+		expect(res.statusCode).toBe(401)
+	})
+
+	it('returns 400 without a locale in the body', async () => {
+		const res = await app.inject({
+			method: 'PATCH', url: '/api/v1/users/me/locale',
+			headers: { Authorization: `Bearer ${makeToken()}` }, payload: {},
+		})
+		expect(res.statusCode).toBe(400)
+	})
+
+	it('locale supportée (en) -> stockée telle quelle', async () => {
+		const res = await app.inject({
+			method: 'PATCH', url: '/api/v1/users/me/locale',
+			headers: { Authorization: `Bearer ${makeToken()}` }, payload: { locale: 'en' },
+		})
+		expect(res.statusCode).toBe(200)
+		expect(JSON.parse(res.body).locale).toBe('en')
+	})
+
+	it('locale NON supportée (de) sur une instance FR -> retombe sur fr', async () => {
+		process.env.NODYX_COMMUNITY_LANGUAGE = 'fr'
+		const res = await app.inject({
+			method: 'PATCH', url: '/api/v1/users/me/locale',
+			headers: { Authorization: `Bearer ${makeToken()}` }, payload: { locale: 'de' },
+		})
+		expect(JSON.parse(res.body).locale).toBe('fr')
+	})
+
+	it('locale NON supportée (de) sur une instance EN -> retombe sur EN, pas sur fr', async () => {
+		process.env.NODYX_COMMUNITY_LANGUAGE = 'en'
+		const res = await app.inject({
+			method: 'PATCH', url: '/api/v1/users/me/locale',
+			headers: { Authorization: `Bearer ${makeToken()}` }, payload: { locale: 'de' },
+		})
+		expect(JSON.parse(res.body).locale).toBe('en')
+	})
 })
 
 // ── Tests — GET /:username/profile ────────────────────────────


### PR DESCRIPTION
## Pourquoi

Passe de vérification demandée avant de déployer #496. Trouvé un bug réel : `PATCH /me/locale` passait `null` comme langue de repli au lieu de `NODYX_COMMUNITY_LANGUAGE`, contredisant son propre commentaire.

Conséquence concrète : sur une instance anglophone, un membre qui choisit une langue non traduite côté core (ex. allemand, supportée par le frontend) se voyait stocker `'fr'` au lieu de `'en'`, et recevait des emails en français sur une instance anglaise.

## Changements

- `users.ts` : `resolveServerLocale(locale, process.env.NODYX_COMMUNITY_LANGUAGE)` au lieu de `null`.
- `user.ts` : `findById`/`findByUsername` sélectionnent maintenant `locale` (trou de typage lié — l'interface `User` le promettait, la requête SQL ne le ramenait pas). Vérifié sans risque PII : `toPublicUser`/`toSelfUser` restent des listes blanches explicites, `locale` n'y est pas ajouté.

## Tests

5 cas sur `PATCH /me/locale`, dont celui qui aurait détecté la régression (instance EN + locale non supportée → doit rendre `'en'`, pas `'fr'`). Suite complète : 465/465 verts, `tsc` clean.