### PR TITLE
fix(docs): la doc Homepage Builder décrivait un système remplacé depuis avril 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The community-tools landscape isn't a battle. Each project optimizes for differe
 - Passwordless login (ECDSA P-256 PWA, Nodyx Signet)
 - Collaborative jukebox (YouTube queue)
 - Event calendar (OSM maps, RSVP, SEO)
-- **Homepage Builder** with 11 layout zones, drag & drop
+- **Homepage Builder**, drag-and-drop rows and columns on a 12-unit grid
 - **Widget Store**, install external widgets via .zip
 - **Widget SDK**, build custom widgets, no framework needed
 - **OctoGuard**, native auto-mod (regex/word/link/emoji-flood, ReDoS-safe via Google `re2`), welcome bot, custom commands, mutes, signed webhook, all admin-tunable, off by default
@@ -166,7 +166,7 @@ The community-tools landscape isn't a battle. Each project optimizes for differe
 
 ## Homepage Builder + Widget SDK
 
-Nodyx ships with a **drag-and-drop Homepage Builder** (11 layout zones, 4 native widgets, per-widget audience and scheduling) and a complete **Widget SDK**, plain JavaScript Custom Elements, no React, no Vue, no npm required. Any developer can package a widget as a `.zip` and install it on any Nodyx instance in one click, no rebuild, no deploy. Two features that no other self-hosted community platform offers together.
+Nodyx ships with a **drag-and-drop Homepage Builder** (rows split into resizable columns on a 12-unit grid, 9 native widgets, per-widget audience rules, draft/publish) and a complete **Widget SDK**, plain JavaScript Custom Elements, no React, no Vue, no npm required. Any developer can package a widget as a `.zip` and install it on any Nodyx instance in one click, no rebuild, no deploy. Two features that no other self-hosted community platform offers together.
 
 → **[Homepage Builder, full guide](docs/en/HOMEPAGE-BUILDER.md)**, layout zones, native widgets, the Widget Store
 → **[Build your first widget](https://nodyx.dev/create-widget)**, step-by-step SDK guide for non-developers
@@ -263,9 +263,9 @@ Board-scoped chat (independent from the voice channel chat)
 
 <b>,  Homepage Builder , </b>
 
-<img src="docs/img/Nodyx_grid_builder_home_page_website.png" alt="Homepage Builder, drag & drop, 11 zones, live preview" width="940"/>
+<img src="docs/img/Nodyx_grid_builder_home_page_website.png" alt="Homepage Builder, drag & drop rows and columns, live preview" width="940"/>
 
-<sub>Drag-and-drop grid editor, 11 layout zones, live preview, per-widget audience rules and scheduling</sub>
+<sub>Drag-and-drop grid editor, resizable rows and columns on a 12-unit grid, live preview, per-widget audience rules</sub>
 
 </div>
 
@@ -427,7 +427,7 @@ Each Nodyx instance runs a **Gossip Protocol** scheduler that periodically pings
 | TURN relay | **nodyx-turn**, Rust 2.9 MB, replaces coturn |
 | P2P relay | **nodyx-relay**, Rust TCP tunnel, runs on home servers |
 | Collaborative canvas | **NodyxCanvas**, CRDT LWW, Socket.IO sync, 11 tools, resize handles, undo/redo |
-| Homepage | **Homepage Builder**, 11 zones, drag & drop, visibility rules |
+| Homepage | **Homepage Builder**, rows/columns grid, drag & drop, visibility rules |
 | Widgets | **Widget Store**, .zip install + **Widget SDK** (Web Components) |
 | Passwordless auth | **Nodyx Signet**, ECDSA P-256 PWA, `nodyx-authenticator/` |
 

--- a/docs/en/HOMEPAGE-BUILDER.md
+++ b/docs/en/HOMEPAGE-BUILDER.md
@@ -1,37 +1,30 @@
 # Homepage Builder
 
-> Available in Nodyx v2.1+. A drag-and-drop admin tool that turns your instance's public homepage into a real, composable website, no template lock-in, no rebuild, no deploy.
+> Available in Nodyx v2.1+, rebuilt as Grid Builder v2 in v2.3. A drag-and-drop admin tool that turns your instance's public homepage into a real, composable website, no template lock-in, no rebuild, no deploy.
 
 :::info Related documentation
-**Homepage Builder** and **Module System** are two distinct but connected systems, read both to understand the full picture.
+**Homepage Builder** and **[Module System](module-system)** are two distinct but connected systems, read both to understand the full picture.
 - The **Homepage Builder** controls *what visitors see* on your public homepage (layout, widgets, theme)
 - The **Module System** controls *what features exist* on your instance (forum, chat, voice, wiki...)
 - A `website` module exposes widgets that appear in the Homepage Builder, but only when the module is active
-
-See [Module System](module-system) for the other half of the picture.
 :::
 
 Nodyx ships with a drag-and-drop Homepage Builder and a complete Widget SDK, two features that no other self-hosted community platform offers together.
 
-## The 11 layout zones
+## Rows and columns, not fixed zones
 
-Place widgets anywhere on your homepage. Positions include:
+Earlier versions positioned widgets into a fixed set of named zones (banner, hero, sidebar...). That system is gone. The homepage is now a free stack of **rows**, each split into **columns** on a 12-unit grid, closer to Bootstrap or CSS Grid than to a template.
 
-```
-banner          → full-width top announcement strip
-hero            → main hero section
-stats-bar       → community counters (members, online, posts)
-main            → above main content
-sidebar         → right column (join card, etc.)
-half-1 / half-2 → 2-column grid
-trio-1/2/3      → 3-column grid
-footer-1/2/3    → footer columns
-footer-bar      → full-width footer strip
-```
+- **Add a row** from a preset: 1, 2, 3 or 4 equal columns, or an asymmetric split like `8+4`, `6+3+3`, `4+4+4`, `2+8+2`. The preset only sets the starting point.
+- **Resize a column** by dragging the handle between two adjacent columns. Its neighbor shrinks by the same amount, the row's spans always sum back to 12, and each column keeps a minimum width of 2 units.
+- **Add or remove a column** inside an existing row at any time, as long as at least one remains.
+- **Reorder rows** by dragging the row handle, drop it above or below any other row.
+- Each row has its own gap, vertical padding and an optional background color override.
+- Every column independently adapts down to tablet and mobile widths, and can be hidden on either.
 
-Every zone accepts any widget, native or third-party. Drag a widget from the picker, drop it in a zone, done, no page reload, no build step.
+There are no named zones left to reason about, a row is a row wherever it sits on the page. Order is everything.
 
-## 4 native widgets (Phase 1)
+## 9 native widgets (Phase 1)
 
 | Widget | Description |
 |---|---|
@@ -39,13 +32,23 @@ Every zone accepts any widget, native or third-party. Drag a widget from the pic
 | **Stats Bar** | Live member count, online count, thread count with animated counters |
 | **Join Card** | CTA card for guests, hidden for logged-in members |
 | **Announcement Banner** | Closeable info/warning/error strip with icon |
+| **Article Slideshow** | Rotating showcase of featured articles |
+| **Articles Showcase** | Configurable grid or list of recent articles |
+| **Recent Threads** | Latest forum activity, with a custom section heading |
+| **Social Links Bar** | Row of social/external links with brand icons |
+| **Twitch Stream** | Embedded live channel, on air or offline state |
+
+Drop any widget into any column, on any row, click the empty cell and pick it from the picker.
 
 ## Visibility rules
 
-Every widget instance carries its own audience and schedule, independent of the others:
+Every widget instance carries its own audience, independent of the others:
 
 - **Audience**: everyone, guests only, or members only
-- **Scheduling**: an optional start and end date, useful for a limited-time event banner that removes itself automatically
+
+## Draft and publish
+
+Edits save as a **draft** (`draft_layout`) that only admins preview, the live site keeps serving the last **published** version (`published_layout`) until you explicitly publish. Nothing a visitor sees changes mid-edit.
 
 ## Widget Store, install in one click
 
@@ -59,7 +62,7 @@ my-widget-1.0.0.zip
 
 The admin panel handles upload, validation, extraction and activation. Under the hood: an XHR progress bar during upload, a 4-step validation pass, and an extraction whitelist so a malicious archive can't write outside its own widget folder. No rebuild, no deploy.
 
-Once installed, a widget from the Store appears in the same picker as the 4 native widgets, drag it into any of the 11 zones like any other.
+Once installed, a widget from the Store appears in the same picker as the 9 native widgets, drop it into any column like any other.
 
 ## Widget SDK, build your own, zero build tools
 


### PR DESCRIPTION
## Pourquoi

Jonathan a soupçonné une coquille dans `HOMEPAGE-BUILDER.md` (créé la veille en recopiant l'ancien README) : "11 layout zones" et "4 native widgets" ne semblaient plus correspondre au produit actuel. Vérifié dans le code, il avait raison sur toute la ligne.

## Ce qui a réellement changé

Le système par zones nommées fixes (`banner`/`hero`/`sidebar`/...) a été remplacé par le **Grid Builder v2** en avril 2026 (commit `1f7b4db`, migration `072_homepage_grid.sql`, commentaire explicite *"Remplace progressivement le système de positions fixes"*). Il n'existe même plus d'UI admin pour éditer l'ancien système : `/admin/homepage` redirige en 301 vers `/admin/homepage/builder`.

Vérifié dans `nodyx-frontend/src/lib/types/homepage.ts` et `src/routes/admin/homepage/builder/+page.svelte` :

- **Des lignes empilables**, chacune divisée en **colonnes sur une grille 12 unités** (spans), plus aucune zone nommée
- **Presets** pour démarrer une ligne (1/2/3/4 colonnes égales, ou asymétrique type `8+4`, `6+3+3`), puis liberté totale : ajouter/retirer une colonne, redimensionner par glisser (span mini 2, somme toujours 12)
- **Lignes réordonnables** par glisser-déposer
- **9 widgets natifs** aujourd'hui (`plugins/index.ts`), pas 4 : Hero Banner, Stats Bar, Join Card, Announcement Banner, Article Slideshow, Articles Showcase, Recent Threads, Social Links Bar, Twitch Stream
- Flux **brouillon/publication** (`draft_layout` / `published_layout`), pas de publication immédiate

## Changements

`HOMEPAGE-BUILDER.md` réécrit pour refléter le vrai système. `README.md` corrigé aux 5 endroits qui répétaient la même erreur (liste "what's inside", résumé Homepage Builder, légende de capture d'écran ×2, tableau Architecture).

## Vérifié

Rendu réel sur un serveur dev jetable (`nodyx-docs`), sans toucher au process de prod.