### PR TITLE
fix(admin): un formulaire de branding perime effacait le fond de sidebar

### DIFF
--- a/nodyx-frontend/src/routes/admin/settings/+page.server.ts
+++ b/nodyx-frontend/src/routes/admin/settings/+page.server.ts
@@ -13,13 +13,22 @@ export const actions: Actions = {
 		const form = await request.formData()
 		const logo_url      = (form.get('logo_url')   as string | null) || null
 		const banner_url    = (form.get('banner_url') as string | null) || null
-		const sidebarBgRaw  = (form.get('sidebar_bg') as string | null) || null
-		const sidebar_bg    = sidebarBgRaw ? JSON.parse(sidebarBgRaw) : null
+
+		// Champ ABSENT du formulaire != champ vide. Une page admin restee ouverte
+		// sur un build anterieur ne connait pas `sidebar_bg` et ne l'envoie pas :
+		// l'enregistrer effacait alors un fond deja configure, en silence. On ne
+		// transmet la cle que si le formulaire l'a reellement portee -- le PATCH
+		// cote core distingue deja `undefined` (ne pas toucher) de `null` (effacer).
+		const payload: Record<string, unknown> = { logo_url, banner_url }
+		if (form.has('sidebar_bg')) {
+			const raw = (form.get('sidebar_bg') as string | null) || null
+			payload.sidebar_bg = raw ? JSON.parse(raw) : null
+		}
 
 		const res = await apiFetch(fetch, '/admin/branding', {
 			method:  'PATCH',
 			headers: { Authorization: `Bearer ${token}` },
-			body:    JSON.stringify({ logo_url, banner_url, sidebar_bg }),
+			body:    JSON.stringify(payload),
 		})
 		if (!res.ok) return { error: (await res.json()).error ?? 'Erreur lors de la sauvegarde' }
 		return { ok: true }


### PR DESCRIPTION
Constate en production juste apres la 2.12.0 : le fond de sidebar configure est revenu a vide tout seul, alors que le logo venait d'etre change depuis la meme page.

**Cause.** `form.get('sidebar_bg')` renvoie `null` dans deux cas tres differents : champ vide, et champ **absent**. Une page d'administration restee ouverte sur un build anterieur ne connait pas ce champ, ne l'envoie pas, et l'enregistrement transmettait alors `sidebar_bg: null`, effacant un fond deja en place.

**Fix.** Ne transmettre la cle que si le formulaire l'a reellement portee (`form.has`). Le PATCH cote core distinguait deja `undefined` (ne pas toucher) de `null` (effacer) : c'est le frontend qui n'exploitait pas cette distinction.

Vaut pour toute cle ajoutee plus tard a ce formulaire : un client qui ignore un champ ne doit jamais pouvoir le remettre a zero.