### PR TITLE
docs: mettre à jour SECURITY.md et ajouter un CODE_OF_CONDUCT.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -16,7 +16,7 @@ We only provide security fixes for the latest major release.
 Instead, please report them privately:
 
 1. **Email:** Send details to **security@nodyx.org**
-2. **GitHub:** Use [GitHub's private vulnerability reporting](https://github.com/Pokled/Nodyx/security/advisories/new)
+2. **GitHub:** Use [GitHub's private vulnerability reporting](https://github.com/Pokled/nodyx/security/advisories/new)
 
 ### What to include
 
@@ -36,14 +36,17 @@ Instead, please report them privately:
 
 Nodyx takes security seriously:
 
-- **E2E Encrypted DMs** — ECDH P-256 key exchange + AES-256-GCM encryption. Private keys never leave the browser.
-- **Two-Factor Authentication** — TOTP (Google Authenticator, Aegis, Bitwarden) + Nodyx Signet (ECDSA P-256 passwordless PWA).
-- **Session management** — JWT + Redis with configurable TTL, forced logout capability.
-- **Rate limiting** — Per-endpoint rate limits on all API routes.
-- **Input validation** — Zod schemas on all API inputs.
-- **SQL injection protection** — Parameterized queries only, no string concatenation.
-- **XSS protection** — Content Security Policy headers via Caddy, sanitized HTML rendering.
-- **AGPL-3.0** — Full source code always available for inspection.
+- **Password hashing:** Argon2id with OWASP-recommended parameters, transparent migration path for any legacy bcrypt hash.
+- **E2E encrypted DMs:** ECDH P-256 key exchange with AES-256-GCM encryption. Private keys never leave the browser, the server only ever handles ciphertext.
+- **Two-factor authentication:** TOTP (Google Authenticator, Aegis, Bitwarden) and Nodyx Signet, a passwordless ECDSA P-256 PWA.
+- **Session management:** JWT and Redis with a configurable TTL, forced logout on demand.
+- **Spoofing-resistant rate limiting:** the trusted proxy chain is scoped explicitly, so a forged `X-Forwarded-For` header cannot impersonate an internal request or dodge a limit.
+- **Input validation:** Zod schemas on every API input.
+- **SQL injection protection:** parameterized queries only, no string concatenation.
+- **XSS and clickjacking protection:** Content-Security-Policy, X-Frame-Options and HSTS headers on every response, sanitized HTML rendering.
+- **Verified backups:** every nightly backup is proven by an automated restore, not just a file copy sitting untested.
+- **Owner account recovery:** a dedicated CLI mints a one-time reset link without ever touching or logging a password, for instances that lock themselves out.
+- **AGPL-3.0:** the full source is always available for inspection, by anyone, forever.
 
 ## Responsible Disclosure
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,86 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+This Code of Conduct governs the Nodyx project itself, meaning its GitHub repository, issues, pull requests, and discussions. It has no bearing on what any individual admin decides to allow or moderate on their own self-hosted Nodyx instance : that choice belongs entirely to them.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at security@nodyx.org. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
## Pourquoi

Suite à l'ajout du fichier `LICENSE` : vérifié le [community health checklist](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions) de GitHub via l'API (`GET /repos/{owner}/{repo}/community/profile`), 85% de santé, une seule pièce vraiment manquante : `CODE_OF_CONDUCT.md`.

En parallèle, `SECURITY.md` n'avait pas suivi le rythme du projet.

## Changements

**`SECURITY.md`** : liste des fonctionnalités de sécurité mise à jour pour refléter ce qui est réellement livré aujourd'hui (vérifié dans le code, pas juste réécrit) :
- Hachage **Argon2id** (absent de la liste précédente)
- Rate limiting durci contre le spoofing `X-Forwarded-For`
- Sauvegardes **vérifiées** par restauration automatique, pas une simple copie de fichier
- Récupération de compte owner par CLI dédiée
- En-têtes complets : CSP **+ X-Frame-Options + HSTS** (seule CSP était mentionnée avant)
- Lien d'advisory corrigé (`Pokled/Nodyx` → `Pokled/nodyx`)

**`CODE_OF_CONDUCT.md`** (nouveau) : Contributor Covenant 2.1, texte standard pour rester reconnu par les détecteurs (GitHub et les autres). Une clause de portée précise que ce texte gouverne les espaces du projet Nodyx (issues, PR, discussions), pas ce qu'un admin choisit d'autoriser sur sa propre instance auto-hébergée, cohérent avec la philosophie du projet (l'instance reste libre, seul l'annuaire central est modéré).

## Vérifié

Aucun tiret cadratin dans les deux fichiers. Pas de lint markdown en CI qui réagirait à ce diff.