### PR TITLE
feat(homepage-builder): le thème du builder pilote vraiment les widgets

### DIFF
--- a/nodyx-frontend/src/lib/components/homepage/GridRenderer.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/GridRenderer.svelte
@@ -55,9 +55,12 @@
 		// (glows, dégradés translucides) — même technique que --nx-*-rgb dans app.css.
 		`--np-rgb: ${hexToRgbTriplet(t.primary)}`,
 		`--na-rgb: ${hexToRgbTriplet(t.accent)}`,
+		`--nl: ${t.link_color}`,
+		`--nl-rgb: ${hexToRgbTriplet(t.link_color)}`,
 		`--nb: ${t.bg}`,
 		`--nc: ${t.card_bg}`,
 		`--nborder: ${t.border_color}`,
+		`--nbw: ${t.border_width}`,
 		`--nr: ${t.border_radius}`,
 		`--nfont: ${t.font_family}, Inter, sans-serif`,
 		`--nfs: ${t.font_size_base}`,

--- a/nodyx-frontend/src/lib/components/homepage/widgets/AnnouncementBanner.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/AnnouncementBanner.svelte
@@ -12,7 +12,14 @@
 	let { config }: Props = $props();
 
 	const text        = $derived((config.text as string) ?? '');
-	const color       = $derived((config.color as string) ?? '#7c3aed');
+	// Couleur d'accent de la bannière : si l'admin en fixe une (config.color),
+	// on garde l'astuce hex+alpha (#rrggbb + "22"/"55"). Sinon on suit le thème
+	// du Homepage Builder EN DIRECT via --nl (couleur de lien), pas un hex figé.
+	const customColor = $derived(config.color as string | undefined);
+	const bannerBg     = $derived(customColor ? `${customColor}22` : 'rgb(var(--nl-rgb) / .13)');
+	const bannerBorder = $derived(customColor ? `${customColor}55` : 'rgb(var(--nl-rgb) / .33)');
+	const bannerDot    = $derived(customColor ?? 'var(--nl)');
+	const bannerLink   = $derived(customColor ?? 'var(--nl)');
 	const linkUrl     = $derived((config.link_url as string) ?? null);
 	const linkText    = $derived((config.link_text as string) ?? null);
 	const dismissable = $derived((config.dismissable as boolean) ?? false);
