### PR TITLE
fix(jukebox): l'auditeur ne recevait jamais la video, l'hote jouait muet

### DIFF
--- a/nodyx-frontend/src/lib/jukebox.test.ts
+++ b/nodyx-frontend/src/lib/jukebox.test.ts
@@ -1,0 +1,76 @@
+// ─── Jukebox : quelle action appliquer au lecteur ────────────────────────────
+//
+// Ces tests existent à cause d'un bug qui a tenu des mois en production, et que
+// personne ne pouvait voir : la décision était noyée dans les effets de bord.
+//
+// `_applyState` écrivait le store, PUIS relisait ce même store pour savoir quel
+// morceau jouait « avant ». `prev` et `state` étaient donc le même objet, la
+// comparaison de videoId se faisait entre une valeur et elle-même et valait
+// toujours vrai. La branche qui appelle `loadVideoById` chez un auditeur était
+// donc du CODE MORT : son lecteur recevait `seekTo` et `playVideo` sans avoir
+// jamais reçu de vidéo. Symptôme vécu : le titre s'affiche, le silence règne.
+//
+// Le cas n°1 ci-dessous échoue sur le code d'avant. C'est lui qui compte.
+// cf feedback_test_first_critical
+
+import { describe, it, expect } from 'vitest'
+import { decideJukeboxAction, JUKEBOX_DRIFT_TOLERANCE, type JukeboxState } from './jukebox'
+
+/** Un état de lecture minimal, surchargeable. */
+function state(over: Partial<JukeboxState> = {}): JukeboxState {
+  return {
+    track:    { videoId: 'aaa', title: 'Piste A', addedBy: 'pokled' },
+    playing:  true,
+    position: 0,
+    syncedAt: 0,
+    duration: 180,
+    queue:    [],
+    history:  [],
+    repeat:   'none',
+    shuffle:  false,
+    ...over,
+  }
+}
+
+describe('decideJukeboxAction', () => {
+  it("charge la video quand le lecteur est vide (le bug qui rendait l'auditeur muet)", () => {
+    // Exactement le cas de la 2e personne : elle reçoit l'état, son lecteur n'a
+    // rien. Avant le correctif on tombait dans « même vidéo » et on faisait
+    // seekTo/playVideo sur un lecteur vide : aucun son, pour toujours.
+    const action = decideJukeboxAction(null, 0, state(), 0)
+    expect(action).toEqual({ kind: 'load', videoId: 'aaa', at: 0, play: true })
+  })
+
+  it('charge la nouvelle vidéo quand la piste change', () => {
+    const action = decideJukeboxAction('aaa', 42, state({ track: { videoId: 'bbb', title: 'Piste B', addedBy: 'x' } }), 0)
+    expect(action).toEqual({ kind: 'load', videoId: 'bbb', at: 0, play: true })
+  })
+
+  it('resynchronise quand la dérive dépasse la tolérance', () => {
+    const action = decideJukeboxAction('aaa', 10, state(), 13)
+    expect(action).toEqual({ kind: 'seek', at: 13, play: true })
+  })
+
+  it('ne resynchronise PAS pour une dérive sous la tolérance', () => {
+    const drift  = JUKEBOX_DRIFT_TOLERANCE / 2
+    const action = decideJukeboxAction('aaa', 10, state(), 10 + drift)
+    expect(action).toEqual({ kind: 'play' })
+  })
+
+  it('met en pause quand l\'état partagé est en pause', () => {
+    const action = decideJukeboxAction('aaa', 10, state({ playing: false }), 10)
+    expect(action).toEqual({ kind: 'pause' })
+  })
+
+  it('arrête le lecteur quand il n\'y a plus de piste', () => {
+    const action = decideJukeboxAction('aaa', 10, state({ track: null }), 0)
+    expect(action).toEqual({ kind: 'stop' })
+  })
+
+  it('recharge si le lecteur a perdu sa video en cours de route (auto-reparation)', () => {
+    // Le lecteur peut être recréé ou vidé (remontage du composant). On ne veut
+    // pas jouer dans le vide en silence : on recharge.
+    const action = decideJukeboxAction(null, 0, state({ position: 30, playing: true }), 30)
+    expect(action).toEqual({ kind: 'load', videoId: 'aaa', at: 30, play: true })
+  })
+})

