### PR TITLE
fix(homepage-builder): 8 widgets sur 9 ignoraient le thème du Grid Builder

### DIFF
--- a/nodyx-frontend/src/lib/components/homepage/GridRenderer.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/GridRenderer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { hexToRgbTriplet } from '$lib/types/homepage'
 	import type { GridLayout, GridTheme, GridRow, GridColumn } from '$lib/types/homepage'
 	import { DEFAULT_THEME, autoSpanMd, autoSpanSm } from '$lib/types/homepage'
 	import { PLUGIN_REGISTRY } from './plugins'
@@ -50,6 +51,10 @@
 	const cssVars = $derived([
 		`--np: ${t.primary}`,
 		`--na: ${t.accent}`,
+		// Triplets RGB pour les widgets natifs qui composent des rgb(var(--x) / alpha)
+		// (glows, dégradés translucides) — même technique que --nx-*-rgb dans app.css.
+		`--np-rgb: ${hexToRgbTriplet(t.primary)}`,
+		`--na-rgb: ${hexToRgbTriplet(t.accent)}`,
 		`--nb: ${t.bg}`,
 		`--nc: ${t.card_bg}`,
 		`--nborder: ${t.border_color}`,

--- a/nodyx-frontend/src/lib/components/homepage/widgets/ArticleSlideshow.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/ArticleSlideshow.svelte
@@ -346,7 +346,7 @@
 		position: absolute;
 		bottom: 0; left: 0;
 		width: 320px; height: 200px;
-		background: radial-gradient(ellipse at bottom left, rgb(var(--nx-accent-2-rgb) / .18), transparent 70%);
+		background: radial-gradient(ellipse at bottom left, rgb(var(--np-rgb) / .18), transparent 70%);
 		pointer-events: none;
 	}
 
@@ -364,7 +364,7 @@
 	.as-spinner {
 		width: 24px; height: 24px;
 		border: 2px solid rgba(167,139,250,.2);
-		border-top-color: var(--nx-accent-2-soft);
+		border-top-color: var(--np);
 		border-radius: 50%;
 		animation: spin .7s linear infinite;
 	}
@@ -382,16 +382,16 @@
 	.as-play svg {
 		width: 64px; height: 64px;
 		color: rgba(255,255,255,.85);
-		background: rgb(var(--nx-accent-2-rgb) / .35);
+		background: rgb(var(--np-rgb) / .35);
 		border-radius: 50%;
 		padding: 14px;
-		border: 2px solid rgb(var(--nx-accent-2-rgb) / .5);
+		border: 2px solid rgb(var(--np-rgb) / .5);
 		transition: transform .15s, background .15s;
-		filter: drop-shadow(0 4px 24px rgb(var(--nx-accent-2-rgb) / .4));
+		filter: drop-shadow(0 4px 24px rgb(var(--np-rgb) / .4));
 	}
 	.as-play:hover svg {
 		transform: scale(1.08);
-		background: rgb(var(--nx-accent-2-rgb) / .55);
+		background: rgb(var(--np-rgb) / .55);
 	}
 
 	/* ── Content ────────────────────────────────────────────────────────────── */
@@ -415,7 +415,7 @@
 	.as-cat-line {
 		height: 1px;
 		width: 2.5rem;
-		background: linear-gradient(to right, var(--nx-accent-2-strong), var(--nx-cyan));
+		background: linear-gradient(to right, var(--np), var(--na));
 		flex-shrink: 0;
 	}
 	.as-cat-text {
@@ -423,14 +423,14 @@
 		font-weight: 800;
 		text-transform: uppercase;
 		letter-spacing: .22em;
-		color: var(--nx-accent-2-soft);
+		color: var(--np);
 	}
 	.as-cat-badge {
 		font-size: 10px;
 		font-weight: 700;
-		color: var(--nx-cyan);
-		background: rgb(var(--nx-cyan-rgb) / .12);
-		border: 1px solid rgb(var(--nx-cyan-rgb) / .25);
+		color: var(--na);
+		background: rgb(var(--na-rgb) / .12);
+		border: 1px solid rgb(var(--na-rgb) / .25);
 		padding: 1px 7px;
 		border-radius: 3px;
 	}
@@ -455,7 +455,7 @@
 		text-decoration: none;
 		transition: color .15s;
 	}
