### PR TITLE
fix(vocal): les panneaux etaient pieges par le transform de la sidebar

### DIFF
--- a/nodyx-frontend/src/lib/actions/anchoredPopover.ts
+++ b/nodyx-frontend/src/lib/actions/anchoredPopover.ts
@@ -1,0 +1,99 @@
+import { browser } from '$app/environment'
+
+export interface AnchoredPopoverOptions {
+	/** Élément de référence. Par défaut : le parent du nœud AVANT le portal. */
+	anchor?: HTMLElement | null
+	/** Écart en px entre l'ancre et le panneau. */
+	gap?: number
+	/** Marge minimale conservée avec les bords de l'écran. */
+	margin?: number
+	/** 'bottom' ouvre sous l'ancre et bascule au-dessus si ça déborde ; 'top' l'inverse. */
+	placement?: 'bottom' | 'top'
+	/** Aligne le panneau sur le bord droit de l'ancre plutôt que sur le gauche. */
+	align?: 'start' | 'end'
+}
+
+/**
+ * Panneau ancré à un bouton : portalé dans `<body>`, positionné en `fixed`
+ * depuis le rectangle de son ancre, borné à l'écran DES DEUX CÔTÉS, et bascule
+ * de l'autre côté quand il n'y a plus la place.
+ *
+ * Extrait de `editor/NodyxEditor.svelte` (action `autoFlip`), où ce calcul est
+ * en production depuis longtemps : c'est le seul endroit du dépôt qui traitait
+ * correctement le problème. Il est promu ici en primitive partagée plutôt que
+ * recopié une nième fois, parce que six stratégies de positionnement
+ * différentes coexistaient et que seule celle-ci résistait aux ancêtres
+ * transformés (cf `portal.ts` pour le détail du piège).
+ *
+ * Le suivi du scroll est en phase de CAPTURE : un `position: fixed` ne suit pas
+ * le défilement d'un conteneur interne, il faut le repositionner à la main.
+ */
+export function anchoredPopover(node: HTMLElement, options: AnchoredPopoverOptions = {}) {
+	if (!browser) return
+
+	const gap       = options.gap ?? 4
+	const margin    = options.margin ?? 8
+	const placement = options.placement ?? 'bottom'
+	const align     = options.align ?? 'start'
+
+	// L'ancre doit être lue AVANT de déplacer le nœud : après le portal, son
+	// parent est <body> et l'information est perdue.
+	let anchor: HTMLElement | null = options.anchor ?? node.parentElement
+
+	document.body.appendChild(node)
+
+	function place() {
+		if (!anchor || !anchor.isConnected) return
+
+		// Réinitialisé avant mesure : sinon on mesure le panneau contraint par sa
+		// position précédente, et il rétrécit un peu plus à chaque repositionnement.
+		node.style.left   = '0px'
+		node.style.top    = '0px'
+		node.style.right  = 'auto'
+		node.style.bottom = 'auto'
+
+		const pw = node.offsetWidth
+		const ph = node.offsetHeight
+		const a  = anchor.getBoundingClientRect()
+		const vw = window.innerWidth
+		const vh = window.innerHeight
+
+		const wanted = align === 'end' ? a.right - pw : a.left
+		const left   = Math.max(margin, Math.min(wanted, vw - pw - margin))
+
+		let top: number
+		if (placement === 'bottom') {
+			top = a.bottom + gap
+			if (top + ph > vh - margin && a.top - ph - gap >= margin) top = a.top - ph - gap
+		} else {
+			top = a.top - ph - gap
+			if (top < margin && a.bottom + gap + ph <= vh - margin) top = a.bottom + gap
+		}
+		top = Math.max(margin, Math.min(top, vh - ph - margin))
+
+		node.style.left = `${Math.round(left)}px`
+		node.style.top  = `${Math.round(top)}px`
+	}
+
+	place()
+
+	// Le panneau peut grandir après coup (contenu asynchrone, police chargée) :
+	// on le repositionne alors, sinon il déborde sans que rien ne le rattrape.
+	const ro = new ResizeObserver(place)
+	ro.observe(node)
+	window.addEventListener('resize', place)
+	window.addEventListener('scroll', place, true)
+
+	return {
+		update(next: AnchoredPopoverOptions = {}) {
+			if (next.anchor !== undefined) anchor = next.anchor
+			place()
+		},
+		destroy() {
+			ro.disconnect()
+			window.removeEventListener('resize', place)
+			window.removeEventListener('scroll', place, true)
+			node.remove()
+		},
+	}
+}

