### PR TITLE
fix(homepage-builder): les polices et l'arrondi du thème n'avaient aucun effet

### DIFF
--- a/nodyx-frontend/src/lib/components/homepage/widgets/ArticleSlideshow.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/ArticleSlideshow.svelte
@@ -313,6 +313,7 @@
 		position: relative;
 		width: 100%;
 		overflow: hidden;
+		border-radius: var(--nr, 0px);
 		background: var(--nb, #06060d);
 	}
 

--- a/nodyx-frontend/src/lib/components/homepage/widgets/ArticlesShowcase.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/ArticlesShowcase.svelte
@@ -463,6 +463,7 @@
 		display: flex; flex-direction: column;
 		background: var(--nc, rgba(255,255,255,.03));
 		border: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.07));
+		border-radius: var(--nr, 0px);
 		overflow: hidden;
 		text-decoration: none; color: inherit;
 		transition: border-color .2s, transform .2s;
@@ -520,6 +521,7 @@
 		display: flex; flex-direction: column;
 		background: var(--nc, rgba(255,255,255,.03));
 		border: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.07));
+		border-radius: var(--nr, 0px);
 		overflow: hidden;
 		text-decoration: none; color: inherit;
 		transition: border-color .2s;
@@ -572,6 +574,7 @@
 		gap: 1rem; align-items: center;
 		background: var(--nc, rgba(255,255,255,.025));
 		border: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.06));
+		border-radius: var(--nr, 0px);
 		padding: .75rem;
 		text-decoration: none; color: inherit;
 		transition: border-color .2s, background .2s;
@@ -583,6 +586,7 @@
 	.as-horiz-cover {
 		width: 180px; height: 110px;
 		position: relative; overflow: hidden;
+		border-radius: var(--nr, 0px);
 		background: var(--nc, #0d0d12);
 	}
 	.as-horiz-cover img { width: 100%; height: 100%; object-fit: cover; transition: transform .5s; }
@@ -617,6 +621,7 @@
 		position: relative;
 		background: var(--nc, rgba(255,255,255,.03));
 		border: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.07));
+		border-radius: var(--nr, 0px);
 		overflow: hidden;
 	}
 	.as-slide { display: block; text-decoration: none; color: inherit; }

--- a/nodyx-frontend/src/lib/components/homepage/widgets/HeroBanner.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/HeroBanner.svelte
@@ -271,6 +271,7 @@
 		overflow: hidden;
 		background: var(--nc, #0a0a0f);
 		border-bottom: var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.05));
