### PR TITLE
fix(homepage-builder): scroller vers une ligne cliquée + aura de sélection

### DIFF
--- a/nodyx-frontend/src/lib/components/homepage/GridRenderer.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/GridRenderer.svelte
@@ -296,6 +296,14 @@
 	.gr-col--selected {
 		outline: 2px solid var(--nx-accent-2-soft) !important;
 		outline-offset: -1px;
+		animation: gr-col-aura 1.8s ease-in-out infinite;
+	}
+	@keyframes gr-col-aura {
+		0%, 100% { box-shadow: 0 0 0 0 rgb(var(--nx-accent-2-rgb) / .35), inset 0 0 20px rgb(var(--nx-accent-2-rgb) / .05); }
+		50%      { box-shadow: 0 0 24px 3px rgb(var(--nx-accent-2-rgb) / .55), inset 0 0 30px rgb(var(--nx-accent-2-rgb) / .12); }
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.gr-col--selected { animation: none; box-shadow: 0 0 16px 2px rgb(var(--nx-accent-2-rgb) / .4); }
 	}
 	.gr-col--empty {
 		min-height: 80px;

--- a/nodyx-frontend/src/routes/admin/homepage/builder/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/homepage/builder/+page.svelte
@@ -202,6 +202,25 @@
 		})
 	}
 
+	// Cliquer une ligne dans le panneau de gauche ne bougeait jamais le canvas :
+	// sur un layout un peu long, la ligne cliquée pouvait être hors écran sans
+	// aucun retour visuel (retour Jonathan, 2026-08-09). Même geste que addRow()
+	// (scroll centré + flash), plus la sélection du premier widget de la ligne
+	// pour que l'aura de .gr-col--selected pointe dessus.
+	function jumpToRow(rowId: string) {
+		const row = draft.rows.find(r => r.id === rowId)
+		if (!row) return
+		const firstWithWidget = row.columns.find(c => c.widget)
+		if (firstWithWidget) selectedCol = { rowId, colId: firstWithWidget.id }
+		tick().then(() => {
+			const el = document.querySelector(`.canvas-preview [data-row-id="${rowId}"]`)
+			if (!el) return
+			el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+			el.classList.add('gr-row--jump')
+			setTimeout(() => el.classList.remove('gr-row--jump'), 1600)
+		})
+	}
+
 	function deleteRow(rowId: string) {
 		if (!confirm(tFn('hpb.confirm_delete_row'))) return
 		draft = { ...draft, rows: draft.rows.filter(r => r.id !== rowId) }
@@ -656,11 +675,12 @@
 								class:row-item--dragover={dragOverIdx === idx && dragRowId !== row.id}
 								data-row-id={row.id}
 								role="listitem"
+								onclick={() => jumpToRow(row.id)}
 							>
 								<!-- Handle drag -->
 								<button
 									class="row-item-handle"
-									onpointerdown={(e) => onRowDragStart(e, row.id)}
+									onpointerdown={(e) => { e.stopPropagation(); onRowDragStart(e, row.id) }}
 									title={tFn('hpb.move')}
 								>⠿</button>
 
@@ -676,8 +696,8 @@
 
 								<!-- Actions -->
 								<div class="row-item-actions">
-									<button class="riba" title={tFn('hpb.settings')} onclick={() => { editRowId = row.id; activePanel = 'rowsettings' }}>⚙</button>
-									<button class="riba riba--del" title={tFn('hpb.delete')} onclick={() => deleteRow(row.id)}>✕</button>
+									<button class="riba" title={tFn('hpb.settings')} onclick={(e) => { e.stopPropagation(); editRowId = row.id; activePanel = 'rowsettings'; jumpToRow(row.id) }}>⚙</button>
+									<button class="riba riba--del" title={tFn('hpb.delete')} onclick={(e) => { e.stopPropagation(); deleteRow(row.id) }}>✕</button>
 								</div>
 							</div>
 						{/each}
@@ -1816,6 +1836,17 @@
 		0%   { box-shadow: inset 0 0 0 2px rgba(167, 139, 250, .9);  background: rgba(167, 139, 250, .10); }
 		60%  { box-shadow: inset 0 0 0 2px rgba(167, 139, 250, .45); background: rgba(167, 139, 250, .04); }
 		100% { box-shadow: inset 0 0 0 2px rgba(167, 139, 250, 0);   background: transparent; }
+	}
+
+	/* Même mécanique que gr-row--born, posée par jumpToRow() quand on clique
+	   une ligne existante dans le panneau : deux flashes au lieu d'un fondu
+	   unique, pour se distinguer visuellement de la naissance d'une ligne. */
+	:global(.canvas-preview .gr-row--jump) {
+		animation: row-jump 1.6s ease-out;
+	}
+	@keyframes row-jump {
+		0%, 40%, 100% { box-shadow: inset 0 0 0 2px rgba(167, 139, 250, 0);   background: transparent; }
+		20%, 60%      { box-shadow: inset 0 0 0 2px rgba(167, 139, 250, .85); background: rgba(167, 139, 250, .08); }
 	}
 
 	.canvas-empty {


### PR DESCRIPTION
## Pourquoi

Cliquer une ligne dans le panneau "lignes" du Homepage Builder ne faisait rien bouger dans le canvas : sur un layout un peu long, la ligne cliquée pouvait rester hors écran, sans aucun retour visuel.

## Changements

- `jumpToRow()` reprend exactement le mécanisme déjà en prod pour `addRow()` (scroll centré + flash via `data-row-id`), déclenché au clic sur une ligne **existante** dans le panneau plutôt qu'à sa création. Sélectionne aussi le premier widget de la ligne, pour que l'aura de sélection pointe dessus.
- `.gr-col--selected` (déjà posée sur la colonne active) gagne une **animation de pulsation** au lieu d'un simple contour statique, pour que le widget sélectionné se distingue vraiment. Respecte `prefers-reduced-motion`.

## Vérifié

`svelte-check` : 0 erreur (2 nouveaux warnings a11y, même catégorie que 132 déjà tolérés ailleurs dans ce projet, non bloquants). Le mécanisme de scroll est une reprise directe du code `addRow()` déjà prouvé en prod, pas de nouvelle logique inventée.