--- a/nodyx-frontend/src/lib/actions/portal.ts
+++ b/nodyx-frontend/src/lib/actions/portal.ts
@@ -1,0 +1,38 @@
+import { browser } from '$app/environment'
+
+/**
+ * Déplace le nœud dans `<body>` tant qu'il est monté, puis le retire.
+ *
+ * ─── Pourquoi cette action existe ────────────────────────────────────────────
+ * `position: fixed` ne suffit PAS à sortir un panneau de son conteneur. Dès
+ * qu'un ancêtre porte un `transform`, un `filter`, un `backdrop-filter`, un
+ * `will-change: transform` ou `contain: paint`, cet ancêtre devient le BLOC
+ * CONTENEUR de tous ses descendants `fixed` : `inset-0` ne désigne alors plus le
+ * viewport mais la boîte de l'ancêtre, et `left: 50%` se calcule sur SA largeur.
+ *
+ * Constaté deux fois en production dans ce dépôt :
+ *  - la sidebar gauche (`.nodyx-sb .panel`) porte `transform: translateX(0)` pour
+ *    son animation de repli. Le sélecteur de partage d'écran, en `fixed inset-0`,
+ *    s'y retrouvait dessiné dans 220px au lieu du viewport ; le panneau d'options
+ *    vocales, en `left-1/2 -translate-x-1/2 w-[360px]`, débordait à -14px et se
+ *    faisait cisailler ses libellés.
+ *  - la sidebar des membres (`.members-c`) cumule `will-change: transform` ET
+ *    `overflow: hidden` : piégé PUIS rogné.
+ *
+ * Le transform n'est pas le fautif, il porte une vraie animation : c'est au
+ * panneau de sortir de la zone piégée. Portaler dans `<body>` est la seule
+ * parade robuste, parce qu'elle ne dépend d'aucune hypothèse sur les ancêtres.
+ *
+ * ⚠ Le nœud change de parent : les styles hérités et le CSS scopé fondé sur un
+ * ancêtre ne s'appliquent plus. Les composants portalés doivent porter leurs
+ * classes utilitaires directement (c'est déjà le cas partout ici).
+ */
+export function portal(node: HTMLElement) {
+	if (!browser) return
+	document.body.appendChild(node)
+	return {
+		destroy() {
+			if (document.body.contains(node)) document.body.removeChild(node)
+		},
+	}
+}

--- a/nodyx-frontend/src/lib/components/NodyxCanvas.svelte
+++ b/nodyx-frontend/src/lib/components/NodyxCanvas.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { portal } from '$lib/actions/portal'
 	import { onMount, onDestroy }   from 'svelte'
 	import { browser }              from '$app/environment'
 	import CanvasLeftToolbar        from './CanvasLeftToolbar.svelte'
@@ -1882,14 +1883,6 @@
 	}
 	function onKeyup(e: KeyboardEvent) {
 		if (e.code === 'Space') spaceDown = false
-	}
-
-	// ── Portal ────────────────────────────────────────────────────────────────
-
-	function portal(node: HTMLElement) {
-		if (!browser) return
-		document.body.appendChild(node)
-		return { destroy() { if (document.body.contains(node)) document.body.removeChild(node) } }
 	}
 
 	// ── Lifecycle ─────────────────────────────────────────────────────────────

