### PR TITLE
fix(directory): une instance jamais allumee restait affichee a vie

### DIFF
--- a/nodyx-core/src/routes/directory.ts
+++ b/nodyx-core/src/routes/directory.ts
@@ -164,9 +164,17 @@ export default async function directoryRoutes(app: FastifyInstance) {
              logo_url, banner_url
       FROM directory_instances
       WHERE status = 'active'
+        -- Archivage (migration 083) : la colonne et ses index existaient, mais
+        -- la requete ne les lisait pas. Une instance archivee restait donc
+        -- affichee, l'archivage n'avait aucun effet visible.
+        AND archived_at IS NULL
         AND (
-          last_seen IS NULL
-          OR last_seen > NOW() - INTERVAL '15 minutes'
+          last_seen > NOW() - INTERVAL '15 minutes'
+          -- Une instance fraichement enregistree n'a pas encore pingue : on lui
+          -- laisse le temps de demarrer, mais BORNE dans le temps. Avant, un
+          -- simple "last_seen IS NULL" la rendait visible A VIE, meme si elle
+          -- n'avait jamais ete allumee une seule seconde.
+          OR (last_seen IS NULL AND registered_at > NOW() - INTERVAL '15 minutes')
         )
       ORDER BY members DESC, registered_at ASC
     `);

--- a/nodyx-core/src/tests/directory-visibility.test.ts
+++ b/nodyx-core/src/tests/directory-visibility.test.ts
@@ -1,0 +1,84 @@
+// ─── Annuaire fédéré : qui a le droit d'être affiché ────────────────────────
+//
+// Deux défauts corrigés ensemble, tous deux constatés en production :
+//
+// 1. `last_seen IS NULL` était un passe-droit ILLIMITÉ. Une instance qui
+//    s'enregistrait puis n'était jamais allumée échappait à la règle des 15
+//    minutes (qui ne s'applique qu'à celles ayant déjà pingé) et restait donc
+//    affichée À VIE. Cas réel : « GameDev Fr », inscrite en mars, jamais un
+//    seul ping, toujours listée cinq mois plus tard.
+//
+// 2. `archived_at` (migration 083) n'était lu NULLE PART. La migration avait
+//    pourtant créé la colonne ET un index partiel `WHERE archived_at IS NULL`,
+//    en documentant l'intention : « exclue de la carte et de la liste
+//    principale ». La fonctionnalité était livrée à moitié : archiver une
+//    instance n'avait aucun effet visible.
+//
+// Ces tests échouent sur le code d'avant. cf feedback_test_first_critical.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { buildApp } from './helpers/buildApp'
+
+vi.mock('../config/database', () => ({
+  db: { query: vi.fn() },
+  redis: {
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue('OK'),
+    incr: vi.fn().mockResolvedValue(1),
+    expire: vi.fn().mockResolvedValue(1),
+    ttl: vi.fn().mockResolvedValue(60),
+  },
+}))
+
+import { db } from '../config/database'
+import directoryRoutes from '../routes/directory'
+
+/** Le SQL réellement envoyé à Postgres par la liste publique. */
+async function listSql(): Promise<string> {
+  vi.mocked(db.query).mockResolvedValue({ rows: [] } as never)
+  const app = await buildApp(async (a) => { await a.register(directoryRoutes, { prefix: '/api' }) })
+  const res = await app.inject({ method: 'GET', url: '/api/directory' })
+  await app.close()
+  expect(res.statusCode).toBe(200)
+
+  const call = vi.mocked(db.query).mock.calls.find(
+    ([sql]) => typeof sql === 'string' && sql.includes('FROM directory_instances'),
+  )
+  if (!call) throw new Error('aucun SELECT directory_instances exécuté')
+  return call[0] as string
+}
+
+/** Sans les commentaires SQL, pour ne tester que la clause réellement exécutée. */
+function withoutComments(sql: string): string {
+  return sql.replace(/--[^\n]*/g, '')
+}
+
+describe('GET /api/directory — règles de visibilité', () => {
+  beforeEach(() => { vi.resetAllMocks() })
+
+  it('exclut les instances archivées', async () => {
+    const sql = withoutComments(await listSql())
+    expect(sql).toMatch(/archived_at\s+IS\s+NULL/i)
+  })
+
+  it("n'accorde plus de visibilité illimitée à une instance qui n'a jamais pingé", async () => {
+    const sql = withoutComments(await listSql())
+
+    // Le passe-droit doit être BORNÉ : s'il reste un `last_seen IS NULL`, il
+    // doit être accompagné d'une contrainte sur registered_at.
+    const hasNullClause = /last_seen\s+IS\s+NULL/i.test(sql)
+    if (hasNullClause) {
+      expect(sql).toMatch(/registered_at\s*>\s*NOW\(\)\s*-\s*INTERVAL/i)
+    }
+  })
+
+  it('garde la règle des 15 minutes pour les instances qui ont déjà pingé', async () => {
+    const sql = withoutComments(await listSql())
+    expect(sql).toMatch(/last_seen\s*>\s*NOW\(\)\s*-\s*INTERVAL\s*'15 minutes'/i)
+  })
+
+  it("ne liste que les instances au statut 'active'", async () => {
+    const sql = withoutComments(await listSql())
+    expect(sql).toMatch(/status\s*=\s*'active'/i)
+  })
+})


### PR DESCRIPTION
Trouve en nettoyant l'annuaire : **« GameDev Fr », inscrite le 7 mars, n'a jamais envoye un seul ping, et etait toujours listee publiquement cinq mois plus tard.**

Deux defauts distincts derriere le meme symptome.

### 1. Le passe-droit `last_seen IS NULL` n'avait aucune borne

```sql
AND (last_seen IS NULL OR last_seen > NOW() - INTERVAL '15 minutes')
```

La regle des 15 minutes ne s'applique qu'aux instances qui ont **deja** pingue. Une instance qui ne pingue jamais tombe dans la branche `IS NULL` et devient **visible a vie**. C'est l'exact inverse de l'intention : une instance jamais allumee est precisement celle qu'il ne faut pas montrer.

Elle garde desormais une fenetre de demarrage, mais **bornee sur `registered_at`** : le temps de booter et d'emettre son premier heartbeat.

### 2. `archived_at` n'etait lu nulle part

La migration 083 a cree la colonne **et** un index partiel `WHERE archived_at IS NULL`, en documentant l'intention : *« exclue de la carte et de la liste principale »*. La requete de la liste ne l'a jamais lue. La fonctionnalite etait **livree a moitie** : archiver une instance n'avait aucun effet visible. GameDev Fr etait archivee depuis le 15 mai et s'affichait quand meme.

La liste honore maintenant le drapeau, et utilise l'index qui l'attendait depuis le debut.

### Effet de bord corrige au passage

Une instance fraichement enregistree apparaissait **immediatement mais nue** : 0 membre, ni logo ni banniere, puisque ces champs ne sont remplis que par le premier ping. Constate en direct en enregistrant une nouvelle instance. Elle attend maintenant d'avoir pingue, sauf pendant sa fenetre de demarrage.

### Tests

4 cas sur le SQL reellement emis par la route. Les 2 qui portent sur les defauts ci-dessus **echouent sur le code d'avant** (verifie en remettant temporairement l'ancienne clause) ; les 2 autres verrouillent les regles deja correctes (statut actif, fenetre de 15 minutes).

`tsc --noEmit` propre, 469 tests core verts.