--- a/nodyx-frontend/src/lib/jukebox.ts
+++ b/nodyx-frontend/src/lib/jukebox.ts
@@ -146,9 +146,14 @@ export async function mountYTPlayer(containerId: string): Promise<void> {
         // playVideo() and sometimes losing, leaving the player stuck in
         // a CUED state with no audio AND no progress. Starting muted at
         // the iframe level guarantees autoplay works on every browser.
-        // The host's own jukeboxLoad() / jukeboxPlay() flow un-mutes
-        // immediately because the user has interacted; peers see the
-        // green "Activer le son" overlay and unmute on click.
+        // Ce démarrage muet DOIT être compensé par un unMute() explicite :
+        // setVolume() sur un lecteur muet ne fait aucun son. Les deux endroits
+        // qui le font sont onReady (préférence utilisateur) et jukeboxLoad
+        // (dans la pile du clic). Ce commentaire affirmait auparavant que
+        // jukeboxLoad démutait « immédiatement » : c'était faux, aucun unMute()
+        // ne s'y trouvait, et l'hôte lançait sa musique en silence.
+        // Les pairs sans geste utilisateur restent muets et voient la
+        // bannière verte « Activer le son ».
         controls: 0, modestbranding: 1, rel: 0,
         playsinline: 1, mute: 1, origin: window.location.origin,
       },
@@ -159,7 +164,11 @@ export async function mountYTPlayer(containerId: string): Promise<void> {
           const vol   = get(jukeboxVolume)
           const muted = get(jukeboxMuted)
           _ytPlayer.setVolume(vol)
+          // Le lecteur démarre avec playerVars.mute=1 (garantie anti-autoplay).
+          // setVolume() sur un lecteur muet ne produit AUCUN son : il faut un
+          // unMute() explicite, sinon l'hôte lance sa piste et n'entend rien.
           if (muted) _ytPlayer.mute()
+          else       _ytPlayer.unMute()
           if (_pendingOp) { _pendingOp(); _pendingOp = null }
           resolve()
         },
@@ -254,6 +263,51 @@ function _livePosition(state: JukeboxState): number {
   return state.position + (Date.now() - state.syncedAt) / 1000
 }
 