-	.as-title a:hover { color: var(--nx-accent-2-soft2); }
+	.as-title a:hover { color: var(--np); }
 
 	/* ── Excerpt ────────────────────────────────────────────────────────────── */
 	.as-excerpt {
@@ -485,8 +485,8 @@
 	.as-avatar {
 		width: 28px; height: 28px;
 		overflow: hidden;
-		background: rgb(var(--nx-accent-2-rgb) / .3);
-		outline: 1.5px solid rgb(var(--nx-accent-2-rgb) / .4);
+		background: rgb(var(--np-rgb) / .3);
+		outline: 1.5px solid rgb(var(--np-rgb) / .4);
 		outline-offset: 1px;
 		border-radius: 2px;
 		display: flex;
@@ -512,14 +512,14 @@
 		letter-spacing: .1em;
 		color: #fff;
 		text-decoration: none;
-		background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .55), rgb(var(--nx-cyan-rgb) / .25));
-		border: 1px solid rgb(var(--nx-accent-2-rgb) / .45);
+		background: linear-gradient(135deg, rgb(var(--np-rgb) / .55), rgb(var(--na-rgb) / .25));
+		border: 1px solid rgb(var(--np-rgb) / .45);
 		transition: background .15s, border-color .15s;
 		white-space: nowrap;
 	}
 	.as-cta:hover {
-		background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .75), rgb(var(--nx-cyan-rgb) / .4));
-		border-color: rgb(var(--nx-accent-2-rgb) / .7);
+		background: linear-gradient(135deg, rgb(var(--np-rgb) / .75), rgb(var(--na-rgb) / .4));
+		border-color: rgb(var(--np-rgb) / .7);
 	}
 	.as-cta svg { width: 14px; height: 14px; transition: transform .15s; }
 	.as-cta:hover svg { transform: translateX(3px); }
@@ -556,7 +556,7 @@
 		top: -1px;
 		left: 0;
 		height: 4px;
-		background: linear-gradient(to right, var(--nx-accent-2-strong), var(--nx-cyan));
+		background: linear-gradient(to right, var(--np), var(--na));
 		transition: none;
 	}
 	.as-arrows {
@@ -577,8 +577,8 @@
 		border-radius: 2px;
 	}
 	.as-arrow:hover {
-		border-color: rgb(var(--nx-accent-2-rgb) / .5);
-		color: var(--nx-accent-2-soft);
+		border-color: rgb(var(--np-rgb) / .5);
+		color: var(--np);
 	}
 	.as-arrow svg { width: 14px; height: 14px; }
 

--- a/nodyx-frontend/src/lib/components/homepage/widgets/ArticlesShowcase.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/ArticlesShowcase.svelte
@@ -392,7 +392,7 @@
 	/* ─── Common cover placeholder + badges ────────────────────────────────── */
 	.as-cover-placeholder {
 		width: 100%; height: 100%;
-		background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .15), rgba(14,116,144,.12));
+		background: linear-gradient(135deg, rgb(var(--np-rgb) / .15), rgba(14,116,144,.12));
 		position: relative;
 	}
 	.as-cover-placeholder::after {

--- a/nodyx-frontend/src/lib/components/homepage/widgets/HeroBanner.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/HeroBanner.svelte
@@ -294,19 +294,19 @@
 	.hb-orb--tl {
 		top: -160px; left: -80px;
 		width: 500px; height: 500px;
-		background: radial-gradient(circle, rgb(var(--nx-accent-2-rgb) / .16) 0%, transparent 65%);
+		background: radial-gradient(circle, rgb(var(--np-rgb) / .16) 0%, transparent 65%);
 	}
 	.hb-orb--br {
 		bottom: -80px; right: 0;
 		width: 380px; height: 380px;
-		background: radial-gradient(circle, rgb(var(--nx-cyan-rgb) / .09) 0%, transparent 65%);
+		background: radial-gradient(circle, rgb(var(--na-rgb) / .09) 0%, transparent 65%);
 	}
 	.hb-deco-letter {
 		position: absolute; right: 6%; top: 50%; transform: translateY(-50%);
 		font-family: 'Space Grotesk', sans-serif; font-weight: 800;
 		font-size: clamp(120px, 18vw, 260px);
 		line-height: 1;
-		background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .45) 0%, rgb(var(--nx-cyan-rgb) / .18) 50%, transparent 80%);
+		background: linear-gradient(135deg, rgb(var(--np-rgb) / .45) 0%, rgb(var(--na-rgb) / .18) 50%, transparent 80%);
 		-webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
 		user-select: none; pointer-events: none; opacity: .7;
 	}