+		border-radius: var(--nr, 0px);
 	}
 
 	.noise::after {

--- a/nodyx-frontend/src/lib/components/homepage/widgets/JoinCard.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/JoinCard.svelte
@@ -42,7 +42,7 @@
 </script>
 
 <div class="p-5 flex flex-col gap-4"
-     style="background:var(--nc); border:var(--nbw) solid var(--nborder)">
+     style="background:var(--nc); border:var(--nbw) solid var(--nborder); border-radius:var(--nr, 0px); overflow:hidden">
 
 	<!-- Title -->
 	<div>

--- a/nodyx-frontend/src/lib/components/homepage/widgets/StatsBar.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/StatsBar.svelte
@@ -104,7 +104,7 @@
 <div class="flex flex-wrap items-stretch gap-0.5">
 	{#each visibleStats as stat (stat.key)}
 		<div class="flex flex-col items-center justify-center px-6 py-2 gap-0.5"
-		     style="background:var(--nc); border:var(--nbw) solid var(--nborder)">
+		     style="background:var(--nc); border:var(--nbw) solid var(--nborder); border-radius:var(--nr, 0px)">
 			<span
 				class="font-black text-xl tabular-nums"
 				class:sglow={stat.glow}

--- a/nodyx-frontend/src/lib/components/homepage/widgets/TwitchStream.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/TwitchStream.svelte
@@ -159,7 +159,7 @@
 {#if !configuredChannel}
 	<!-- Empty state : aucune chaîne configurée -->
 	<div class="relative flex flex-col items-center justify-center gap-3 px-6 py-12 text-center"
-	     style="background:var(--nc, rgba(255,255,255,.03)); border:var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.07))">
+	     style="background:var(--nc, rgba(255,255,255,.03)); border:var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.07)); border-radius:var(--nr, 0px)">
 		<svg viewBox="0 0 24 24" class="w-8 h-8" style="color:{accent}" fill="currentColor" aria-hidden="true">
 			<path d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714Z"/>
 		</svg>
@@ -174,7 +174,7 @@
 {:else}
 	<div class="twitch-widget relative overflow-hidden"
 	     class:is-live={isMainLive || isFallbackLive}
-	     style="--accent:{accent}; background:var(--nc, rgba(255,255,255,.03)); border:var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.07))">
+	     style="--accent:{accent}; background:var(--nc, rgba(255,255,255,.03)); border:var(--nbw, 1px) solid var(--nborder, rgba(255,255,255,.07)); border-radius:var(--nr, 0px)">
 
 		<!-- Gradient shine animée (purple Twitch → teal Nodyx) -->
 		<div class="twitch-shine" aria-hidden="true"></div>

--- a/nodyx-frontend/src/lib/types/homepage.ts
+++ b/nodyx-frontend/src/lib/types/homepage.ts
@@ -1,3 +1,21 @@
+// ── Polices proposées par le thème du Homepage Builder ────────────────────────
+// Choisir une police dans le panneau ne l'affichait jamais : aucun <link>
+// Google Fonts ne les chargeait nulle part (seule 'Space Grotesk' l'était,
+// par un lien codé en dur SANS RAPPORT avec ce sélecteur). URL construite une
+// fois pour les 10 polices, chargée à la fois sur la page publique et dans
+// l'éditeur admin, même technique que GOOGLE_FONTS_URL dans nameEffects.ts.
+export const GRID_FONTS = [
+	'Space Grotesk', 'Inter', 'DM Sans', 'Sora', 'Outfit',
+	'Nunito', 'Poppins', 'Raleway', 'Rubik', 'Manrope',
+] as const;
+
+export const GRID_GOOGLE_FONTS_URL = (() => {
+	const families = GRID_FONTS
+		.map(f => `family=${encodeURIComponent(f)}:wght@400;500;600;700;800`)
+		.join('&');
+	return `https://fonts.googleapis.com/css2?${families}&display=swap`;
+})();
+
 // ── Ancien système (positions fixes) ──────────────────────────────────────────
 export interface HomepageWidget {
 	id:           string;
@@ -54,7 +72,11 @@ export const DEFAULT_THEME: GridTheme = {
 	card_bg:             'rgba(255,255,255,.03)',
 	border_color:        'rgba(255,255,255,.08)',
 	border_width:        '1px',
-	border_radius:       '10px',
+	// 0 par défaut : l'identité "flat design" du site (voir CHANGELOG v1.9.5,
+	// "forum redesign, flat design, zero radius") ne doit pas changer d'un coup
+	// pour les instances existantes le jour où border_radius devient réellement
+	// appliqué. Les préthèmes ci-dessous, eux, arrondissent volontairement.
+	border_radius:       '0px',
 	font_family:         'Space Grotesk',
 	font_size_base:      '15px',
 	font_weight_heading: '700',

--- a/nodyx-frontend/src/routes/+page.svelte
+++ b/nodyx-frontend/src/routes/+page.svelte
@@ -5,6 +5,7 @@
 	import WidgetZone from '$lib/components/homepage/WidgetZone.svelte';
 	import GridRenderer from '$lib/components/homepage/GridRenderer.svelte';
 	import type { HomepagePosition, GridLayout, GridTheme } from '$lib/types/homepage';
+	import { GRID_GOOGLE_FONTS_URL } from '$lib/types/homepage';
 	const tFn = $derived($t)
 
 	let { data }: { data: PageData } = $props();
@@ -86,7 +87,10 @@
 	<meta property="og:description" content={instance.description} />
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-	<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700;800&display=swap" rel="stylesheet" />
+	<!-- Les 10 polices proposées par le thème du Homepage Builder (--nfont) : sans
+	     ce lien, choisir une police dans le panneau n'a aucun effet visuel, le
+	     navigateur retombe sur une police système générique. -->
+	<link href={GRID_GOOGLE_FONTS_URL} rel="stylesheet" />
 </svelte:head>
 
 <style>

--- a/nodyx-frontend/src/routes/admin/homepage/builder/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/homepage/builder/+page.svelte
@@ -11,7 +11,7 @@
 		GridLayout, GridRow, GridColumn, GridTheme,
 	} from '$lib/types/homepage'
 	import {
-		DEFAULT_THEME, GRID_THEME_PRESETS, genId, makeRow, makeRowFromSpans,
+		DEFAULT_THEME, GRID_THEME_PRESETS, GRID_GOOGLE_FONTS_URL, genId, makeRow, makeRowFromSpans,
 		parseColorAlpha, composeRgba,
 	} from '$lib/types/homepage'
 	import { untrack, tick } from 'svelte'
@@ -661,7 +661,14 @@
 	]
 </script>
 
-<svelte:head><title>Grid Builder · Admin</title></svelte:head>
+<svelte:head>
+	<title>Grid Builder · Admin</title>
+	<!-- Polices du thème (--nfont) : sans ce lien, le sélecteur change une valeur
+	     que le navigateur ne peut pas afficher, l'aperçu ne bouge pas. -->
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+	<link href={GRID_GOOGLE_FONTS_URL} rel="stylesheet" />
+</svelte:head>
 
 <!-- ── Toasts ───────────────────────────────────────────────────────────────── -->
 <div class="toasts">


### PR DESCRIPTION
## Pourquoi

Après le fix des couleurs (#505) : *"les arrondis ne fonctionnent pas et la typo ne change pas"*.

**Police** : le sélecteur propose 10 polices, mais **aucune n'était chargée** dans le navigateur. Changer la valeur mettait bien à jour `--nfont` en CSS, mais sans fichier de police disponible, le navigateur retombait sur un sans-serif générique. Seule "Space Grotesk" semblait fonctionner, via un lien Google Fonts **sans rapport** (codé en dur pour un tout autre usage sur la page d'accueil, poids 500/700/800 uniquement).

**Arrondi** : `--nr` n'était consommé que par 2 widgets sur 9. Les cartes/avatars/badges utilisent en général leur propre petite échelle fixe (50% pour les ronds, 2-6px pour les badges), distincte à raison du réglage macro du thème — mais les **vrais conteneurs de carte** (racine Hero Banner, cartes Articles Showcase, tuile Join Card/Stats Bar, widget Twitch) n'avaient eux jamais reçu de `border-radius` du tout.

## Changements

- `GRID_GOOGLE_FONTS_URL` (même technique que le mécanisme existant pour les polices de pseudo) : charge les 10 polices sur la page publique **et** dans l'éditeur admin (l'aperçu en direct affiche enfin la vraie police).
- `border-radius: var(--nr, 0px)` branché sur les conteneurs de carte identifiés. Comme ils ont déjà `overflow: hidden`, arrondir le conteneur suffit à découper proprement l'image de couverture à l'intérieur, sans toucher aux éléments internes.
- `DEFAULT_THEME.border_radius` : `10px` → `0px`. Le reste du site est en "flat design, zéro radius" par choix assumé (CHANGELOG v1.9.5) — sans ce changement, brancher `--nr` aurait arrondi d'un coup tous les coins de chaque instance existante dès le déploiement. Les préthèmes, eux, arrondissent volontairement.

## Vérifié

`svelte-check` : 0 erreur, 0 nouveau warning. `i18n:check` : 0 chaîne en dur (aucun nouveau texte, changement CSS/ressource pur). Aucun changement backend.