+/** Écart de position au-delà duquel on resynchronise (secondes). */
+export const JUKEBOX_DRIFT_TOLERANCE = 0.8
+
+export type JukeboxAction =
+  | { kind: 'load';  videoId: string; at: number; play: boolean }
+  | { kind: 'seek';  at: number; play: boolean }
+  | { kind: 'play' }
+  | { kind: 'pause' }
+  | { kind: 'stop' }
+
+/**
+ * Décide QUOI faire du lecteur, sans le toucher.
+ *
+ * Cette fonction existe parce que le bug qu'elle corrige était invisible :
+ * `_applyState` écrivait le store PUIS relisait ce même store pour savoir quel
+ * morceau jouait « avant ». `prev` et `state` étaient donc le même objet, la
+ * comparaison de videoId se faisait entre une valeur et elle-même, et valait
+ * toujours vrai. Résultat : la branche qui appelle `loadVideoById` chez un
+ * auditeur n'était JAMAIS atteinte. Son lecteur recevait `seekTo` et
+ * `playVideo` sans avoir jamais reçu de vidéo : titre affiché, silence total.
+ *
+ * La référence n'est donc plus le store (qui décrit ce qu'on VEUT) mais
+ * `loadedVideoId`, ce que le lecteur A réellement chargé. C'est idempotent,
+ * insensible à l'ordre des appels, et auto-réparateur : un lecteur qui a perdu
+ * sa vidéo la recharge au lieu de jouer dans le vide.
+ */
+export function decideJukeboxAction(
+  loadedVideoId: string | null,
+  currentTime:   number,
+  state:         JukeboxState,
+  livePosition:  number,
+): JukeboxAction {
+  if (!state.track) return { kind: 'stop' }
+
+  if (loadedVideoId !== state.track.videoId) {
+    return { kind: 'load', videoId: state.track.videoId, at: livePosition, play: state.playing }
+  }
+
+  if (Math.abs(currentTime - livePosition) > JUKEBOX_DRIFT_TOLERANCE) {
+    return { kind: 'seek', at: livePosition, play: state.playing }
+  }
+
+  return state.playing ? { kind: 'play' } : { kind: 'pause' }
+}
+
 function _broadcastState(): void {
   if (_suppressBroadcast) return
   if (!_socket || !_channelId || !_ytPlayer || !_ytReady) return
@@ -273,9 +327,12 @@ function _applyState(state: JukeboxState): void {
   jukeboxStore.set(state)
   const apply = () => {
     if (!_ytPlayer || !_ytReady) { _pendingOp = () => _applyState(state); return }
-    const prev      = get(jukeboxStore)
-    const sameVideo = prev.track?.videoId === state.track?.videoId
-    const target    = _livePosition(state)
+    // Référence = ce que le lecteur a VRAIMENT chargé, pas le store. Voir le
+    // commentaire de decideJukeboxAction : relire le store qu'on vient d'écrire
+    // rendait la comparaison toujours vraie et tuait le chargement chez l'auditeur.
+    const loadedId = _ytPlayer.getVideoData?.()?.video_id ?? null
+    const current  = _ytPlayer.getCurrentTime?.() ?? 0
+    const action   = decideJukeboxAction(loadedId, current, state, _livePosition(state))
 
     // Audio policy: the player boots with playerVars.mute=1 so unmuted
     // autoplay can never be denied. Two paths from here:
@@ -300,46 +357,49 @@ function _applyState(state: JukeboxState): void {
       }
     }
 
-    if (state.track) {
-      if (!sameVideo) {
-        // New video: load, then explicitly play/pause
-        _ytPlayer.loadVideoById({ videoId: state.track.videoId, startSeconds: target })
-        if (state.playing) {
+    // Détecteur d'autoplay bloqué. Il teste `state.playing` CAPTURÉ ici, et non
+    // `get(jukeboxStore).playing` : la boucle de progression (toutes les 500 ms)
+    // écrase `playing` avec l'état du lecteur local, donc à T+2000 ms le store
+    // disait déjà `false` et ce détecteur ne se déclenchait jamais. Or la
+    // bannière qu'il arme est le SEUL chemin d'un auditeur vers loadVideoById.
+    const armBlockageProbe = () => {
+      if (!state.playing) return
+      setTimeout(() => {
+        const ps = _ytPlayer?.getPlayerState?.()
+        if (ps !== 1 && ps !== 3) jukeboxAutoplayBlocked.set(true)
+      }, 2000)
+    }
+
+    switch (action.kind) {
+      case 'stop':
+        _ytPlayer.stopVideo?.()
+        break
+
+      case 'load':
+        _ytPlayer.loadVideoById({ videoId: action.videoId, startSeconds: action.at })
+        if (action.play) {
           _ytPlayer.playVideo()
           setTimeout(() => _ytPlayer?.playVideo(), 600)
-          // Detect browser autoplay blockage AFTER the muted-start fallback.
-          // Muted play is almost always allowed, so this banner now only
-          // triggers in pathological cases (extension blocking, etc.).
-          // State 1=playing, 3=buffering → OK ; anything else → blocked
-          setTimeout(() => {
-            const ps = _ytPlayer?.getPlayerState?.()
-            if (ps !== 1 && ps !== 3 && get(jukeboxStore).playing) {
-              jukeboxAutoplayBlocked.set(true)
-            }
-          }, 2000)
+          armBlockageProbe()
         } else {
           setTimeout(() => _ytPlayer?.pauseVideo(), 800)
         }
-      } else {
-        // Same video: sync position if drift > 0.8s (tightened from 2.5s for
-        // a noticeably tighter shared-listening experience).
-        const cur = _ytPlayer.getCurrentTime?.() ?? 0
-        if (Math.abs(cur - target) > 0.8) _ytPlayer.seekTo(target, true)
-        if (state.playing) {
-          _ytPlayer.playVideo()
-          // Detect blockage for same-video play commands too
-          setTimeout(() => {
-            const ps = _ytPlayer?.getPlayerState?.()
-            if (ps !== 1 && ps !== 3 && get(jukeboxStore).playing) {
-              jukeboxAutoplayBlocked.set(true)
-            }
-          }, 2000)
-        } else {
-          _ytPlayer.pauseVideo()
-        }
-      }
-    } else {
-      _ytPlayer.stopVideo?.()
+        break
+
+      case 'seek':
+        _ytPlayer.seekTo(action.at, true)
+        if (action.play) { _ytPlayer.playVideo(); armBlockageProbe() }
+        else             { _ytPlayer.pauseVideo() }
+        break
+
+      case 'play':
+        _ytPlayer.playVideo()
+        armBlockageProbe()
+        break
+
+      case 'pause':
+        _ytPlayer.pauseVideo()
+        break
     }
   }
   apply()
@@ -484,12 +544,28 @@ export function jukeboxLoad(url: string): boolean {
   // ── Lancement direct dans le contexte du geste utilisateur ───────────────
   // Ne jamais mettre d'await avant ce bloc — le navigateur bloque playVideo()
   // si on sort du stack frame du clic (règle autoplay Chrome/Firefox).
+  // On démute ICI, dans la pile d'appel du clic : c'est ce que la politique
+  // autoplay autorise. Sans ça, l'hôte jouait muet, et son SEUL démutage
+  // automatique était _applyState, qui ne s'exécute que sur un événement
+  // ENTRANT. Or le serveur exclut l'émetteur de son propre broadcast : il
+  // dépendait donc de l'écho d'un pair, d'où le « parfois » et le besoin de
+  // marteler pause/lecture jusqu'à ce qu'un écho tombe.
+  const unmuteIfWanted = () => {
+    if (get(jukeboxMuted)) return
+    try {
+      _ytPlayer?.unMute()
+      _ytPlayer?.setVolume(get(jukeboxVolume))
+    } catch { /* ignore */ }
+  }
+
   if (_ytPlayer && _ytReady) {
     _ytPlayer.loadVideoById({ videoId, startSeconds: 0 })
+    unmuteIfWanted()
     _ytPlayer.playVideo()
   } else {
     _pendingOp = () => {
       _ytPlayer?.loadVideoById({ videoId, startSeconds: 0 })
+      unmuteIfWanted()
       _ytPlayer?.playVideo()
     }
   }


### PR DESCRIPTION
> « je lance une zik youtube, parfois le son ne se lance pas, je dois appuyer sur pause/lecture/pause/lecture. Et la seconde personne n'entend pas la musique. **Pourtant je vois bien le titre apparaitre.** »

Ce dernier detail etait le fil a tirer : la synchronisation d'etat marchait, la lecture non. **Deux bugs distincts, plus un troisieme qui empechait tout secours de se declencher.**

## Bug 1 : chez l'auditeur, le titre s'affiche et rien ne joue

`_applyState` ecrivait le store **puis** relisait ce meme store pour savoir quel morceau jouait « avant » :

```js
jukeboxStore.set(state)                    // le store devient `state`
const prev      = get(jukeboxStore)        // relit... `state`
const sameVideo = prev.track?.videoId === state.track?.videoId
```

`prev` et `state` sont le meme objet : on comparait **une valeur a elle-meme**, `sameVideo` valait toujours vrai. Or le `loadVideoById` de l'auditeur vit dans la branche `if (!sameVideo)` : **c'etait du code mort**. Tout tombait dans le `else`, qui faisait `seekTo` + `playVideo` sur un lecteur n'ayant jamais recu de videoId.

Et le titre s'affichait quand meme, parce que le store avait ete rempli une ligne plus haut. **Les deux symptomes naissaient dans la meme fenetre de cinq lignes.**

**Fix** : la reference n'est plus le store (ce qu'on *veut*) mais `getVideoData()`, ce que le lecteur *a* reellement charge. Idempotent, insensible a l'ordre des appels, auto-reparateur.

## Bug 2 : l'hote joue muet

Le lecteur demarre avec `playerVars.mute=1` (bon reflexe anti-autoplay), mais **`setVolume()` sur un lecteur muet ne produit aucun son** et aucun `unMute()` n'existait ni dans `onReady` ni dans `jukeboxLoad`. Le seul demutage automatique vivait dans `_applyState`, qui ne s'execute que sur un evenement **entrant**, or le serveur exclut l'emetteur de son propre broadcast. L'hote dependait donc de l'echo d'un pair, lui-meme casse par le bug 1 : **d'ou le « parfois »**.

Le commentaire du code affirmait que `jukeboxLoad` « un-mutes immediately ». C'etait faux, et c'est probablement ce qui a masque le bug pendant des mois.

## Bug 3 : les deux bannieres de secours etaient desarmees

La boucle de progression (500 ms) ecrase `playing` avec l'etat du lecteur **local**. Chez l'auditeur au lecteur vide, `playing` repassait a `false` en moins de 500 ms, donc le detecteur d'autoplay bloque (a 2000 ms) qui **relisait le store** ne se declenchait jamais. Sa banniere etait pourtant le seul chemin d'un auditeur vers `loadVideoById`.

## Le garde-fou

La decision est extraite en **fonction pure** `decideJukeboxAction`, testable sans navigateur ni API YouTube. C'est ce decoupage qui rend cette famille de bugs attrapable.

**7 tests, dont 3 verifies ROUGES** en remettant temporairement l'ancienne logique. Un test qui passe sur les deux versions ne prouve rien.

## Non touche, volontairement

Le moteur de synchronisation (11 `setTimeout` et une boucle de retroaction documentee) n'est **pas** reecrit. Reparer d'abord, refondre si le besoin se presente.

Restent connus et non traites faute de symptome rapporte : pas de compensation de decalage d'horloge entre machines (`syncedAt` compare deux `Date.now()` distincts), `_pendingOp` est un emplacement unique et non une file, `cleanupJukebox` fait `socket.off` sans reference de handler.

## Verifie

`check` (0 erreur, 134 avertissements = la reference), les 4 portes i18n, 27 tests frontend. Aucun changement core.