@@ -344,12 +344,12 @@
 	.hb-event-eyebrow {
 		display: flex; align-items: center; gap: .6rem;
 		font-size: 10px; font-weight: 800; text-transform: uppercase;
-		letter-spacing: .22em; color: var(--nx-accent-2-soft);
+		letter-spacing: .22em; color: var(--np);
 		font-family: 'Space Grotesk', sans-serif;
 	}
 	.hb-eyebrow-line {
 		height: 1px; width: 40px;
-		background: linear-gradient(to right, var(--nx-accent-2-strong), var(--nx-cyan));
+		background: linear-gradient(to right, var(--np), var(--na));
 	}
 
 	.hb-identity {
@@ -359,7 +359,7 @@
 	.hb-logo {
 		width: 48px; height: 48px;
 		object-fit: cover; flex-shrink: 0;
-		outline: 2px solid rgb(var(--nx-accent-2-rgb) / .45);
+		outline: 2px solid rgb(var(--np-rgb) / .45);
 		outline-offset: 2px;
 	}
 	.hb-logo-fallback {
@@ -367,15 +367,15 @@
 		display: flex; align-items: center; justify-content: center;
 		font-family: 'Space Grotesk', sans-serif; font-weight: 900;
 		font-size: 1.3rem; color: #fff;
-		background: linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .4), rgb(var(--nx-cyan-rgb) / .15));
-		border: 1px solid rgb(var(--nx-accent-2-rgb) / .3);
+		background: linear-gradient(135deg, rgb(var(--np-rgb) / .4), rgb(var(--na-rgb) / .15));
+		border: 1px solid rgb(var(--np-rgb) / .3);
 	}
 
 	.hb-title {
 		font-family: 'Space Grotesk', sans-serif; font-weight: 800;
 		font-size: clamp(1.25rem, 2.4vw, 1.85rem);
 		line-height: 1.05; margin: 0 0 .2rem;
-		background: linear-gradient(135deg, var(--nx-accent-2-soft) 0%, var(--nx-cyan) 100%);
+		background: linear-gradient(135deg, var(--np) 0%, var(--na) 100%);
 		-webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
 	}
 	.hb-title--event {
@@ -400,14 +400,14 @@
 	}
 	.hb-btn:active { transform: scale(.97); }
 	.hb-btn--primary {
-		background: linear-gradient(135deg, var(--nx-accent-2-strong), var(--nx-cyan-deep));
-		border: 1px solid rgb(var(--nx-accent-2-rgb) / .45); color: #fff;
+		background: linear-gradient(135deg, var(--np), var(--na));
+		border: 1px solid rgb(var(--np-rgb) / .45); color: #fff;
 	}
 	.hb-btn--primary:hover { filter: brightness(1.12); }
 	.hb-btn--ghost {
 		border: 1px solid rgba(255,255,255,.12); color: #9ca3af;
 	}
-	.hb-btn--ghost:hover { border-color: rgba(167,139,250,.4); color: var(--nx-accent-2-soft2); }
+	.hb-btn--ghost:hover { border-color: rgba(167,139,250,.4); color: var(--np); }
 
 	/* ── Stats dock ────────────────────────────────────────────────────────── */
 	.hb-stats-dock {
@@ -428,9 +428,9 @@
 		display: flex; align-items: center; gap: 5px;
 		font-variant-numeric: tabular-nums;
 	}