--- a/nodyx-frontend/src/lib/components/ScreenShareModal.svelte
+++ b/nodyx-frontend/src/lib/components/ScreenShareModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { startScreenShare, screenShareSupported, type DisplaySurface, type ShareQuality, type ShareFps } from '$lib/voice'
+    import { portal } from '$lib/actions/portal'
     import { t } from '$lib/i18n'
 
     const tFn = $derived($t)
@@ -47,7 +48,13 @@
 </script>
 
 <!-- Overlay -->
+<!-- Portalée dans <body> : ce composant est ouvert depuis VoicePanel, qui vit
+     dans la sidebar gauche. Celle-ci porte `transform: translateX(0)` pour son
+     animation de repli, ce qui en fait le bloc conteneur des descendants
+     `fixed` : sans portal, `inset-0` désignait la sidebar (220px) et non le
+     viewport, la carte tombait à ~188px et `max-w-md` ne s'appliquait jamais. -->
 <div
+    use:portal
     class="fixed inset-0 z-[300] flex items-center justify-center p-4"
     style="background: rgba(0,0,0,0.75); backdrop-filter: blur(6px);"
     role="dialog"

--- a/nodyx-frontend/src/lib/components/StageView.svelte
+++ b/nodyx-frontend/src/lib/components/StageView.svelte
@@ -549,7 +549,10 @@
              laisse un onglet fin pour le rouvrir (on ne cherche pas un bouton). -->
         {#if channelId}
             {#if showChat}
-                <div class="w-80 shrink-0 min-h-0 xl:w-96">
+                <!-- Largeur FIXE à 320px, y compris sur très grand écran : le
+                     `xl:w-96` d'avant élargissait le chat à 384px là où c'est
+                     justement la vidéo qui doit récupérer la place gagnée. -->
+                <div class="w-80 shrink-0 min-h-0">
                     <StageChat channelId={channelId} oncollapse={() => showChat = false}/>
                 </div>
             {:else}

--- a/nodyx-frontend/src/lib/components/VoicePanel.svelte
+++ b/nodyx-frontend/src/lib/components/VoicePanel.svelte
@@ -12,6 +12,7 @@
     import VoiceSettings    from './VoiceSettings.svelte'
     import ScreenShareModal from './ScreenShareModal.svelte'
     import { stageOpenStore } from '$lib/stageStore'
+    import { portal } from '$lib/actions/portal'
     import { onMount } from 'svelte'
     import { t } from '$lib/i18n'
     import { voicePanelTarget } from '$lib/voicePanel'
@@ -228,13 +229,16 @@
     <!-- ── Panneau "Vous" ──────────────────────────────────────────── -->
     {#if selfInfo !== null}
         {@const si = selfInfo}
-        <div class='fixed inset-0 z-40 backdrop-blur-sm bg-black/20'
+        <!-- use:portal — en mode sidebar ce panneau est rendu dans un conteneur
+             transformé (voir actions/portal.ts) : sans portal, `left-1/2` se
+             calcule sur 220px et le panneau part hors écran. -->
+        <div use:portal class='fixed inset-0 z-40 backdrop-blur-sm bg-black/20'
              role='button' tabindex='-1'
              onclick={() => selfInfo = null}
              onkeydown={e => e.key === 'Escape' && (selfInfo = null)}
              aria-label={tFn('voice.close_panel')}></div>
 
-        <div class='fixed bottom-16 left-1/2 -translate-x-1/2 z-50 w-72 rounded-2xl
+        <div use:portal class='fixed bottom-16 left-1/2 -translate-x-1/2 z-50 w-72 rounded-2xl
                     bg-gradient-to-b from-gray-900 to-gray-950
                     border border-green-500/30 shadow-2xl shadow-green-500/10
                     overflow-hidden backdrop-blur-sm
@@ -314,6 +318,7 @@
 
         <!-- Overlay de fermeture -->
         <div
+            use:portal
             class='fixed inset-0 z-40 backdrop-blur-sm bg-black/20'
             role='button' tabindex='-1'
             onclick={closePanel}
@@ -322,7 +327,7 @@
         ></div>
 
         <!-- Panneau popup -->
-        <div class='fixed bottom-16 left-1/2 -translate-x-1/2 z-50 w-72 rounded-2xl 
+        <div use:portal class='fixed bottom-16 left-1/2 -translate-x-1/2 z-50 w-72 rounded-2xl
                     bg-gradient-to-b from-gray-900 to-gray-950 
                     border border-indigo-500/30 shadow-2xl shadow-indigo-500/20 
                     overflow-hidden backdrop-blur-sm
@@ -1056,15 +1061,20 @@
                 </button>
             </div>
 
-            <!-- VoiceSettings popup (fixed, échappe la sidebar) -->
+            <!-- VoiceSettings popup — `fixed` NE SUFFIT PAS à échapper la sidebar :
+                 celle-ci porte `transform: translateX(0)` (animation de repli), donc
+                 elle devient le bloc conteneur des descendants fixed. `left-1/2` se
+                 calculait sur 220px et `-translate-x-1/2` de 360px sortait le panneau
+                 à -14px : les libellés étaient cisaillés à gauche. Le portal le sort
+                 pour de bon (voir actions/portal.ts). -->
             {#if showVoiceSettings}
-                <div class="fixed inset-0 z-[199] backdrop-blur-sm bg-black/20"
+                <div use:portal class="fixed inset-0 z-[199] backdrop-blur-sm bg-black/20"
                      role="button" tabindex="-1"
                      onclick={() => showVoiceSettings = false}
                      onkeydown={e => e.key === 'Escape' && (showVoiceSettings = false)}
                      aria-label={tFn('voice_panel.close_settings')}>
                 </div>
-                <div class="fixed bottom-24 left-1/2 -translate-x-1/2 w-[360px] z-[200]
+                <div use:portal class="fixed bottom-24 left-1/2 -translate-x-1/2 w-[360px] z-[200]
                             animate-in fade-in slide-in-from-bottom-4 duration-300">
                     <div class="relative bg-gradient-to-b from-gray-900 to-gray-950
                                 border border-amber-500/30 rounded-2xl shadow-2xl shadow-amber-500/10

--- a/nodyx-frontend/src/lib/components/VoiceRoom.svelte
+++ b/nodyx-frontend/src/lib/components/VoiceRoom.svelte
@@ -54,6 +54,36 @@
 		}
 	});
 
+	// ── Hauteur de la bande d'aperçu ──────────────────────────────────────────
+	// Elle était figée à 42vh. Pour qui REGARDE un partage sans vouloir ouvrir la
+	// Scène, c'était trop peu et rien ne permettait d'en gagner. On la rend donc
+	// ajustable à la souris et on mémorise le choix, comme les deux sidebars.
+	const SCREEN_H_MIN = 20;
+	const SCREEN_H_MAX = 80;
+	let screenBandVh = $state(
+		browser ? Number(localStorage.getItem('nodyx:voice:screen_h')) || 42 : 42,
+	);
+	let resizingBand = $state(false);
+
+	function startBandResize(e: PointerEvent) {
+		e.preventDefault();
+		resizingBand = true;
+		const startY  = e.clientY;
+		const startVh = screenBandVh;
+		const move = (ev: PointerEvent) => {
+			const deltaVh = ((ev.clientY - startY) / window.innerHeight) * 100;
+			screenBandVh = Math.min(SCREEN_H_MAX, Math.max(SCREEN_H_MIN, startVh + deltaVh));
+		};
+		const up = () => {
+			resizingBand = false;
+			if (browser) localStorage.setItem('nodyx:voice:screen_h', String(Math.round(screenBandVh)));
+			window.removeEventListener('pointermove', move);
+			window.removeEventListener('pointerup', up);
+		};
+		window.addEventListener('pointermove', move);
+		window.addEventListener('pointerup', up);
+	}
+
 	// Grille qui TIENT dans la hauteur allouée, quel que soit le nombre d'écrans.
 	// Avant : colonnes fixes + tuiles forcées en `aspect-ratio: 16/9` dans un
 	// conteneur `overflow-y-auto` → sur une colonne large, la tuile devenait plus
@@ -286,7 +316,7 @@
 	<div class="shrink-0 grid gap-2 p-3 overflow-hidden"
 	     style="grid-template-columns: repeat({gridCols}, minmax(0, 1fr));
 	            grid-template-rows: repeat({gridRows}, minmax(0, 1fr));
-	            height: 42vh; background: #07070f; border-bottom: 1px solid rgba(255,255,255,0.05);">
+	            height: {screenBandVh}vh; background: #07070f; border-bottom: 1px solid rgba(255,255,255,0.05);">
 		{#if localScreen}
 			<div class="relative group/sc overflow-hidden bg-black min-w-0 min-h-0"
 			     style="border: 1px solid rgba(59,130,246,0.35); box-shadow: 0 0 24px rgba(59,130,246,0.12);">
@@ -375,6 +405,25 @@
 			</div>
 		{/each}
 	</div>
+
+	<!-- Poignée de redimensionnement de la bande d'aperçu. Au clavier aussi :
+	     flèches haut/bas, sinon la fonction n'existe que pour ceux qui peuvent
+	     viser 6px à la souris. -->
+	<button
+		type="button"
+		class="shrink-0 w-full h-1.5 cursor-ns-resize transition-colors"
+		class:bg-indigo-500={resizingBand}
+		style="background: {resizingBand ? '' : 'rgba(255,255,255,0.05)'};"
+		aria-label={tFn('voice_room.resize_preview')}
+		onpointerdown={startBandResize}
+		onkeydown={(e) => {
+			if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+			e.preventDefault();
+			const next = screenBandVh + (e.key === 'ArrowDown' ? 2 : -2);
+			screenBandVh = Math.min(SCREEN_H_MAX, Math.max(SCREEN_H_MIN, next));
+			if (browser) localStorage.setItem('nodyx:voice:screen_h', String(Math.round(screenBandVh)));
+		}}
+	></button>
 {/if}
 
 <!-- ── Stage (participants) ────────────────────────────────────────────────── -->

--- a/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
+++ b/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
@@ -2,6 +2,7 @@
 	import { onMount, onDestroy, untrack } from 'svelte'
 	import { page } from '$app/stores'
 	import { apiFetch } from '$lib/api'
+	import { anchoredPopover } from '$lib/actions/anchoredPopover'
 	import { t } from '$lib/i18n'
 	import { TextSelection } from '@tiptap/pm/state'
 
@@ -643,49 +644,9 @@
 		}
 	}
 