@@ -22,16 +29,16 @@
 
 {#if text && !dismissed}
 	<div class="relative flex items-center justify-center gap-3 px-6 py-2.5 text-sm font-medium text-white"
-	     style="background:{color}22; border-bottom:1px solid {color}55">
+	     style="background:{bannerBg}; border-bottom:1px solid {bannerBorder}">
 
-		<span class="w-1.5 h-1.5 rounded-full shrink-0" style="background:{color}"></span>
+		<span class="w-1.5 h-1.5 rounded-full shrink-0" style="background:{bannerDot}"></span>
 
-		<span style="color:#e2e8f0">{text}</span>
+		<span style="color:var(--nt)">{text}</span>
 
 		{#if linkUrl && linkText}
 			<a href={linkUrl}
 			   class="font-bold underline underline-offset-2 transition-opacity hover:opacity-80 shrink-0"
-			   style="color:{color}">
+			   style="color:{bannerLink}">
 				{linkText}
 			</a>
 		{/if}
@@ -40,7 +47,7 @@
 			<button
 				onclick={() => dismissed = true}
 				class="absolute right-3 top-1/2 -translate-y-1/2 p-1 transition-opacity hover:opacity-80"
-				style="color:#6b7280"
+				style="color:var(--ntm)"
 				aria-label={tFn('common.close')}
 			>
 				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">

--- a/nodyx-frontend/src/lib/components/homepage/widgets/ArticleSlideshow.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/ArticleSlideshow.svelte
@@ -308,10 +308,12 @@
 <style>
 	/* ── Root ──────────────────────────────────────────────────────────────── */
 	.as-root {
+		/* Couche de base (rarement visible, .as-bg-fallback la recouvre) :
+		   suit le fond de site --nb, pas --nc (réservé aux surfaces "carte"). */
 		position: relative;
 		width: 100%;
 		overflow: hidden;
-		background: #06060d;
+		background: var(--nb, #06060d);
 	}
 
 	/* ── Background ─────────────────────────────────────────────────────────── */
@@ -324,9 +326,11 @@
 		opacity: .48;
 	}
 	.as-bg-fallback {
+		/* Dégradé de secours (pas d'image) : suit primary/accent du thème plutôt
+		   qu'un violet fixe, pour rester cohérent avec un préthème différent. */
 		position: absolute;
 		inset: 0;
-		background: linear-gradient(135deg, #12012c 0%, #020c1b 100%);
+		background: linear-gradient(135deg, rgb(var(--np-rgb) / .35) 0%, var(--nb, #020c1b) 100%);
 	}
 
 	/* ── Overlays ───────────────────────────────────────────────────────────── */
@@ -358,12 +362,12 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		color: #374151;
+		color: var(--ntm, #374151);
 		font-size: 13px;
 	}
 	.as-spinner {
 		width: 24px; height: 24px;
-		border: 2px solid rgba(167,139,250,.2);
+		border: 2px solid rgb(var(--np-rgb) / .2);
 		border-top-color: var(--np);
 		border-radius: 50%;
 		animation: spin .7s linear infinite;
@@ -438,8 +442,8 @@
 	/* ── Title ──────────────────────────────────────────────────────────────── */
 	.as-title {
 		font-size: clamp(1.25rem, 2.2vw, 1.85rem);
-		font-weight: 800;
-		color: #fff;
+		font-weight: var(--nfwh, 800);
+		color: var(--nt, #fff);
 		line-height: 1.25;
 		-webkit-line-clamp: 3;
 		line-clamp: 3;
@@ -455,12 +459,12 @@
 		text-decoration: none;
 		transition: color .15s;
 	}
-	.as-title a:hover { color: var(--np); }
+	.as-title a:hover { color: var(--nl, var(--np)); }
 
 	/* ── Excerpt ────────────────────────────────────────────────────────────── */
 	.as-excerpt {
 		font-size: 13px;
-		color: #6b7280;
+		color: var(--ntm, #6b7280);
 		line-height: 1.6;
 		-webkit-line-clamp: 2;
 		line-clamp: 2;
@@ -496,10 +500,12 @@
 	}
 	.as-avatar img { width: 100%; height: 100%; object-fit: cover; }
 	.as-avatar span { font-size: 11px; font-weight: 700; color: #fff; }
-	.as-author-name { font-size: 13px; color: #9ca3af; }
-	.as-dot { color: #374151; }
-	.as-date { font-size: 13px; color: #6b7280; }
+	.as-author-name { font-size: 13px; color: var(--ntm, #9ca3af); }
+	.as-dot { color: var(--ntm, #374151); }
+	.as-date { font-size: 13px; color: var(--ntm, #6b7280); }
 
+	/* CTA sur fond dégradé primary/accent : texte blanc fixe pour le contraste,
+	   pas --nl (qui pourrait se fondre dans le dégradé selon le préthème). */
 	.as-cta {
 		margin-left: auto;
 		display: flex;
@@ -539,7 +545,7 @@
 	.as-dot-btn {
 		position: relative;
 		height: 2px;
-		background: rgba(255,255,255,.15);
+		background: var(--nborder, rgba(255,255,255,.15));
 		border: none;
 		padding: 0;
 		cursor: pointer;
@@ -569,9 +575,9 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		border: 1px solid rgba(255,255,255,.08);
+		border: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.08));
 		background: transparent;
-		color: #6b7280;
+		color: var(--ntm, #6b7280);
 		cursor: pointer;
 		transition: border-color .15s, color .15s;
 		border-radius: 2px;

--- a/nodyx-frontend/src/lib/components/homepage/widgets/ArticlesShowcase.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/ArticlesShowcase.svelte
@@ -48,7 +48,11 @@
 	const showCategory  = $derived((config.show_category as boolean) ?? true)
 	const showViews     = $derived((config.show_views    as boolean) ?? false)
 	const ctaText       = $derived((config.cta_text      as string)  ?? tFn('widgets.read_more'))
-	const accent        = $derived((config.accent_color  as string)  ?? '#a78bfa')
+	// Si l'admin fixe une couleur (config.accent_color), elle prime. Sinon on
+	// suit la couleur de lien du thème du Homepage Builder EN DIRECT (var(--nl)
+	// est une référence CSS valide, elle se recompose très bien dans --accent
+	// ci-dessous puisque les custom properties peuvent en référencer d'autres).
+	const accent        = $derived((config.accent_color  as string)  ?? 'var(--nl)')
 	const aspectRatio   = $derived((config.aspect_ratio  as string)  ?? '16:9')
 	const sliderAuto    = $derived((config.slider_autoplay as boolean) ?? true)
 	const sliderDelay   = $derived(Math.max(3, Number(config.slider_delay_sec ?? 6)))
@@ -166,7 +170,9 @@
 						{#if magazineHero.cover_url}
 							<img src={magazineHero.cover_url} alt="" loading="lazy" />
 						{:else}
-							<div class="as-cover-placeholder" style="--cat:{accent}"></div>
+							<!-- --cat: variable morte retirée (jamais lue, le CSS lit var(--accent)
+							     hérité du .as-root ancêtre — même valeur, pas besoin de la reposer ici) -->
+							<div class="as-cover-placeholder"></div>
 						{/if}
 						<div class="as-hero-gradient"></div>
 						{#if showCategory}
@@ -349,8 +355,8 @@
 <style>
 	.as-root {
 		width: 100%;
-		font-family: Inter, system-ui, sans-serif;
-		color: #e2e8f0;
+		font-family: var(--nfont, Inter, system-ui, sans-serif);
+		color: var(--nt, #e2e8f0);
 	}
 
 	/* ─── Header ────────────────────────────────────────────────────────────── */
@@ -361,13 +367,13 @@
 		background: var(--accent);
 	}
 	.as-header h2 {
-		font-family: 'Space Grotesk', sans-serif;
-		font-size: 1.25rem; font-weight: 800;
+		font-family: var(--nfont, 'Space Grotesk', sans-serif);
+		font-size: 1.25rem; font-weight: var(--nfwh, 800);
 		letter-spacing: -.01em;
-		color: #fff;
+		color: var(--nt, #fff);
 		margin: 0;
 	}
-	.as-subheading { font-size: 13px; color: #6b7280; margin: .4rem 0 0 calc(4px + .75rem); }
+	.as-subheading { font-size: 13px; color: var(--ntm, #6b7280); margin: .4rem 0 0 calc(4px + .75rem); }
 
 	/* ─── Loading ───────────────────────────────────────────────────────────── */
 	.as-loading { display: flex; flex-direction: column; gap: .75rem; }
@@ -384,15 +390,15 @@
 
 	.as-empty {
 		padding: 2rem; text-align: center;
-		font-size: 13px; color: #4b5563;
-		background: rgba(255,255,255,.02);
-		border: 1px solid rgba(255,255,255,.06);
+		font-size: 13px; color: var(--ntm, #4b5563);
+		background: var(--nc, rgba(255,255,255,.02));
+		border: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.06));
 	}
 
 	/* ─── Common cover placeholder + badges ────────────────────────────────── */
 	.as-cover-placeholder {
 		width: 100%; height: 100%;
-		background: linear-gradient(135deg, rgb(var(--np-rgb) / .15), rgba(14,116,144,.12));
+		background: linear-gradient(135deg, rgb(var(--np-rgb) / .15), rgb(var(--na-rgb) / .12));
 		position: relative;
 	}
 	.as-cover-placeholder::after {
@@ -408,7 +414,7 @@
 		font-size: 10px; font-weight: 800;
 		text-transform: uppercase;
 		letter-spacing: .15em;
-		font-family: 'Space Grotesk', sans-serif;
+		font-family: var(--nfont, 'Space Grotesk', sans-serif);
 		color: #fff;
 		background: rgba(0,0,0,.6);
 		backdrop-filter: blur(8px);
@@ -419,23 +425,23 @@
 		display: inline-block;
 		font-size: 10px; font-weight: 800; letter-spacing: .15em;
 		text-transform: uppercase;
-		font-family: 'Space Grotesk', sans-serif;
+		font-family: var(--nfont, 'Space Grotesk', sans-serif);
 		color: var(--accent);
 		margin-bottom: .35rem;
 	}
 
 	.as-meta {
 		display: flex; align-items: center; gap: .4rem; flex-wrap: wrap;
-		font-size: 12px; color: #6b7280; margin-top: .5rem;
+		font-size: 12px; color: var(--ntm, #6b7280); margin-top: .5rem;
 	}
 	.as-meta--sm { font-size: 11px; margin-top: .35rem; }
-	.as-meta strong { color: #cbd5e1; font-weight: 600; }
-	.as-meta-dot { color: #374151; }
+	.as-meta strong { color: var(--nt, #cbd5e1); font-weight: 600; }
+	.as-meta-dot { color: var(--ntm, #374151); }
 
 	.as-cta {
 		display: inline-flex; align-items: center; gap: .4rem;
 		font-size: 12px; font-weight: 700;
-		font-family: 'Space Grotesk', sans-serif;
+		font-family: var(--nfont, 'Space Grotesk', sans-serif);
 		text-transform: uppercase; letter-spacing: .12em;
 		color: var(--accent);
 		margin-top: .75rem;
@@ -455,18 +461,18 @@
 
 	.as-hero {
 		display: flex; flex-direction: column;
-		background: rgba(255,255,255,.03);
-		border: 1px solid rgba(255,255,255,.07);
+		background: var(--nc, rgba(255,255,255,.03));
+		border: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.07));
 		overflow: hidden;
 		text-decoration: none; color: inherit;
 		transition: border-color .2s, transform .2s;
 	}
-	.as-hero:hover { border-color: rgba(167,139,250,.4); }
+	.as-hero:hover { border-color: rgb(var(--np-rgb) / .4); }
 	.as-hero-cover {
 		position: relative; width: 100%;
 		padding-top: var(--aspect);
 		overflow: hidden;
-		background: #0d0d12;
+		background: var(--nc, #0d0d12);
 	}
 	.as-hero-cover img {
 		position: absolute; inset: 0; width: 100%; height: 100%;
@@ -481,17 +487,17 @@
 	}
 	.as-hero-body { padding: 1.25rem 1.25rem 1.5rem; }
 	.as-hero-title {
-		font-family: 'Space Grotesk', sans-serif;
-		font-size: 1.35rem; font-weight: 800;
+		font-family: var(--nfont, 'Space Grotesk', sans-serif);
+		font-size: 1.35rem; font-weight: var(--nfwh, 800);
 		line-height: 1.25;
-		color: #fff;
+		color: var(--nt, #fff);
 		margin: 0 0 .5rem;
 		display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2;
 		-webkit-box-orient: vertical; overflow: hidden;
 	}
 	.as-hero-excerpt {
 		font-size: 13px; line-height: 1.55;
-		color: #94a3b8; margin: 0;
+		color: var(--ntm, #94a3b8); margin: 0;
 		display: -webkit-box; -webkit-line-clamp: 3; line-clamp: 3;
 		-webkit-box-orient: vertical; overflow: hidden;
 	}
@@ -512,19 +518,19 @@
 	/* ─── CARD générique ───────────────────────────────────────────────────── */
 	.as-card {
 		display: flex; flex-direction: column;
-		background: rgba(255,255,255,.03);
-		border: 1px solid rgba(255,255,255,.07);
+		background: var(--nc, rgba(255,255,255,.03));
+		border: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.07));
 		overflow: hidden;
 		text-decoration: none; color: inherit;
 		transition: border-color .2s;
 	}
-	.as-card:hover { border-color: rgba(167,139,250,.4); }
+	.as-card:hover { border-color: rgb(var(--np-rgb) / .4); }
 
 	.as-card-cover {
 		position: relative; width: 100%;
 		padding-top: var(--aspect);
 		overflow: hidden;
-		background: #0d0d12;
+		background: var(--nc, #0d0d12);
 	}
 	.as-card-cover img {
 		position: absolute; inset: 0; width: 100%; height: 100%;
@@ -536,10 +542,10 @@
 
 	.as-card-body { padding: .875rem 1rem 1rem; flex: 1; display: flex; flex-direction: column; }
 	.as-card-title {
-		font-family: 'Space Grotesk', sans-serif;
+		font-family: var(--nfont, 'Space Grotesk', sans-serif);
 		font-size: 15px; font-weight: 700;
 		line-height: 1.3;
-		color: #fff; margin: 0 0 .35rem;
+		color: var(--nt, #fff); margin: 0 0 .35rem;
 		display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2;
 		-webkit-box-orient: vertical; overflow: hidden;
 	}
@@ -548,7 +554,7 @@
 
 	.as-card-excerpt {
 		font-size: 12px; line-height: 1.5;
-		color: #94a3b8; margin: 0;
+		color: var(--ntm, #94a3b8); margin: 0;
 		display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2;
 		-webkit-box-orient: vertical; overflow: hidden;
 	}
@@ -564,33 +570,33 @@
 	.as-horiz-item {
 		display: grid; grid-template-columns: 180px 1fr auto;
 		gap: 1rem; align-items: center;
-		background: rgba(255,255,255,.025);
-		border: 1px solid rgba(255,255,255,.06);
+		background: var(--nc, rgba(255,255,255,.025));
+		border: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.06));
 		padding: .75rem;
 		text-decoration: none; color: inherit;
 		transition: border-color .2s, background .2s;
 	}
 	.as-horiz-item:hover {
-		border-color: rgba(167,139,250,.35);
-		background: rgba(167,139,250,.04);
+		border-color: rgb(var(--np-rgb) / .35);
+		background: rgb(var(--np-rgb) / .04);
 	}
 	.as-horiz-cover {
 		width: 180px; height: 110px;
 		position: relative; overflow: hidden;
-		background: #0d0d12;
+		background: var(--nc, #0d0d12);
 	}
 	.as-horiz-cover img { width: 100%; height: 100%; object-fit: cover; transition: transform .5s; }
 	.as-horiz-item:hover .as-horiz-cover img { transform: scale(1.05); }
 	.as-horiz-body { min-width: 0; }
 	.as-horiz-title {
-		font-family: 'Space Grotesk', sans-serif;
+		font-family: var(--nfont, 'Space Grotesk', sans-serif);
 		font-size: 16px; font-weight: 700; line-height: 1.3;
-		color: #fff; margin: 0 0 .3rem;
+		color: var(--nt, #fff); margin: 0 0 .3rem;
 		display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2;
 		-webkit-box-orient: vertical; overflow: hidden;
 	}
 	.as-horiz-excerpt {
-		font-size: 12px; color: #94a3b8; margin: 0 0 .35rem;
+		font-size: 12px; color: var(--ntm, #94a3b8); margin: 0 0 .35rem;
 		display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2;
 		-webkit-box-orient: vertical; overflow: hidden;
 	}
@@ -609,15 +615,15 @@
 	/* ─── SLIDER ───────────────────────────────────────────────────────────── */
 	.as-slider {
 		position: relative;
-		background: rgba(255,255,255,.03);
-		border: 1px solid rgba(255,255,255,.07);
+		background: var(--nc, rgba(255,255,255,.03));
+		border: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.07));
 		overflow: hidden;
 	}
 	.as-slide { display: block; text-decoration: none; color: inherit; }
 	.as-slide-cover {
 		position: relative; width: 100%;
 		padding-top: var(--aspect);
-		background: #0d0d12; overflow: hidden;
+		background: var(--nc, #0d0d12); overflow: hidden;
 	}
 	.as-slide-cover img {
 		position: absolute; inset: 0;
@@ -682,11 +688,11 @@
 	.as-ticker-item {
 		display: flex; align-items: center; gap: .75rem;
 		padding: .75rem 1rem;
-		border-bottom: 1px solid rgba(255,255,255,.05);
+		border-bottom: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.05));
 		text-decoration: none; color: inherit;
 		transition: background .15s;
 	}
-	.as-ticker-item:hover { background: rgba(167,139,250,.05); }
+	.as-ticker-item:hover { background: rgb(var(--np-rgb) / .05); }
 	.as-ticker-cover {
 		width: 56px; height: 56px; flex-shrink: 0;
 		overflow: hidden;
@@ -694,19 +700,19 @@
 	.as-ticker-cover img { width: 100%; height: 100%; object-fit: cover; }
 	.as-ticker-body { flex: 1; min-width: 0; }
 	.as-ticker-title {
-		font-size: 13px; font-weight: 600; color: #fff;
+		font-size: 13px; font-weight: 600; color: var(--nt, #fff);
 		margin: 0 0 .15rem;
 		display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2;
 		-webkit-box-orient: vertical; overflow: hidden;
 	}
-	.as-ticker-date { font-size: 10px; color: #6b7280; }
+	.as-ticker-date { font-size: 10px; color: var(--ntm, #6b7280); }
 
 	/* ─── HEADLINES ────────────────────────────────────────────────────────── */
 	.as-headlines {
 		list-style: none; padding: 0; margin: 0;
-		border-top: 1px solid rgba(255,255,255,.06);
+		border-top: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.06));
 	}
-	.as-headlines li { border-bottom: 1px solid rgba(255,255,255,.06); }
+	.as-headlines li { border-bottom: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.06)); }
 
 	.as-headline {
 		display: grid; grid-template-columns: auto 1fr;
@@ -715,10 +721,10 @@
 		text-decoration: none; color: inherit;
 		transition: background .15s;
 	}
-	.as-headline:hover { background: rgba(167,139,250,.04); }
+	.as-headline:hover { background: rgb(var(--np-rgb) / .04); }
 
 	.as-headline-num {
-		font-family: 'Space Grotesk', sans-serif;
+		font-family: var(--nfont, 'Space Grotesk', sans-serif);
 		font-size: 1.75rem; font-weight: 800;
 		line-height: 1;
 		color: var(--accent); opacity: .4;
@@ -729,9 +735,9 @@
 
 	.as-headline-body { min-width: 0; }
 	.as-headline-title {
-		font-family: 'Space Grotesk', sans-serif;
+		font-family: var(--nfont, 'Space Grotesk', sans-serif);
 		font-size: 15px; font-weight: 700;
-		color: #fff; margin: .1rem 0;
+		color: var(--nt, #fff); margin: .1rem 0;
 		display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2;
 		-webkit-box-orient: vertical; overflow: hidden;
 	}

--- a/nodyx-frontend/src/lib/components/homepage/widgets/HeroBanner.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/HeroBanner.svelte
@@ -269,8 +269,8 @@
 	.hb-root {
 		position: relative;
 		overflow: hidden;
-		background: #0a0a0f;
-		border-bottom: 1px solid rgba(255,255,255,.05);
+		background: var(--nc, #0a0a0f);
+		border-bottom: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.05));
 	}
 
 	.noise::after {
@@ -303,7 +303,7 @@
 	}
 	.hb-deco-letter {
 		position: absolute; right: 6%; top: 50%; transform: translateY(-50%);
-		font-family: 'Space Grotesk', sans-serif; font-weight: 800;
+		font-family: var(--nfont, 'Space Grotesk', sans-serif); font-weight: 800;
 		font-size: clamp(120px, 18vw, 260px);
 		line-height: 1;
 		background: linear-gradient(135deg, rgb(var(--np-rgb) / .45) 0%, rgb(var(--na-rgb) / .18) 50%, transparent 80%);
@@ -320,7 +320,7 @@
 		border: 1px solid rgba(239,68,68,.4);
 		font-size: 11px; font-weight: 900; text-transform: uppercase;
 		letter-spacing: .18em; color: #ef4444;
-		font-family: 'Space Grotesk', sans-serif;
+		font-family: var(--nfont, 'Space Grotesk', sans-serif);
 	}
 	.hb-live-dot {
 		width: 7px; height: 7px;
@@ -345,7 +345,7 @@
 		display: flex; align-items: center; gap: .6rem;
 		font-size: 10px; font-weight: 800; text-transform: uppercase;
 		letter-spacing: .22em; color: var(--np);
-		font-family: 'Space Grotesk', sans-serif;
+		font-family: var(--nfont, 'Space Grotesk', sans-serif);
 	}
 	.hb-eyebrow-line {
 		height: 1px; width: 40px;
@@ -365,14 +365,14 @@
 	.hb-logo-fallback {
 		width: 48px; height: 48px; flex-shrink: 0;
 		display: flex; align-items: center; justify-content: center;
-		font-family: 'Space Grotesk', sans-serif; font-weight: 900;
+		font-family: var(--nfont, 'Space Grotesk', sans-serif); font-weight: 900;
 		font-size: 1.3rem; color: #fff;
 		background: linear-gradient(135deg, rgb(var(--np-rgb) / .4), rgb(var(--na-rgb) / .15));
 		border: 1px solid rgb(var(--np-rgb) / .3);
 	}
 
 	.hb-title {
-		font-family: 'Space Grotesk', sans-serif; font-weight: 800;
+		font-family: var(--nfont, 'Space Grotesk', sans-serif); font-weight: 800;
 		font-size: clamp(1.25rem, 2.4vw, 1.85rem);
 		line-height: 1.05; margin: 0 0 .2rem;
 		background: linear-gradient(135deg, var(--np) 0%, var(--na) 100%);
@@ -383,7 +383,7 @@
 	}
 
 	.hb-subtitle {
-		font-size: .875rem; color: #6b7280;
+		font-size: .875rem; color: var(--ntm, #6b7280);
 		max-width: 480px; line-height: 1.5; margin: 0;
 	}
 
@@ -393,29 +393,30 @@
 	}
 	.hb-btn {
 		padding: .55rem 1.2rem;
-		font-family: 'Space Grotesk', sans-serif; font-weight: 700;
+		font-family: var(--nfont, 'Space Grotesk', sans-serif); font-weight: 700;
 		font-size: .8rem; text-transform: uppercase; letter-spacing: .1em;
 		text-decoration: none; transition: filter .15s, transform .1s;
 		white-space: nowrap;
 	}
 	.hb-btn:active { transform: scale(.97); }
 	.hb-btn--primary {
+		/* Texte blanc fixe : contraste garanti sur le dégradé, pas --nl ici. */
 		background: linear-gradient(135deg, var(--np), var(--na));
 		border: 1px solid rgb(var(--np-rgb) / .45); color: #fff;
 	}
 	.hb-btn--primary:hover { filter: brightness(1.12); }
 	.hb-btn--ghost {
-		border: 1px solid rgba(255,255,255,.12); color: #9ca3af;
+		border: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.12)); color: var(--ntm, #9ca3af);
 	}
-	.hb-btn--ghost:hover { border-color: rgba(167,139,250,.4); color: var(--np); }
+	.hb-btn--ghost:hover { border-color: rgb(var(--np-rgb) / .4); color: var(--nl, var(--np)); }
 
 	/* ── Stats dock ────────────────────────────────────────────────────────── */
 	.hb-stats-dock {
 		position: relative; z-index: 10;
 		display: flex; align-items: center;
 		padding: .6rem 2rem;
-		border-top: 1px solid rgba(255,255,255,.06);
-		background: rgba(0,0,0,.25);
+		border-top: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.06));
+		background: var(--nc, rgba(0,0,0,.25));
 		gap: 0;
 	}
 	.hb-stat {
@@ -423,7 +424,7 @@
 		flex: 1; justify-content: center;
 	}
 	.hb-stat-num {
-		font-family: 'Space Grotesk', sans-serif; font-weight: 900;
+		font-family: var(--nfont, 'Space Grotesk', sans-serif); font-weight: 900;
 		font-size: 1.15rem; line-height: 1;
 		display: flex; align-items: center; gap: 5px;
 		font-variant-numeric: tabular-nums;
@@ -434,11 +435,11 @@
 	.hb-stat-label {
 		font-size: .65rem; font-weight: 700;
 		text-transform: uppercase; letter-spacing: .16em;
-		color: #374151;
+		color: var(--ntm, #374151);
 	}
 	.hb-stat-sep {
 		width: 1px; height: 28px; flex-shrink: 0;
-		background: rgba(255,255,255,.06);
+		background: var(--nborder, rgba(255,255,255,.06));
 	}
 	.hb-pulse-dot {
 		display: inline-block;
@@ -447,8 +448,8 @@
 		animation: dotpulse 2s ease-out infinite;
 	}
 	@keyframes numglow {
-		0%, 100% { text-shadow: 0 0 0 rgba(167,139,250,0); }
-		50%       { text-shadow: 0 0 18px rgba(167,139,250,.45); }
+		0%, 100% { text-shadow: 0 0 0 rgb(var(--np-rgb) / 0); }
+		50%       { text-shadow: 0 0 18px rgb(var(--np-rgb) / .45); }
 	}
 	@keyframes dotpulse {
 		0%   { box-shadow: 0 0 0 0 rgba(74,222,128,.55); }
@@ -460,11 +461,11 @@
 		position: relative; z-index: 10;
 		display: flex; align-items: center; gap: .75rem;
 		padding: .55rem 2rem;
-		border-top: 1px solid rgba(255,255,255,.05);
-		background: rgba(0,0,0,.18);
+		border-top: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.05));
+		background: var(--nc, rgba(0,0,0,.18));
 	}
 	.hb-live-names {
-		font-size: 11px; color: #6b7280;
+		font-size: 11px; color: var(--ntm, #6b7280);
 		display: flex; align-items: center; gap: 6px;
 		min-width: 0; overflow: hidden;
 		text-overflow: ellipsis; white-space: nowrap;
@@ -475,21 +476,21 @@
 		animation: dotpulse 2s ease-out infinite;
 	}
 	.hb-live-count {
-		font-size: 11px; color: #4b5563;
+		font-size: 11px; color: var(--ntm, #4b5563);
 		display: flex; align-items: center; gap: 6px;
 	}
 	.hb-live-empty {
-		font-size: 11px; color: #374151;
+		font-size: 11px; color: var(--ntm, #374151);
 		display: flex; align-items: center; gap: 6px;
 	}
 	.hb-live-empty svg { width: 13px; height: 13px; }
 	.hb-live-cta {
-		font-size: 11px; font-weight: 600; color: var(--np);
+		font-size: 11px; font-weight: 600; color: var(--nl, var(--np));
 		text-decoration: none;
 		display: flex; align-items: center; gap: 4px;
 		transition: color .15s;
 	}
-	.hb-live-cta:hover { color: var(--np); }
+	.hb-live-cta:hover { color: var(--nl, var(--np)); filter: brightness(1.15); }
 	.hb-live-cta svg { width: 11px; height: 11px; }
 
 	/* ── Avatars ───────────────────────────────────────────────────────────── */
@@ -501,13 +502,13 @@
 		position: relative;
 		width: 28px; height: 28px;
 		border-radius: 4px;
-		border: 1.5px solid rgba(167,139,250,.25);
+		border: 1.5px solid rgb(var(--np-rgb) / .25);
 		overflow: visible;
 		flex-shrink: 0;
 		margin-right: -7px;
 		transition: transform .15s, z-index 0s;
 		cursor: default;
-		background: rgba(167,139,250,.1);
+		background: rgb(var(--np-rgb) / .1);
 	}
 	/* Need inner clip for image without clipping tooltip */
 	.hb-avatar img,
@@ -527,15 +528,15 @@
 		z-index: 50;
 	}
 	.hb-avatar--overflow {
-		background: rgba(255,255,255,.07);
-		border-color: rgba(255,255,255,.12);
+		background: var(--nc, rgba(255,255,255,.07));
+		border-color: var(--nborder, rgba(255,255,255,.12));
 		display: flex; align-items: center; justify-content: center;
-		font-size: 9px; font-weight: 800; color: #6b7280;
+		font-size: 9px; font-weight: 800; color: var(--ntm, #6b7280);
 		cursor: default;
 		overflow: hidden;
 	}
 	.hb-avatar--blur {
-		background: rgba(167,139,250,.08);
+		background: rgb(var(--np-rgb) / .08);
 		filter: blur(2px);
 		cursor: default;
 	}
@@ -546,7 +547,7 @@
 		position: absolute;
 		bottom: -4px; right: -4px;
 		font-size: 9px; line-height: 1;
-		background: #0a0a0f;
+		background: var(--nc, #0a0a0f);
 		border-radius: 50%;
 		padding: 1px;
 		pointer-events: none;
@@ -558,8 +559,8 @@
 		bottom: calc(100% + 8px);
 		left: 50%;
 		transform: translateX(-50%);
-		background: #12121c;
-		border: 1px solid rgba(255,255,255,.1);
+		background: var(--nc, #12121c);
+		border: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.1));
 		padding: 6px 10px;
 		border-radius: 5px;
 		white-space: nowrap;
@@ -576,13 +577,13 @@
 		position: absolute; top: 100%; left: 50%;
 		transform: translateX(-50%);
 		border: 5px solid transparent;
-		border-top-color: rgba(255,255,255,.1);
+		border-top-color: var(--nborder, rgba(255,255,255,.1));
 	}
 	.hb-avatar:hover .hb-tip { opacity: 1; }
 
-	.hb-tip-name  { font-weight: 700; color: #e2e8f0; }
+	.hb-tip-name  { font-weight: 700; color: var(--nt, #e2e8f0); }
 	.hb-tip-grade { font-size: 10px; font-weight: 600; }
-	.hb-tip-status { font-size: 10px; color: #6b7280; }
+	.hb-tip-status { font-size: 10px; color: var(--ntm, #6b7280); }
 
 	/* ── Responsive ────────────────────────────────────────────────────────── */
 	@media (max-width: 640px) {

--- a/nodyx-frontend/src/lib/components/homepage/widgets/JoinCard.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/JoinCard.svelte
@@ -42,16 +42,16 @@
 </script>
 
 <div class="p-5 flex flex-col gap-4"
-     style="background:rgba(255,255,255,.03); border:1px solid rgba(255,255,255,.07)">
+     style="background:var(--nc); border:var(--nbw) solid var(--nborder)">
 
 	<!-- Title -->
 	<div>
-		<h3 class="font-extrabold text-base text-white mb-0.5"
-		    style="font-family:'Space Grotesk',sans-serif">
+		<h3 class="font-extrabold text-base mb-0.5"
+		    style="font-family:var(--nfont); color:var(--nt)">
 			{cardTitle || tFn('home.join_community')}
 		</h3>
 		{#if cardSubtitle}
-			<p class="text-xs leading-relaxed" style="color:#6b7280">{cardSubtitle}</p>
+			<p class="text-xs leading-relaxed" style="color:var(--ntm)">{cardSubtitle}</p>
 		{/if}
 	</div>
 
@@ -61,7 +61,7 @@
 			<div class="flex -space-x-2">
 				{#each recentAvatars.slice(0, 5) as u}
 					<div class="w-7 h-7 rounded-full overflow-hidden shrink-0"
-					     style="background:rgb(var(--np-rgb) / .3); border:2px solid #0d0d12; outline:1px solid rgb(var(--np-rgb) / .25)">
+					     style="background:rgb(var(--np-rgb) / .3); border:2px solid var(--nb); outline:1px solid rgb(var(--np-rgb) / .25)">
 						{#if u.avatar_url}
 							<img src={u.avatar_url} alt={u.username} class="w-full h-full object-cover" />
 						{:else}
@@ -74,21 +74,23 @@
 			</div>
 		{/if}
 
-		<div class="text-xs leading-tight" style="color:#6b7280">
+		<div class="text-xs leading-tight" style="color:var(--ntm)">
 			<span style="color:var(--np); font-weight:700">{memberCount.toLocaleString()}</span>
 			{tFn('common.members')}
 			{#if showOnlineCount}
-				<span class="mx-1" style="color:#374151">·</span>
+				<span class="mx-1" style="color:var(--ntm)">·</span>
 				<span style="color:#4ade80; font-weight:700">{onlineCount}</span>
 				{tFn('common.online')}
 			{/if}
 		</div>
 	</div>
 
-	<!-- CTA -->
+	<!-- CTA : texte blanc volontairement fixe (contraste garanti sur le dégradé
+	     primary/accent, pas de couleur de lien --nl ici : un bouton plein, pas
+	     un lien texte). -->
 	<a href="/auth/register"
 	   class="w-full flex items-center justify-center gap-2 py-2.5 text-sm font-bold uppercase tracking-wider text-white transition-all"
-	   style="font-family:'Space Grotesk',sans-serif; background:linear-gradient(135deg,var(--np),var(--na)); border:1px solid rgb(var(--np-rgb) / .4)">
+	   style="font-family:var(--nfont); background:linear-gradient(135deg,var(--np),var(--na)); border:1px solid rgb(var(--np-rgb) / .4)">
 		{ctaText || tFn('common.join')}
 		<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
 			<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>

--- a/nodyx-frontend/src/lib/components/homepage/widgets/RecentThreads.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/RecentThreads.svelte
@@ -197,17 +197,17 @@
 	.rt-heading-line {
 		flex: 1;
 		height: 1px;
-		background: linear-gradient(to right, rgba(167,139,250,.3), transparent);
+		background: linear-gradient(to right, rgb(var(--np-rgb, 167 139 250) / .3), transparent);
 	}
 	.rt-heading-line--r {
-		background: linear-gradient(to left, rgba(167,139,250,.3), transparent);
+		background: linear-gradient(to left, rgb(var(--np-rgb, 167 139 250) / .3), transparent);
 	}
 	.rt-heading-text {
 		font-size: 10px;
 		font-weight: 800;
 		text-transform: uppercase;
 		letter-spacing: .2em;
-		color: var(--np, var(--nx-accent-2-soft));
+		color: var(--np, #a78bfa);
 		white-space: nowrap;
 	}
 
@@ -225,7 +225,7 @@
 	.rt-empty {
 		padding: 1.5rem 1rem;
 		font-size: 13px;
-		color: #4b5563;
+		color: var(--ntm, #4b5563);
 		text-align: center;
 	}
 
@@ -233,15 +233,15 @@
 	.rt-avatar {
 		width: 36px; height: 36px;
 		flex-shrink: 0;
-		background: rgba(167,139,250,.15);
-		border: 1px solid rgba(167,139,250,.2);
+		background: rgb(var(--np-rgb, 167 139 250) / .15);
+		border: 1px solid rgb(var(--np-rgb, 167 139 250) / .2);
 		border-radius: 4px;
 		overflow: hidden;
 		display: flex; align-items: center; justify-content: center;
 	}
 	.rt-avatar--sm { width: 20px; height: 20px; border-radius: 2px; }
 	.rt-avatar img  { width: 100%; height: 100%; object-fit: cover; }
-	.rt-avatar span { font-size: 13px; font-weight: 700; color: var(--nx-accent-2-soft); }
+	.rt-avatar span { font-size: 13px; font-weight: 700; color: var(--np, #a78bfa); }
 	.rt-avatar--sm span { font-size: 9px; }
 
 	/* ── LIST style ─────────────────────────────────────────────────────────── */
@@ -255,7 +255,7 @@
 		text-decoration: none;
 		transition: background .15s;
 	}
-	.rt-item:hover { background: rgba(167,139,250,.05); }
+	.rt-item:hover { background: rgb(var(--np-rgb, 167 139 250) / .05); }
 
 	.rt-item-body { flex: 1; min-width: 0; }
 
@@ -277,10 +277,10 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
-	.rt-item:hover .rt-item-title { color: var(--nx-accent-2-soft2); }
-	.rt-item-title--locked { color: #6b7280 !important; }
+	.rt-item:hover .rt-item-title { color: var(--nl, var(--np)); }
+	.rt-item-title--locked { color: var(--ntm, #6b7280) !important; }
 
-	.rt-lock { width: 11px; height: 11px; flex-shrink: 0; color: #4b5563; }
+	.rt-lock { width: 11px; height: 11px; flex-shrink: 0; color: var(--ntm, #4b5563); }
 
 	.rt-item-meta {
 		display: flex;
@@ -292,24 +292,24 @@
 	.rt-cat-badge {
 		font-size: 10px;
 		font-weight: 600;
-		color: var(--np, var(--nx-accent-2-soft));
-		background: rgba(167,139,250,.1);
-		border: 1px solid rgba(167,139,250,.18);
+		color: var(--np, #a78bfa);
+		background: rgb(var(--np-rgb, 167 139 250) / .1);
+		border: 1px solid rgb(var(--np-rgb, 167 139 250) / .18);
 		padding: 0 5px;
 		border-radius: 2px;
 		white-space: nowrap;
 	}
-	.rt-meta-date { font-size: 11px; color: #4b5563; }
-	.rt-meta-dot  { font-size: 11px; color: #374151; }
+	.rt-meta-date { font-size: 11px; color: var(--ntm, #4b5563); }
+	.rt-meta-dot  { font-size: 11px; color: var(--ntm, #374151); }
 	.rt-meta-replies {
 		display: flex; align-items: center; gap: 3px;
-		font-size: 11px; color: #4b5563;
+		font-size: 11px; color: var(--ntm, #4b5563);
 	}
 	.rt-meta-replies svg { width: 11px; height: 11px; }
 
 	.rt-divider {
 		height: 1px;
-		background: rgba(255,255,255,.04);
+		background: var(--nborder, rgba(255,255,255,.04));
 		margin: 0 1rem;
 	}
 
@@ -333,8 +333,8 @@
 		transition: border-color .15s, background .15s;
 	}
 	.rt-card:hover {
-		border-color: rgba(167,139,250,.35);
-		background: rgba(167,139,250,.07);
+		border-color: rgb(var(--np-rgb, 167 139 250) / .35);
+		background: rgb(var(--np-rgb, 167 139 250) / .07);
 	}
 
 	.rt-card-cat {
@@ -342,7 +342,7 @@
 		font-weight: 700;
 		text-transform: uppercase;
 		letter-spacing: .12em;
-		color: var(--np, var(--nx-accent-2-soft));
+		color: var(--np, #a78bfa);
 	}
 
 	.rt-card-title {
@@ -358,7 +358,7 @@
 		margin: 0;
 		flex: 1;
 	}
-	.rt-card:hover .rt-card-title { color: var(--nx-accent-2-soft2); }
+	.rt-card:hover .rt-card-title { color: var(--nl, var(--np)); }
 
 	.rt-card-meta {
 		display: flex;
@@ -366,7 +366,7 @@
 		gap: .35rem;
 		margin-top: .25rem;
 	}
-	.rt-meta-author { font-size: 11px; color: #6b7280; }
+	.rt-meta-author { font-size: 11px; color: var(--ntm, #6b7280); }
 
 	/* ── Responsive ─────────────────────────────────────────────────────────── */
 	@media (max-width: 639px) {

--- a/nodyx-frontend/src/lib/components/homepage/widgets/SocialLinksBar.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/SocialLinksBar.svelte
@@ -211,8 +211,9 @@
 		},
 
 		// ── Lien custom ───────────────────────────────────────────────────────
+		// Seul type sans marque réelle à respecter : suit la couleur de lien du thème.
 		custom: {
-			color: '#a78bfa',
+			color: 'var(--nl)',
 			stroke: true,
 			path: 'M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14',
 		},
@@ -269,25 +270,25 @@
 		display: flex;
 		align-items: center;
 		gap: .4rem;
-		color: rgba(255,255,255,.4);
+		color: var(--ntm, rgba(255,255,255,.4));
 		text-decoration: none;
-		border-radius: 6px;
+		border-radius: var(--nr, 6px);
 		padding: 6px;
 		transition: color .15s, background .15s, transform .15s;
 	}
 	.sl-link:hover {
-		color: var(--ic, var(--np));
+		color: var(--ic, var(--nl));
 		background: rgba(255,255,255,.06);
 		transform: translateY(-2px);
 	}
 	.sl-link--pill {
 		padding: 5px 12px;
-		background: rgba(255,255,255,.05);
-		border: 1px solid rgba(255,255,255,.08);
+		background: var(--nc, rgba(255,255,255,.05));
+		border: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.08));
 	}
 	.sl-link--pill:hover {
 		background: rgba(255,255,255,.09);
-		border-color: var(--ic, rgba(167,139,250,.4));
+		border-color: var(--ic, rgb(var(--np-rgb) / .4));
 	}
 	.sl-label {
 		font-size: 12px;

--- a/nodyx-frontend/src/lib/components/homepage/widgets/StatsBar.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/StatsBar.svelte
@@ -76,19 +76,21 @@
 	const allStats: Record<string, () => StatDef> = {
 		members: () => ({
 			key: 'members', value: displayed.members,
-			label: tFn('common.members'), color: '#a78bfa', pulse: false, glow: true,
+			label: tFn('common.members'), color: 'var(--np)', pulse: false, glow: true,
 		}),
 		online: () => ({
+			// Vert "en ligne" volontairement fixe : couleur de statut sémantique,
+			// pas un accent de thème (cohérence avec les autres indicateurs "online" du site).
 			key: 'online', value: displayed.online,
 			label: tFn('common.online'), color: '#4ade80', pulse: true, glow: false,
 		}),
 		threads: () => ({
 			key: 'threads', value: displayed.threads,
-			label: tFn('common.topics'), color: '#67e8f9', pulse: false, glow: false,
+			label: tFn('common.topics'), color: 'var(--na)', pulse: false, glow: false,
 		}),
 		posts: () => ({
 			key: 'posts', value: displayed.posts,
-			label: tFn('nav.dm'), color: '#94a3b8', pulse: false, glow: false,
+			label: tFn('nav.dm'), color: 'var(--ntm)', pulse: false, glow: false,
 		}),
 	};
 
@@ -102,11 +104,11 @@
 <div class="flex flex-wrap items-stretch gap-0.5">
 	{#each visibleStats as stat (stat.key)}
 		<div class="flex flex-col items-center justify-center px-6 py-2 gap-0.5"
-		     style="background:rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.06)">
+		     style="background:var(--nc); border:var(--nbw) solid var(--nborder)">
 			<span
 				class="font-black text-xl tabular-nums"
 				class:sglow={stat.glow}
-				style="font-family:'Space Grotesk',sans-serif; color:{stat.color}"
+				style="font-family:var(--nfont); color:{stat.color}"
 			>
 				{#if stat.pulse}
 					<span class="flex items-center gap-2">
@@ -117,7 +119,7 @@
 					{stat.value.toLocaleString()}
 				{/if}
 			</span>
-			<span class="text-[9px] uppercase tracking-[.18em] font-bold" style="color:#374151">
+			<span class="text-[9px] uppercase tracking-[.18em] font-bold" style="color:var(--ntm)">
 				{stat.label}
 			</span>
 		</div>

--- a/nodyx-frontend/src/lib/components/homepage/widgets/TwitchStream.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/TwitchStream.svelte
@@ -22,7 +22,14 @@
 	const autoplay      = $derived((config.autoplay as boolean) ?? false)
 	const muted         = $derived((config.muted as boolean) ?? true)
 	const showHeader    = $derived((config.show_header as boolean) ?? true)
-	const accent        = $derived((config.accent_color as string) ?? '#9146FF')
+	// Couleur d'accent du widget : si l'admin la fixe (config.accent_color,
+	// ex. le violet de marque Twitch #9146FF), on garde l'astuce hex+alpha.
+	// Sinon on suit le thème du Homepage Builder EN DIRECT via --nl.
+	const customAccent  = $derived(config.accent_color as string | undefined)
+	const accent        = $derived(customAccent ?? 'var(--nl)')
+	const accentBgWeak  = $derived(customAccent ? `${customAccent}1a` : 'rgb(var(--nl-rgb) / .1)')
+	const accentBrdWeak = $derived(customAccent ? `${customAccent}33` : 'rgb(var(--nl-rgb) / .2)')
+	const accentBrdMed  = $derived(customAccent ? `${customAccent}55` : 'rgb(var(--nl-rgb) / .33)')
 	const fallbackCat   = $derived((config.fallback_category as string) ?? '')
 	const fallbackLang  = $derived((config.fallback_language as string) ?? 'any')
 
@@ -152,14 +159,14 @@
 {#if !configuredChannel}
 	<!-- Empty state : aucune chaîne configurée -->
 	<div class="relative flex flex-col items-center justify-center gap-3 px-6 py-12 text-center"
-	     style="background:rgba(255,255,255,.03); border:1px solid rgba(255,255,255,.07)">
+	     style="background:var(--nc, rgba(255,255,255,.03)); border:var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.07))">
 		<svg viewBox="0 0 24 24" class="w-8 h-8" style="color:{accent}" fill="currentColor" aria-hidden="true">
 			<path d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714Z"/>
 		</svg>
-		<p class="text-sm font-bold uppercase tracking-[.18em]" style="font-family:'Space Grotesk',sans-serif; color:#e2e8f0">
+		<p class="text-sm font-bold uppercase tracking-[.18em]" style="font-family:var(--nfont, 'Space Grotesk', sans-serif); color:var(--nt, #e2e8f0)">
 			Twitch Stream
 		</p>
-		<p class="text-xs max-w-xs" style="color:#6b7280">
+		<p class="text-xs max-w-xs" style="color:var(--ntm, #6b7280)">
 			{tFn('widgets.twitch_configure')}
 		</p>
 	</div>
@@ -167,7 +174,7 @@
 {:else}
 	<div class="twitch-widget relative overflow-hidden"
 	     class:is-live={isMainLive || isFallbackLive}
-	     style="--accent:{accent}; background:rgba(255,255,255,.03); border:1px solid rgba(255,255,255,.07)">
+	     style="--accent:{accent}; background:var(--nc, rgba(255,255,255,.03)); border:var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.07))">
 
 		<!-- Gradient shine animée (purple Twitch → teal Nodyx) -->
 		<div class="twitch-shine" aria-hidden="true"></div>
@@ -175,12 +182,12 @@
 		{#if showHeader}
 			<!-- Header : logo + pseudo + badge live + CTA -->
 			<div class="relative flex items-center justify-between gap-3 px-4 py-2.5"
-			     style="background:rgba(0,0,0,.35); border-bottom:1px solid rgba(255,255,255,.06); backdrop-filter:blur(12px)">
+			     style="background:rgba(0,0,0,.35); border-bottom:var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.06)); backdrop-filter:blur(12px)">
 
 				<div class="flex items-center gap-2.5 min-w-0 flex-1">
 					<!-- Twitch glyph -->
 					<div class="relative shrink-0 flex items-center justify-center w-7 h-7"
-					     style="background:{accent}1a; border:1px solid {accent}33">
+					     style="background:{accentBgWeak}; border:1px solid {accentBrdWeak}">
 						<svg viewBox="0 0 24 24" class="w-3.5 h-3.5" style="color:{accent}" fill="currentColor" aria-hidden="true">
 							<path d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714Z"/>
 						</svg>
@@ -189,21 +196,21 @@
 					<!-- Channel name + meta -->
 					<div class="min-w-0">
 						<div class="flex items-center gap-2">
-							<p class="text-sm font-bold truncate" style="font-family:'Space Grotesk',sans-serif; color:#e2e8f0">
+							<p class="text-sm font-bold truncate" style="font-family:var(--nfont, 'Space Grotesk', sans-serif); color:var(--nt, #e2e8f0)">
 								{activeChannel}
 							</p>
 
 							{#if isMainLive || isFallbackLive}
 								<!-- Badge LIVE pulsant -->
 								<span class="flex items-center gap-1 px-1.5 py-0.5 text-[9px] font-black uppercase tracking-[.22em] shrink-0"
-								      style="background:#ef4444; color:#fff; font-family:'Space Grotesk',sans-serif">
+								      style="background:#ef4444; color:#fff; font-family:var(--nfont, 'Space Grotesk', sans-serif)">
 									<span class="w-1.5 h-1.5 rounded-full opulse" style="background:#fff"></span>
 									Live
 								</span>
 							{/if}
 						</div>
 
-						<p class="text-[9px] uppercase tracking-[.22em] font-bold truncate" style="color:#6b7280">
+						<p class="text-[9px] uppercase tracking-[.22em] font-bold truncate" style="color:var(--ntm, #6b7280)">
 							{#if isFallbackLive && currentStream}
 								Fallback · {currentStream.game_name} · {formatViewers(currentStream.viewers)} viewers
 							{:else if isMainLive && currentStream}
@@ -222,7 +229,7 @@
 				   target="_blank"
 				   rel="noopener noreferrer"
 				   class="shrink-0 flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-bold uppercase tracking-[.18em] transition-all twitch-cta"
-				   style="font-family:'Space Grotesk',sans-serif; color:#e2e8f0; background:{accent}1a; border:1px solid {accent}55"
+				   style="font-family:var(--nfont, 'Space Grotesk', sans-serif); color:var(--nt, #e2e8f0); background:{accentBgWeak}; border:1px solid {accentBrdMed}"
 				   aria-label={tFn('widgets.twitch_open_channel', { channel: activeChannel })}>
 					<span class="hidden sm:inline">{tFn('widgets.open')}</span>
 					<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
@@ -235,12 +242,12 @@
 		<!-- Bannière fallback : main offline, on montre un autre stream -->
 		{#if isFallbackLive && widgetData?.main === null && configuredChannel !== activeChannel}
 			<div class="relative flex items-center gap-2 px-4 py-1.5 text-[10px]"
-			     style="background:rgba(145,70,255,.08); border-bottom:1px solid rgba(145,70,255,.2); color:var(--np)">
+			     style="background:rgb(var(--np-rgb) / .08); border-bottom:1px solid rgb(var(--np-rgb) / .2); color:var(--np)">
 				<svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
 					<path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"/>
 				</svg>
 				<span class="truncate">
-					<span style="color:#6b7280">{configuredChannel}</span> {tFn('widgets.twitch_offline_mid')} <span class="font-bold">{activeChannel}</span> {tFn('widgets.twitch_offline_end')}
+					<span style="color:var(--ntm, #6b7280)">{configuredChannel}</span> {tFn('widgets.twitch_offline_mid')} <span class="font-bold">{activeChannel}</span> {tFn('widgets.twitch_offline_end')}
 				</span>
 			</div>
 		{/if}
@@ -257,11 +264,11 @@
 				{#if !iframeLoaded}
 					<!-- Skeleton loader pulse -->
 					<div class="absolute inset-0 flex items-center justify-center"
-					     style="background:linear-gradient(135deg, rgb(var(--np-rgb) / .08), rgba(14,116,144,.08))">
+					     style="background:linear-gradient(135deg, rgb(var(--np-rgb) / .08), rgb(var(--na-rgb) / .08))">
 						<div class="flex flex-col items-center gap-3">
 							<div class="w-8 h-8 rounded-full border-2 animate-spin"
-							     style="border-color:rgba(145,70,255,.2); border-top-color:{accent}"></div>
-							<span class="text-[10px] uppercase tracking-[.18em] font-bold" style="color:#6b7280; font-family:'Space Grotesk',sans-serif">
+							     style="border-color:{accentBrdWeak}; border-top-color:{accent}"></div>
+							<span class="text-[10px] uppercase tracking-[.18em] font-bold" style="color:var(--ntm, #6b7280); font-family:var(--nfont, 'Space Grotesk', sans-serif)">
 								{tFn('widgets.twitch_loading')}
 							</span>
 						</div>
@@ -289,7 +296,7 @@
 				     class:md:w-80={chatRight}
 				     class:md:border-l={chatRight}
 				     class:border-t={!chatRight}
-				     style="height:{chatRight ? `${height}px` : '280px'}; border-color:rgba(255,255,255,.06); background:#0d0d12">
+				     style="height:{chatRight ? `${height}px` : '280px'}; border-color:var(--nborder, rgba(255,255,255,.06)); background:var(--nc, #0d0d12)">
 					{#if mounted && parentDomain}
 						{#key activeChannel + parentDomain}
 							<iframe

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -2517,6 +2517,14 @@
   "hpb.th_bg": "Page background",
   "hpb.th_text_primary": "Primary text",
   "hpb.th_text_secondary": "Secondary text",
+  "hpb.presets": "Presets",
+  "hpb.reset_theme": "Reset",
+  "hpb.confirm_reset_theme": "Reset the theme to the Nodyx default? All custom colors and settings will be lost.",
+  "hpb.toast_theme_reset": "Theme reset",
+  "hpb.toast_preset_applied": "Preset \"{{name}}\" applied",
+  "hpb.th_link": "Link color",
+  "hpb.opacity": "Opacity ({{v}}%)",
+  "hpb.border_width": "Border width ({{v}})",
   "hpb.backgrounds_borders": "Backgrounds & Borders",
   "hpb.th_card_bg": "Card background",
   "hpb.th_border": "Border color",
@@ -4437,6 +4445,6 @@
   "translate.safety": "<b>You cannot break the app by translating.</b> Translations go through pull requests: continuous integration checks that every <code>{{variable}}</code> is left intact before anything gets merged.",
   "translate.safety_link": "How to contribute",
   "translate.footer_note": "self-hosted, no telemetry",
-"nav.panel_toggle_aria": "Resize or collapse the community menu",
-"home.hero_welcome": "Welcome to the community"
+  "nav.panel_toggle_aria": "Resize or collapse the community menu",
+  "home.hero_welcome": "Welcome to the community"
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -3619,6 +3619,14 @@
   "hpb.th_bg": "Fond de page",
   "hpb.th_text_primary": "Texte principal",
   "hpb.th_text_secondary": "Texte secondaire",
+  "hpb.presets": "Préthèmes",
+  "hpb.reset_theme": "Réinitialiser",
+  "hpb.confirm_reset_theme": "Réinitialiser le thème au défaut Nodyx ? Toutes les couleurs et réglages personnalisés seront perdus.",
+  "hpb.toast_theme_reset": "Thème réinitialisé",
+  "hpb.toast_preset_applied": "Préthème « {{name}} » appliqué",
+  "hpb.th_link": "Couleur des liens",
+  "hpb.opacity": "Opacité ({{v}}%)",
+  "hpb.border_width": "Épaisseur de bordure ({{v}})",
   "hpb.backgrounds_borders": "Fonds & Bordures",
   "hpb.th_card_bg": "Fond des cartes",
   "hpb.th_border": "Couleur des bordures",
@@ -4437,6 +4445,6 @@
   "translate.safety": "<b>Impossible de casser l'application en traduisant.</b> Les traductions passent par pull request : l'intégration continue vérifie que chaque <code>{{variable}}</code> reste intacte avant la moindre fusion.",
   "translate.safety_link": "Comment contribuer",
   "translate.footer_note": "auto-hébergé, sans télémétrie",
-"nav.panel_toggle_aria": "Redimensionner ou replier le menu communauté",
-"home.hero_welcome": "Bienvenue dans la communauté"
+  "nav.panel_toggle_aria": "Redimensionner ou replier le menu communauté",
+  "home.hero_welcome": "Bienvenue dans la communauté"
 }

--- a/nodyx-frontend/src/lib/types/homepage.ts
+++ b/nodyx-frontend/src/lib/types/homepage.ts
@@ -32,9 +32,11 @@ export interface HomepageData {
 export interface GridTheme {
 	primary:             string;   // ex: "#a78bfa"
 	accent:              string;   // ex: "#06b6d4"
+	link_color:          string;   // ex: "#a78bfa" — couleur des liens/CTA, distincte de primary/accent
 	bg:                  string;   // ex: "#05050a"
 	card_bg:             string;   // ex: "rgba(255,255,255,.03)"
 	border_color:        string;   // ex: "rgba(255,255,255,.08)"
+	border_width:        string;   // ex: "1px"
 	border_radius:       string;   // ex: "10px"
 	font_family:         string;   // ex: "Space Grotesk"
 	font_size_base:      string;   // ex: "15px"
@@ -47,9 +49,11 @@ export interface GridTheme {
 export const DEFAULT_THEME: GridTheme = {
 	primary:             '#a78bfa',
 	accent:              '#06b6d4',
+	link_color:          '#a78bfa',
 	bg:                  '#05050a',
 	card_bg:             'rgba(255,255,255,.03)',
 	border_color:        'rgba(255,255,255,.08)',
+	border_width:        '1px',
 	border_radius:       '10px',
 	font_family:         'Space Grotesk',
 	font_size_base:      '15px',
@@ -57,6 +61,93 @@ export const DEFAULT_THEME: GridTheme = {
 	text_primary:        '#e2e8f0',
 	text_secondary:      '#6b7280',
 	shadow:              '0 4px 24px rgba(0,0,0,.4)',
+}
+
+/**
+ * Préthèmes prêts à l'emploi : point de départ pour un admin qui n'ose pas
+ * toucher aux couleurs une par une. Un clic remplace le thème entier (couleurs
+ * ET typographie ET forme), avec Réinitialiser pour toujours pouvoir revenir
+ * en arrière sans perte.
+ */
+export interface GridThemePreset {
+	id:    string;
+	label: string;
+	emoji: string;
+	theme: GridTheme;
+}
+
+export const GRID_THEME_PRESETS: GridThemePreset[] = [
+	{ id: 'default', label: 'Nodyx', emoji: '🌑', theme: DEFAULT_THEME },
+	{
+		id: 'midnight', label: 'Minuit', emoji: '🌌',
+		theme: {
+			primary: '#3b82f6', accent: '#22d3ee', link_color: '#60a5fa', bg: '#020617',
+			card_bg: 'rgba(59,130,246,.05)', border_color: 'rgba(59,130,246,.14)', border_width: '1px',
+			border_radius: '10px', font_family: 'Space Grotesk', font_size_base: '15px',
+			font_weight_heading: '700', text_primary: '#e2e8f0', text_secondary: '#64748b',
+			shadow: '0 4px 24px rgba(0,0,0,.5)',
+		},
+	},
+	{
+		id: 'forest', label: 'Forêt', emoji: '🌲',
+		theme: {
+			primary: '#22c55e', accent: '#84cc16', link_color: '#4ade80', bg: '#031f0f',
+			card_bg: 'rgba(34,197,94,.05)', border_color: 'rgba(34,197,94,.14)', border_width: '1px',
+			border_radius: '8px', font_family: 'Inter', font_size_base: '15px',
+			font_weight_heading: '700', text_primary: '#f0fdf4', text_secondary: '#6b9a7d',
+			shadow: '0 4px 24px rgba(0,0,0,.45)',
+		},
+	},
+	{
+		id: 'warm', label: 'Chaleur', emoji: '🔥',
+		theme: {
+			primary: '#f97316', accent: '#facc15', link_color: '#fb923c', bg: '#1c0a00',
+			card_bg: 'rgba(249,115,22,.06)', border_color: 'rgba(249,115,22,.16)', border_width: '1px',
+			border_radius: '12px', font_family: 'Space Grotesk', font_size_base: '16px',
+			font_weight_heading: '800', text_primary: '#fff7ed', text_secondary: '#c99a72',
+			shadow: '0 4px 24px rgba(0,0,0,.45)',
+		},
+	},
+	{
+		id: 'rose', label: 'Rose', emoji: '🌸',
+		theme: {
+			primary: '#ec4899', accent: '#a78bfa', link_color: '#f472b6', bg: '#1a0010',
+			card_bg: 'rgba(236,72,153,.05)', border_color: 'rgba(236,72,153,.15)', border_width: '1px',
+			border_radius: '14px', font_family: 'Space Grotesk', font_size_base: '15px',
+			font_weight_heading: '700', text_primary: '#fdf2f8', text_secondary: '#c48aa8',
+			shadow: '0 4px 24px rgba(0,0,0,.4)',
+		},
+	},
+	{
+		id: 'minimal', label: 'Minimal', emoji: '◻️',
+		theme: {
+			primary: '#e2e8f0', accent: '#94a3b8', link_color: '#e2e8f0', bg: '#0a0a0a',
+			card_bg: 'rgba(255,255,255,.02)', border_color: 'rgba(255,255,255,.10)', border_width: '1px',
+			border_radius: '2px', font_family: 'Inter', font_size_base: '15px',
+			font_weight_heading: '600', text_primary: '#f5f5f5', text_secondary: '#8a8a8a',
+			shadow: '0 2px 12px rgba(0,0,0,.3)',
+		},
+	},
+]
+
+/** Parse une couleur "rgba(r,g,b,a)" ou hex en { hex, alpha } pour un color picker natif + curseur d'opacité. */
+export function parseColorAlpha(input: string): { hex: string; alpha: number } {
+	const rgba = /rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+))?\s*\)/i.exec(input ?? '')
+	if (rgba) {
+		const [, r, g, b, a] = rgba
+		const hex = '#' + [r, g, b].map(v => Math.max(0, Math.min(255, parseInt(v, 10))).toString(16).padStart(2, '0')).join('')
+		return { hex, alpha: a !== undefined ? parseFloat(a) : 1 }
+	}
+	const hexMatch = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(input?.trim() ?? '')
+	if (hexMatch) return { hex: '#' + (hexMatch[1].length === 3 ? hexMatch[1].split('').map(c => c + c).join('') : hexMatch[1]), alpha: 1 }
+	return { hex: '#a78bfa', alpha: 1 }
+}
+
+/** Recompose "rgba(r,g,b,a)" à partir d'un hex (color picker) + une opacité 0-1 (slider). */
+export function composeRgba(hex: string, alpha: number): string {
+	const { hex: h } = parseColorAlpha(hex)
+	const triplet = hexToRgbTriplet(h)
+	return `rgba(${triplet.split(' ').join(',')},${Math.round(alpha * 100) / 100})`
 }
 
 export interface GridColumn {

--- a/nodyx-frontend/src/routes/admin/homepage/builder/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/homepage/builder/+page.svelte
@@ -11,7 +11,8 @@
 		GridLayout, GridRow, GridColumn, GridTheme,
 	} from '$lib/types/homepage'
 	import {
-		DEFAULT_THEME, genId, makeRow, makeRowFromSpans
+		DEFAULT_THEME, GRID_THEME_PRESETS, genId, makeRow, makeRowFromSpans,
+		parseColorAlpha, composeRgba,
 	} from '$lib/types/homepage'
 	import { untrack, tick } from 'svelte'
 	import { t as i18n } from '$lib/i18n'
@@ -375,6 +376,36 @@
 	function updateTheme<K extends keyof GridTheme>(key: K, value: GridTheme[K]) {
 		theme = { ...theme, [key]: value }
 		markUnsaved()
+	}
+
+	// Réinitialise le thème entier au défaut Nodyx. Confirmation requise : ça
+	// écrase toutes les couleurs/typo/forme personnalisées d'un coup.
+	function resetTheme() {
+		if (!confirm(tFn('hpb.confirm_reset_theme'))) return
+		theme = { ...DEFAULT_THEME }
+		markUnsaved()
+		toast(tFn('hpb.toast_theme_reset'))
+	}
+
+	// Applique un préthème complet (couleurs + typo + forme) en un clic.
+	function applyPreset(presetId: string) {
+		const preset = GRID_THEME_PRESETS.find(p => p.id === presetId)
+		if (!preset) return
+		theme = { ...preset.theme }
+		markUnsaved()
+		toast(tFn('hpb.toast_preset_applied', { name: preset.label }))
+	}
+
+	// Helpers pour le color picker avec transparence (card_bg / border_color).
+	// Le <input type="color"> natif ne gère pas l'alpha : on le pilote via une
+	// paire { hex, alpha } dérivée de la chaîne rgba() stockée dans le thème.
+	function updateColorAlphaHex(key: 'card_bg' | 'border_color', hex: string) {
+		const { alpha } = parseColorAlpha(theme[key])
+		updateTheme(key, composeRgba(hex, alpha))
+	}
+	function updateColorAlphaOpacity(key: 'card_bg' | 'border_color', alpha: number) {
+		const { hex } = parseColorAlpha(theme[key])
+		updateTheme(key, composeRgba(hex, alpha))
 	}
 
 	// ── Save / Publish ────────────────────────────────────────────────────────
@@ -1162,11 +1193,31 @@
 		<!-- ── Panel : thème ─────────────────────────────────────────── -->
 		{:else if activePanel === 'theme'}
 			<div class="panel-body">
-				<div class="panel-section-title">{tFn('hpb.colors')}</div>
+				<!-- Préthèmes : point de départ sûr, un clic remplace tout, Réinitialiser
+				     permet toujours de revenir en arrière sans perte. -->
+				<div class="panel-section-title">{tFn('hpb.presets')}</div>
+				<div class="preset-theme-grid">
+					{#each GRID_THEME_PRESETS as p}
+						<button
+							class="preset-theme-btn"
+							title={p.label}
+							onclick={() => applyPreset(p.id)}
+						>
+							<span class="preset-theme-swatch" style="background: linear-gradient(135deg, {p.theme.primary}, {p.theme.accent})">{p.emoji}</span>
+							<span class="preset-theme-label">{p.label}</span>
+						</button>
+					{/each}
+				</div>
+				<button class="btn-secondary preset-theme-reset" onclick={resetTheme}>
+					↺ {tFn('hpb.reset_theme')}
+				</button>
+
+				<div class="panel-section-title" style="margin-top:14px">{tFn('hpb.colors')}</div>
 
 				{#each [
 					{ key: 'primary',       labelKey: 'hpb.th_primary' },
 					{ key: 'accent',        labelKey: 'hpb.th_accent' },
+					{ key: 'link_color',     labelKey: 'hpb.th_link' },
 					{ key: 'bg',            labelKey: 'hpb.th_bg' },
 					{ key: 'text_primary',  labelKey: 'hpb.th_text_primary' },
 					{ key: 'text_secondary',labelKey: 'hpb.th_text_secondary' },
@@ -1189,14 +1240,29 @@
 					{ key: 'card_bg',      labelKey: 'hpb.th_card_bg' },
 					{ key: 'border_color', labelKey: 'hpb.th_border' },
 				] as f}
+					{@const parsed = parseColorAlpha(theme[f.key as 'card_bg' | 'border_color'])}
 					<label class="pfield">
 						<span>{tFn(f.labelKey)}</span>
-						<input type="text" value={theme[f.key as keyof GridTheme] as string}
-							placeholder={tFn('hpb.ph_rgba_hex')}
-							onchange={(e) => updateTheme(f.key as keyof GridTheme, (e.target as HTMLInputElement).value as any)}
-						/>
+						<div class="pfield-color">
+							<input type="color" value={parsed.hex}
+								oninput={(e) => updateColorAlphaHex(f.key as 'card_bg' | 'border_color', (e.target as HTMLInputElement).value)}
+							/>
+							<input type="range" min="0" max="1" step="0.01" value={parsed.alpha}
+								title={tFn('hpb.opacity', { v: Math.round(parsed.alpha * 100) })}
+								oninput={(e) => updateColorAlphaOpacity(f.key as 'card_bg' | 'border_color', parseFloat((e.target as HTMLInputElement).value))}
+							/>
+							<span class="pfield-opacity-val">{Math.round(parsed.alpha * 100)}%</span>
+						</div>
 					</label>
 				{/each}
+
+				<label class="pfield">
+					<span>{tFn('hpb.border_width', { v: theme.border_width })}</span>
+					<input type="range" min="0" max="4" step="1"
+						value={parseInt(theme.border_width)}
+						oninput={(e) => updateTheme('border_width', `${(e.target as HTMLInputElement).value}px`)}
+					/>
+				</label>
 
 				<div class="panel-section-title" style="margin-top:8px">{tFn('hpb.typography')}</div>
 
@@ -1689,9 +1755,51 @@
 		flex-shrink: 0;
 	}
 	.pfield-color input[type="text"] { flex: 1; }
+	.pfield-color input[type="range"] { flex: 1; }
+	.pfield-opacity-val {
+		font-size: 10px; color: #6b7280;
+		width: 32px; text-align: right; flex-shrink: 0;
+		font-variant-numeric: tabular-nums;
+	}
 	.pfield-clear {
 		background: none; border: none; color: #6b7280;
 		cursor: pointer; font-size: 11px;
+	}
+
+	/* ── Préthèmes ────────────────────────────────────────────────────────────── */
+	.preset-theme-grid {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 6px;
+	}
+	.preset-theme-btn {
+		display: flex; flex-direction: column; align-items: center; gap: 5px;
+		padding: 8px 4px;
+		background: rgba(255,255,255,.03);
+		border: 1px solid rgba(255,255,255,.08);
+		border-radius: 5px;
+		cursor: pointer;
+		transition: border-color .15s, background .15s;
+	}
+	.preset-theme-btn:hover {
+		background: rgba(167,139,250,.06);
+		border-color: rgba(167,139,250,.35);
+	}
+	.preset-theme-swatch {
+		width: 32px; height: 32px;
+		border-radius: 50%;
+		display: flex; align-items: center; justify-content: center;
+		font-size: 15px;
+		box-shadow: inset 0 0 0 1px rgba(255,255,255,.15);
+	}
+	.preset-theme-label {
+		font-size: 10px; color: #9ca3af;
+		white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%;
+	}
+	.preset-theme-reset {
+		width: 100%;
+		margin-top: 8px;
+		font-size: 11px;
 	}
 
 	/* Toggle */


### PR DESCRIPTION
## Pourquoi

*"je n'ose pas jouer avec le thème"*, puis *"même texte secondaire n'a pas l'air de fonctionner, manque aussi couleur des url, bref il manque énormément de chose"*.

Audit complet des 9 widgets natifs avant toute correction : **169 déclarations de couleur en dur** trouvées. Deux widgets considérés « corrigés » dans un patch précédent (#504 : Articles Showcase, Twitch Stream) utilisaient en réalité une couleur de config **locale** (`accent_color`), quasi déconnectée du thème du builder, une seule référence réelle sur ~55 chacun.

Cause de fond : `text_secondary` (`--ntm`) et `shadow` (`--nsh`) avaient **zéro usage réel** nulle part ; `card_bg`/`border_color`/`border_radius` n'étaient utilisés que par **un** widget sur neuf. Aucune variable de couleur de lien n'existait dans le thème.

## Changements

**Modèle de thème étendu** : `link_color`, `border_width` (demandé explicitement), 6 **préthèmes** prêts à l'emploi, `parseColorAlpha`/`composeRgba` pour un color picker avec transparence.

**9 widgets** : les 169 déclarations reconnectées à la bonne variable (`--nt`, `--ntm`, `--nc`, `--nborder`, `--nbw`, `--nl`, `--nfont`, `--nfwh`). Pour les widgets à couleur configurable par instance, le **défaut** suit désormais le thème en direct, l'admin peut toujours le personnaliser. Les vraies couleurs de marque (violet Twitch, icônes Discord/YouTube...) restent volontairement hors-scope.

**Panneau Thème** : galerie de 6 préthèmes en un clic, bouton **Réinitialiser** (confirmation requise), color picker + curseur d'opacité pour `card_bg`/`border_color`, nouveaux champs couleur de lien et épaisseur de bordure.

## Vérifié

`svelte-check` : 0 erreur. **4 portes i18n locales** : `i18n:check` (0 chaîne en dur), `i18n:keys:check`, `i18n:parity:check` (EN 100%), `i18n:placeholders:check` — 8 nouvelles clés dans `fr.json` + `en.json`, même PR. Aucun changement backend (thème stocké en JSONB libre, pas de validation de schéma côté nodyx-core).