-	.hb-stat--purple { color: var(--nx-accent-2-soft); animation: numglow 4s ease-in-out infinite; }
+	.hb-stat--purple { color: var(--np); animation: numglow 4s ease-in-out infinite; }
 	.hb-stat--green  { color: #4ade80; }
-	.hb-stat--cyan   { color: var(--nx-cyan-soft); }
+	.hb-stat--cyan   { color: var(--na); }
 	.hb-stat-label {
 		font-size: .65rem; font-weight: 700;
 		text-transform: uppercase; letter-spacing: .16em;
@@ -484,12 +484,12 @@
 	}
 	.hb-live-empty svg { width: 13px; height: 13px; }
 	.hb-live-cta {
-		font-size: 11px; font-weight: 600; color: var(--nx-accent-2-soft);
+		font-size: 11px; font-weight: 600; color: var(--np);
 		text-decoration: none;
 		display: flex; align-items: center; gap: 4px;
 		transition: color .15s;
 	}
-	.hb-live-cta:hover { color: var(--nx-accent-2-soft2); }
+	.hb-live-cta:hover { color: var(--np); }
 	.hb-live-cta svg { width: 11px; height: 11px; }
 
 	/* ── Avatars ───────────────────────────────────────────────────────────── */
@@ -519,7 +519,7 @@
 		overflow: hidden;
 	}
 	.hb-avatar-letter {
-		font-size: 11px; font-weight: 800; color: var(--nx-accent-2-soft);
+		font-size: 11px; font-weight: 800; color: var(--np);
 		display: flex !important; align-items: center; justify-content: center;
 	}
 	.hb-avatar:hover {

--- a/nodyx-frontend/src/lib/components/homepage/widgets/JoinCard.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/JoinCard.svelte
@@ -61,7 +61,7 @@
 			<div class="flex -space-x-2">
 				{#each recentAvatars.slice(0, 5) as u}
 					<div class="w-7 h-7 rounded-full overflow-hidden shrink-0"
-					     style="background:rgb(var(--nx-accent-2-rgb) / .3); border:2px solid #0d0d12; outline:1px solid rgb(var(--nx-accent-2-rgb) / .25)">
+					     style="background:rgb(var(--np-rgb) / .3); border:2px solid #0d0d12; outline:1px solid rgb(var(--np-rgb) / .25)">
 						{#if u.avatar_url}
 							<img src={u.avatar_url} alt={u.username} class="w-full h-full object-cover" />
 						{:else}
@@ -75,7 +75,7 @@
 		{/if}
 
 		<div class="text-xs leading-tight" style="color:#6b7280">
-			<span style="color:var(--nx-accent-2-soft); font-weight:700">{memberCount.toLocaleString()}</span>
+			<span style="color:var(--np); font-weight:700">{memberCount.toLocaleString()}</span>
 			{tFn('common.members')}
 			{#if showOnlineCount}
 				<span class="mx-1" style="color:#374151">·</span>
@@ -88,7 +88,7 @@
 	<!-- CTA -->
 	<a href="/auth/register"
 	   class="w-full flex items-center justify-center gap-2 py-2.5 text-sm font-bold uppercase tracking-wider text-white transition-all"
-	   style="font-family:'Space Grotesk',sans-serif; background:linear-gradient(135deg,var(--nx-accent-2-strong),var(--nx-cyan-deep)); border:1px solid rgb(var(--nx-accent-2-rgb) / .4)">
+	   style="font-family:'Space Grotesk',sans-serif; background:linear-gradient(135deg,var(--np),var(--na)); border:1px solid rgb(var(--np-rgb) / .4)">
 		{ctaText || tFn('common.join')}
 		<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
 			<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>

--- a/nodyx-frontend/src/lib/components/homepage/widgets/SocialLinksBar.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/SocialLinksBar.svelte
@@ -276,7 +276,7 @@
 		transition: color .15s, background .15s, transform .15s;
 	}
 	.sl-link:hover {
-		color: var(--ic, var(--nx-accent-2-soft));
+		color: var(--ic, var(--np));
 		background: rgba(255,255,255,.06);
 		transform: translateY(-2px);
 	}

--- a/nodyx-frontend/src/lib/components/homepage/widgets/StatsBar.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/StatsBar.svelte
@@ -126,8 +126,8 @@
 
 <style>
 	@keyframes sglow {
-		0%,100% { text-shadow: 0 0 0 rgb(var(--nx-accent-2-rgb) / 0); }
-		50%      { text-shadow: 0 0 20px rgb(var(--nx-accent-2-rgb) / .5); }
+		0%,100% { text-shadow: 0 0 0 rgb(var(--np-rgb) / 0); }
+		50%      { text-shadow: 0 0 20px rgb(var(--np-rgb) / .5); }
 	}
 	.sglow { animation: sglow 4s ease-in-out infinite; }
 

--- a/nodyx-frontend/src/lib/components/homepage/widgets/TwitchStream.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/TwitchStream.svelte
@@ -235,7 +235,7 @@
 		<!-- Bannière fallback : main offline, on montre un autre stream -->
 		{#if isFallbackLive && widgetData?.main === null && configuredChannel !== activeChannel}
 			<div class="relative flex items-center gap-2 px-4 py-1.5 text-[10px]"
-			     style="background:rgba(145,70,255,.08); border-bottom:1px solid rgba(145,70,255,.2); color:var(--nx-accent-2-soft2)">
+			     style="background:rgba(145,70,255,.08); border-bottom:1px solid rgba(145,70,255,.2); color:var(--np)">
 				<svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
 					<path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"/>
 				</svg>
@@ -257,7 +257,7 @@
 				{#if !iframeLoaded}
 					<!-- Skeleton loader pulse -->
 					<div class="absolute inset-0 flex items-center justify-center"
-					     style="background:linear-gradient(135deg, rgb(var(--nx-accent-2-rgb) / .08), rgba(14,116,144,.08))">
+					     style="background:linear-gradient(135deg, rgb(var(--np-rgb) / .08), rgba(14,116,144,.08))">
 						<div class="flex flex-col items-center gap-3">
 							<div class="w-8 h-8 rounded-full border-2 animate-spin"
 							     style="border-color:rgba(145,70,255,.2); border-top-color:{accent}"></div>
@@ -322,7 +322,7 @@
 			transparent 0deg,
 			var(--accent) 80deg,
 			transparent 160deg,
-			var(--nx-cyan-deep) 240deg,
+			var(--na) 240deg,
 			transparent 320deg,
 			transparent 360deg
 		);

--- a/nodyx-frontend/src/lib/types/homepage.ts
+++ b/nodyx-frontend/src/lib/types/homepage.ts
@@ -90,6 +90,25 @@ export function genId(): string {
 	return Math.random().toString(36).slice(2, 9)
 }
 
+/**
+ * Triplet RGB "R G B" (espaces, sans virgules) à partir d'un hex #rgb/#rrggbb,
+ * pour composer des rgb(var(--x) / alpha) comme le fait déjà --nx-*-rgb dans
+ * app.css. Les widgets natifs (Hero Banner, Stats Bar...) étaient câblés sur
+ * ce palette --nx-* statique et ignoraient le thème du Homepage Builder ;
+ * cette fonction leur donne l'équivalent GridTheme pour la transparence.
+ * Repli sur le violet par défaut du thème (167 139 250) si le hex est invalide.
+ */
+export function hexToRgbTriplet(hex: string): string {
+	const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(hex?.trim() ?? '')
+	if (!m) return '167 139 250'
+	let h = m[1]
+	if (h.length === 3) h = h.split('').map(c => c + c).join('')
+	const r = parseInt(h.slice(0, 2), 16)
+	const g = parseInt(h.slice(2, 4), 16)
+	const b = parseInt(h.slice(4, 6), 16)
+	return `${r} ${g} ${b}`
+}
+
 /** Retourne le span_md automatique selon le span desktop */
 export function autoSpanMd(span: number): number {
 	if (span >= 8) return 12


### PR DESCRIPTION
## Pourquoi

Jonathan : *"le thème ne fonctionne que partiellement, je pense qu'il y a un conflit entre le thème du gridbuilder et le thème du profil"*. Confirmé, en plus précis : ce n'est pas deux systèmes qui s'écrasent, c'est que **8 widgets natifs sur 9** étaient câblés sur `--nx-*`, la palette de marque **statique** de `app.css` (jamais affectée ni par le thème d'instance/profil `--p-*`, ni par le `GridTheme` `--n*` du Homepage Builder), au lieu de suivre le thème du builder. Seul `RecentThreads.svelte` utilisait déjà les bonnes variables.

Vérifié fichier par fichier avant de toucher au code : Hero Banner (17 refs), Article Slideshow (21), Join Card (3), Stats Bar (2), Twitch Stream (3), Articles Showcase (1), Social Links Bar (1) — tous branchés sur `--nx-*`.

Architecturalement ça n'avait pas de sens : la homepage publique est visible par des visiteurs **sans compte** (donc sans thème de profil), le thème qui doit s'appliquer est celui que l'admin configure dans le builder, pas la palette de marque par défaut de l'app.

## Changements

- `homepage.ts` : `hexToRgbTriplet()`, convertit un hex `GridTheme` en triplet RGB espacé, pour composer des `rgb(var(--x) / alpha)` comme le fait déjà `--nx-*-rgb` dans `app.css`.
- `GridRenderer.svelte` : `cssVars` expose `--np-rgb` / `--na-rgb` en plus de `--np`/`--na`.
- **7 widgets** : substitution mécanique 1:1, `--nx-accent-2-*` (soft/soft2/strong/rgb) → `--np(-rgb)`, `--nx-cyan-*` (soft/deep/rgb/plain) → `--na(-rgb)`. Chaque remplacement garde le même rôle (couleur pleine vs triplet pour la transparence), perd seulement la nuance de teinte (GridTheme n'a qu'une couleur par rôle, pas de variantes soft/strong distinctes), compromis assumé. Les couleurs de marque Twitch (violet Twitch en dur, jamais un `--nx-*`) restent intactes.

## Vérifié

`svelte-check` : 0 erreur, 0 nouveau warning. Résolution garantie par construction : `.gr-root` pose `--np`/`--na`/`--np-rgb`/`--na-rgb` en style inline, et chaque widget est un descendant DOM (`.gr-root` → `.gr-row` → `.gr-col` → `<plugin.component>`) — l'héritage CSS des custom properties traverse les frontières de composants Svelte normalement, ce n'est pas une résolution incertaine.