-	// ── Placement des popups (portalées dans <body>) ─────────────────────────
-	// Bug RÉCURRENT : les popups (lien/YouTube/image/audio/emoji/tableau) étaient
-	// tronquées dès que l'éditeur vivait dans un conteneur en overflow (modal du
-	// chat, carte de tâche, panneau qui scrolle). Un simple `position: fixed` ne
-	// suffit PAS : dès qu'un ancêtre a un `transform`/`filter`/`backdrop-filter`
-	// (le modal du chat en a un), il devient le « bloc conteneur » du fixed, qui se
-	// retrouve piégé et re-clippé. La seule solution robuste : PORTALER la popup
-	// dans <body>, où plus aucun ancêtre ne la piège, et la positionner en `fixed`
-	// depuis son bouton, bornée à l'écran des DEUX côtés, bascule haut/bas.
-	function autoFlip(node: HTMLElement) {
-		const anchor = node.parentElement   // le groupe du bouton, AVANT de déplacer
-		document.body.appendChild(node)
-		function place() {
-			if (!anchor) return
-			node.style.left = '0px'
-			node.style.top = '0px'
-			node.style.right = 'auto'
-			node.style.bottom = 'auto'
-			const pw = node.offsetWidth
-			const ph = node.offsetHeight
-			const a = anchor.getBoundingClientRect()
-			const vw = window.innerWidth
-			const vh = window.innerHeight
-			const left = Math.max(8, Math.min(a.left, vw - pw - 8))
-			let top = a.bottom + 4
-			if (top + ph > vh - 8 && a.top - ph - 4 >= 8) top = a.top - ph - 4
-			node.style.left = `${Math.round(left)}px`
-			node.style.top = `${Math.round(top)}px`
-		}
-		place()
-		const ro = new ResizeObserver(place)
-		ro.observe(node)
-		window.addEventListener('resize', place)
-		window.addEventListener('scroll', place, true)  // suit le scroll (fixed ne suit pas seul)
-		return {
-			destroy() {
-				ro.disconnect()
-				window.removeEventListener('resize', place)
-				window.removeEventListener('scroll', place, true)
-				node.remove()   // retire la popup portalée
-			},
-		}
-	}
+	// Placement des popups : action partagée `anchoredPopover` (portal dans <body>
+	// + ancrage au bouton + bornage écran + bascule). Le calcul vient d'ici à
+	// l'origine ; il est désormais mutualisé, cf src/lib/actions/anchoredPopover.ts.
 
 	$effect(() => {
 		document.addEventListener('click', onDocClick)
@@ -1258,7 +1219,7 @@
 				<svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-width="2" d="M7 20h10M12 4l5 12H7L12 4z"/></svg>
 			</button>
 			{#if showColor}
-			<div class="popup w-48 grid grid-cols-6 gap-1 p-2" use:autoFlip>
+			<div class="popup w-48 grid grid-cols-6 gap-1 p-2" use:anchoredPopover>
 				<button type="button" onclick={() => editor?.chain().focus().unsetColor().run()} class="col-span-6 text-xs text-gray-400 hover:text-white text-left mb-1">{tFn('editor.color_reset')}</button>
 				{#each COLORS as c}
 					<button type="button" onclick={() => setColor(c)} class="w-6 h-6 rounded border border-gray-700 hover:scale-110 transition-transform" style="background:{c}" title={c}></button>
@@ -1275,7 +1236,7 @@
 				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/></svg>
 			</button>
 			{#if showLink}
-			<div class="popup w-72 flex flex-col gap-2 p-3" use:autoFlip>
+			<div class="popup w-72 flex flex-col gap-2 p-3" use:anchoredPopover>
 				<input type="url" bind:value={linkUrl} placeholder={tFn('editor.link.url_ph')} class="popup-input" onkeydown={e => e.key === 'Enter' && insertLink()} />
 				<div class="flex gap-2">
 					<button type="button" onclick={insertLink} class="flex-1 popup-btn-primary">{tFn('editor.insert')}</button>
@@ -1291,7 +1252,7 @@
 				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2" stroke-width="2"/><circle cx="8.5" cy="8.5" r="1.5" fill="currentColor" stroke="none"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 15l-5-5L5 21"/></svg>
 			</button>
 			{#if showImage}
-			<div class="popup w-80 flex flex-col gap-2 p-3" use:autoFlip>
+			<div class="popup w-80 flex flex-col gap-2 p-3" use:anchoredPopover>
 				{#if replaceImagePos !== null}
 					<div class="flex items-center gap-1.5 text-[11px] text-amber-300 bg-amber-500/10 border border-amber-500/30 rounded px-2 py-1">
 						<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M16 3h5v5M21 3l-7 7M8 21H3v-5M3 21l7-7"/></svg>
@@ -1332,7 +1293,7 @@
 				<svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24"><path d="M19.615 3.184c-3.604-.246-11.631-.245-15.23 0-3.897.266-4.356 2.62-4.385 8.816.029 6.185.484 8.549 4.385 8.816 3.6.245 11.626.246 15.23 0 3.897-.266 4.356-2.62 4.385-8.816-.029-6.185-.484-8.549-4.385-8.816zm-10.615 12.816v-8l8 3.993-8 4.007z"/></svg>
 			</button>
 			{#if showVideo}
-			<div class="popup w-80 flex flex-col gap-2 p-3" use:autoFlip>
+			<div class="popup w-80 flex flex-col gap-2 p-3" use:anchoredPopover>
 				<p class="text-xs text-gray-500">{tFn('editor.video_hint')}</p>
 				<input type="url" bind:value={videoUrl} placeholder={tFn('editor.video.url_ph')} class="popup-input" onkeydown={e => e.key === 'Enter' && insertVideo()} />
 				<button type="button" onclick={insertVideo} class="popup-btn-primary">{tFn('editor.embed_video')}</button>
@@ -1346,7 +1307,7 @@
 				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19a3 3 0 11-6 0 3 3 0 016 0zm12-3a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
 			</button>
 			{#if showAudio}
-			<div class="popup w-96 flex flex-col gap-2 p-3" use:autoFlip>
+			<div class="popup w-96 flex flex-col gap-2 p-3" use:anchoredPopover>
 				<p class="text-xs text-gray-500">{tFn('editor.audio.hint')}</p>
 				<input
 					bind:this={audioFileEl}
@@ -1433,7 +1394,7 @@
 		<div class="relative">
 			<button type="button" onclick={() => { showEmoji = !showEmoji; showColor = showLink = showImage = showVideo = showAudio = showTable = false }} class="tb-btn text-base" title={tFn('editor.insert_emoji')}>😊</button>
 			{#if showEmoji}
-			<div class="popup w-72 p-2 grid grid-cols-10 gap-0.5 max-h-48 overflow-y-auto" use:autoFlip>
+			<div class="popup w-72 p-2 grid grid-cols-10 gap-0.5 max-h-48 overflow-y-auto" use:anchoredPopover>
 				{#each EMOJIS as e}
 					<button type="button" onclick={() => insertEmoji(e)} class="text-base p-1 rounded hover:bg-gray-700 transition-colors leading-none">{e}</button>
 				{/each}
@@ -1456,7 +1417,7 @@
 				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2" stroke-width="2"/><path stroke-width="1.5" d="M3 9h18M3 15h18M9 3v18M15 3v18"/></svg>
 			</button>
 			{#if showTable}
-			<div class="popup w-52 p-2 flex flex-col gap-1" use:autoFlip>
+			<div class="popup w-52 p-2 flex flex-col gap-1" use:anchoredPopover>
 				{#if !a.table}
 					<button type="button" onclick={() => { toggleAny('insertTable'); showTable = false }} class="table-btn">{tFn('editor.insert_table')}</button>
 				{:else}
@@ -1639,7 +1600,7 @@
 
 	/* ── Popups ────────────────────────────────────────────────────────── */
 	:global(.popup) {
-		position: fixed;        /* échappe au clipping des overflow ancêtres ; placée par use:autoFlip */
+		position: fixed;        /* échappe au clipping des overflow ancêtres ; placée par use:anchoredPopover */
 		z-index: 1000;          /* au-dessus des modals (chat z-400, tâches…) */
 		max-width: calc(100vw - 16px);   /* jamais plus large que l'écran (mobile) */
 		background-color: rgb(31 41 55);

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -4003,6 +4003,7 @@
   "voice_room.click_expand": "Click to open in large view",
   "voice_room.expand": "Open in large view",
   "voice_room.fullscreen": "Fullscreen",
+  "voice_room.resize_preview": "Resize preview (up/down arrows)",
   "voice_room.show_chat": "Show the room chat",
   "communities.lang.all": "All",
   "communities.lang.fr": "🇫🇷 Français",

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -1558,6 +1558,7 @@
   "voice_room.click_expand": "Cliquer pour ouvrir en grand",
   "voice_room.expand": "Ouvrir en grand",
   "voice_room.fullscreen": "Plein écran",
+  "voice_room.resize_preview": "Redimensionner l'aperçu (flèches haut/bas)",
   "voice_room.show_chat": "Afficher le chat du salon",
   "voice_settings.input_volume": "🎙️ Volume d'entrée",
   "voice_settings.gain_high": "⚠️ Gain élevé, risque de saturation",


### PR DESCRIPTION
Captures a l'appui : le selecteur de partage d'ecran rendu dans **~170px** avec les libelles casses en plein mot, et le panneau d'options vocales **decale hors ecran par la gauche** (« Gain d'entree » affiche « ne d'entree », « passe-haut » → « se-haut »).

## La cause, et elle se calcule

La sidebar gauche porte, pour son animation de repli :

```css
.nodyx-sb .panel { position: fixed; width: var(--left-panel-width, 220px);
                   transform: translateX(0); }
```

**Un `transform` non-`none` fait de l'element le bloc conteneur de tous ses descendants `position: fixed`.** Les panneaux ne se positionnaient donc pas par rapport au viewport, mais par rapport a une boite de 220px :

| Panneau | Calcul | Resultat |
|---|---|---|
| Partage d'ecran | `inset-0` → 220px, moins `p-4` (32px) → carte a **188px** ; `max-w-md` (448px) ne s'applique jamais | comprime |
| Options vocales | `left-1/2` = 109,5px, puis `-translate-x-1/2` de 360px = −180px → **−14,5px** dans le viewport | ~24px de texte cisailles |

Deux commentaires du code racontent l'erreur de raisonnement d'origine : *« VoiceSettings popup (fixed, echappe la sidebar) »* (justement non) et *« Modals au niveau racine — hors de tout backdrop-filter »* (le `backdrop-filter` **interne** avait ete vu, le `transform` de l'**ancetre** non).

## Ce qui n'est pas fait

Le `transform` n'est pas supprime : il porte une vraie animation, et le remplacer par `translate:` ou une classe Tailwind piege identiquement (Tailwind v4 emet `translate: 0 0`). **C'est aux panneaux de sortir de la zone piegee, pas a l'animation de disparaitre.**

## Le correctif

La parade existait **deja dans le depot**, dans `NodyxEditor`, avec un commentaire qui decrit exactement ce bug et conclut : *« la seule solution robuste : PORTALER la popup dans `<body>` »*. Elle n'avait jamais ete generalisee — **six strategies de positionnement coexistaient**. Elle devient une primitive partagee :

- `src/lib/actions/portal.ts` — deplace le noeud dans `<body>`
- `src/lib/actions/anchoredPopover.ts` — portal + ancrage au bouton + bornage ecran des deux cotes + bascule haut/bas

`NodyxEditor` (8 sites) et `NodyxCanvas` migrent dessus : c'est de leur code que vient l'extraction, la garder en double n'avait plus de sens.

**L'enquete a corrige mon estimation initiale** : 6 popups piegees, pas 8. Les toasts et le mode « float » sont montes **hors** de l'aside (`ChannelSidebar` les rend apres `</aside>`), donc jamais piegés — et les portaler aurait casse le `sm:absolute` du mode float.

## Zone de visionnage

Deux causes distinctes, aucune n'est ce piege :

- la bande d'apercu du salon etait figee a `42vh` → **redimensionnable a la souris et au clavier**, choix memorise, comme les sidebars ;
- le chat de la Scene passait a 384px en `xl:` alors que c'est la video qui doit recuperer la place sur grand ecran → plafonne a 320px.

## Verifie

`check` (0 erreur, 134 avertissements = la reference exacte), les 4 portes i18n, 20 tests front, `tsc` core (aucun changement core). Aucun changement de design : seuls changent l'endroit du DOM ou le noeud est monte, et deux dimensionnements explicitement demandes.