### PR TITLE
SDK d'extensions : specifications et substrat de securite (P0-A)

### DIFF
--- a/SPECS/NODYX_SDK_CDC.md
+++ b/SPECS/NODYX_SDK_CDC.md
@@ -645,7 +645,13 @@ Règles fondatrices intactes : note de curation obligatoire, zéro étoile, zér
 - **Le format v0 disparaît.** Un manifeste sans `api: 1` est refusé, avec un message qui pointe le guide de migration. Coût réel : un widget, `video-player`, qui est à nous.
 - **`video-player` devient natif.** Il embarque des iframes YouTube, Twitch, Vimeo, or une frame à origine opaque ne peut pas embarquer de frame tierce (les drapeaux du bac à sable se propagent aux contextes imbriqués, l'embed casse). Il a sa place à l'étage 1, il garde son `id`, donc **les layouts d'accueil existants continuent de rendre à l'identique**.
 - **`installed_widgets` est remplacée** par `installed_extensions`. Migration 112 : création. La suppression de l'ancienne table attend la release suivante, une fois les 4 instances vérifiées.
-- **L'embed tiers dans une extension** (un lecteur YouTube dans une extension de la communauté) exige une origine dédiée `ext.<domaine>`, donc du DNS et un certificat, donc une entorse au zéro configuration. Reporté en P3, activable par ceux qui ont le DNS, jamais exigé.
+- **L'embed tiers dans une extension** (un lecteur YouTube dans une extension de la communauté) est impossible en v1 : les drapeaux du bac à sable se propagent aux frames imbriquées, donc l'embed du fournisseur casse.
+
+  **C'est la limite la plus gênante du modèle, et il faut la nommer** : la catégorie de widget la plus évidente pour une communauté, le lecteur média, est justement celle que la v1 ferme aux tiers. Un contributeur qui voudrait écrire un meilleur lecteur que le nôtre ne le pourra pas en extension, seulement en natif, donc par une PR sur le dépôt.
+
+  **Déverrouillage retenu pour P3 : une primitive d'embarquement rendue par l'hôte.** L'extension déclare `embed: ["youtube", "twitch"]`, appelle `nodyx.ui.embed({ provider, id, rect })`, et l'hôte pose l'iframe du fournisseur **hors du bac à sable**, à l'emplacement indiqué. L'extension ne gagne aucun privilège, le fournisseur tourne en première partie comme aujourd'hui, et la liste des fournisseurs embarquables est **livrée avec Nodyx**, donc identique partout. Coût : le positionnement d'une surface superposée, et une liste à maintenir. Bénéfice secondaire non négligeable : l'ensemble des tiers qui peuvent être encadrés est revu par nous, pas choisi par un auteur d'extension.
+
+  **L'idée d'une origine dédiée `ext.<domaine>` est écartée** (Jonathan, 2026-08-14). L'objection décisive n'est pas la friction DNS, c'est la portabilité : **une extension s'installe sur n'importe quelle instance.** Si les embeds ne fonctionnaient que là où un sous-domaine a été configuré, la même extension se comporterait différemment selon l'hébergeur, un auteur ne pourrait pas savoir si son travail marchera chez ses utilisateurs, et le magasin ne pourrait plus affirmer qu'une extension fonctionne. C'est de la fragmentation du contrat, pas un simple coût d'installation. Le paquet est portable, la capacité doit l'être aussi.
 
 ---
 
@@ -756,7 +762,7 @@ Action, dans P0-A, avant le port : **aligner `svelte.config.js` sur ce que la pr
 Le rapprochement de la configuration du proxy avec le disque reste hors de ce lot, et soumis au danger déjà documenté dans `CLAUDE.md`.
 
 **P3, l'ouverture**
-Surfaces `panel` et `card` (enrichissement chat et forum, l'étagère de la communauté), écritures core avec consentement, origine dédiée optionnelle pour les embeds tiers.
+Surfaces `panel` et `card` (enrichissement chat et forum, l'étagère de la communauté), écritures core avec consentement, primitive d'embarquement rendue par l'hôte pour les lecteurs tiers (§12).
 
 ---
 

--- a/SPECS/NODYX_SDK_CDC.md
+++ b/SPECS/NODYX_SDK_CDC.md
@@ -706,7 +706,18 @@ Configuration réellement enregistrée dans la mise en page publiée de nodyx.or
 
 Les quatre clés attendues, et rien d'autre. Le composant natif doit les lire telles quelles, y compris `title` vide (qui doit retomber sur le titre par défaut) et `show_controls` absent traité comme vrai.
 
-**Attention à la source du port** (signalé par Jonathan) : la copie installée en production provient d'une démonstration d'installation par `.zip` faite avec une version ancienne. Tout ce qui est observable est en v1.2.0, disque et base, sur les quatre instances, mais **s'il existe une version plus récente hors dépôt, c'est elle qui fait référence pour le port**, pas celle qui est déployée.
+**Source du port, vérifiée.** Jonathan a signalé que la copie installée venait d'une démonstration d'installation par `.zip` faite avec une version ancienne, donc possiblement pas la dernière. Recherche menée le 2026-08-14 :
+
+| Piste | Résultat |
+|---|---|
+| Fichiers des 4 instances | v1.2.0, empreinte identique partout |
+| Source du dépôt `widget-demos/` | v1.2.0, même empreinte |
+| Manifeste stocké en base | v1.2.0, équivalent au fichier (seul l'ordre des clés diffère, JSONB réordonne) |
+| Historique git, toutes branches | deux versions seulement : v1.1.0 le 2026-05-05, v1.2.0 le 2026-05-06 |
+| Sauvegardes, 10 jours de rétention | v1.2.0, même empreinte sur toutes |
+| Archives `.zip` ou `.nyx` sur la machine | aucune |
+
+**Aucune trace d'une version supérieure à 1.2.0.** L'installation de démonstration a donc soit utilisé la 1.1.0 puis été réécrite, soit utilisé la 1.2.0. La référence du port est **v1.2.0**, et c'est aussi ce que rend la page d'accueil aujourd'hui. Si une version plus récente existe sur une machine de développement, le port en composant Svelte reste trivial à mettre à jour, mais rien ici ne l'atteste.
 
 **Ce qui ne doit pas bouger, et pourquoi ça tient**
 

--- a/SPECS/NODYX_SDK_CDC.md
+++ b/SPECS/NODYX_SDK_CDC.md
@@ -1,0 +1,802 @@
+# CDC, SDK Nodyx et place de marché d'extensions
+
+Statut : **VALIDÉ par Jonathan le 2026-08-14, révision 3, prêt à implémenter (P0-A)**
+Date : 2026-08-14 (r1 le matin, r2 après revue croisée cf §16, r3 après validation)
+Auteur : session Nodyx
+Préalable au code (règle maison : CDC formel avant tout module critique)
+
+---
+
+## 0. Ce que ce document tranche
+
+| # | Question | Décision proposée |
+|---|---|---|
+| D1 | Réconcilier les deux systèmes de widgets ? | **Un seul contrat, deux étages** : natif compilé (dans le dépôt, plein pouvoir) et extension tierce (paquet, bac à sable). Le catalogue, le builder et la doc ne connaissent qu'un vocabulaire. |
+| D2 | Isolation du code tiers | **iframe à origine opaque** (`sandbox="allow-scripts"`, sans `allow-same-origin`), pont `postMessage`. Frontière garantie par le navigateur, zéro moteur d'isolation à écrire. |
+| D3 | Une extension peut-elle livrer du code serveur ? | **Non, jamais.** Elle obtient du stockage clé/valeur cloisonné, un proxy réseau sur liste blanche, et des lectures cadrées du core. Aucune migration, aucune route, aucun process tiers. |
+| D4 | Points d'accroche v1 | **page pleine** (entre les sidebars) et **widget** (grille d'accueil). Le reste plus tard. |
+| D5 | i18n d'une extension | Les chaînes du manifeste sont des **clés**, résolues dans les bundles livrés avec le paquet. `default_locale` obligatoire, refus à l'installation sinon. |
+| D6 | Distribution | **Une vitrine et un tuyau** : satellite `nodyx-store` sur `extensions.nodyx.org` (site public façon extensions.joomla.org) qui sert aussi l'index JSON signé consommé par les instances. Publication par PR GitHub assistée, zéro infra à opérer, **zéro monétisation, zéro étoile**. La vitrine est une surface de visibilité durable, donc soumise aux exigences de fabrication de §9.9 (i18n, design, référencement). |
+| D7 | Compatibilité | `api: 1` dans le manifeste. Le format actuel (sans `api`) est **cassé volontairement** : un seul widget existe et il est à nous. |
+| D8 | Vocabulaire | **Extension** = le paquet distribué. Deux types : **Widget** (bloc du frontpage editor) et **Module** (application avec ses pages, ex la médiathèque). Les 35 interrupteurs natifs de `/admin/modules` deviennent les **Fonctionnalités**. Le mot « plugin » sort du vocabulaire. |
+
+Le banc d'essai qui valide tout : **la médiathèque devient une extension**. Si le bac à sable ne la porte pas, le bac à sable est faux.
+
+---
+
+## 1. Déclencheur
+
+Deux pages jugées trop pauvres : `nodyx.dev/create-widget` (13 Ko de tutoriel honnête mais qui s'arrête au « hello world ») et `nodyx.org/admin/widgets`. Le vrai problème est en dessous : **il n'y a rien à documenter de plus, parce que le SDK n'existe pas.** Un widget reçoit trois attributs JSON et se débrouille.
+
+### 1.1 État réel du code, vérifié le 2026-08-14
+
+Quatre vocabulaires cohabitent aujourd'hui :
+
+| Nom | Où | Quoi | Installable ? |
+|---|---|---|---|
+| **Modules** | table `modules` (migration 062), `nodyx-frontend/src/lib/modules.ts` | 35 fonctionnalités natives avec un interrupteur | Non, registre figé |
+| **Plugins homepage** | descripteurs `homepage/plugins/*.ts` (10 plus `_types.ts` et `index.ts`), composants `homepage/widgets/*.svelte` (10) | Descripteur typé plus composant Svelte compilé dans le frontend | Non, il faut un commit et un build |
+| **Widgets installés** | table `installed_widgets` (071), `uploads/widgets/<id>/`, `widgetStore.ts` | Web Component IIFE livré en `.zip` | Oui, et c'est le seul chemin tiers |
+| **Templates de table** | `plugins/table-templates/*/template.json` | Thèmes JSON pour le canvas | Sans rapport, mais le mot « plugin » y traîne |
+
+`catalog.ts` préfigure déjà la fusion des deux premiers étages avec son type `CatalogEntry`. C'est la bonne intuition, ce CDC la termine.
+
+### 1.2 Le trou, mesuré
+
+`DynamicWidget.svelte` charge le JS du widget par `document.head.appendChild(<script src="/api/v1/widget-assets/...">)`. Le Shadow DOM isole **les styles**, pas le JavaScript : le code tourne dans le contexte principal de la page, avec tous les droits de la page.
+
+Or `+layout.server.ts` renvoie `token` dans les données de layout, donc le JWT de session est sérialisé dans la charge SSR de chaque page pour un utilisateur connecté. La CSP (`script-src 'self'` avec nonce) ne bloque rien : le script du widget est servi par notre propre origine à travers Caddy.
+
+Conclusion factuelle, sans dramatisation : **installer un widget aujourd'hui, c'est donner son instance à son auteur.** Le widget peut lire le jeton de session de tout visiteur connecté qui charge la page d'accueil, l'owner compris, appeler n'importe quelle route `/api/v1` en son nom, et réécrire la page.
+
+C'est acceptable tant qu'un widget = du code qu'on a écrit ou lu. Ça ne l'est plus une seconde après l'ouverture d'une place de marché. **Le bac à sable n'est pas une option de confort du SDK, c'est sa condition d'existence**, exactement comme l'ICE complet pour l'auto-hébergement.
+
+---
+
+## 2. Principes directeurs
+
+1. **Une extension ne peut pas nuire.** Ce qu'elle n'a pas demandé, elle ne l'a pas. Ce qu'elle a demandé, l'admin l'a vu et accepté.
+2. **Le core reste sanctuaire.** Aucun code tiers dans le process API, aucune migration tierce dans la séquence numérotée.
+3. **Aucun octet du visiteur ne part chez un tiers.** Tout appel réseau d'une extension passe par l'instance. C'est la traduction technique du « zéro analytics ».
+4. **L'instance vit sans nodyx.org.** Le registre par défaut est un service de confort, remplaçable et contournable (installation par fichier).
+5. **Gratuit.** Pas de paiement, pas de commission, pas de classement sponsorisé. La monétisation a déjà été refusée, elle reste refusée.
+6. **L'i18n part avec la fonctionnalité**, pour les extensions comme pour le reste.
+7. **Le plein pouvoir reste accessible** : c'est de l'AGPL auto-hébergé. Qui veut un composant sans limite écrit un widget natif dans son fork. Ce n'est pas un cas dégradé, c'est le chemin prévu.
+
+---
+
+## 3. Les deux étages (D1)
+
+```
+                     MEME CONTRAT (manifeste, schéma de config, i18n, thème)
+   ┌──────────────────────────────┬──────────────────────────────────────┐
+   │  ETAGE 1, NATIF              │  ETAGE 2, EXTENSION                  │
+   ├──────────────────────────────┼──────────────────────────────────────┤
+   │  Composant Svelte du dépôt   │  Paquet .nyx installé par l'admin    │
+   │  Compilé dans le frontend    │  Chargé au runtime dans une iframe   │
+   │  Contexte principal          │  Origine opaque, permissions         │
+   │  Ajout = une PR relue        │  Ajout = un clic                     │
+   │  Ex : hero-banner, header,   │  Ex : médiathèque, et tout ce que    │
+   │       video-player           │       la communauté écrira           │
+   └──────────────────────────────┴──────────────────────────────────────┘
+```
+
+Ce qui est commun : l'identité (`id`, `label`, `icon`, `family`), le schéma de configuration (`FieldSchema`, déjà typé), la résolution i18n, les jetons de thème, la place dans le catalogue du builder, la page de doc générée.
+
+Ce qui diffère : le runtime, et rien d'autre.
+
+**On ne fait pas passer les natifs par le bac à sable** : ils y perdraient Svelte, les stores partagés et la fluidité, contre une sécurité qui n'a pas de sens pour du code du dépôt. **On ne fait pas entrer de code tiers dans le bundle** : c'est le modèle qu'on remplace.
+
+Le fichier `catalog.ts` devient le point de fusion officiel (`CatalogEntry` v2), `PLUGIN_REGISTRY` est renommé `NATIVE_WIDGETS`, le dossier de descripteurs `homepage/plugins/` devient `homepage/natives/`. Attention, `homepage/widgets/` existe déjà et contient les 10 composants Svelte : il ne bouge pas, et `widgets/native/` n'est donc pas une cible de renommage valide. Le mot « plugin » disparaît du code et de la doc.
+
+### 3.1 `CatalogEntry` v2, orienté surfaces
+
+Le `CatalogEntry` actuel est modelé sur le widget d'accueil : `schema`, `entry`, `family`, et une union discriminée `native | installed`. Ça ne suffit plus, parce que `kind` y mélange deux questions distinctes : **ce qu'est l'extension** et **comment on l'exécute**.
+
+```
+CatalogEntry v2
+├── identity      id, version, author, source, license
+├── presentation  label, description, icon, family   (clés i18n résolues)
+├── surfaces[]    { type, id, route?, configSchema?, nav? }
+├── localization  default_locale, locales livrées
+├── capabilities  permissions demandées, telles qu'accordées
+└── runtime       'native' | 'sandboxed'
+```
+
+**Le catalogue ne décide pas du runtime, il le porte.** Il répond à « qu'est-ce que c'est, et où ça peut vivre ». C'est le renderer qui tranche : surface native, on monte le composant Svelte ; surface tierce, on monte la frame. Cette séparation est ce qui permet, plus tard, de déplacer un widget natif vers un paquet, ou l'inverse, sans toucher au builder.
+
+---
+
+## 4. Le bac à sable (D2)
+
+### 4.1 La frontière
+
+```html
+<iframe sandbox="allow-scripts"
+        src="/api/v1/extensions/<id>/<version>/frame?surface=<sid>"
+        referrerpolicy="no-referrer"
+        allow=""></iframe>
+```
+
+Drapeaux du bac à sable : **`allow-scripts` et rien d'autre**. Pas de `allow-same-origin`, pas de `allow-top-navigation`, pas de `allow-popups`, pas de `allow-modals`, pas de `allow-forms`, pas de `allow-downloads`. Toute demande d'ajout d'un drapeau se traite comme un changement de modèle de sécurité, pas comme un réglage.
+
+`allow-scripts` sans `allow-same-origin` place le document dans une **origine opaque**. Conséquences, garanties par le navigateur, pas par notre code :
+
+- `document.cookie` inaccessible, `localStorage` et `sessionStorage` lèvent une exception
+- `window.parent.document` inaccessible, la messagerie est le seul canal
+- aucune requête ne peut porter les cookies de l'instance
+- la charge SSR de la page hôte, donc le jeton de session, est hors de portée
+
+**Trois origines à ne jamais confondre**, parce que le raccourci est la source d'erreur classique :
+
+| | Quoi | Valeur |
+|---|---|---|
+| origine hôte | la page Nodyx qui monte la frame | `https://instance.example` |
+| origine du document de frame | ce que voit le code de l'extension | **opaque**, `null` |
+| origine qui sert le document | d'où vient l'octet HTML | `https://instance.example` |
+
+Conséquence directe : **`Origin: null` n'est jamais une authentification.** C'est une conséquence du bac à sable, que n'importe qui peut produire. L'identité vient du `ext_token`, uniquement.
+
+### 4.2 Le document d'accueil
+
+Servi par le core, minimal, avec une CSP explicite (on écrit l'origine en clair : dans une origine opaque, `'self'` ne matche rien) :
+
+```
+Content-Security-Policy:
+  default-src     'none';
+  script-src      'nonce-<n>' <origine_instance>;
+  style-src       'nonce-<n>' <origine_instance>;
+  style-src-attr  'unsafe-inline';
+  img-src         <origine_instance> data: blob:;
+  media-src       <origine_instance> blob:;
+  connect-src     <origine_instance>;
+  frame-src       'none';
+  form-action     'none';
+  base-uri        'none';
+```
+
+Trois précisions qui évitent une CSP de façade :
+
+- **pas de `'unsafe-inline'` dans `style-src`.** Un nonce le neutralise de toute façon quand les deux sont présents, donc l'écrire ne fait que masquer l'intention. Les attributs `style=""` dynamiques, eux, sont réels et fréquents : ils passent par `style-src-attr`, exactement comme le frontend principal le fait déjà.
+- **le JS d'extension est un asset same-origin**, chargé par balise depuis `<origine_instance>`, jamais inline. Seul l'amorceur injecté par l'hôte porte le nonce. C'est ce qui permet la mise en cache par version.
+- `frame-src 'none'` : une extension ne peut pas embarquer d'iframe tierce en v1 (voir §12, limite assumée).
+
+### 4.3 Les assets
+
+Servis par `GET /api/v1/extensions/:id/:version/assets/*`, avec la version dans le chemin : une mise à jour invalide le cache d'elle-même, et une frame ouverte ne peut pas se retrouver à mélanger l'ancien et le nouveau code.
+
+Règles : chemin validé et aplati, aucun `..`, aucun lien symbolique, `Content-Type` déterminé par le serveur depuis une table blanche d'extensions (jamais deviné depuis le contenu), `X-Content-Type-Options: nosniff`, `Cross-Origin-Resource-Policy: same-origin`.
+
+**La route publique `/api/v1/widget-assets/:id/:file` disparaît avec P0.** Elle sert aujourd'hui du JS tiers en `application/javascript` sur l'origine principale, ce qui est précisément le chemin qu'on supprime. Le JS d'une extension n'est jamais chargeable comme script de la page hôte.
+
+### 4.4 Séquence de démarrage
+
+```
+hôte                                        frame (origine opaque)
+ │  1. POST /extensions/<id>/session ────────────────────────────►  core
+ │     (jeton utilisateur réel)                                     mint jeton d'extension
+ │  ◄──── ext_token (10 min, scope = id + user + permissions)
+ │
+ │  2. monte l'iframe
+ │                                          3. charge le SDK hôte (nodyx.js)
+ │  ◄──── postMessage { type: 'hello' }
+ │  4. postMessage { ext_token, config, user?, instance, locale,
+ │                   messages, theme } ────────────────────────►
+ │                                          5. Nodyx.connect() résout
+ │  ◄──── postMessage { type: 'resize', h } (ResizeObserver)
+```
+
+Le SDK (`nodyx.js`) est **servi par l'hôte**, jamais empaqueté par l'auteur. Sa version suit toujours celle de l'instance, donc pas de dérive de contrat.
+
+### 4.5 Le canal : `MessageChannel`, pas `window.postMessage`
+
+Avec une origine opaque, `event.origin` vaut `"null"` et ne prouve rien, et `window` est écoutable par tout ce qui obtient une référence. Filtrer les messages à la main est donc fragile.
+
+**L'hôte n'envoie qu'un seul message sur `window` : le message d'amorçage, qui transfère un `MessagePort`.** Tout le reste passe par ce port privé, non énumérable, propre à cette frame et à cette session. Une autre frame ne peut pas s'y adresser, il n'y a rien à usurper. En complément, l'hôte vérifie `event.source === iframe.contentWindow` sur ce message unique.
+
+### 4.6 Le protocole, versionné et corrélé
+
+```jsonc
+// requête, dans les deux sens
+{ "p": 1, "id": "c3f1", "ext": "library", "surface": "page",
+  "type": "storage.get", "payload": { "key": "watched" } }
+
+// réponse, toujours corrélée
+{ "p": 1, "id": "c3f1", "ok": true,  "result": [ ... ] }
+{ "p": 1, "id": "c3f1", "ok": false, "error": { "code": "QUOTA_EXCEEDED", "message": "..." } }
+
+// notification hôte vers extension, sans réponse attendue
+{ "p": 1, "event": "theme" | "locale" | "config" | "route" | "session", "payload": { ... } }
+```
+
+`p` est la version du protocole, indépendante de `api` du manifeste. Un `id` inconnu, déjà consommé, ou reçu avant la fin de la poignée de main est rejeté et journalisé. Les codes d'erreur sont en SCREAMING_SNAKE_CASE, cohérents avec la règle maison des réponses du core.
+
+### 4.7 Le `ext_token`
+
+JWT court signé par le core, lié à tout ce qui doit l'être :
+
+```jsonc
+{
+  "iss": "https://instance.example",   // l'instance émettrice
+  "aud": "nodyx-extension",            // ne vaut que pour les routes extension
+  "ins": "<instance_id>",              // pas rejouable sur une autre instance
+  "ext": "library",                    // pas rejouable par une autre extension
+  "sur": "page",                       // pas rejouable sur une autre surface
+  "sub": "<user_id | null>",           // null pour un visiteur
+  "prm": ["storage.user", "identity"], // permissions accordées, pas demandées
+  "jti": "...", "iat": ..., "exp": ... // 10 minutes
+}
+```
+
+Les routes `/api/v1/extensions/:id/*` acceptent ce jeton, acceptent `Origin: null`, et **n'acceptent jamais le cookie de session ni le jeton utilisateur**. Un `jti` révoqué (désinstallation, désactivation, retrait de permission) est refusé immédiatement.
+
+**Le jeton ne transite que par le port privé.** Jamais dans une URL, un `src`, un référent, un journal ou un message d'erreur. Le renouvellement est **à la demande de la frame** (`session.renew`), l'hôte re-frappe un jeton auprès du core avec la session utilisateur réelle : il n'y a pas de flux périodique qui pousse des JWT dans la frame.
+
+### 4.8 Le pont, surface exposée au développeur
+
+```js
+const nodyx = await Nodyx.connect()
+
+nodyx.config                       // config du builder, typée par le schéma du manifeste
+nodyx.user                         // { id, username, avatar, locale } ou null, selon permission
+nodyx.instance                     // { name, memberCount, onlineCount, logoUrl }
+nodyx.locale                       // 'fr' | 'en' | ...
+nodyx.t('key', { count: 3 })       // bundle de l'extension, interpolation {{}}
+nodyx.theme                        // jetons résolus, CSS déjà injecté dans la frame
+
+await nodyx.storage.get('watched')            // scope user par défaut
+await nodyx.storage.set('watched', [...])
+await nodyx.storage.list({ scope: 'instance' })
+
+await nodyx.fetch('https://api.themoviedb.org/3/movie/603')   // proxy, liste blanche
+await nodyx.core.get('members', { limit: 20 })                // scopes de lecture
+
+await nodyx.ui.confirm({ title, body })       // rendu par l'HOTE, hors de la frame
+nodyx.ui.toast('ok')
+nodyx.router.push('/film/42')                 // reflété dans l'URL de l'hôte
+nodyx.on('theme' | 'locale' | 'config' | 'route', cb)
+```
+
+Les dialogues et toasts sont **rendus par l'hôte** : une frame ne peut pas dessiner par-dessus la page, et on ne veut pas qu'elle le puisse. Bénéfice collatéral, une extension a le look Nodyx sans effort.
+
+### 4.9 Ce qui est refusé, définitivement
+
+Le jeton de session, les cookies, le DOM de l'hôte, le contenu des DM, les e-mails, toute route admin, l'écriture sur les ressources du core en v1, l'exécution serveur, l'accès disque, les iframes tierces (v1).
+
+---
+
+## 5. Le manifeste v1
+
+```json
+{
+  "api": 1,
+  "id": "library",
+  "version": "1.0.0",
+  "nodyx_min": "2.13.0",
+  "license": "AGPL-3.0-or-later",
+  "author": { "name": "Nodyx", "url": "https://github.com/Pokled/nodyx" },
+  "source": "https://github.com/Pokled/nodyx-library",
+
+  "default_locale": "en",
+  "label":       "@ext.label",
+  "description": "@ext.description",
+  "icon":        "icon.svg",
+  "family":      "content",
+
+  "surfaces": [
+    {
+      "type": "page",
+      "path": "library",
+      "entry": "ui/page.js",
+      "nav": { "label": "@nav.label", "icon": "twemoji:clapper-board" }
+    },
+    {
+      "type": "widget",
+      "id": "tonight",
+      "entry": "ui/widget.js",
+      "label": "@widget.tonight",
+      "schema": [
+        { "key": "mood", "type": "select", "label": "@widget.mood",
+          "options": [{ "value": "learn", "label": "@mood.learn" }] }
+      ]
+    }
+  ],
+
+  "permissions": {
+    "identity": ["id", "username", "avatar", "locale"],
+    "storage":  { "user": "1mb", "instance": "8mb" },
+    "core":     ["members:read"],
+    "network": {
+      "api.themoviedb.org": {
+        "methods": ["GET"],
+        "paths":   ["/3/movie/*", "/3/search/movie"],
+        "secret":  "TMDB_API_KEY",
+        "rate":    "60/min"
+      },
+      "image.tmdb.org": { "methods": ["GET"], "paths": ["/t/p/*"] }
+    }
+  }
+}
+```
+
+Règles dures, vérifiées à l'installation :
+
+- toute chaîne visible commence par `@` et est une clé, résolue dans `i18n/<locale>.json` ; une clé absente du bundle `default_locale` fait **échouer** l'installation
+- `type` de champ : `text | textarea | url | number | boolean | select | color | image`. `checkbox` est refusé (la tolérance actuelle de `catalog.ts` disparaît, le SDK impose `boolean`)
+- une permission inconnue fait échouer l'installation, elle n'est pas ignorée
+- `id` en minuscules, chiffres et tirets, unique, et **refusé s'il appartient au domaine réservé natif**. Le validateur connaît la liste des identifiants natifs : ce n'est pas « le natif gagne à l'affichage », c'est « l'installation est refusée ». La règle actuelle `filter(m => !PLUGIN_REGISTRY[m.id])` masque une collision, elle ne l'empêche pas.
+- une permission `network` déclare **hôte, méthodes et préfixes de chemin**. Un hôte nu, sans méthode ni chemin, est refusé : l'écran de permissions doit pouvoir dire « peut lire les fiches publiques TMDB (GET /3/movie/...) », pas « accès réseau à api.themoviedb.org ».
+- taille du paquet plafonnée (proposition : 20 Mo, dataset compris), nombre de fichiers plafonné, profondeur de répertoires plafonnée
+
+Le manifeste a un **JSON Schema versionné dans le dépôt**, et la page de doc est générée à partir de lui. Une seule source de vérité pour le validateur, l'IDE et la documentation.
+
+---
+
+## 6. Permissions et capacités
+
+### 6.1 `storage`
+
+Deux portées : `user` (par utilisateur connecté) et `instance` (partagé). Quatre capacités distinctes, jamais implicites : `storage.user`, `storage.instance.read`, `storage.instance.write`.
+
+**Règle des deux axes.** La permission de l'extension et les droits de l'utilisateur sont deux axes séparés, et le droit effectif est leur **intersection**. Une extension qui détient `storage.instance.write` n'écrit pas parce qu'un membre a ouvert son interface : elle écrit dans le cadre de ce que ce membre a le droit de déclencher. Une capacité accordée par l'admin à l'installation n'est jamais une élévation de privilège pour l'utilisateur courant.
+
+Migration `1xx_extensions.sql`, numéro attribué au moment de l'implémentation. La branche et `origin/main` sont à **111** au 2026-08-14, donc 112 aujourd'hui, mais on ne fige pas un numéro dans une spécification : deux branches qui avancent en parallèle produiraient une collision.
+
+```sql
+CREATE TABLE installed_extensions (
+  id            TEXT        PRIMARY KEY,
+  manifest      JSONB       NOT NULL,
+  version       TEXT        NOT NULL,
+  origin        TEXT        NOT NULL,          -- 'file' | 'registry:<host>'
+  sha256        TEXT        NOT NULL,
+  enabled       BOOLEAN     NOT NULL DEFAULT true,
+  granted       JSONB       NOT NULL DEFAULT '{}',   -- permissions acceptées par l'admin
+  installed_by  UUID        REFERENCES users(id),
+  installed_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE extension_storage (
+  extension_id TEXT        NOT NULL REFERENCES installed_extensions(id) ON DELETE CASCADE,
+  scope        TEXT        NOT NULL CHECK (scope IN ('instance','user')),
+  user_id      UUID        REFERENCES users(id) ON DELETE CASCADE,
+  key          TEXT        NOT NULL,
+  value        JSONB       NOT NULL,
+  bytes        INTEGER     NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE NULLS NOT DISTINCT (extension_id, scope, user_id, key)
+);
+
+CREATE TABLE extension_secrets (
+  extension_id TEXT NOT NULL REFERENCES installed_extensions(id) ON DELETE CASCADE,
+  name         TEXT NOT NULL,
+  value        TEXT NOT NULL,          -- jamais renvoyé par l'API, injecté côté serveur
+  PRIMARY KEY (extension_id, name)
+);
+```
+
+`UNIQUE NULLS NOT DISTINCT` exige PostgreSQL 15+, la prod est en 16.14.
+
+**Un quota en octets ne suffit pas.** Une extension peut faire exploser le CPU et la base sans jamais dépasser 1 Mo. Limites appliquées, toutes en dur côté serveur :
+
+| Limite | Valeur proposée |
+|---|---|
+| longueur d'une clé | 128 caractères |
+| taille d'une valeur | 64 Ko |
+| nombre de clés par portée | 500 |
+| profondeur JSON | 16 niveaux |
+| écritures | 30 par minute et par utilisateur, par extension |
+| total | le quota déclaré au manifeste, accordé par l'admin |
+
+Dépassement : erreur nette avec un code stable, jamais de purge silencieuse.
+
+### 6.2 `identity`
+
+Liste explicite de champs. Jamais l'e-mail, jamais le rôle admin sans demande. Visiteur non connecté : `nodyx.user === null`, l'extension doit fonctionner quand même (règle de vue invité, déjà apprise à nos dépens côté i18n).
+
+### 6.3 `core`, lectures cadrées
+
+v1 en lecture seule, avec **les droits de l'utilisateur courant**, jamais élevés : `members:read`, `forum:read`, `instance:read`. L'écriture arrive en v2, avec consentement par action. Un visiteur anonyme ne voit que le public, comme partout ailleurs.
+
+### 6.4 `network` et `secrets`, le proxy
+
+Aucune requête sortante depuis la frame. Et le proxy **n'est pas un `fetch` générique derrière une liste blanche** : c'est une API de données bornée par ce que le manifeste a déclaré et que l'admin a accepté. La différence se voit à l'écran de permissions, qui doit rester lisible par un humain.
+
+`nodyx.fetch()` tape `POST /api/v1/extensions/:id/fetch`, qui applique dans l'ordre :
+
+1. **hôte, méthode et préfixe de chemin** vérifiés contre la déclaration accordée. Le port est celui du schéma (443), un port explicite non déclaré est refusé.
+2. **résolution DNS puis validation de l'adresse obtenue**, et connexion **à cette adresse** (épinglage). Vérifier le nom avant de résoudre ne protège de rien : un nom public qui résout en adresse privée est le contournement classique. Sont refusés : RFC1918, loopback v4 et v6, lien-local, ULA, multicast, adresses mappées, et les écritures exotiques d'IP.
+3. **redirections limitées à 3, chacune revalidée intégralement** (hôte, chemin, adresse résolue).
+4. **secrets injectés par le serveur, selon une recette que le serveur possède** (nom de l'en-tête ou du paramètre, emplacement). L'extension déclare `"secret": "TMDB_API_KEY"` et ne choisit ni le nom de l'en-tête ni sa destination. Sans ça, `nodyx.fetch()` pourrait demander `X-Peu-Importe: <secret>` vers un hôte contrôlé et récupérer indirectement ce qu'il n'a pas le droit de voir.
+5. **en-têtes filtrés dans les deux sens** (liste blanche courte à l'aller, `Set-Cookie` et compagnie retirés au retour).
+6. **réponse plafonnée** : taille, délai, type de contenu, taux de compression (une archive zip de 10 Ko qui se décompresse en 10 Go est un déni de service).
+7. **débit plafonné** par extension et par utilisateur, mis en cache selon les en-têtes.
+
+Les images passent par le même chemin (`/extensions/:id/img?u=...`, réponse mise en cache). Coût : de la bande passante sur l'instance. Contrepartie : **le navigateur du visiteur ne parle à personne d'autre qu'à sa communauté**, et une clé d'API tierce ne fuit jamais.
+
+Le SDK **n'expose jamais l'URL réelle du proxy** au développeur, seulement `nodyx.fetch(url)`. Sinon la première extension venue reconstruira l'appel à la main et le contrat deviendra une convention.
+
+---
+
+## 7. Points d'accroche (D4)
+
+| Surface | v1 | Description |
+|---|---|---|
+| `widget` | oui | Bloc dans la grille de la page d'accueil, config par le builder, exactement là où vivent les widgets aujourd'hui |
+| `page` | oui | Route `/x/<ext-id>/*` dans la coque de l'app, entre les sidebars, avec entrée de navigation optionnelle |
+| `panel` | non, v2 | Panneau latéral contextuel |
+| `card` | non, v2 | Enrichissement d'un lien cité dans le chat ou le forum, brancherait `services/linkPreview.ts` au-delà du fil social |
+| `profile-tab` | non, v3 | Onglet sur la page profil |
+
+La `page` est la nouveauté qui change la nature du système : jusqu'ici une extension ne pouvait qu'orner l'accueil. C'est elle qui permet à une vraie application, la médiathèque, d'exister sans toucher au core.
+
+Correspondance avec les catégories du magasin (D8), corrigée : **une extension n'a pas de type global.** Elle expose des surfaces, et le magasin range par surface. Une extension qui livre une page et deux widgets apparaît dans Modules **et** dans Widgets, et sa fiche annonce « Page plus 2 widgets ». C'est ce que font Joomla et WordPress avec leurs listings multi-catégories, et ça évite une taxonomie artificielle où il faudrait trancher ce qu'« est » une extension mixte.
+
+**Marqueur d'origine.** Toute surface d'extension est identifiée comme telle par l'hôte, **à l'extérieur de la frame** donc non falsifiable : un liseré discret et le nom de l'extension. Un membre doit pouvoir distinguer ce que dit Nodyx de ce que dit une extension, sinon une fausse invite de connexion dessinée dans un widget est indiscernable de la vraie. C'est le pendant visuel des dialogues rendus par l'hôte (§4.8), et la réponse à la non garantie N4 de `NODYX_SDK_SECURITY.md`.
+
+Le manifeste ne porte donc **aucun champ `type`** : le rangement se déduit des surfaces, l'auteur ne déclare rien de plus, et une extension qui gagne une page en v1.1 change de rangement toute seule (ce que le diff de capacités de §9.5 rend visible).
+
+---
+
+## 8. Thème et i18n (D5)
+
+**Thème** : l'hôte injecte dans la frame les jetons CSS résolus et pousse une mise à jour sur changement. Attention au piège maison des trois palettes parallèles (`--nx-*`, `--p-*`, `--n*`) : le SDK expose **un seul jeu de noms stables** (`--nodyx-bg`, `--nodyx-fg`, `--nodyx-accent`, `--nodyx-border`, `--nodyx-radius`, `--nodyx-font`), l'hôte fait la correspondance. Une extension câblée sur ces noms suit le thème de l'instance, quel que soit le système interne du moment.
+
+**i18n** : bundles plats `i18n/<locale>.json` (clés à points, interpolation `{{}}`, pas de pluriel, comme le frontend). `default_locale` obligatoire et complet. Les autres locales sont un bonus, résolution en cascade : locale demandée, puis `default_locale`, puis la clé brute. Le store affiche les langues couvertes.
+
+Pour les extensions **publiées par nous**, les quatre portes CI s'appliquent sans exception, et FR + EN sont livrés ensemble dans la même PR.
+
+---
+
+## 9. Empaquetage et distribution (D6)
+
+### 9.1 Le paquet
+
+```
+library-1.0.0.nyx          (zip)
+├── manifest.json
+├── icon.svg
+├── preview.png
+├── LICENSE
+├── i18n/{en,fr}.json
+├── ui/{page.js, widget.js, style.css}
+└── data/works.json        (dataset optionnel livré avec l'extension)
+```
+
+Extensions autorisées à l'extraction : `.js .css .json .svg .png .jpg .jpeg .webp .woff2 .md`. Aplatissement des chemins (protection zip slip, déjà en place dans `widgetStore.ts`), liens symboliques refusés, plafond de taille, plafond de nombre de fichiers, plafond de profondeur, plafond de ratio de décompression.
+
+**Le SVG n'est pas une image.** `icon.svg` et `preview.png` sont affichés par l'admin et par le magasin, donc **hors du bac à sable**, sur l'origine principale. Un SVG peut porter `<script>`, des gestionnaires d'événements en attribut, des `<foreignObject>`, des références externes. Sans traitement, l'icône d'une extension devient une XSS sur la page d'administration, indépendamment de toute la §4.
+
+Règle : tout SVG est **assaini à l'installation** (réécrit vers un sous-ensemble sûr : pas de script, pas d'attribut `on*`, pas de référence externe, pas de `foreignObject`), servi avec `Content-Type: image/svg+xml`, `nosniff` et `Content-Security-Policy: default-src 'none'`. Un SVG qui ne survit pas à l'assainissement fait échouer l'installation, il n'est pas silencieusement vidé.
+
+### 9.2 La vitrine et le tuyau
+
+Référence assumée : `extensions.joomla.org` et `fr.wordpress.org/plugins`. Un écosystème n'existe pas autour d'un fichier JSON, il existe autour d'un endroit où l'on flâne, où l'on lit une fiche, où l'on voit ce que les autres ont fait.
+
+**Un seul satellite, `nodyx-store`, deux faces sur la même base** (SvelteKit plus SQLite plus PM2, le patron déjà éprouvé de `nodyx-hub` et de la médiathèque) :
+
+| Face | Pour qui | Quoi |
+|---|---|---|
+| `extensions.nodyx.org` | humains | catalogue, catégories, fiches, guide de publication, formulaire de soumission |
+| `/index.json` (+ `.sig`) | instances | index statique signé Ed25519, consommé par l'admin de chaque instance |
+
+**L'admin d'instance n'embarque jamais le site en iframe.** Il consomme l'index et **rend le catalogue nativement**, comme le fait WordPress et contrairement à Joomla. Raisons : thème de l'instance respecté, i18n de l'instance, CSP propre, et surtout la doctrine tenue. Si `extensions.nodyx.org` tombe, une instance perd la découverte, pas l'installation ni ses extensions.
+
+**La chaîne de confiance, en trois maillons qu'il ne faut pas confondre :**
+
+```
+clé publique du registre (épinglée dans l'instance)
+        ↓  signe
+index.json  (liste, versions, permissions, sha256 de chaque paquet)
+        ↓  référence
+sha256 du paquet
+        ↓  vérifie
+paquet .nyx téléchargé
+```
+
+Le `sha256` prouve l'intégrité du téléchargement, **pas l'authenticité** : si l'index est compromis, un hash cohérent avec un paquet malveillant l'est tout autant. C'est la signature de l'index qui porte l'authenticité, et la clé publique doit donc être livrée avec l'instance, pas récupérée depuis le registre lui-même.
+
+**Une version publiée est immuable.** Un paquet republié sous le même numéro est refusé : un correctif est une nouvelle version. Sans cette règle, un hash épinglé ne veut plus rien dire. La signature par l'auteur, en plus de celle du registre, est un ajout naturel en v2.
+
+### 9.3 Les catégories du magasin
+
+Elles rangent par **surface exposée**, pas par nature de l'extension (§7). Une extension mixte apparaît dans plusieurs catégories, c'est voulu :
+
+- **Widgets** : blocs du frontpage editor
+- **Modules** : applications avec leurs pages, la médiathèque en tête
+- **Thèmes** : v2, quand les jetons de thème seront stables
+- filtres transverses : famille (`media`, `gaming`, `community`, `esport`, `social`, `content`), permissions demandées, langues, compatibilité `nodyx_min`, licence
+
+### 9.4 La fiche
+
+Ce qu'on reprend à Joomla et WordPress : captures, description longue, auteur et ses autres extensions, versions et changelog, compatibilité, licence et lien vers les sources, langues couvertes, nombre d'installations.
+
+Ce qu'ils ne font pas et qui devient notre signature : **la fiche affiche les permissions demandées, en clair, avant l'installation**. « Cette extension peut : lire ton pseudo, stocker 1 Mo par membre, appeler `api.themoviedb.org` ». Leurs fiches disent ce qu'une extension fait, jamais ce qu'elle peut toucher.
+
+**Pas d'étoiles.** Même raisonnement que la médiathèque : une moyenne sur trois votes est du bruit, et 4,2 sur 5 ne dit rien de ce qu'un paquet fait à ton instance. Des avis écrits courts, ou rien en v1.
+
+Compteur d'installations : agrégé au téléchargement du paquet, sans stockage d'IP ni d'identifiant d'instance. Le « zéro analytics » vaut aussi pour nous.
+
+### 9.5 Installer depuis le site
+
+Le magasin ne pousse jamais rien vers une instance. Le flux ne s'inverse pas :
+
+```
+fiche → « Installer » → saisie du domaine de l'instance
+      → redirection vers https://<instance>/admin/extensions/install?src=…&id=…&v=…
+      → admin authentifié, écran de permissions
+      → l'INSTANCE télécharge le paquet, vérifie le sha256 de l'index, installe
+```
+
+Depuis l'admin, la même chose sans l'aller-retour. Installation par fichier local toujours disponible, avec le même écran de permissions.
+
+**Le lien d'installation est une surface d'attaque, et il faut la traiter comme telle.** Un lien fabriqué avec `src=<registre_de_l_attaquant>` envoyé à un owner installerait du code arbitraire en un clic. Trois règles :
+
+- `src` est validé contre la **liste des registres configurés dans l'instance**, jamais suivi tel quel. Un registre inconnu affiche un refus, pas une invite à l'ajouter.
+- le lien ne fait **que pré-remplir un écran**. L'installation est un `POST` authentifié, protégé contre le CSRF, avec confirmation explicite.
+- l'écran nomme la provenance en clair : « depuis `extensions.nodyx.org` », jamais un simple « Installer ».
+
+**Jamais de mise à jour automatique.** Une mise à jour est une action d'admin, avec le changelog et surtout le **diff de capacités** en évidence. Pas seulement les permissions : ce qui compte, c'est le changement de profil de risque.
+
+```
+library  1.0.0 → 1.1.0
+
++ réseau     api.foo.com  (GET /v2/*)
++ stockage   instance.write
+- identité   avatar
++ surface    page  /x/library/settings
+```
+
+Une extension qui passe de widget à application complète a changé de nature. Un ajout de surface, une nouvelle route, une nouvelle capacité se lisent au même endroit que les permissions. C'est l'instant précis où une extension honnête devient malveillante, il doit être visible sans effort.
+
+### 9.6 Publier, côté développeur
+
+Le site porte le parcours complet : pourquoi, comment fabriquer, comment tester, comment soumettre. **La documentation technique reste canonique sur `nodyx.dev`**, la vitrine y renvoie et ne la duplique pas (le coût de la doc en double est déjà connu de la maison).
+
+Soumission : un **formulaire guidé qui génère la PR GitHub pré-remplie** sur le dépôt `nodyx-extensions`. La CI valide le paquet contre le JSON Schema du manifeste, un mainteneur relit, l'index se régénère au merge. Zéro service à opérer, zéro compte à gérer, zéro file de modération à héberger, et le développeur garde une trace publique de son travail. Upload direct avec comptes seulement si le volume le justifie un jour.
+
+Modération : le magasin est le **niveau 2** du modèle de liberté à deux étages. Une instance installe ce qu'elle veut par fichier, le registre officiel, lui, est modéré.
+
+### 9.7 Amorçage, le vrai risque
+
+Un magasin vide tue sa propre crédibilité, et aujourd'hui l'écosystème compte **un** widget. Le jour de l'ouverture il faut douze fiches réelles : les 10 widgets natifs de la page d'accueil, `video-player`, la médiathèque. Elles seront marquées « officielles, préinstallées ». C'est aussi le meilleur test du format de fiche : si nos propres widgets y rentrent mal, ceux d'un tiers y rentreront plus mal encore.
+
+### 9.8 Économie
+
+Gratuit. Licence OSI et lien vers les sources exigés au registre officiel. Pas de paiement, pas de commission, pas de classement sponsorisé. Un registre tiers fait ce qu'il veut, c'est le choix de celui qui l'ajoute.
+
+### 9.9 Exigences de fabrication de la vitrine
+
+`extensions.nodyx.org` n'est pas un outil interne, c'est une **surface de visibilité durable** : une page par extension, indexée, partagée, citée, qui vivra des années. Elle se construit donc au niveau du reste, pas en vitesse.
+
+**i18n, non négociable.** FR et EN dès le premier commit, aucune chaîne en dur, même pour un libellé de filtre. Le satellite reprend le patron déjà éprouvé sur la médiathèque (`src/lib/i18n/{fr,en}.json` plus un helper), et **les portes CI sont câblées sur le satellite lui-même** : les scripts de `nodyx-frontend/scripts/i18n/` sont partagés ou portés, pas réécrits. Ce qui est traduit : toute la chrome du site. Ce qui ne l'est pas : le contenu rédigé par un auteur d'extension, qui reste dans la langue qu'il a choisie, avec sa langue affichée sur la fiche.
+
+**Design, la barre.** Références : Linear, Vercel, Stripe. Un catalogue est un **outil de navigation dense**, pas une page d'atterrissage.
+
+| Règle | Détail |
+|---|---|
+| Rayons | l'échelle de la maison, mesurée : `lg` (8px) pour les surfaces, `sm`/`md` pour les champs, `full` réservé aux pastilles et aux avatars. **`2xl` et au-delà sont interdits** (40 et 1 occurrences dans tout le frontend, ce sont des accidents, pas un style) |
+| Pas de gloss | pas de verre dépoli, pas de halo néon, pas de dégradé sur un bouton, pas d'ombre portée par défaut. Des aplats, une bordure discrète, **un seul accent** |
+| Densité | la fiche et la liste montrent de l'information réelle (version, licence, langues, permissions), pas des cartes géantes à trois mots |
+| Typographie | la pile du frontend, deux graisses, une échelle. Aucune police chargée depuis un tiers |
+| Thèmes | clair et sombre, `prefers-color-scheme` respecté, contraste AA vérifié, focus visible, navigation clavier complète |
+| Copie | **aucun tiret cadratin**, ni en FR ni en EN. Deux-points ou virgule. Ton factuel, zéro superlatif marketing |
+| Captures | ce sont elles le contenu. Le gabarit les sert, il ne se sert pas d'elles |
+
+**Zéro tiers, y compris ici.** Aucune police, aucun script, aucune image chargés depuis un CDN, aucune mesure d'audience. Un site qui vend l'auto-hébergement sans traqueur ne peut pas en poser lui-même : la vitrine est la démonstration de la doctrine, sa page réseau doit être vide.
+
+**Référencement, puisque c'est l'enjeu.** Rendu serveur, une URL stable par extension (`/e/<id>`), titre et description propres, image Open Graph générée par extension (icône, nom, auteur, surfaces), `sitemap.xml`, données structurées `SoftwareApplication`, pages de catégories indexables. Le site doit être lisible et rapide sans JavaScript pour tout ce qui est consultation.
+
+**Zéro étoile, rappel.** Le classement par défaut est éditorial et explicite (officielles, puis récemment mises à jour), jamais une note agrégée déguisée en pertinence.
+
+---
+
+## 10. Outillage développeur
+
+C'est la réponse directe au « les deux pages sont trop pauvres ». Le SDK sans outillage, c'est encore un tutoriel.
+
+- **`npm create nodyx-extension`** : squelette complet (manifeste, i18n fr/en, page, widget, thème câblé, README), qui tourne en 30 secondes.
+- **`nodyx-ext dev`** : serveur local qui monte le paquet dans une frame identique à la production, avec un hôte simulé : données bidon, changement de thème, changement de langue, permissions activables une à une pour voir ce que ça casse.
+- **`nodyx-ext check`** : le validateur du core, en CLI. Le même code que celui de l'installation, donc pas de surprise à l'upload.
+- **`/admin/extensions/lab`** : sur l'instance, charge une URL de dev dans le bac à sable réel, avec le journal du pont (chaque appel, chaque refus, chaque quota). Même esprit que `/admin/sfu-lab`.
+- **`@nodyx/sdk`** : types TypeScript pour `Nodyx`, `manifest.json` typé, autocomplétion sur `nodyx.config` dérivée du schéma déclaré.
+- **Doc générée** depuis le JSON Schema, plus de table à maintenir à la main dans `CREATE-WIDGET.md`.
+
+---
+
+## 11. La médiathèque, composant de référence
+
+Elle est le critère d'acceptation, pas une démonstration.
+
+| Besoin de la médiathèque | Réponse du SDK |
+|---|---|
+| 229 œuvres, 67 univers, 60 leçons | `data/works.json` livré dans le paquet, filtré et cherché côté client |
+| Statuts vus / à voir par personne | `storage` portée `user`, ce qui règle enfin le point dur mono-utilisateur |
+| Favoris, note perso | idem, aucune table dédiée, aucune migration |
+| Affiches et fiches TMDB | `network` sur liste blanche, à travers le proxy, clé TMDB en `secrets` |
+| 4 écrans (parcours, bibliothèque, film, ce soir) | une surface `page` avec routage interne, `nodyx.router` pour les liens profonds |
+| i18n FR / EN, 72 clés à parité | bundles du paquet, déjà écrits le 2026-08-14 |
+| Rendu entre les sidebars, au thème de l'instance | surface `page` plus jetons de thème |
+| Authentification | héritée, il n'y a rien à écrire, c'était l'argument de départ |
+
+Le corpus éditorial (notes de curation, leçons) **n'est pas traduit**, décision déjà prise et inchangée : c'est du contenu, pas de l'interface.
+
+Ce qui reste franchement à l'épreuve : SQLite disparaît au profit d'un dataset plus du KV. Les recherches et filtres passent côté client sur un JSON d'environ 300 Ko. Si ça tient pour 229 œuvres, ça tient pour l'usage visé.
+
+Mais le critère d'acceptation n'est pas « 300 Ko passent ». C'est : **une extension ne doit jamais avoir besoin d'un privilège supplémentaire simplement parce que son jeu de données grossit.** Le SDK traite donc `data/*.json` comme des assets versionnés, servis par la route d'assets, sans permission associée. Le jour où une médiathèque atteint 30 000 œuvres, on ajoute une API de dataset indexée côté serveur ; le modèle de sécurité, lui, ne bouge pas.
+
+Règles fondatrices intactes : note de curation obligatoire, zéro étoile, zéro recommandation algorithmique.
+
+---
+
+## 12. Ce qu'on casse, assumé (D7)
+
+- **Le format v0 disparaît.** Un manifeste sans `api: 1` est refusé, avec un message qui pointe le guide de migration. Coût réel : un widget, `video-player`, qui est à nous.
+- **`video-player` devient natif.** Il embarque des iframes YouTube, Twitch, Vimeo, or une frame à origine opaque ne peut pas embarquer de frame tierce (les drapeaux du bac à sable se propagent aux contextes imbriqués, l'embed casse). Il a sa place à l'étage 1, il garde son `id`, donc **les layouts d'accueil existants continuent de rendre à l'identique**.
+- **`installed_widgets` est remplacée** par `installed_extensions`. Migration 112 : création. La suppression de l'ancienne table attend la release suivante, une fois les 4 instances vérifiées.
+- **L'embed tiers dans une extension** (un lecteur YouTube dans une extension de la communauté) exige une origine dédiée `ext.<domaine>`, donc du DNS et un certificat, donc une entorse au zéro configuration. Reporté en P3, activable par ceux qui ont le DNS, jamais exigé.
+
+---
+
+## 13. Phasage
+
+**P0, le socle, découpé en trois lots livrables séparément**
+
+Le P0 initial contenait presque tout le système, ce qui rend les régressions impossibles à localiser. Découpage :
+
+- **P0-A, le substrat de sécurité.** Lecteur de paquet, JSON Schema du manifeste, validateur, assainissement SVG, installation par fichier, document de frame et sa CSP, route d'assets versionnée, `MessageChannel` et protocole `p:1`, `ext_token`, **suppression du chargeur par balise script et de `/widget-assets`**, `video-player` passé natif.
+  Cette suppression tient **dès le premier lot** : une fois `video-player` natif, il n'existe plus aucune extension tierce en production sur les 4 instances. Le chemin non isolé meurt donc avant même qu'une surface tierce existe, ce qui est l'ordre le plus sûr.
+- **P0-B, l'API de runtime.** `config`, thème, i18n, `identity`, `storage` et ses limites, redimensionnement, routeur, UI rendue par l'hôte.
+- **P0-C, les surfaces.** `widget` dans le builder, `page` dans la coque, `CatalogEntry` v2, écran de permissions, administration des extensions.
+
+Aucun lot ne réintroduit un chemin non isolé, et chacun se déploie seul.
+
+**P1, le banc d'essai**
+Proxy réseau plus secrets, `core:read`, médiathèque portée en extension et déployée sur nodyx.org, outillage développeur (`create`, `dev`, `check`, lab).
+
+**Porte d'entrée de P1 : aucune API réseau d'extension n'existe tant que les tests de confinement de §14, point 1, ne sont pas verts.** Le proxy est lui-même une capacité de sécurité, il ne se pose pas sur un bac à sable non prouvé.
+
+**P2, la place de marché**
+Satellite `nodyx-store` (site public plus index signé), fiches et catégories, catalogue rendu nativement dans l'admin, flux d'installation depuis le site, mises à jour avec diff de permissions, dépôt `nodyx-extensions` et sa CI, formulaire de soumission générateur de PR, amorçage des 12 fiches, réécriture de `CREATE-WIDGET.md` en manuel SDK généré sur `nodyx.dev`. Renommage `/admin/modules` en Fonctionnalités.
+
+### 13.1 Plan de non-régression de P0-A
+
+Ce lot touche le rendu de la page d'accueil des 4 instances de production. Inventaire vérifié le 2026-08-14, pas supposé.
+
+**Ce qui est modifié**
+
+| Fichier | Changement |
+|---|---|
+| `homepage/DynamicWidget.svelte` | remplacé par un composant de frame isolée |
+| `homepage/WidgetZone.svelte` L52 | site d'appel |
+| `homepage/GridRenderer.svelte` L154 | site d'appel |
+| `homepage/catalog.ts` | `CatalogEntry` v2 |
+| `homepage/plugins/index.ts` | `video-player` enregistré comme natif |
+| core `widgetStore.ts` | route `/widget-assets` supprimée, store remplacé |
+| core `widgetDemo.ts` | démo devenue inutile, `video-player` étant natif |
+
+**Ce qui ne doit pas bouger, et pourquoi ça tient**
+
+1. **Les mises en page enregistrées.** La grille stocke `widget_type: 'video-player'`. Les deux renderers testent le natif **en premier** (`{#if plugin}` dans `GridRenderer`, `{#if nativePlugin}` dans `WidgetZone`), et `catalog.ts` filtre déjà les widgets installés qui masqueraient un natif (`filter(m => !PLUGIN_REGISTRY[m.id])`, `toInstalledWidgetsMap` fait de même). Enregistrer `video-player` dans le registre natif **suffit** à ce que les mises en page existantes rendent, sans migration de données. Condition : le composant natif lit **exactement** les mêmes clés de configuration, `url`, `title`, `autoplay`, `show_controls`.
+2. **Les deux chargements serveur** qui appellent `/widget-store-public` (`routes/+page.server.ts` L14 et `admin/homepage/builder/+page.server.ts` L11) doivent être migrés **en même temps** que la route, sinon l'accueil et le builder cassent ensemble.
+3. **La table `installed_widgets` et les dossiers `uploads/widgets/`** restent en place le temps d'une release. Aucune suppression dans le même lot que la bascule.
+
+**Preuves exigées avant merge**
+
+- captures avant et après de la page d'accueil des 4 instances, à 375, 768 et 1366 pixels, comparées
+- `video-player` rendu par le chemin natif, avec une configuration existante non modifiée
+- `npm run check` et `tsc` propres, suite core verte, portes i18n vertes
+- aucune requête vers `/api/v1/widget-assets` dans le journal réseau d'un chargement d'accueil
+- l'extension hostile de §14 échoue sur toutes ses tentatives
+
+**Preuves exigées après déploiement**
+
+- les 4 instances en 200, version attendue, `pm2 list` propre
+- une page d'accueil chargée sur chaque instance, sans erreur console, sans violation de politique de sécurité
+- `sidebar_bg` et les autres réglages d'instance inchangés (le déploiement touche le frontend, pas la configuration)
+
+**Repli** : le lot est réversible par retour arrière du frontend seul tant que la table `installed_widgets` n'est pas supprimée. C'est la raison pour laquelle sa suppression est repoussée d'une release.
+
+**P3, l'ouverture**
+Surfaces `panel` et `card` (enrichissement chat et forum, l'étagère de la communauté), écritures core avec consentement, origine dédiée optionnelle pour les embeds tiers.
+
+---
+
+## 14. Critères d'acceptation
+
+Prouvés par des tests exécutables en CI, pas par du raisonnement.
+
+1. **Extension hostile en fixture** (`tests/fixtures/evil-extension`). Chaque tentative échoue, test Playwright vert. Le catalogue d'attaques, par famille :
+
+| Famille | Tentatives |
+|---|---|
+| DOM et fenêtres | `window.parent.document`, `window.top`, `window.frames`, `document.cookie`, `localStorage`, lecture de la charge SSR de l'hôte |
+| Navigation | `window.top.location`, `window.open`, sortie de la surface autorisée, soumission de formulaire |
+| Messagerie | message forgé depuis une autre frame, message sur `window` après la poignée de main, `requestId` inconnu, `requestId` rejoué, réponse non sollicitée, message adressé au port d'une autre extension |
+| Jeton | rejeu sur une autre extension, une autre surface, une autre instance, après expiration, après désinstallation |
+| Réseau | hors liste blanche, méthode non déclarée, chemin non déclaré, port explicite, redirection vers `127.0.0.1`, vers RFC1918, vers `::1`, **DNS rebinding** (nom public résolvant en adresse privée), écriture exotique d'IP, exfiltration de secret par en-tête choisi, bombe de décompression |
+| Stockage | hors quota d'octets, clé trop longue, valeur trop grosse, trop de clés, JSON trop profond, martèlement en écriture, écriture dans l'espace d'une autre extension, écriture instance sans la capacité |
+| Paquet | zip slip, lien symbolique, fichier géant, 100 000 fichiers minuscules, arborescence profonde, type MIME menti, **SVG porteur de script ou d'attribut `on*`** |
+
+Le SVG mérite sa ligne : c'est la seule attaque de cette liste qui frappe **hors** du bac à sable, sur la page d'administration.
+2. **Le jeton de session n'est jamais lisible** depuis une extension, y compris quand un admin est connecté.
+3. **Une extension qui boucle ou qui plante** ne fige pas la page hôte, et affiche une carte d'erreur propre.
+4. **Zéro régression d'accueil** : les layouts des 4 instances rendent à l'identique après P0 (comparaison de captures).
+5. **Installation refusée** pour : zip slip, `entry` absent, permission inconnue, `default_locale` incomplet, dépassement de taille, `api` absent.
+6. **La médiathèque tourne comme extension** sur nodyx.org, avec statuts par utilisateur, i18n FR et EN, thème de l'instance, entre les sidebars.
+7. **Portes i18n vertes** sur tout ce qu'on livre.
+8. **Quotas appliqués** : dépassement de stockage et de débit réseau prouvés par test, erreur nette.
+
+---
+
+## 15. Risques et points à arbitrer
+
+| Risque | Traitement |
+|---|---|
+| Le bac à sable bride trop, personne n'écrit d'extension | La médiathèque est le juge. Ce qu'elle exige, le SDK le fournit. Si elle passe, une extension de communauté passe. |
+| Une iframe par widget sur l'accueil, coût de rendu | Chargement paresseux hors du viewport, frame unique par extension quand plusieurs de ses widgets sont sur la même page. À mesurer, pas à supposer. |
+| Le proxy réseau fait de l'instance un relais ouvert | Liste blanche par extension, anti SSRF, quotas, journal. Aucun hôte libre. |
+| Le registre par défaut recentralise Nodyx | Index statique signé, remplaçable, cumulable, contournable par fichier. L'admin rend le catalogue nativement, jamais en iframe. Si le magasin tombe, une instance perd la découverte, pas l'installation. |
+| Magasin vide à l'ouverture | Amorçage à 12 fiches réelles (§9.7). Un magasin qui s'ouvre à une entrée ne se remplit jamais. |
+| Chaîne d'approvisionnement (auteur compromis) | Pas de mise à jour automatique, diff de permissions à chaque montée de version, sha256 épinglé, sources exigées au registre officiel. |
+| Deux runtimes à maintenir | C'est le prix, et il est borné : le contrat, l'i18n, le thème et le catalogue sont communs. Seul le rendu diffère. |
+
+**Tranché par Jonathan, 2026-08-14. Plus aucun point ouvert.**
+
+| # | Décision | Statut |
+|---|---|---|
+| A | Vocabulaire : Extension = le paquet, Widget et Module = ses surfaces, **Fonctionnalités** = les 35 interrupteurs natifs. `/admin/modules` est renommé, `MODULE-SYSTEM.md` et la navigation admin suivent. Le mot « plugin » sort du code et de la doc. | validé |
+| A bis | Domaine de la vitrine : **`extensions.nodyx.org`**, la documentation technique restant sur `nodyx.dev`. | validé |
+| B | **La médiathèque devient une extension sandboxée**, pas des pages natives. C'est le critère d'acceptation du SDK. | validé |
+| C | **Rupture v0** assumée, `video-player` passe natif. | validé |
+| D | Registre par défaut sur `extensions.nodyx.org`, remplaçable, cumulable, contournable par fichier. | validé |
+| E | P0 découpé en A, B et C. La suppression du chargement non isolé reste dans **P0-A**. | validé |
+| F | La vitrine est une surface de visibilité durable : i18n FR et EN dès le premier commit, design sobre sans gloss, rayons bornés, zéro tiret cadratin, référencement soigné. Détail en §9.9. | validé |
+
+Prochain livrable : **P0-A**, le substrat de sécurité (§13).
+
+---
+
+## 16. Revue croisée (2026-08-14)
+
+Le CDC r1 a été soumis à une revue externe. Verdict : direction validée, feu vert refusé sur P0 tant que huit corrections n'étaient pas intégrées. Les huit sont dans la r2.
+
+**Retenu et intégré**
+
+| Point | Où |
+|---|---|
+| `CatalogEntry` v2 orienté surfaces, le catalogue ne décide pas du runtime | §3.1 |
+| Protocole de messagerie versionné, corrélé par `requestId` | §4.6 |
+| `Origin: null` n'est pas une authentification, trois origines distinctes | §4.1 |
+| `ext_token` lié à l'émetteur, l'audience, l'instance, l'extension, la surface, avec `jti` | §4.7 |
+| Renouvellement de jeton à la demande, jamais dans une URL | §4.7 |
+| SSRF : rebinding DNS, épinglage de l'adresse résolue, ports, méthodes, chemins, en-têtes, taille, compression | §6.4 |
+| Le serveur possède la recette d'injection du secret, pas l'extension | §6.4 |
+| Limites fines du stockage : clé, valeur, nombre, profondeur, fréquence | §6.1 |
+| Deux axes séparés, capacité d'extension et droits utilisateur, droit effectif = intersection | §6.1 |
+| Domaine d'identifiants natifs réservé : refus à l'installation, pas simple masquage | §5 |
+| Assainissement SVG (XSS hors bac à sable, sur la page d'administration) | §9.1 |
+| Signature de l'index distincte de l'intégrité du paquet, versions immuables | §9.2 |
+| Diff de **capacités**, pas seulement de permissions | §9.5 |
+| Pas de type global d'extension, rangement par surface, listing multi-catégories | §7, §9.3 |
+| Découpage de P0 en trois lots | §13 |
+| Catalogue d'attaques étendu (messagerie, navigation, rejeu, paquet, SVG) | §14 |
+| Le dataset ne doit jamais coûter un privilège de plus | §11 |
+
+**Ajouté au-delà de la revue**
+
+- `MessageChannel` avec port privé transféré à l'amorçage, plutôt qu'un filtrage manuel sur `window` : la revue proposait de tester le message forgé, le port privé le rend structurellement impossible. §4.5
+- Le lien d'installation du magasin est une surface d'attaque : `src` validé contre les registres configurés, installation en `POST` confirmé. Non relevé par la revue, c'était un trou de la r1. §9.5
+- Assets versionnés dans le chemin, `nosniff`, CORP, et disparition explicite de `/api/v1/widget-assets`. §4.3
+
+**Écarté, avec raison**
+
+- *« `style-src 'nonce' 'unsafe-inline'` sans raison documentée »* : juste sur le fond, mais la raison existe et elle est connue de la maison. Les attributs `style=""` dynamiques sont réels (185 occurrences dans le frontend principal), donc `style-src-attr 'unsafe-inline'`, exactement le réglage déjà en place dans `svelte.config.js`. Corrigé dans ce sens, pas supprimé.
+- *« le parent ne devrait pas rafraîchir le jeton »* : le parent est le seul à détenir la session utilisateur, donc le seul à pouvoir faire frapper un jeton. Le fond du reproche (pas de flux périodique poussé dans la frame) est retenu, le mécanisme reste médié par le parent.
+- *« l'écriture instance accordée à l'extension est dangereuse »* : le diagnostic mélangeait capacité et privilège. Traité par la règle des deux axes plutôt que par une restriction supplémentaire.
+
+**Deux affirmations factuelles corrigées**
+
+- *« les migrations vont jusqu'à 097 »* : faux. La branche `spec/mediatheque` et `origin/main` sont toutes deux à **111** (`111_community_sidebar_bg.sql`). La recommandation de ne pas figer le numéro reste bonne et est appliquée, mais pas pour la raison avancée.
+- *« l'arborescence frontend a évolué, le CDC est basé sur une photographie obsolète »* : les chemins de la r1 étaient exacts. Ce qui manquait, c'est que `homepage/plugins/` (descripteurs `.ts`) et `homepage/widgets/` (composants `.svelte`) coexistent. La conséquence, elle, est réelle et a été corrigée : le renommage proposé en r1 vers `widgets/native/` entrait en collision avec un dossier existant.

--- a/SPECS/NODYX_SDK_CDC.md
+++ b/SPECS/NODYX_SDK_CDC.md
@@ -686,6 +686,28 @@ Ce lot touche le rendu de la page d'accueil des 4 instances de production. Inven
 | core `widgetStore.ts` | route `/widget-assets` supprimée, store remplacé |
 | core `widgetDemo.ts` | démo devenue inutile, `video-player` étant natif |
 
+**État réel de l'existant, relevé le 2026-08-14 sur les quatre instances**
+
+| Instance | Fichiers sur disque | Ligne en base | Présent dans une mise en page |
+|---|---|---|---|
+| nodyx.org | v1.2.0 | `video-player` v1.2.0 | **oui, brouillon et publié** |
+| demo | v1.2.0 | aucune | non |
+| sleemstudio | v1.2.0 | aucune | non |
+| vieuxlooters | v1.2.0 | aucune | non |
+
+Les fichiers sont identiques partout (même empreinte), et identiques à la source du dépôt `nodyx-core/widget-demos/video-player/`. Trois instances portent donc les fichiers sans que le widget soit installé : **une seule instance est réellement concernée par la bascule, et son widget est le nôtre.**
+
+Configuration réellement enregistrée dans la mise en page publiée de nodyx.org :
+
+```json
+{ "url": "https://www.youtube.com/watch?v=...", "title": "",
+  "autoplay": false, "show_controls": true }
+```
+
+Les quatre clés attendues, et rien d'autre. Le composant natif doit les lire telles quelles, y compris `title` vide (qui doit retomber sur le titre par défaut) et `show_controls` absent traité comme vrai.
+
+**Attention à la source du port** (signalé par Jonathan) : la copie installée en production provient d'une démonstration d'installation par `.zip` faite avec une version ancienne. Tout ce qui est observable est en v1.2.0, disque et base, sur les quatre instances, mais **s'il existe une version plus récente hors dépôt, c'est elle qui fait référence pour le port**, pas celle qui est déployée.
+
 **Ce qui ne doit pas bouger, et pourquoi ça tient**
 
 1. **Les mises en page enregistrées.** La grille stocke `widget_type: 'video-player'`. Les deux renderers testent le natif **en premier** (`{#if plugin}` dans `GridRenderer`, `{#if nativePlugin}` dans `WidgetZone`), et `catalog.ts` filtre déjà les widgets installés qui masqueraient un natif (`filter(m => !PLUGIN_REGISTRY[m.id])`, `toInstalledWidgetsMap` fait de même). Enregistrer `video-player` dans le registre natif **suffit** à ce que les mises en page existantes rendent, sans migration de données. Condition : le composant natif lit **exactement** les mêmes clés de configuration, `url`, `title`, `autoplay`, `show_controls`.

--- a/SPECS/NODYX_SDK_CDC.md
+++ b/SPECS/NODYX_SDK_CDC.md
@@ -417,7 +417,19 @@ Aucune requête sortante depuis la frame. Et le proxy **n'est pas un `fetch` gé
 `nodyx.fetch()` tape `POST /api/v1/extensions/:id/fetch`, qui applique dans l'ordre :
 
 1. **hôte, méthode et préfixe de chemin** vérifiés contre la déclaration accordée. Le port est celui du schéma (443), un port explicite non déclaré est refusé.
-2. **résolution DNS puis validation de l'adresse obtenue**, et connexion **à cette adresse** (épinglage). Vérifier le nom avant de résoudre ne protège de rien : un nom public qui résout en adresse privée est le contournement classique. Sont refusés : RFC1918, loopback v4 et v6, lien-local, ULA, multicast, adresses mappées, et les écritures exotiques d'IP.
+2. **résolution DNS puis validation de l'adresse obtenue**, et connexion **à cette adresse** (épinglage). Vérifier le nom avant de résoudre ne protège de rien : un nom public qui résout en adresse privée est le contournement classique.
+
+   **Trois niveaux, pas un interdit** (révisé le 2026-08-14). Une instance Nodyx vit très bien sur un intranet d'entreprise, un réseau domestique, ou une simple adresse IP sans nom de domaine. Refuser en bloc les adresses privées reviendrait à interdire les extensions qui servent justement à parler aux services de cette maison, et à réserver le SDK aux instances publiques. Ce n'est pas notre public.
+
+   | Cible | Traitement |
+   |---|---|
+   | adresse publique | déclarable, accordée comme tout appel sortant |
+   | **réseau privé** : RFC1918, ULA, partage d'adresse opérateur, `.local`, `.internal`, `.lan`, `.home.arpa` | déclarable, mais exige un **accord explicite et distinct de l'admin**, montré à part sur l'écran de permissions : « cette extension veut joindre `10.0.0.5`, une machine de votre réseau interne » |
+   | **boucle locale et lien local** : `127.0.0.0/8`, `::1`, `localhost`, `169.254.0.0/16` | **jamais**, même avec l'accord de l'admin |
+
+   La dernière ligne n'est pas une rigidité de principe : ces cibles sont la machine de l'instance elle même, donc sa base, son cache, son API interne et les métadonnées d'identité de l'hébergeur. Un admin n'y gagne rien de légitime qu'il n'obtienne en exposant son service sur l'adresse de son réseau. Pour le développement, une variable d'environnement dédiée lève la restriction sur une instance de développement, jamais en production.
+
+   Restent refusés en toute circonstance : multicast, diffusion, plages réservées, adresses mappées et écritures exotiques d'IP.
 3. **redirections limitées à 3, chacune revalidée intégralement** (hôte, chemin, adresse résolue).
 4. **secrets injectés par le serveur, selon une recette que le serveur possède** (nom de l'en-tête ou du paramètre, emplacement). L'extension déclare `"secret": "TMDB_API_KEY"` et ne choisit ni le nom de l'en-tête ni sa destination. Sans ça, `nodyx.fetch()` pourrait demander `X-Peu-Importe: <secret>` vers un hôte contrôlé et récupérer indirectement ce qu'il n'a pas le droit de voir.
 5. **en-têtes filtrés dans les deux sens** (liste blanche courte à l'aller, `Set-Cookie` et compagnie retirés au retour).

--- a/SPECS/NODYX_SDK_CDC.md
+++ b/SPECS/NODYX_SDK_CDC.md
@@ -17,7 +17,8 @@ Préalable au code (règle maison : CDC formel avant tout module critique)
 | D4 | Points d'accroche v1 | **page pleine** (entre les sidebars) et **widget** (grille d'accueil). Le reste plus tard. |
 | D5 | i18n d'une extension | Les chaînes du manifeste sont des **clés**, résolues dans les bundles livrés avec le paquet. `default_locale` obligatoire, refus à l'installation sinon. |
 | D6 | Distribution | **Une vitrine et un tuyau** : satellite `nodyx-store` sur `extensions.nodyx.org` (site public façon extensions.joomla.org) qui sert aussi l'index JSON signé consommé par les instances. Publication par PR GitHub assistée, zéro infra à opérer, **zéro monétisation, zéro étoile**. La vitrine est une surface de visibilité durable, donc soumise aux exigences de fabrication de §9.9 (i18n, design, référencement). |
-| D7 | Compatibilité | `api: 1` dans le manifeste. Le format actuel (sans `api`) est **cassé volontairement** : un seul widget existe et il est à nous. |
+| D7 | Compatibilité | `api: 1` dans le manifeste. Le format actuel (sans `api`) est **cassé volontairement** : un seul widget existe et il est à nous. `video-player` est **repaqueté en extension v1**, pas passé en natif (révisé le 2026-08-14, cf §12). |
+| D9 | Embarquement de fournisseurs tiers | **Primitive rendue par l'hôte, en v1.** Une extension ne peut pas encadrer un tiers depuis le bac à sable, c'est mesuré (§12). Elle appelle `nodyx.ui.embed()`, l'hôte pose la frame du fournisseur depuis une liste livrée avec Nodyx. |
 | D8 | Vocabulaire | **Extension** = le paquet distribué. Deux types : **Widget** (bloc du frontpage editor) et **Module** (application avec ses pages, ex la médiathèque). Les 35 interrupteurs natifs de `/admin/modules` deviennent les **Fonctionnalités**. Le mot « plugin » sort du vocabulaire. |
 
 Le banc d'essai qui valide tout : **la médiathèque devient une extension**. Si le bac à sable ne la porte pas, le bac à sable est faux.
@@ -643,7 +644,22 @@ Règles fondatrices intactes : note de curation obligatoire, zéro étoile, zér
 ## 12. Ce qu'on casse, assumé (D7)
 
 - **Le format v0 disparaît.** Un manifeste sans `api: 1` est refusé, avec un message qui pointe le guide de migration. Coût réel : un widget, `video-player`, qui est à nous.
-- **`video-player` devient natif.** Il embarque des iframes YouTube, Twitch, Vimeo, or une frame à origine opaque ne peut pas embarquer de frame tierce (les drapeaux du bac à sable se propagent aux contextes imbriqués, l'embed casse). Il a sa place à l'étage 1, il garde son `id`, donc **les layouts d'accueil existants continuent de rendre à l'identique**.
+- **`video-player` reste une extension, et devient l'exemple de référence** (décision Jonathan, 2026-08-14, qui renverse la position précédente). L'argument est produit, pas technique : *si un simple lecteur vidéo ne passe pas en extension, le SDK ne vaut rien pour tout ce qui est plus ambitieux.* C'est juste. Le lecteur est le plus petit cas réaliste, il doit passer, sinon la place de marché n'a aucun sens.
+
+  **Mesure, banc identique, seule différence l'attribut `sandbox`** (Chromium, 2026-08-14) :
+
+  | Fournisseur | Sans bac à sable | Dans le bac à sable |
+  |---|---|---|
+  | YouTube | lecteur monté, 6 contrôles | document vide |
+  | Vimeo | lecteur monté, 14 contrôles | document vide |
+  | Dailymotion | 3 éléments média | quasi rien |
+  | Twitch | lecteur monté | **refus net, `frame-ancestors` violé** |
+  | SoundCloud | contenu rendu | document vide |
+  | Spotify | rendu | rendu, seul survivant |
+
+  Cinq sur six meurent. Le stockage est refusé (`SecurityError`) dans tous les cas, et Twitch va plus loin : sa propre politique `frame-ancestors` **ne peut pas être satisfaite depuis une origine opaque**, donc l'embarquement est refusé avant même de charger. C'est structurel.
+
+  **Conséquence : la primitive d'embarquement rendue par l'hôte (D9) passe de P3 à la v1.** Elle n'est plus un confort, elle est ce qui rend un lecteur possible en extension. Répartition : l'extension fait l'analyse d'URL, la détection de plateforme, l'habillage, la configuration et l'i18n ; l'hôte pose la frame du fournisseur, et lui seul sait renseigner correctement le paramètre `parent=` qu'exige Twitch, qui dépend du domaine de l'instance.
 - **`installed_widgets` est remplacée** par `installed_extensions`. Migration 112 : création. La suppression de l'ancienne table attend la release suivante, une fois les 4 instances vérifiées.
 - **L'embed tiers dans une extension** (un lecteur YouTube dans une extension de la communauté) est impossible en v1 : les drapeaux du bac à sable se propagent aux frames imbriquées, donc l'embed du fournisseur casse.
 
@@ -661,10 +677,10 @@ Règles fondatrices intactes : note de curation obligatoire, zéro étoile, zér
 
 Le P0 initial contenait presque tout le système, ce qui rend les régressions impossibles à localiser. Découpage :
 
-- **P0-A, le substrat de sécurité.** Lecteur de paquet, JSON Schema du manifeste, validateur, assainissement SVG, installation par fichier, document de frame et sa CSP, route d'assets versionnée, `MessageChannel` et protocole `p:1`, `ext_token`, **suppression du chargeur par balise script et de `/widget-assets`**, `video-player` passé natif.
-  Cette suppression tient **dès le premier lot** : une fois `video-player` natif, il n'existe plus aucune extension tierce en production sur les 4 instances. Le chemin non isolé meurt donc avant même qu'une surface tierce existe, ce qui est l'ordre le plus sûr.
+- **P0-A, le substrat de sécurité.** Lecteur de paquet, JSON Schema du manifeste, validateur, assainissement SVG, installation par fichier, document de frame et sa CSP, route d'assets versionnée, `MessageChannel` et protocole `p:1`, `ext_token`, **suppression du chargeur par balise script et de `/widget-assets`**.
+  Attention à l'ordre, il a changé avec D7 révisé : `video-player` restant une extension, le chemin non isolé ne peut mourir qu'une fois la surface `widget` isolée disponible. La suppression bascule donc en **fin de P0-C**, et P0-A se contente de ne plus créer de nouveau chemin non isolé. Tant que la bascule n'est pas faite, l'ancien chargeur reste le seul à servir la page d'accueil de nodyx.org.
 - **P0-B, l'API de runtime.** `config`, thème, i18n, `identity`, `storage` et ses limites, redimensionnement, routeur, UI rendue par l'hôte.
-- **P0-C, les surfaces.** `widget` dans le builder, `page` dans la coque, `CatalogEntry` v2, écran de permissions, administration des extensions.
+- **P0-C, les surfaces.** `widget` dans le builder, `page` dans la coque, primitive d'embarquement (D9), `CatalogEntry` v2, écran de permissions, administration des extensions, repaquetage de `video-player`, **puis** suppression de l'ancien chargeur.
 
 Aucun lot ne réintroduit un chemin non isolé, et chacun se déploie seul.
 
@@ -727,7 +743,9 @@ Les quatre clés attendues, et rien d'autre. Le composant natif doit les lire te
 
 **Ce qui ne doit pas bouger, et pourquoi ça tient**
 
-1. **Les mises en page enregistrées.** La grille stocke `widget_type: 'video-player'`. Les deux renderers testent le natif **en premier** (`{#if plugin}` dans `GridRenderer`, `{#if nativePlugin}` dans `WidgetZone`), et `catalog.ts` filtre déjà les widgets installés qui masqueraient un natif (`filter(m => !PLUGIN_REGISTRY[m.id])`, `toInstalledWidgetsMap` fait de même). Enregistrer `video-player` dans le registre natif **suffit** à ce que les mises en page existantes rendent, sans migration de données. Condition : le composant natif lit **exactement** les mêmes clés de configuration, `url`, `title`, `autoplay`, `show_controls`.
+1. **Les mises en page enregistrées.** La grille stocke `widget_type: 'video-player'` avec sa configuration. Le widget restant une extension (D7 révisé), la continuité ne passe plus par le registre natif mais par un **repaquetage en extension v1, réinstallé sous le même `id`**. La mise en page n'est pas touchée : elle référence un identifiant et une configuration, que le nouveau format conserve à l'identique (`url`, `title`, `autoplay`, `show_controls`). C'est plus exigeant que la bascule en natif, et c'est le prix de la décision : **la continuité de la page d'accueil de nodyx.org devient la première preuve que le bac à sable tient en vrai.**
+
+   Filet pendant la bascule : la seule instance concernée est nodyx.org, et le repli est le retour arrière du frontend, la table `installed_widgets` et les fichiers restant en place une release entière.
 2. **Les deux chargements serveur** qui appellent `/widget-store-public` (`routes/+page.server.ts` L14 et `admin/homepage/builder/+page.server.ts` L11) doivent être migrés **en même temps** que la route, sinon l'accueil et le builder cassent ensemble.
 3. **La table `installed_widgets` et les dossiers `uploads/widgets/`** restent en place le temps d'une release. Aucune suppression dans le même lot que la bascule.
 

--- a/SPECS/NODYX_SDK_CDC.md
+++ b/SPECS/NODYX_SDK_CDC.md
@@ -677,7 +677,7 @@ Règles fondatrices intactes : note de curation obligatoire, zéro étoile, zér
 
 Le P0 initial contenait presque tout le système, ce qui rend les régressions impossibles à localiser. Découpage :
 
-- **P0-A, le substrat de sécurité.** Lecteur de paquet, JSON Schema du manifeste, validateur, assainissement SVG, installation par fichier, document de frame et sa CSP, route d'assets versionnée, `MessageChannel` et protocole `p:1`, `ext_token`, **suppression du chargeur par balise script et de `/widget-assets`**.
+- **P0-A, le substrat de sécurité.** Lecteur de paquet, JSON Schema du manifeste, validateur, assainissement SVG, installation par fichier, document de frame et sa CSP (en-tête et balise `meta`), route d'assets versionnée, `MessageChannel` et protocole `p:1`, `ext_token`. Aucun nouveau chemin non isolé n'est créé, mais l'ancien survit jusqu'en P0-C.
   Attention à l'ordre, il a changé avec D7 révisé : `video-player` restant une extension, le chemin non isolé ne peut mourir qu'une fois la surface `widget` isolée disponible. La suppression bascule donc en **fin de P0-C**, et P0-A se contente de ne plus créer de nouveau chemin non isolé. Tant que la bascule n'est pas faite, l'ancien chargeur reste le seul à servir la page d'accueil de nodyx.org.
 - **P0-B, l'API de runtime.** `config`, thème, i18n, `identity`, `storage` et ses limites, redimensionnement, routeur, UI rendue par l'hôte.
 - **P0-C, les surfaces.** `widget` dans le builder, `page` dans la coque, primitive d'embarquement (D9), `CatalogEntry` v2, écran de permissions, administration des extensions, repaquetage de `video-player`, **puis** suppression de l'ancien chargeur.

--- a/SPECS/NODYX_SDK_CDC.md
+++ b/SPECS/NODYX_SDK_CDC.md
@@ -155,6 +155,16 @@ Content-Security-Policy:
   base-uri        'none';
 ```
 
+**Cette politique est servie DEUX FOIS : en en-tête de réponse, et en `<meta http-equiv="Content-Security-Policy">` dans le document lui même.** Ce n'est pas de la ceinture et bretelles décorative, c'est une nécessité vérifiée le 2026-08-14 sur notre propre production :
+
+- le proxy de nodyx.org pose la politique du site avec l'opération **`set`**, donc il **remplace** celle que l'application envoie, y compris sur `/api/v1/*` (constaté : une réponse d'API porte la CSP du site)
+- un en-tête seul serait donc effacé, et le document de frame hériterait de la politique permissive du site, ce qui rouvrirait le réseau sortant direct depuis la frame et annulerait le principe 3
+- une balise `meta` n'est pas réécrite par un proxy. Quand les deux politiques coexistent, le navigateur applique **l'intersection**, donc la plus stricte l'emporte directive par directive : le résultat est correct avec ou sans proxy réécrivant
+
+Cette contrainte n'est pas propre à notre hébergement. Un produit auto-hébergé tourne derrière le proxy que son administrateur a choisi, et beaucoup de configurations toutes faites imposent des en-têtes de sécurité. **Une frontière de sécurité ne doit jamais dépendre d'un en-tête qu'un intermédiaire peut réécrire.**
+
+À noter, l'isolation elle même ne dépend pas de la CSP : elle vient de l'origine opaque, portée par l'attribut `sandbox`, que rien d'externe ne peut modifier. La CSP est la défense en profondeur, et c'est elle qui interdit le réseau direct.
+
 Trois précisions qui évitent une CSP de façade :
 
 - **pas de `'unsafe-inline'` dans `style-src`.** Un nonce le neutralise de toute façon quand les deux sont présents, donc l'écrire ne fait que masquer l'intention. Les attributs `style=""` dynamiques, eux, sont réels et fréquents : ils passent par `style-src-attr`, exactement comme le frontend principal le fait déjà.
@@ -697,6 +707,20 @@ Ce lot touche le rendu de la page d'accueil des 4 instances de production. Inven
 - `sidebar_bg` et les autres réglages d'instance inchangés (le déploiement touche le frontend, pas la configuration)
 
 **Repli** : le lot est réversible par retour arrière du frontend seul tant que la table `installed_widgets` n'est pas supprimée. C'est la raison pour laquelle sa suppression est repoussée d'une release.
+
+**Mine découverte le 2026-08-14, antérieure à ce chantier, à désamorcer avant le port de `video-player`.** La politique de sécurité servie en production **ne vient pas de l'application** : le proxy la pose en mode `set` sur tous les hôtes, et elle **diverge de celle du dépôt**.
+
+| | `frame-src` en production | `frame-src` dans `svelte.config.js` |
+|---|---|---|
+| YouTube, Vimeo, OpenStreetMap | présents | présents |
+| `player.twitch.tv`, `www.twitch.tv`, `clips.twitch.tv` | présents | **absents** |
+| `geo.dailymotion.com`, `w.soundcloud.com`, `open.spotify.com` | présents | **absents** |
+
+Conséquence directe : `video-player` annonce sept plateformes, quatre d'entre elles ne fonctionnent en production **que** parce que le proxy est plus permissif que le dépôt. Le jour où la configuration du proxy est réconciliée avec le disque, ces embarquements cassent, et le coupable désigné sera le port en natif alors que la cause lui est antérieure.
+
+Action, dans P0-A, avant le port : **aligner `svelte.config.js` sur ce que la production sert déjà** pour ces six hôtes. C'est un alignement du dépôt sur la réalité, pas un élargissement de la politique en vigueur. En revanche, le `'unsafe-inline'` présent dans le `script-src` du proxy et volontairement retiré du dépôt **n'est pas réintroduit** : c'est un durcissement voulu, et il devra être vérifié au moment où la configuration du proxy sera réconciliée.
+
+Le rapprochement de la configuration du proxy avec le disque reste hors de ce lot, et soumis au danger déjà documenté dans `CLAUDE.md`.
 
 **P3, l'ouverture**
 Surfaces `panel` et `card` (enrichissement chat et forum, l'étagère de la communauté), écritures core avec consentement, origine dédiée optionnelle pour les embeds tiers.

--- a/SPECS/NODYX_SDK_REFERENCE.md
+++ b/SPECS/NODYX_SDK_REFERENCE.md
@@ -544,7 +544,7 @@ Dépassement : une erreur nette avec un code stable. **Jamais de troncature sile
 | Appeler `/api/v1` directement | votre frame n'a pas la session | `nodyx.core.get` |
 | Écrire dans le forum, le chat, les membres | v1 en lecture seule | attendez les écritures avec consentement, v2 |
 | Appeler un service tiers depuis le navigateur | doctrine, aucune fuite chez un tiers | `nodyx.fetch`, déclaré au manifeste |
-| Embarquer une iframe tierce (lecteur vidéo externe) | les drapeaux du bac à sable se propagent, l'embed casserait | v1 : non. Un lecteur externe reste un widget natif de Nodyx |
+| Embarquer une iframe tierce (lecteur vidéo externe) | les drapeaux du bac à sable se propagent, l'embed casserait | v1 : non, un lecteur externe reste un widget natif. P3 : `nodyx.ui.embed({ provider, id })`, l'hôte pose l'iframe du fournisseur pour vous, avec la même liste de fournisseurs sur toutes les instances |
 | Livrer du code serveur, une table, une migration | le cœur est sanctuarisé | `storage`, jeu de données livré, proxy réseau |
 | Ouvrir une popup, naviguer la page du haut, télécharger un fichier | drapeaux non accordés | `nodyx.openExternal`, `nodyx.navigate` |
 | Charger une police, un script ou une image depuis un CDN | politique de sécurité de la frame | livrez-les dans le paquet |

--- a/SPECS/NODYX_SDK_REFERENCE.md
+++ b/SPECS/NODYX_SDK_REFERENCE.md
@@ -1,0 +1,862 @@
+# Manuel du SDK Nodyx, référence développeur
+
+Statut : **normatif, écrit avant l'implémentation.** Ce document est la spécification que P0 doit satisfaire, et il deviendra la documentation publiée sur `nodyx.dev` quand P0-C sera livré. Toute divergence entre le code et ce document est un bogue du code, pas une évolution du contrat.
+Version du contrat : `api: 1`, protocole de messagerie `p: 1`
+Document parent : `NODYX_SDK_CDC.md`. Modèle de menace : `NODYX_SDK_SECURITY.md`.
+
+---
+
+## 1. En cinq minutes
+
+Une extension Nodyx est un dossier zippé. Voici la plus petite qui existe, deux fichiers.
+
+`manifest.json`
+
+```json
+{
+  "api": 1,
+  "id": "hello",
+  "version": "1.0.0",
+  "license": "MIT",
+  "default_locale": "en",
+  "label": "@label",
+  "description": "@description",
+  "surfaces": [
+    { "type": "widget", "id": "main", "entry": "ui/widget.js", "label": "@label" }
+  ]
+}
+```
+
+`i18n/en.json`
+
+```json
+{ "label": "Hello", "description": "Says hello." }
+```
+
+`ui/widget.js`
+
+```js
+export function mount({ root, nodyx }) {
+  root.textContent = nodyx.t('label')
+}
+```
+
+Zippez le contenu, renommez en `hello-1.0.0.nyx`, déposez le dans **Administration, Extensions, Installer un fichier**. C'est tout : pas de build, pas de npm, pas de framework.
+
+Trois choses à retenir dès maintenant, elles expliquent tout le reste du document :
+
+1. **Votre code tourne dans une iframe isolée**, sans accès à la page Nodyx, à ses cookies, ni à sa session. Ce n'est pas une gêne à contourner, c'est le contrat qui permet à un admin d'installer votre travail sans vous connaître.
+2. **Tout ce qui sort de cette iframe passe par l'objet `nodyx`.** Il n'y a pas d'autre porte.
+3. **Tout ce que voit un humain est une clé de traduction.** Une chaîne écrite en dur dans le manifeste fait échouer l'installation.
+
+---
+
+## 2. Anatomie d'un paquet
+
+```
+mon-extension-1.0.0.nyx        (une archive zip, extension .nyx)
+├── manifest.json              obligatoire, à la racine de l'archive
+├── icon.svg                   recommandé, 1:1, assaini à l'installation
+├── preview.png                recommandé pour la fiche du magasin
+├── LICENSE                    obligatoire au registre officiel
+├── README.md                  facultatif
+├── i18n/
+│   ├── en.json                obligatoire si default_locale vaut en
+│   └── fr.json                autant de locales que vous voulez
+├── ui/
+│   ├── widget.js              un point d'entrée par surface
+│   ├── page.js
+│   └── style.css              facultatif, chargé par vous
+└── data/
+    └── catalogue.json         jeu de données livré avec l'extension
+```
+
+**Le manifeste est à la racine**, pas dans un sous-dossier. C'est l'erreur d'empaquetage la plus fréquente.
+
+Types de fichiers acceptés à l'extraction : `.js .css .json .svg .png .jpg .jpeg .webp .woff2 .md`. Tout le reste est ignoré silencieusement à l'extraction, sauf le point d'entrée déclaré, dont l'absence fait échouer l'installation.
+
+| Plafond | Valeur |
+|---|---|
+| taille de l'archive | 20 Mo |
+| taille décompressée | 60 Mo |
+| nombre de fichiers | 2 000 |
+| profondeur de répertoires | 6 |
+| taille d'un fichier | 8 Mo |
+
+Les liens symboliques, les chemins absolus et les chemins remontants (`../`) font échouer l'installation. Ce n'est pas négociable, voir `NODYX_SDK_SECURITY.md` §4.6.
+
+---
+
+## 3. Le manifeste, champ par champ
+
+### 3.1 Racine
+
+| Champ | Type | Requis | Contrainte |
+|---|---|---|---|
+| `api` | entier | oui | vaut `1`. Un manifeste sans `api` est refusé. |
+| `id` | chaîne | oui | `^[a-z][a-z0-9-]{2,38}$`. Unique sur l'instance. Refusé s'il appartient au domaine réservé natif (§3.6). |
+| `version` | chaîne | oui | semver strict `MAJEUR.MINEUR.CORRECTIF`. Une version publiée est immuable. |
+| `nodyx_min` | chaîne | non | version minimale de Nodyx. Installation refusée en dessous. |
+| `license` | chaîne | oui | identifiant SPDX. Le registre officiel exige une licence OSI. |
+| `author` | objet | non | `{ name, url? }` |
+| `source` | URL | non | dépôt public. **Exigé au registre officiel.** |
+| `default_locale` | chaîne | oui | code de langue dont le bundle doit être complet. |
+| `label` | clé | oui | commence par `@`, résolue dans les bundles. |
+| `description` | clé | oui | idem. |
+| `icon` | chemin | non | SVG ou PNG carré, assaini à l'installation. |
+| `family` | énum | non | `media` `gaming` `community` `esport` `social` `content`. Défaut `content`. |
+| `surfaces` | tableau | oui | au moins une entrée. |
+| `permissions` | objet | non | absent vaut aucune permission. |
+
+Il n'existe **aucun champ `type`**. Ce qu'est votre extension se déduit de ses surfaces : le magasin range une extension qui expose une page dans Modules, une qui expose des widgets dans Widgets, et une qui fait les deux apparaît dans les deux.
+
+### 3.2 Les surfaces
+
+Une surface est un endroit de Nodyx où votre code s'affiche. Chacune a son point d'entrée, son cycle de vie, sa configuration.
+
+```json
+"surfaces": [
+  {
+    "type": "widget",
+    "id": "tonight",
+    "entry": "ui/tonight.js",
+    "label": "@widget.tonight.label",
+    "description": "@widget.tonight.desc",
+    "schema": [ /* §3.3 */ ],
+    "default_height": 320
+  },
+  {
+    "type": "page",
+    "path": "library",
+    "entry": "ui/page.js",
+    "nav": { "label": "@nav.label", "icon": "twemoji:clapper-board", "position": "main" }
+  }
+]
+```
+
+| Champ | `widget` | `page` |
+|---|---|---|
+| `id` | obligatoire, unique dans l'extension | interdit |
+| `path` | interdit | obligatoire, `^[a-z][a-z0-9-]{1,30}$`, monte sous `/x/<ext-id>/<path>` |
+| `entry` | obligatoire | obligatoire |
+| `label` | obligatoire, affiché dans le builder | facultatif |
+| `schema` | facultatif, formulaire du builder | interdit, une page se configure par son stockage |
+| `nav` | interdit | facultatif, ajoute une entrée de navigation |
+| `default_height` | facultatif, hauteur initiale en pixels | ignoré, une page occupe la zone de contenu |
+
+Deux surfaces peuvent partager un même fichier d'entrée. Chaque surface est montée dans **sa propre iframe**, avec son propre jeton : elles ne partagent ni mémoire ni variables. Ce qu'elles partagent, c'est le stockage de l'extension.
+
+### 3.3 Le schéma de configuration
+
+Il décrit le formulaire que l'admin remplit dans le builder d'accueil. Le SDK vous rend le résultat dans `nodyx.config`.
+
+```json
+{
+  "key": "mood",
+  "type": "select",
+  "label": "@field.mood",
+  "hint": "@field.mood.hint",
+  "details": "@field.mood.details",
+  "required": true,
+  "default": "learn",
+  "options": [
+    { "value": "learn", "label": "@mood.learn" },
+    { "value": "laugh", "label": "@mood.laugh" }
+  ]
+}
+```
+
+| `type` | Rendu | Type reçu dans `config` | Champs additionnels |
+|---|---|---|---|
+| `text` | champ une ligne | `string` | `placeholder`, `max` |
+| `textarea` | champ multiligne | `string` | `placeholder`, `max` |
+| `url` | champ URL validé | `string` | `placeholder` |
+| `number` | champ numérique | `number` | `min`, `max` |
+| `boolean` | interrupteur | `boolean` | |
+| `select` | liste déroulante | `string` | `options` obligatoire |
+| `color` | sélecteur de couleur | `string` (`#rrggbb`) | |
+| `image` | téléversement ou URL | `string` (URL) | |
+
+Champs communs : `key` (obligatoire, `^[a-z][a-z0-9_]{0,39}$`), `label` (clé, obligatoire), `hint` (clé, une ligne sous le champ), `details` (clé, panneau dépliable derrière une icône), `required`, `default`.
+
+**`checkbox` n'existe pas.** L'ancien format le tolérait, le SDK v1 le refuse à l'installation. Utilisez `boolean`.
+
+Ne considérez jamais une valeur comme garantie : un admin peut vider un champ facultatif, et une configuration enregistrée par une version antérieure de votre extension peut manquer une clé que vous venez d'ajouter. Toujours une valeur de repli côté code.
+
+### 3.4 Les permissions
+
+Absentes, votre extension n'a rien : elle s'affiche, elle lit sa configuration, elle parle sa langue. C'est déjà suffisant pour beaucoup de widgets, et c'est le cas le plus facile à faire installer.
+
+```json
+"permissions": {
+  "identity": ["id", "username", "avatar", "locale"],
+  "storage":  { "user": "1mb", "instance": "8mb" },
+  "core":     ["members:read"],
+  "network": {
+    "api.themoviedb.org": {
+      "methods": ["GET"],
+      "paths":   ["/3/movie/*", "/3/search/movie"],
+      "secret":  "TMDB_API_KEY",
+      "rate":    "60/min"
+    }
+  }
+}
+```
+
+| Permission | Ce qu'elle ouvre | Ce que l'admin voit |
+|---|---|---|
+| `identity` | les champs listés de l'utilisateur courant, et eux seuls | « peut voir votre pseudo et votre avatar » |
+| `storage.user` | lecture et écriture par utilisateur | « peut stocker 1 Mo par membre » |
+| `storage.instance.read` | lecture des données partagées | « peut lire les données partagées de l'extension » |
+| `storage.instance.write` | écriture des données partagées | « peut modifier les données partagées » |
+| `core` | lectures cadrées, avec les droits de l'utilisateur | « peut lire la liste des membres » |
+| `network` | appels sortants, par hôte, méthode et chemin | « peut lire les fiches TMDB (GET /3/movie/...) » |
+
+Règles d'or, elles décident souvent de votre taux d'installation :
+
+- **Demandez le minimum.** Chaque ligne est affichée à l'admin avant l'installation et à chaque mise à jour.
+- **Un hôte réseau nu est refusé.** Déclarez méthodes et préfixes de chemin, sinon l'écran de permissions devient illisible et l'installation échoue.
+- **Une permission ajoutée en cours de vie est un événement.** Elle apparaît dans le diff de capacités de la mise à jour, en évidence. Prévoyez-la, ne la glissez pas.
+
+### 3.5 Les champs interdits
+
+Un manifeste qui contient une clé inconnue est **refusé**, il n'est pas nettoyé. C'est délibéré : une faute de frappe sur `permissions` ne doit jamais aboutir à une extension qui tourne avec moins de droits que prévu et échoue à l'usage.
+
+### 3.6 Le domaine réservé
+
+Les identifiants des widgets natifs sont réservés et refusés à l'installation : `hero-banner`, `header`, `stats-bar`, `join-card`, `announcement-banner`, `article-slideshow`, `articles-showcase`, `recent-threads`, `social-links-bar`, `twitch-stream`, `video-player`. La liste vit dans le validateur et grandit avec les widgets natifs.
+
+---
+
+## 4. Cycle de vie d'une surface
+
+```
+1. l'hôte crée l'iframe et charge le document de frame
+2. l'hôte injecte le SDK, puis transfère un port privé avec la charge d'amorçage
+3. l'hôte importe votre module d'entrée
+4. l'hôte appelle mount({ root, nodyx })
+5. votre code vit, réagit aux événements
+6. l'hôte appelle unmount() si vous l'exportez, puis détruit l'iframe
+```
+
+Votre module d'entrée est un **module ES**. Il exporte `mount`, et facultativement `unmount`.
+
+```js
+/** @param {{ root: HTMLElement, nodyx: Nodyx }} ctx */
+export function mount({ root, nodyx }) {
+  const el = document.createElement('div')
+  el.textContent = nodyx.t('greeting', { name: nodyx.user?.username ?? '' })
+  root.append(el)
+
+  const off = nodyx.on('locale', () => {
+    el.textContent = nodyx.t('greeting', { name: nodyx.user?.username ?? '' })
+  })
+
+  return { unmount: () => off() }
+}
+```
+
+`mount` peut être asynchrone. Tant qu'elle n'a pas résolu, l'hôte affiche son propre indicateur de chargement : n'en dessinez pas un deuxième.
+
+**Délai d'amorçage : 5 secondes.** Au delà, l'hôte affiche une carte d'erreur propre à la place de votre surface et journalise. Ne faites pas dépendre votre `mount` d'un appel réseau lent : montez d'abord la structure, remplissez ensuite.
+
+`root` est un élément de votre document de frame. Vous y faites ce que vous voulez : DOM natif, template littéral, ou un framework que vous embarquez. Le SDK n'impose rien et n'en fournit aucun.
+
+**Redimensionnement.** Pour une surface `widget`, l'hôte observe la hauteur de `root` et ajuste l'iframe automatiquement. Vous n'avez rien à appeler. `nodyx.resize(px)` existe pour les cas où votre contenu sort du flux (une animation, un élément positionné). Une surface `page` occupe toute la zone de contenu et défile à l'intérieur.
+
+---
+
+## 5. L'objet `nodyx`
+
+### 5.1 Obtention
+
+Le SDK est déjà chargé quand votre module est importé, et `nodyx` vous est passé à `mount`. Vous n'avez ni script à inclure, ni dépendance à installer, ni version à suivre : **c'est l'instance qui sert le SDK**, sa version suit toujours celle de Nodyx.
+
+Pour un usage hors `mount` (un module utilitaire) :
+
+```js
+import { getNodyx } from 'nodyx:sdk'
+```
+
+### 5.2 Lecture seule
+
+| Propriété | Type | Toujours présent |
+|---|---|---|
+| `nodyx.api` | `1` | oui |
+| `nodyx.extension` | `{ id, version }` | oui |
+| `nodyx.surface` | `{ type, id? , path? }` | oui |
+| `nodyx.config` | objet issu du schéma | oui, vide si aucun schéma |
+| `nodyx.locale` | `'fr'`, `'en'`, ... | oui |
+| `nodyx.theme` | jetons résolus (§7) | oui |
+| `nodyx.instance` | `{ name, memberCount, onlineCount, logoUrl }` | oui |
+| `nodyx.user` | champs autorisés, ou `null` | **non, `null` pour un visiteur** |
+
+`nodyx.user` vaut `null` pour un visiteur non connecté, et aussi pour un membre si vous n'avez pas demandé `identity`. **Une extension qui plante quand `user` est `null` est cassée** : les pages publiques d'une instance sont vues par des gens qui n'ont pas de compte, et c'est souvent leur premier contact avec la communauté.
+
+### 5.3 Traduction
+
+```js
+nodyx.t('key')                          // "Bonjour"
+nodyx.t('greeting', { name: 'Ada' })    // "Bonjour Ada"
+nodyx.t('inconnue')                     // "inconnue", la clé elle-même
+```
+
+Interpolation `{{nom}}`, pas de pluriel, clés plates. Résolution en cascade : locale courante, puis `default_locale`, puis la clé brute. Voir §8.
+
+### 5.4 Stockage
+
+```js
+await nodyx.storage.get('watched')                      // valeur ou undefined
+await nodyx.storage.set('watched', [603, 27205])        // remplace
+await nodyx.storage.delete('watched')
+await nodyx.storage.list()                              // [{ key, bytes, updatedAt }]
+
+await nodyx.storage.get('featured', { scope: 'instance' })
+await nodyx.storage.set('featured', {...}, { scope: 'instance' })
+```
+
+Portée par défaut : `user`. Les valeurs sont du JSON sérialisable, pas de `Date`, pas de `Map`, pas de référence circulaire.
+
+Sémantique : **dernière écriture gagnante**, pas de transaction, pas de verrou. Si deux onglets du même membre écrivent la même clé, le dernier gagne. Pour un compteur partagé, ne lisez pas puis écrivez : structurez la donnée pour que deux écritures concurrentes ne se détruisent pas.
+
+Pour un visiteur non connecté, la portée `user` **échoue** avec `NOT_AUTHENTICATED`. C'est volontaire : il n'y a personne à qui rattacher la donnée. Gardez l'état local en mémoire dans ce cas, et proposez la connexion.
+
+### 5.5 Réseau
+
+```js
+const res = await nodyx.fetch('https://api.themoviedb.org/3/movie/603')
+if (!res.ok) { /* ... */ }
+const data = await res.json()
+```
+
+L'objet rendu ressemble à une `Response` : `ok`, `status`, `headers` (filtrés), `json()`, `text()`, `arrayBuffer()`.
+
+Ce qui se passe réellement : la requête part vers votre instance, qui vérifie l'hôte, la méthode et le chemin contre ce que le manifeste a déclaré et que l'admin a accepté, injecte les secrets si vous en avez, appelle le service distant, et vous rend la réponse. **Vous ne verrez jamais la clé d'API**, et le navigateur du visiteur ne parle jamais au service tiers. C'est un choix de doctrine : une communauté ne doit pas fuiter chez un tiers parce qu'elle affiche une affiche de film.
+
+Pour les images, n'appelez pas `fetch`, utilisez l'aide dédiée qui rend une URL utilisable dans un `src` et met en cache côté instance :
+
+```js
+img.src = nodyx.imageUrl('https://image.tmdb.org/t/p/w500/abc.jpg')
+```
+
+L'hôte ne suit que 3 redirections, revalide chaque saut, refuse les adresses privées, plafonne la taille et le temps de réponse. Un service lent ou hostile ne peut pas geler votre extension, mais il peut vous rendre `UPSTREAM_TIMEOUT` : traitez ce cas.
+
+### 5.6 Lectures Nodyx
+
+```js
+await nodyx.core.get('instance')                       // toujours autorisé
+await nodyx.core.get('members', { limit: 20, page: 1 }) // permission members:read
+await nodyx.core.get('forum.threads', { limit: 10 })    // permission forum:read
+```
+
+Les lectures s'exécutent **avec les droits de l'utilisateur courant**, jamais élevés. Un visiteur ne voit que le public, exactement comme dans l'interface. Aucune écriture en v1.
+
+### 5.7 Interface rendue par l'hôte
+
+Votre iframe ne peut pas dessiner par dessus la page, et c'est voulu. Pour tout ce qui doit sortir de votre cadre, demandez à l'hôte :
+
+```js
+nodyx.ui.toast('Ajouté à ta liste')
+const ok = await nodyx.ui.confirm({ title: '@confirm.title', body: '@confirm.body' })
+await nodyx.ui.modal({ title: '@modal.title', surface: 'detail', props: { id: 42 } })
+```
+
+Bénéfice pour vous : ces éléments ont l'apparence de l'instance, y compris son thème et sa langue, sans une ligne de CSS.
+
+### 5.8 Navigation
+
+Pour une surface `page`, l'hôte reflète votre chemin interne dans l'URL du navigateur, ce qui rend vos vues partageables et compatibles avec le bouton retour.
+
+```js
+nodyx.router.push('/film/603')      // devient /x/library/film/603
+nodyx.router.replace('/')
+nodyx.router.current                // '/film/603'
+nodyx.on('route', ({ path }) => render(path))
+```
+
+Vous ne pouvez naviguer que **dans votre propre espace**. Pour envoyer l'utilisateur ailleurs dans Nodyx, passez par l'hôte, qui applique ses propres règles :
+
+```js
+nodyx.navigate('/forum')            // navigation hôte, vérifiée
+nodyx.openExternal('https://...')   // lien externe, confirmation utilisateur
+```
+
+### 5.9 Événements
+
+```js
+const off = nodyx.on('theme', (theme) => { /* ... */ })
+off()
+```
+
+| Événement | Quand | Charge |
+|---|---|---|
+| `theme` | l'instance change de thème | jetons résolus |
+| `locale` | l'utilisateur change de langue | `{ locale }` |
+| `config` | l'admin modifie la config dans le builder (aperçu direct) | nouvelle config |
+| `route` | l'URL change, surface `page` | `{ path }` |
+| `visible` | la surface entre ou sort du viewport | `{ visible }` |
+| `session` | le jeton a été renouvelé, ou la session a expiré | `{ state }` |
+
+`visible` mérite votre attention : les widgets hors écran sont montés paresseusement et peuvent être suspendus. Arrêtez vos animations et vos sondages quand `visible` est faux, c'est ce qui fait la différence entre une page d'accueil vive et une page qui rame.
+
+### 5.10 Les erreurs
+
+Tout appel asynchrone du SDK peut rejeter avec une `NodyxError` portant un `code` stable, en majuscules. Testez le code, jamais le message : le message est traduit et peut changer.
+
+| Code | Cause |
+|---|---|
+| `PERMISSION_DENIED` | capacité non déclarée ou non accordée |
+| `NOT_AUTHENTICATED` | portée `user` sans utilisateur connecté |
+| `QUOTA_EXCEEDED` | quota d'octets de l'extension atteint |
+| `KEY_TOO_LONG`, `VALUE_TOO_LARGE`, `TOO_MANY_KEYS`, `JSON_TOO_DEEP` | limites de stockage (§9) |
+| `RATE_LIMITED` | trop d'appels, en écriture ou en réseau |
+| `HOST_NOT_ALLOWED`, `METHOD_NOT_ALLOWED`, `PATH_NOT_ALLOWED` | l'appel sort de ce que le manifeste déclare |
+| `UPSTREAM_ERROR`, `UPSTREAM_TIMEOUT`, `RESPONSE_TOO_LARGE` | le service distant |
+| `SESSION_EXPIRED` | jeton périmé, le SDK renouvelle et rejoue une fois, puis remonte |
+| `INVALID_ARGUMENT` | mauvais usage de l'API |
+| `NOT_FOUND` | ressource absente |
+
+```js
+try {
+  await nodyx.storage.set('big', payload)
+} catch (e) {
+  if (e.code === 'QUOTA_EXCEEDED') showCleanupHint()
+  else throw e
+}
+```
+
+---
+
+## 6. Le protocole, pour ceux qui n'utilisent pas le SDK
+
+Le SDK est une commodité, pas une obligation. Le contrat réel est le protocole. Il est versionné par `p`, indépendamment de `api`.
+
+L'hôte n'envoie **qu'un seul message** sur `window`, celui d'amorçage, qui transfère un `MessagePort`. Tout le reste passe par ce port privé.
+
+```jsonc
+// requête, dans les deux sens
+{ "p": 1, "id": "c3f1", "ext": "library", "surface": "page",
+  "type": "storage.get", "payload": { "key": "watched" } }
+
+// réponse, toujours corrélée par id
+{ "p": 1, "id": "c3f1", "ok": true,  "result": [603, 27205] }
+{ "p": 1, "id": "c3f1", "ok": false, "error": { "code": "QUOTA_EXCEEDED", "message": "..." } }
+
+// notification de l'hôte, sans réponse attendue
+{ "p": 1, "event": "theme", "payload": { /* jetons */ } }
+```
+
+Un `id` inconnu, déjà consommé, ou reçu avant la fin de la poignée de main est rejeté et journalisé côté hôte. Un message envoyé sur `window` après l'amorçage est ignoré.
+
+Types de requête : `session.renew`, `storage.get|set|delete|list`, `net.fetch`, `core.get`, `ui.toast|confirm|modal`, `router.push|replace`, `nav.go`, `nav.external`, `surface.resize`.
+
+---
+
+## 7. Le thème
+
+L'hôte injecte dans votre frame un jeu de variables CSS **stables**, et les met à jour quand l'instance change de thème. Ce sont les seuls noms sur lesquels vous devez vous appuyer.
+
+| Jeton | Rôle |
+|---|---|
+| `--nodyx-bg`, `--nodyx-bg-elevated` | fond de page, fond de carte |
+| `--nodyx-fg`, `--nodyx-fg-muted` | texte principal, texte secondaire |
+| `--nodyx-accent`, `--nodyx-accent-fg` | accent de l'instance, texte sur accent |
+| `--nodyx-border` | bordure discrète |
+| `--nodyx-danger`, `--nodyx-success`, `--nodyx-warning` | états |
+| `--nodyx-radius-sm`, `--nodyx-radius-md`, `--nodyx-radius-lg` | rayons de la maison |
+| `--nodyx-space-1` à `--nodyx-space-6` | échelle d'espacement |
+| `--nodyx-font`, `--nodyx-font-mono` | piles typographiques |
+
+```css
+.card {
+  background: var(--nodyx-bg-elevated);
+  color: var(--nodyx-fg);
+  border: 1px solid var(--nodyx-border);
+  border-radius: var(--nodyx-radius-md);
+  padding: var(--nodyx-space-4);
+}
+```
+
+Nodyx possède plusieurs systèmes de palette internes qui ont évolué avec le temps. **Ne les utilisez jamais depuis une extension** : ils ne sont pas un contrat, ils changent, et une extension câblée dessus semblera ignorer le thème. Les jetons `--nodyx-*` existent précisément pour vous en isoler.
+
+Ne chargez aucune police depuis un tiers. La pile de l'instance est dans `--nodyx-font`, et une requête vers un CDN de polices est de toute façon bloquée par la politique de sécurité de votre frame.
+
+---
+
+## 8. i18n
+
+**Règle dure, non négociable, appliquée à l'installation** : toute chaîne visible par un humain est une clé. Dans le manifeste, une clé commence par `@`. Dans votre code, elle passe par `nodyx.t()`.
+
+```
+i18n/
+├── en.json     complet si default_locale vaut "en", sinon l'installation échoue
+├── fr.json
+└── de.json
+```
+
+```json
+{
+  "label": "Médiathèque",
+  "nav.label": "Films",
+  "greeting": "Bonjour {{name}}",
+  "field.mood": "Humeur"
+}
+```
+
+Clés plates avec des points, interpolation `{{}}`, aucune gestion du pluriel. Si vous en avez besoin, gérez-le avec deux clés et une condition dans votre code.
+
+Ce qui doit être traduit : l'interface. Ce qui ne doit pas l'être : le contenu éditorial que vous publiez avec l'extension. Une note écrite à la main dans un jeu de données n'est pas une chaîne d'interface, la traduire est un travail de rédaction, pas d'extraction. Déclarez la langue de votre contenu dans la description, le magasin l'affiche.
+
+Une clé absente rend la clé elle-même, visiblement moche. C'est voulu : un trou de traduction doit se voir en développement, pas se cacher derrière un texte anglais plausible.
+
+---
+
+## 9. Limites et quotas
+
+Toutes appliquées côté serveur. Aucune n'est contournable, aucune n'est négociable par extension.
+
+| Domaine | Limite | Valeur |
+|---|---|---|
+| Stockage | longueur d'une clé | 128 caractères |
+| | taille d'une valeur | 64 Ko |
+| | nombre de clés par portée | 500 |
+| | profondeur JSON | 16 |
+| | écritures | 30 par minute et par membre |
+| | total | le quota déclaré et accordé |
+| Réseau | redirections | 3, chacune revalidée |
+| | délai | 10 s |
+| | taille de réponse | 5 Mo |
+| | débit | ce que déclare `rate`, plafonné par l'instance |
+| Surface | délai d'amorçage | 5 s |
+| | frames simultanées par page | 8, au delà chargement paresseux forcé |
+| Paquet | voir §2 | |
+
+Dépassement : une erreur nette avec un code stable. **Jamais de troncature silencieuse, jamais de purge automatique.** Si votre extension dépasse, elle le sait et peut le dire à l'utilisateur.
+
+---
+
+## 10. Ce que vous ne pouvez pas faire, et par quoi remplacer
+
+| Impossible | Pourquoi | À la place |
+|---|---|---|
+| Lire les cookies, le stockage local ou la session de Nodyx | frontière du bac à sable | `nodyx.storage`, `nodyx.user` |
+| Toucher le DOM de la page hôte | idem | `nodyx.ui.*` pour tout ce qui sort du cadre |
+| Appeler `/api/v1` directement | votre frame n'a pas la session | `nodyx.core.get` |
+| Écrire dans le forum, le chat, les membres | v1 en lecture seule | attendez les écritures avec consentement, v2 |
+| Appeler un service tiers depuis le navigateur | doctrine, aucune fuite chez un tiers | `nodyx.fetch`, déclaré au manifeste |
+| Embarquer une iframe tierce (lecteur vidéo externe) | les drapeaux du bac à sable se propagent, l'embed casserait | v1 : non. Un lecteur externe reste un widget natif de Nodyx |
+| Livrer du code serveur, une table, une migration | le cœur est sanctuarisé | `storage`, jeu de données livré, proxy réseau |
+| Ouvrir une popup, naviguer la page du haut, télécharger un fichier | drapeaux non accordés | `nodyx.openExternal`, `nodyx.navigate` |
+| Charger une police, un script ou une image depuis un CDN | politique de sécurité de la frame | livrez-les dans le paquet |
+
+Si votre besoin n'entre dans aucune case, ouvrez une discussion sur le dépôt avant d'inventer un contournement. Les capacités du SDK grandissent par demandes réelles, et une extension qui contourne se cassera à la prochaine version.
+
+---
+
+## 11. Tutoriel complet, de zéro à publié
+
+Objectif : un widget « Prochain événement » qui affiche le compte à rebours d'une date configurable, traduit, au thème de l'instance, sans aucune permission.
+
+### 11.1 Créer le squelette
+
+```bash
+npm create nodyx-extension next-event
+cd next-event
+```
+
+Arborescence produite, déjà valide :
+
+```
+next-event/
+├── manifest.json
+├── i18n/{en,fr}.json
+├── ui/widget.js
+└── icon.svg
+```
+
+### 11.2 Le manifeste
+
+```json
+{
+  "api": 1,
+  "id": "next-event",
+  "version": "1.0.0",
+  "license": "MIT",
+  "author": { "name": "Votre nom" },
+  "default_locale": "en",
+  "label": "@label",
+  "description": "@description",
+  "icon": "icon.svg",
+  "family": "community",
+  "surfaces": [
+    {
+      "type": "widget",
+      "id": "countdown",
+      "entry": "ui/widget.js",
+      "label": "@label",
+      "default_height": 160,
+      "schema": [
+        { "key": "title", "type": "text", "label": "@field.title", "required": true },
+        { "key": "date",  "type": "text", "label": "@field.date", "hint": "@field.date.hint", "required": true },
+        { "key": "accent", "type": "boolean", "label": "@field.accent", "default": true }
+      ]
+    }
+  ]
+}
+```
+
+### 11.3 Les traductions
+
+`i18n/en.json`
+
+```json
+{
+  "label": "Next event",
+  "description": "A countdown to your next community event.",
+  "field.title": "Event name",
+  "field.date": "Date and time",
+  "field.date.hint": "ISO format, for example 2026-12-24T20:00",
+  "field.accent": "Use the community accent colour",
+  "days": "days", "hours": "hours", "minutes": "min",
+  "past": "This event has already taken place.",
+  "invalid": "Invalid date."
+}
+```
+
+`i18n/fr.json`
+
+```json
+{
+  "label": "Prochain événement",
+  "description": "Un compte à rebours vers le prochain rendez-vous de la communauté.",
+  "field.title": "Nom de l'événement",
+  "field.date": "Date et heure",
+  "field.date.hint": "Format ISO, par exemple 2026-12-24T20:00",
+  "field.accent": "Utiliser la couleur d'accent de la communauté",
+  "days": "jours", "hours": "heures", "minutes": "min",
+  "past": "Cet événement a déjà eu lieu.",
+  "invalid": "Date invalide."
+}
+```
+
+### 11.4 Le code
+
+```js
+// ui/widget.js
+const STYLE = `
+  .wrap {
+    background: var(--nodyx-bg-elevated);
+    color: var(--nodyx-fg);
+    border: 1px solid var(--nodyx-border);
+    border-radius: var(--nodyx-radius-md);
+    padding: var(--nodyx-space-4);
+    font-family: var(--nodyx-font);
+  }
+  .title { font-weight: 600; margin-bottom: var(--nodyx-space-2); }
+  .row   { display: flex; gap: var(--nodyx-space-4); }
+  .n     { font-size: 28px; font-weight: 700; line-height: 1; }
+  .n.accent { color: var(--nodyx-accent); }
+  .u     { font-size: 12px; color: var(--nodyx-fg-muted); }
+  .msg   { color: var(--nodyx-fg-muted); font-size: 14px; }
+`
+
+export function mount({ root, nodyx }) {
+  const style = document.createElement('style')
+  style.textContent = STYLE
+  root.append(style)
+
+  const wrap = document.createElement('div')
+  wrap.className = 'wrap'
+  root.append(wrap)
+
+  let timer = null
+
+  function render() {
+    const cfg    = nodyx.config
+    const target = new Date(cfg.date ?? '')
+    const accent = cfg.accent !== false
+
+    if (Number.isNaN(target.getTime())) {
+      wrap.replaceChildren(text('msg', nodyx.t('invalid')))
+      return
+    }
+
+    const left = target.getTime() - Date.now()
+    if (left <= 0) {
+      wrap.replaceChildren(text('title', cfg.title ?? ''), text('msg', nodyx.t('past')))
+      return
+    }
+
+    const d = Math.floor(left / 86400000)
+    const h = Math.floor(left / 3600000) % 24
+    const m = Math.floor(left / 60000) % 60
+
+    const row = document.createElement('div')
+    row.className = 'row'
+    for (const [value, unit] of [[d, 'days'], [h, 'hours'], [m, 'minutes']]) {
+      const cell = document.createElement('div')
+      const n    = text('n', String(value))
+      if (accent) n.classList.add('accent')
+      cell.append(n, text('u', nodyx.t(unit)))
+      row.append(cell)
+    }
+    wrap.replaceChildren(text('title', cfg.title ?? ''), row)
+  }
+
+  function text(cls, value) {
+    const el = document.createElement('div')
+    el.className = cls
+    el.textContent = value          // jamais innerHTML avec une valeur de config
+    return el
+  }
+
+  function start() { stop(); render(); timer = setInterval(render, 30_000) }
+  function stop()  { if (timer) clearInterval(timer); timer = null }
+
+  const offs = [
+    nodyx.on('config',  render),
+    nodyx.on('locale',  render),
+    nodyx.on('visible', ({ visible }) => visible ? start() : stop()),
+  ]
+
+  start()
+  return { unmount() { stop(); offs.forEach(off => off()) } }
+}
+```
+
+Quatre détails de ce code sont normatifs, pas cosmétiques :
+
+- **`textContent`, jamais `innerHTML`** avec une valeur venant de la configuration. Un admin qui colle du HTML dans un champ texte ne doit pas se retrouver avec du script exécuté dans votre frame. Le bac à sable protège Nodyx de vous, il ne vous protège pas de vous même.
+- **Le minuteur s'arrête quand la surface n'est pas visible.** Huit widgets qui battent la seconde sur une page d'accueil, c'est une page qui chauffe.
+- **Tout est nettoyé dans `unmount`.** Une extension qui laisse un `setInterval` derrière elle fuit à chaque navigation.
+- **Le thème et la langue sont réactifs.** Ils changent sans remontage.
+
+### 11.5 Essayer en local
+
+```bash
+nodyx-ext dev
+```
+
+Un hôte simulé s'ouvre : votre surface dans une frame identique à la production, un panneau pour éditer la configuration en direct, basculer le thème clair et sombre, changer de langue, **et activer ou couper chaque permission une par une** pour voir ce que votre code fait quand une capacité manque. Le journal du pont affiche chaque appel, chaque refus, chaque quota.
+
+Testez au minimum : visiteur non connecté, langue absente de vos bundles, champ facultatif vide, thème clair, largeur de colonne étroite.
+
+### 11.6 Vérifier
+
+```bash
+nodyx-ext check
+```
+
+C'est **le validateur du serveur, en ligne de commande** : le même code, donc pas de surprise à l'installation. Il vérifie le manifeste contre le schéma, la parité et la complétude des bundles, les clés `@` orphelines, les chaînes en dur, les tailles, les SVG, et refuse `checkbox`.
+
+### 11.7 Empaqueter
+
+```bash
+nodyx-ext pack        # produit next-event-1.0.0.nyx
+```
+
+### 11.8 Installer chez soi
+
+Administration, Extensions, Installer un fichier. L'écran de permissions s'affiche même pour une extension qui n'en demande aucune : c'est la même porte pour tout le monde.
+
+### 11.9 Publier
+
+```bash
+nodyx-ext publish
+```
+
+Ouvre le formulaire guidé de `extensions.nodyx.org`, qui produit une PR pré-remplie sur le dépôt `nodyx-extensions`. La CI valide le paquet, un mainteneur relit, l'index se régénère au merge. Voir §13.
+
+---
+
+## 12. Exemple avancé : la forme de la médiathèque
+
+La médiathèque est l'extension de référence, celle qui a servi à valider que le SDK tient. Sa forme est un bon modèle pour toute application un peu ambitieuse.
+
+```json
+{
+  "api": 1,
+  "id": "library",
+  "version": "1.0.0",
+  "license": "AGPL-3.0-or-later",
+  "default_locale": "en",
+  "label": "@label",
+  "description": "@description",
+  "surfaces": [
+    { "type": "page", "path": "library", "entry": "ui/page.js",
+      "nav": { "label": "@nav.label", "icon": "twemoji:clapper-board" } },
+    { "type": "widget", "id": "tonight", "entry": "ui/tonight.js", "label": "@widget.tonight",
+      "schema": [ { "key": "mood", "type": "select", "label": "@field.mood", "options": [ /* ... */ ] } ] }
+  ],
+  "permissions": {
+    "identity": ["id", "username", "locale"],
+    "storage":  { "user": "1mb" },
+    "network": {
+      "api.themoviedb.org": { "methods": ["GET"], "paths": ["/3/movie/*"], "secret": "TMDB_API_KEY" },
+      "image.tmdb.org":     { "methods": ["GET"], "paths": ["/t/p/*"] }
+    }
+  }
+}
+```
+
+Les quatre décisions qui la font tenir :
+
+1. **Le corpus est un asset, pas une base.** `data/works.json` est livré avec le paquet, chargé une fois, filtré et cherché en mémoire. Aucune permission n'est nécessaire pour son propre jeu de données, et le jour où il faudra un index côté serveur, ce sera une capacité du SDK, pas un privilège de plus pour l'extension.
+2. **L'état personnel est dans `storage.user`.** Les films vus, les favoris, la note personnelle. C'est ce qui règle le point dur de la version satellite, où tout le monde partageait les mêmes cases cochées, et ça ne coûte aucune table.
+3. **Les quatre écrans sont une seule surface `page`** avec un routage interne reflété dans l'URL par `nodyx.router`, donc des liens partageables.
+4. **TMDB passe par le proxy**, la clé reste sur l'instance, et les affiches passent par `nodyx.imageUrl`. Le navigateur d'un membre ne signale jamais à un tiers ce qu'il regarde.
+
+---
+
+## 13. Publier au registre officiel
+
+Conditions d'entrée :
+
+- licence OSI et `source` pointant vers un dépôt public accessible
+- `default_locale` complet, et l'anglais fortement recommandé pour la portée
+- `nodyx-ext check` vert
+- permissions justifiées dans la description : dites **pourquoi** vous demandez le réseau, pas seulement que vous le demandez
+- une capture au minimum, une icône, une description qui n'est pas une phrase marketing
+
+Ce qui fait refuser une soumission : une permission sans usage visible dans le code, du code volontairement illisible, la collecte de données personnelles non annoncée, un appel réseau vers un service de mesure d'audience, une icône SVG porteuse de script, un identifiant réservé.
+
+Après publication, une version est **immuable**. Un correctif est une nouvelle version. C'est ce qui donne du sens au hash épinglé dans l'index.
+
+---
+
+## 14. Versionner
+
+| Vous changez | Vous incrémentez |
+|---|---|
+| un correctif sans changement de contrat | correctif |
+| une fonctionnalité, un champ de schéma facultatif, une locale | mineur |
+| **une permission ajoutée**, un champ requis, une surface ajoutée ou retirée, une clé de stockage renommée | majeur |
+
+Une mise à jour n'est jamais automatique. L'admin voit un **diff de capacités** : permissions ajoutées ou retirées, surfaces ajoutées, routes nouvelles. Une extension qui passe de widget à application complète a changé de nature, et ça se lit d'un coup d'œil.
+
+Vos données survivent aux mises à jour : le stockage n'est jamais effacé par une montée de version. Si votre format change, **migrez à la lecture** (détectez l'ancien format, convertissez, réécrivez), jamais au démarrage en masse.
+
+Une extension désinstallée voit ses données supprimées, en cascade. Prévenez l'utilisateur si son travail y vit.
+
+---
+
+## 15. Les dix pièges
+
+1. **`manifest.json` dans un sous-dossier du zip.** Le plus fréquent, et l'installation échoue sans ambiguïté.
+2. **Une chaîne en dur dans le manifeste.** Elle doit commencer par `@` et exister dans le bundle de `default_locale`.
+3. **`checkbox` au lieu de `boolean`.** L'ancien format le tolérait, le SDK v1 le refuse.
+4. **Supposer que `nodyx.user` existe.** Les visiteurs existent, et ils sont votre première impression.
+5. **`innerHTML` avec une valeur de configuration ou une réponse réseau.** Le bac à sable protège Nodyx, pas votre propre interface.
+6. **Lire puis écrire une clé partagée.** Dernière écriture gagnante, deux onglets suffisent à perdre une donnée.
+7. **Un minuteur qui tourne hors écran**, et un `unmount` qui ne nettoie pas.
+8. **Un appel réseau bloquant dans `mount`.** Cinq secondes, et l'hôte affiche une erreur à votre place.
+9. **S'appuyer sur les variables CSS internes de Nodyx** au lieu des jetons `--nodyx-*`. Elles changent, votre extension aura l'air cassée.
+10. **Demander une permission « au cas où ».** Elle s'affiche à l'admin avant l'installation, et elle réapparaît à chaque mise à jour.
+
+---
+
+## 16. Compatibilité
+
+`api: 1` est le contrat décrit ici. Un `api` majeur ultérieur ne cassera pas les extensions existantes : l'hôte continuera de servir le SDK de la génération qu'une extension déclare, tant qu'elle reste supportée. Une dépréciation est annoncée au moins une version mineure de Nodyx à l'avance, visible dans `nodyx-ext check` avant de l'être à l'exécution.
+
+Le format antérieur, celui des widgets `.zip` en Web Component sans champ `api`, **n'est pas supporté**. Il n'a jamais eu de frontière de sécurité, et une seule extension l'utilisait. Migration : remplacez `customElements.define('nodyx-widget-<id>', ...)` par un module qui exporte `mount`, remplacez `this.dataset.config` par `nodyx.config`, ajoutez `api`, `default_locale` et vos bundles.

--- a/SPECS/NODYX_SDK_SECURITY.md
+++ b/SPECS/NODYX_SDK_SECURITY.md
@@ -104,7 +104,7 @@ style-src-attr 'unsafe-inline'; img-src <origine> data: blob:; media-src <origin
 connect-src <origine>; frame-src 'none'; form-action 'none'; base-uri 'none'
 ```
 
-`frame-src 'none'` : pas d'iframe imbriquée. C'est aussi ce qui rend impossible l'embarquement d'un lecteur tiers, limite assumée de la v1.
+`frame-src 'none'` : pas d'iframe imbriquée. C'est aussi ce qui rend impossible l'embarquement d'un lecteur tiers, limite assumée de la v1. Le déverrouillage prévu en P3 ne l'affaiblit pas : c'est l'hôte qui pose l'iframe du fournisseur, hors du bac à sable, depuis une liste livrée avec Nodyx. L'extension demande, elle n'obtient jamais le droit d'encadrer elle même.
 
 **Cette politique est posée en en-tête ET en balise `meta` dans le document.** Vérifié sur notre production le 2026-08-14 : le proxy pose la politique du site en mode `set`, donc il **remplace** celle de l'application, y compris sur les réponses d'API. Un en-tête seul serait effacé et la frame hériterait d'une politique permissive, ce qui rouvrirait le réseau sortant direct et annulerait la garantie G5. Une balise `meta` n'est pas réécrite par un proxy, et quand deux politiques coexistent le navigateur applique leur intersection, donc la plus stricte gagne.
 

--- a/SPECS/NODYX_SDK_SECURITY.md
+++ b/SPECS/NODYX_SDK_SECURITY.md
@@ -106,6 +106,12 @@ connect-src <origine>; frame-src 'none'; form-action 'none'; base-uri 'none'
 
 `frame-src 'none'` : pas d'iframe imbriquée. C'est aussi ce qui rend impossible l'embarquement d'un lecteur tiers, limite assumée de la v1.
 
+**Cette politique est posée en en-tête ET en balise `meta` dans le document.** Vérifié sur notre production le 2026-08-14 : le proxy pose la politique du site en mode `set`, donc il **remplace** celle de l'application, y compris sur les réponses d'API. Un en-tête seul serait effacé et la frame hériterait d'une politique permissive, ce qui rouvrirait le réseau sortant direct et annulerait la garantie G5. Une balise `meta` n'est pas réécrite par un proxy, et quand deux politiques coexistent le navigateur applique leur intersection, donc la plus stricte gagne.
+
+Règle générale, valable au delà de ce cas : **une frontière de sécurité ne doit jamais dépendre d'un en-tête qu'un intermédiaire peut réécrire.** Un produit auto-hébergé tourne derrière le proxy de son administrateur, pas derrière le nôtre.
+
+L'isolation elle même ne dépend pas de la CSP : elle vient de l'origine opaque portée par l'attribut `sandbox`, que rien d'externe ne peut modifier. La CSP est la défense en profondeur, et c'est elle qui ferme le réseau direct.
+
 **Ajouter un drapeau de bac à sable est un changement de modèle de sécurité**, pas un réglage. Toute demande passe par une révision de ce document.
 
 ### 4.2 Le canal

--- a/SPECS/NODYX_SDK_SECURITY.md
+++ b/SPECS/NODYX_SDK_SECURITY.md
@@ -1,0 +1,274 @@
+# Modèle de sécurité des extensions Nodyx
+
+Statut : **normatif, écrit avant l'implémentation.** Accompagne `NODYX_SDK_CDC.md` (architecture) et `NODYX_SDK_REFERENCE.md` (contrat développeur).
+Portée : le code tiers installé sur une instance Nodyx, sa distribution, et ce qui l'entoure.
+
+Ce document existe parce qu'une place de marché change la nature du problème. Tant qu'un widget est du code qu'on a écrit ou lu, l'installer est une décision technique. Le jour où c'est le travail d'un inconnu, installé en un clic, c'est une décision de confiance, et une décision de confiance doit reposer sur des frontières, pas sur des intentions.
+
+---
+
+## 1. Ce qui existe aujourd'hui, et pourquoi on le remplace
+
+Le chargement actuel des widgets installés injecte le JavaScript tiers dans le document principal, par balise `<script>` servie depuis l'origine de l'instance. Le Shadow DOM du Web Component isole **les styles**, pas le code.
+
+Conséquence mesurée, pas supposée : le jeton de session est présent dans la charge SSR de chaque page pour un utilisateur connecté. Un widget installé peut donc lire la session de tout visiteur connecté qui charge la page d'accueil, l'owner compris, appeler l'API en son nom, et réécrire la page.
+
+Ce niveau de confiance est cohérent avec « j'installe mon propre code ». Il est incompatible avec « j'installe le code d'un inconnu depuis un magasin ». **Le bac à sable n'est pas un durcissement du SDK, c'est sa condition d'existence.**
+
+---
+
+## 2. Garanties, et non garanties
+
+Une liste de garanties n'a de valeur que si la liste des non garanties est écrite avec la même franchise.
+
+### 2.1 Ce que la plateforme garantit
+
+| G | Garantie |
+|---|---|
+| G1 | Une extension ne peut pas lire la session, les cookies ni le stockage local de l'instance. |
+| G2 | Une extension ne peut pas lire ni modifier le DOM de la page Nodyx, ni celui d'une autre extension. |
+| G3 | Une extension ne peut appeler l'API Nodyx qu'à travers des lectures cadrées, avec les droits de l'utilisateur courant, jamais élevés. |
+| G4 | Une extension ne peut joindre aucun service réseau qu'elle n'a pas déclaré et que l'admin n'a pas accepté. |
+| G5 | Le navigateur du visiteur n'émet aucune requête vers un tiers du fait d'une extension. |
+| G6 | Une extension ne voit jamais un secret d'instance, même quand il est utilisé pour ses propres appels. |
+| G7 | Une extension ne peut pas consommer sans limite le stockage, la base, le réseau ou le processeur. |
+| G8 | Une extension ne peut pas exécuter de code sur le serveur, créer de table, ni ajouter de migration. |
+| G9 | Aucune extension ne se met à jour toute seule, et tout changement de capacité est montré avant d'être appliqué. |
+| G10 | Une surface d'extension est visuellement identifiée comme telle par l'hôte, de façon non falsifiable (§4.9). |
+
+### 2.2 Ce que la plateforme ne garantit pas
+
+| N | Non garantie | Traitement |
+|---|---|---|
+| N1 | Que le code d'une extension soit correct, ou que son auteur soit honnête. | Revue au registre, permissions visibles, révocation. |
+| N2 | Qu'une extension autorisée à joindre un hôte n'y envoie pas des données qu'elle a le droit de lire. Une liste blanche borne la destination, pas l'intention. | Chemins et méthodes déclarés, journalisation, revue, minimisation des permissions. |
+| N3 | Qu'un défaut du navigateur ne casse pas l'isolation. Nous dépendons de la frontière d'origine du navigateur. | C'est un choix assumé : une frontière maintenue par les éditeurs de navigateurs vaut mieux qu'un interpréteur maison. |
+| N4 | Qu'une extension ne dessine pas une interface trompeuse **dans son propre cadre**. | Marqueur d'hôte non falsifiable, dialogues sensibles rendus par l'hôte, interdiction explicite de demander un mot de passe, revue. |
+| N5 | Qu'un administrateur qui installe délibérément une extension hostile soit protégé de lui même. | L'admin est la racine de confiance de son instance. Le rôle du système est de l'informer, pas de le contredire. |
+| N6 | Que les données d'une extension soient chiffrées au repos indépendamment de la base. | Elles vivent dans PostgreSQL, protégées comme le reste de l'instance. |
+
+---
+
+## 3. Biens, adversaires, hypothèses
+
+**Biens à protéger**, par ordre de gravité : la session et le compte des membres, le contenu privé (messages, courriels, données de profil), l'intégrité de l'instance (base, fichiers, configuration), les secrets d'instance (clés d'API, jetons), la disponibilité, et la vie privée du visiteur, y compris vis-à-vis de nous.
+
+**Adversaires considérés** :
+
+| A | Adversaire | Capacité |
+|---|---|---|
+| A1 | Auteur d'extension malveillant | publie un paquet crédible au registre |
+| A2 | Auteur honnête compromis | pousse une mise à jour hostile sur une extension déjà installée et appréciée |
+| A3 | Extension négligente | pas d'intention, mais une XSS, une fuite ou une boucle infinie |
+| A4 | Membre malveillant de l'instance | utilise l'interface d'une extension pour atteindre ce qu'il n'a pas le droit de voir |
+| A5 | Tiers réseau | contrôle un service que l'extension appelle, ou le DNS qui le résout |
+| A6 | Attaquant externe | envoie un lien piégé à un administrateur |
+
+**Hypothèses de confiance** : le navigateur applique correctement l'isolation d'origine et les drapeaux d'iframe ; l'administrateur d'instance est la racine de confiance ; le serveur de l'instance n'est pas déjà compromis ; les mainteneurs du registre officiel sont honnêtes, et leur compromission est traitée en §8.
+
+---
+
+## 4. Les frontières, une par une
+
+```
+                     ┌─────────────────────────────────────────┐
+   navigateur        │  page Nodyx (origine de l'instance)      │
+                     │  session, DOM, stockage local            │
+                     │  ┌───────────────────────────────────┐   │
+                     │  │ iframe, origine OPAQUE            │   │
+                     │  │ code de l'extension               │   │
+                     │  │      ▲  port privé (MessagePort)  │   │
+                     │  └──────┼────────────────────────────┘   │
+                     └─────────┼──────────────────────────────-─┘
+                               │ ext_token, jamais le cookie
+                     ┌─────────▼───────────────────────────────┐
+   serveur           │  routes /extensions/*  (core)           │
+                     │  storage · core:read · proxy réseau     │
+                     │  secrets (jamais renvoyés)              │
+                     └─────────┬───────────────────────────────┘
+                               │ liste blanche, IP validée
+                     ┌─────────▼───────────────────────────────┐
+   internet          │  service tiers déclaré                  │
+                     └─────────────────────────────────────────┘
+```
+
+### 4.1 La frame
+
+`sandbox="allow-scripts"` et **rien d'autre**. Pas de `allow-same-origin`, ce qui place le document en origine opaque : cookies, `localStorage` et `sessionStorage` inaccessibles, DOM parent inaccessible. Pas de `allow-top-navigation`, `allow-popups`, `allow-modals`, `allow-forms`, `allow-downloads`.
+
+Politique de sécurité de contenu servie avec le document de frame, avec l'origine écrite en clair, puisque `'self'` ne résout rien dans une origine opaque :
+
+```
+default-src 'none'; script-src 'nonce-<n>' <origine>; style-src 'nonce-<n>' <origine>;
+style-src-attr 'unsafe-inline'; img-src <origine> data: blob:; media-src <origine> blob:;
+connect-src <origine>; frame-src 'none'; form-action 'none'; base-uri 'none'
+```
+
+`frame-src 'none'` : pas d'iframe imbriquée. C'est aussi ce qui rend impossible l'embarquement d'un lecteur tiers, limite assumée de la v1.
+
+**Ajouter un drapeau de bac à sable est un changement de modèle de sécurité**, pas un réglage. Toute demande passe par une révision de ce document.
+
+### 4.2 Le canal
+
+Dans une origine opaque, `event.origin` vaut `"null"` et ne prouve rien. Filtrer à la main serait fragile, donc on ne filtre pas : **l'hôte n'envoie qu'un seul message sur `window`**, celui d'amorçage, qui transfère un `MessagePort`. Tout le reste passe par ce port privé, propre à cette frame et à cette session. Une autre frame n'a rien à usurper, il n'y a pas d'adresse publique à viser.
+
+Sur ce message unique, l'hôte vérifie `event.source === iframe.contentWindow`. Après l'amorçage, tout message reçu sur `window` est ignoré et journalisé.
+
+Le protocole est versionné (`p`) et corrélé (`id`). Un identifiant inconnu, déjà consommé, ou reçu avant la fin de la poignée de main est rejeté.
+
+### 4.3 Le jeton
+
+`ext_token`, JWT court signé par le core, lié à tout ce qui doit l'être :
+
+```jsonc
+{ "iss": "<origine>", "aud": "nodyx-extension", "ins": "<instance>",
+  "ext": "<extension>", "sur": "<surface>", "sub": "<user|null>",
+  "prm": [ /* accordées, pas demandées */ ], "jti": "...", "iat": ..., "exp": ... }
+```
+
+Chaque claim ferme un rejeu : une autre instance, une autre extension, une autre surface, un autre utilisateur. Durée 10 minutes, renouvellement **à la demande de la frame**, l'hôte re-frappant le jeton auprès du core avec la session réelle.
+
+Les routes `/api/v1/extensions/:id/*` acceptent ce jeton, acceptent `Origin: null`, et **n'acceptent jamais le cookie de session ni le jeton utilisateur**. `Origin: null` n'est pas une authentification : c'est une conséquence du bac à sable, que n'importe qui peut produire.
+
+Le jeton ne transite que par le port privé. Jamais dans une URL, un `src`, un référent, un journal, un message d'erreur. Un `jti` est révoqué immédiatement à la désactivation, la désinstallation, ou le retrait d'une permission.
+
+### 4.4 Le proxy réseau
+
+Ce n'est pas un `fetch` générique derrière une liste blanche, c'est une porte bornée par ce que le manifeste déclare et que l'admin a accepté. Contrôles, dans l'ordre :
+
+1. hôte, **méthode** et **préfixe de chemin** vérifiés contre l'accord ; port implicite du schéma, un port explicite non déclaré est refusé
+2. résolution DNS, validation de **l'adresse obtenue**, puis connexion **à cette adresse**. Vérifier le nom avant de résoudre ne protège de rien : le rebinding DNS est l'attaque de référence. Refusés : RFC1918, loopback v4 et v6, lien local, ULA, multicast, adresses mappées, écritures exotiques d'IP
+3. 3 redirections au maximum, **chacune revalidée intégralement**, adresse comprise
+4. secrets injectés **selon une recette que le serveur possède** : l'extension nomme le secret, elle ne choisit ni l'en-tête ni sa destination. Sans cette règle, une extension demanderait `X-Peu-Importe: <secret>` vers un hôte qu'elle contrôle
+5. en-têtes filtrés à l'aller (liste blanche courte) et au retour (`Set-Cookie` et apparentés retirés)
+6. réponse plafonnée : taille, délai, type de contenu, **ratio de décompression** (10 Ko qui deviennent 10 Go est un déni de service)
+7. débit plafonné par extension et par utilisateur, journalisation par extension
+
+### 4.5 Le stockage
+
+Cloisonné par extension, par portée, par utilisateur. Aucune extension ne peut nommer l'espace d'une autre : la clé d'extension vient du jeton, pas de la requête.
+
+**Règle des deux axes** : la capacité de l'extension et les droits de l'utilisateur sont deux dimensions distinctes, et le droit effectif est leur **intersection**. Une extension qui détient `storage.instance.write` n'écrit pas parce qu'un membre a ouvert son interface. Une capacité accordée à l'installation n'est jamais une élévation de privilège pour l'utilisateur courant.
+
+Un quota en octets ne suffit pas : sans limites fines, une extension épuise le processeur et la base sans jamais approcher son mégaoctet. Longueur de clé, taille de valeur, nombre de clés, profondeur JSON et fréquence d'écriture sont plafonnés (valeurs en `NODYX_SDK_REFERENCE.md` §9). Dépassement : erreur nette, jamais de purge silencieuse.
+
+### 4.6 Le paquet
+
+À l'installation : manifeste validé contre son JSON Schema, permission inconnue **refusée** et non ignorée, identifiant réservé refusé, `default_locale` incomplet refusé, `api` absent refusé.
+
+À l'extraction : chemins aplatis, `../` refusé, chemin absolu refusé, **lien symbolique refusé**, liste blanche d'extensions de fichiers, plafonds de taille, de nombre de fichiers, de profondeur et de ratio de décompression. Le type de contenu servi est déterminé par le serveur depuis l'extension de fichier, jamais deviné depuis le contenu, avec `X-Content-Type-Options: nosniff` et `Cross-Origin-Resource-Policy: same-origin`.
+
+Les assets sont servis sous `/api/v1/extensions/:id/:version/assets/*`. **La version est dans le chemin** : une mise à jour invalide le cache d'elle même, et une frame ouverte ne peut pas mélanger deux générations de code.
+
+La route publique actuelle `/api/v1/widget-assets/:id/:file` disparaît avec P0-A. Le JavaScript d'une extension n'est jamais chargeable comme script de la page hôte.
+
+### 4.7 Ce qui s'affiche hors du bac à sable
+
+C'est l'angle mort classique. L'icône et l'aperçu d'une extension sont affichés par la page d'administration et par le magasin, donc **sur l'origine principale, hors de toute frame**.
+
+Un SVG n'est pas une image : il peut porter `<script>`, des attributs `on*`, des `<foreignObject>`, des références externes. Sans traitement, l'icône devient une XSS sur la page d'administration, indépendamment de toute la §4.1.
+
+Règle : tout SVG est **assaini à l'installation**, réécrit vers un sous ensemble sûr, et servi avec `image/svg+xml`, `nosniff` et `Content-Security-Policy: default-src 'none'`. Un SVG qui ne survit pas à l'assainissement fait échouer l'installation, il n'est pas silencieusement vidé.
+
+Même vigilance pour toute chaîne du manifeste rendue dans l'administration : elle est du texte, jamais du HTML.
+
+### 4.8 Le magasin et le lien d'installation
+
+Le magasin ne pousse jamais rien. Le flux ne s'inverse pas : la fiche redirige vers l'administration de l'instance, l'admin voit les permissions, et **c'est l'instance qui télécharge**.
+
+Le lien d'installation est une surface d'attaque à part entière : un lien fabriqué avec `src=<registre_de_l_attaquant>`, envoyé à un owner, installerait du code arbitraire en un clic (adversaire A6). Trois contrôles :
+
+- `src` validé contre la **liste des registres configurés dans l'instance**, jamais suivi tel quel. Un registre inconnu est refusé, pas proposé à l'ajout.
+- le lien **ne fait que pré-remplir un écran**. L'installation est un `POST` authentifié, protégé contre le CSRF, avec confirmation explicite.
+- l'écran nomme la provenance en clair.
+
+Chaîne de confiance de la distribution, trois maillons à ne pas confondre :
+
+```
+clé publique du registre (livrée avec l'instance, pas récupérée depuis le registre)
+   signe →  index.json  (versions, permissions, sha256 de chaque paquet)
+            référence →  sha256 du paquet
+                         vérifie →  paquet .nyx téléchargé
+```
+
+Le `sha256` prouve l'intégrité du téléchargement, **pas l'authenticité** : si l'index est compromis, un hash cohérent avec un paquet hostile l'est tout autant. C'est la signature de l'index qui porte l'authenticité. Une version publiée est **immuable**, sans quoi un hash épinglé ne veut plus rien dire.
+
+### 4.9 L'administration, et le marqueur d'origine
+
+Deux écrans portent la sécurité côté humain.
+
+**L'écran de permissions**, à l'installation, en langage clair, orienté « ce que ça peut toucher » plutôt que « ce que ça fait ». Il s'affiche même pour une extension sans permission : la même porte pour tout le monde.
+
+**Le diff de capacités**, à la mise à jour. Pas seulement les permissions : les surfaces ajoutées et les routes nouvelles comptent, parce qu'une extension qui passe de widget à application complète a changé de profil de risque. Aucune mise à jour automatique, jamais.
+
+**Le marqueur d'origine** (G10) répond à la non garantie N4. Une surface d'extension est identifiée par l'hôte, **à l'extérieur de la frame**, donc non falsifiable par l'extension : un liseré discret et le nom de l'extension. Un membre doit pouvoir distinguer ce que dit Nodyx de ce que dit une extension. C'est ce qui rend une fausse demande de mot de passe visible pour ce qu'elle est, et c'est pourquoi les dialogues sensibles sont rendus par l'hôte, jamais dans la frame.
+
+---
+
+## 5. Responsabilités de l'auteur d'extension
+
+Le bac à sable protège Nodyx de votre extension. **Il ne protège pas votre extension d'elle même**, ni vos utilisateurs de vos propres erreurs.
+
+| Vous devez | Pourquoi |
+|---|---|
+| `textContent`, jamais `innerHTML`, avec une valeur de configuration ou une réponse réseau | une XSS dans votre frame reste une XSS pour l'utilisateur qui vous fait confiance |
+| Ne jamais demander un mot de passe, un code, ni un moyen de paiement | Nodyx ne le demande jamais dans une extension, une extension qui le fait est hostile par définition |
+| Demander le minimum de permissions | chaque ligne est affichée avant l'installation et à chaque mise à jour |
+| Annoncer clairement ce que vous stockez et ce que vous envoyez | la description est lue, la revue vérifie qu'elle correspond au code |
+| Ne pas embarquer de traceur, de mesure d'audience, de télémétrie | rejet immédiat au registre, sans exception |
+| Traiter le cas visiteur (`nodyx.user === null`) | les vues publiques sont vues par des gens sans compte |
+| Nettoyer dans `unmount`, suspendre hors écran | une extension qui fuit dégrade toute la page |
+| Ne pas dépendre des variables CSS internes de Nodyx | elles ne sont pas un contrat, seuls les jetons `--nodyx-*` le sont |
+| Publier vos sources et une licence OSI | exigé au registre officiel |
+
+---
+
+## 6. Responsabilités de l'administrateur d'instance
+
+- Lire l'écran de permissions. Une extension d'affichage qui demande le réseau mérite une question.
+- Lire le diff de capacités à chaque mise à jour. C'est le moment précis où une extension honnête peut devenir hostile (adversaire A2).
+- N'ajouter un registre tiers qu'en connaissance de cause : c'est étendre sa racine de confiance.
+- Traiter un secret d'instance (clé d'API) comme un secret : il est utilisé pour l'extension, il ne lui est jamais montré, mais il reste engagé par elle.
+- Désactiver plutôt que désinstaller en cas de doute : la désactivation coupe l'exécution et révoque les jetons, sans détruire les données des membres.
+
+---
+
+## 7. Critères de revue au registre officiel
+
+Refus systématique : permission sans usage repérable dans le code, code volontairement illisible ou empaqueté sans sources, collecte de données personnelles non annoncée, appel vers un service de mesure d'audience, SVG porteur de script, identifiant réservé, licence absente ou non OSI, absence de dépôt public.
+
+Examen manuel obligatoire : toute extension demandant `network`, `secrets`, `storage.instance.write` ou `core`, et toute mise à jour qui **ajoute** une capacité.
+
+Le registre officiel est le **niveau 2** du modèle de liberté à deux étages : une instance installe ce qu'elle veut par fichier, le registre, lui, est modéré.
+
+---
+
+## 8. Révocation et incident
+
+| Situation | Réponse |
+|---|---|
+| Extension hostile découverte | retrait de l'index, marquage de la version dans l'index (`revoked`), avertissement affiché dans l'administration des instances qui l'ont installée |
+| Auteur compromis | même chose, plus gel des publications sous cette identité |
+| Registre compromis | rotation de la clé publique, livrée par mise à jour de Nodyx, jamais par le registre lui même |
+| Défaut du bac à sable côté navigateur | interrupteur global de désactivation des extensions, indépendant de la désinstallation, activable sans redéploiement |
+
+L'instance vérifie l'index à intervalle régulier pour **signaler** une révocation. Elle ne désinstalle jamais toute seule : la décision reste à l'admin, mais elle est informée.
+
+Divulgation responsable : les failles concernant le bac à sable, le proxy ou la chaîne de distribution suivent `SECURITY.md` du dépôt. Une faille dans une extension tierce se signale au registre, qui contacte l'auteur et retire au besoin.
+
+---
+
+## 9. Preuve, et porte d'entrée
+
+Ce modèle ne vaut que prouvé. Le catalogue d'attaques est en `NODYX_SDK_CDC.md` §14, sous forme d'une extension hostile en fixture, exécutée en CI : DOM et fenêtres, navigation, messagerie (forge, rejeu, port d'une autre extension), jeton (rejeu croisé instance, extension, surface, expiration), réseau (rebinding DNS, RFC1918, `::1`, redirections, exfiltration de secret par en-tête, bombe de décompression), stockage (quotas, limites fines, espace d'autrui), paquet (zip slip, lien symbolique, 100 000 fichiers, MIME menti, SVG actif).
+
+**Porte d'entrée, non négociable : aucune capacité réseau d'extension n'existe tant que les tests de confinement ne sont pas verts.** Le proxy est lui même une capacité de sécurité, il ne se pose pas sur un bac à sable non prouvé.
+
+---
+
+## 10. Risques résiduels acceptés
+
+- **Exfiltration par un hôte autorisé** (N2). Une extension autorisée à joindre un service peut y encoder ce qu'elle a le droit de lire. Bornée par la minimisation des permissions, les chemins déclarés, la journalisation et la revue. Non éliminable sans interdire le réseau.
+- **Dépendance à l'isolation du navigateur** (N3). Assumée : une frontière maintenue par les éditeurs de navigateurs est plus solide qu'un interpréteur maison, et l'interrupteur global de §8 est le plan de repli.
+- **Interface trompeuse dans le cadre** (N4). Réduite par le marqueur d'origine, les dialogues rendus par l'hôte et la revue, pas supprimée.
+- **Administrateur qui s'auto-piège** (N5). Hors périmètre : l'admin est la racine de confiance de son instance. Le système l'informe, il ne le contredit pas.

--- a/SPECS/NODYX_SDK_SECURITY.md
+++ b/SPECS/NODYX_SDK_SECURITY.md
@@ -143,7 +143,9 @@ Le jeton ne transite que par le port privé. Jamais dans une URL, un `src`, un r
 Ce n'est pas un `fetch` générique derrière une liste blanche, c'est une porte bornée par ce que le manifeste déclare et que l'admin a accepté. Contrôles, dans l'ordre :
 
 1. hôte, **méthode** et **préfixe de chemin** vérifiés contre l'accord ; port implicite du schéma, un port explicite non déclaré est refusé
-2. résolution DNS, validation de **l'adresse obtenue**, puis connexion **à cette adresse**. Vérifier le nom avant de résoudre ne protège de rien : le rebinding DNS est l'attaque de référence. Refusés : RFC1918, loopback v4 et v6, lien local, ULA, multicast, adresses mappées, écritures exotiques d'IP
+2. résolution DNS, validation de **l'adresse obtenue**, puis connexion **à cette adresse**. Vérifier le nom avant de résoudre ne protège de rien : le rebinding DNS est l'attaque de référence.
+
+   Le refus n'est pas uniforme, et ce n'est pas un relâchement (révisé le 2026-08-14) : **une instance en intranet est un usage normal, pas une anomalie.** Réseau privé, déclarable et accordé sur consentement explicite et distinct de l'admin, qui est la racine de confiance de son instance. Boucle locale et lien local (`127.0.0.0/8`, `::1`, `localhost`, `169.254.0.0/16`, donc les métadonnées d'hébergeur), refusés en toute circonstance y compris avec l'accord de l'admin, parce qu'ils visent la machine de l'instance elle même, sa base, son cache et son API interne. Une variable d'environnement dédiée lève la restriction sur une instance de développement, jamais en production. Restent refusés partout : multicast, diffusion, plages réservées, adresses mappées, écritures exotiques d'IP
 3. 3 redirections au maximum, **chacune revalidée intégralement**, adresse comprise
 4. secrets injectés **selon une recette que le serveur possède** : l'extension nomme le secret, elle ne choisit ni l'en-tête ni sa destination. Sans cette règle, une extension demanderait `X-Peu-Importe: <secret>` vers un hôte qu'elle contrôle
 5. en-têtes filtrés à l'aller (liste blanche courte) et au retour (`Set-Cookie` et apparentés retirés)

--- a/nodyx-core/src/extensions/limits.ts
+++ b/nodyx-core/src/extensions/limits.ts
@@ -1,0 +1,51 @@
+// Limites du SDK d'extensions, source unique.
+//
+// Toute valeur ici est normative : elle est documentée dans
+// SPECS/NODYX_SDK_REFERENCE.md §9, appliquée par le validateur à
+// l'installation, et par le runtime à l'exécution. Un chiffre qui change ici
+// doit changer dans le manuel, jamais l'inverse.
+
+/** Version du contrat portée par `api` dans le manifeste. */
+export const API_VERSION = 1
+
+/** Version du protocole de messagerie hôte <-> frame (`p`). */
+export const PROTOCOL_VERSION = 1
+
+/** Paquet .nyx */
+export const PACKAGE = {
+  maxArchiveBytes:     20 * 1024 * 1024,
+  maxUnpackedBytes:    60 * 1024 * 1024,
+  maxFileBytes:         8 * 1024 * 1024,
+  maxFiles:            2_000,
+  maxDepth:            6,
+  /** Ratio de décompression au delà duquel on refuse (bombe zip). */
+  maxCompressionRatio: 100,
+  allowedExtensions: [
+    '.js', '.css', '.json', '.svg', '.png', '.jpg', '.jpeg', '.webp', '.woff2', '.md',
+  ] as const,
+} as const
+
+/** Stockage clé/valeur */
+export const STORAGE = {
+  maxKeyLength:     128,
+  maxValueBytes:    64 * 1024,
+  maxKeysPerScope:  500,
+  maxJsonDepth:     16,
+  writesPerMinute:  30,
+  /** Plafond absolu d'un quota déclarable au manifeste, par portée. */
+  maxQuotaBytes:    64 * 1024 * 1024,
+} as const
+
+/** Proxy réseau */
+export const NETWORK = {
+  maxRedirects:      3,
+  timeoutMs:         10_000,
+  maxResponseBytes:  5 * 1024 * 1024,
+} as const
+
+/** Surfaces */
+export const SURFACE = {
+  bootTimeoutMs:      5_000,
+  maxFramesPerPage:   8,
+  tokenTtlSeconds:    600,
+} as const

--- a/nodyx-core/src/extensions/manifest.ts
+++ b/nodyx-core/src/extensions/manifest.ts
@@ -30,19 +30,56 @@ export const RE_LOCALE       = /^[a-z]{2}(-[A-Za-z]{2})?$/
 export const RE_MESSAGE_KEY  = /^@[A-Za-z0-9_][A-Za-z0-9_.-]*$/
 export const RE_HOST         = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/
 
+export type HostClass = 'public' | 'private' | 'forbidden' | 'invalid'
+
+const RE_IPV4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/
+
 /**
- * Un hôte déclarable : un nom de domaine, jamais une adresse IP littérale.
+ * Classe un hôte déclarable au manifeste. Trois niveaux, pas un interdit.
  *
- * Le proxy refuse déjà les adresses privées au moment de la connexion, après
- * résolution (NODYX_SDK_SECURITY.md §4.4). Mais une IP littérale n'a aucune
- * raison d'apparaître dans un manifeste : elle ne veut rien dire pour l'admin
- * qui lit l'écran de permissions, et elle ne sert qu'à viser une machine
- * précise. On la refuse à la déclaration, pas seulement à l'usage.
+ * Une instance Nodyx peut très bien vivre sur un intranet d'entreprise, sur un
+ * réseau domestique, ou sur une simple adresse IP sans nom de domaine. Refuser
+ * en bloc les adresses privées reviendrait à interdire les extensions qui
+ * servent justement à parler aux services de cette maison. L'admin est la
+ * racine de confiance de son instance : à lui de décider, en connaissance de
+ * cause.
+ *
+ *   public     déclarable librement
+ *   private    déclarable, mais exige un accord EXPLICITE de l'admin (§6.4)
+ *   forbidden  jamais : ces cibles sont la machine de l'instance elle même,
+ *              donc sa base, son cache, son API interne, ses identifiants de
+ *              plateforme d'hébergement. Un admin n'y gagne rien de légitime.
+ *   invalid    forme inacceptable
+ *
+ * Attention à ne pas confondre les deux couches : cette classification porte
+ * sur la LISIBILITÉ de la déclaration. L'application réelle se fait à la
+ * connexion, après résolution DNS et sur l'adresse obtenue, parce qu'un nom
+ * public peut pointer vers une adresse privée (NODYX_SDK_SECURITY.md §4.4).
  */
-export function isDeclarableHost(host: string): boolean {
-  if (!RE_HOST.test(host)) return false
-  const last = host.slice(host.lastIndexOf('.') + 1)
-  return /[a-z]/.test(last)          // un TLD tout en chiffres = adresse IPv4
+export function classifyHost(host: string): HostClass {
+  if (!host || host.includes(':') || host.includes('/')) return 'invalid'
+
+  const lower = host.toLowerCase()
+  const ip = RE_IPV4.exec(lower)
+
+  if (ip) {
+    const o = ip.slice(1).map(Number)
+    if (o.some(n => n > 255)) return 'invalid'
+    const [a, b] = o
+    if (a === 127) return 'forbidden'                        // boucle locale
+    if (a === 169 && b === 254) return 'forbidden'           // lien local, métadonnées d'hébergeur
+    if (a === 0 || a >= 224) return 'forbidden'              // réservé, multicast, diffusion
+    if (a === 10) return 'private'
+    if (a === 172 && b >= 16 && b <= 31) return 'private'
+    if (a === 192 && b === 168) return 'private'
+    if (a === 100 && b >= 64 && b <= 127) return 'private'   // partage d'adresse opérateur
+    return 'public'
+  }
+
+  if (!RE_HOST.test(lower) && lower !== 'localhost') return 'invalid'
+  if (lower === 'localhost' || lower.endsWith('.localhost')) return 'forbidden'
+  if (/\.(local|internal|lan|intranet)$/.test(lower) || lower.endsWith('.home.arpa')) return 'private'
+  return 'public'
 }
 export const RE_RATE         = /^\d+\/(s|min|h)$/
 export const RE_SIZE         = /^\d+(kb|mb)$/
@@ -175,7 +212,18 @@ export interface ValidationIssue {
 }
 
 export type ValidationResult =
-  | { ok: true;  manifest: ExtensionManifest; messageKeys: string[] }
+  | {
+      ok: true
+      manifest: ExtensionManifest
+      messageKeys: string[]
+      /**
+       * Hôtes déclarés qui visent un réseau privé. Le manifeste est valide,
+       * mais ces cibles exigent un accord EXPLICITE et distinct de l'admin à
+       * l'installation : l'écran de permissions doit les montrer à part, pas
+       * les noyer dans la liste des appels sortants ordinaires.
+       */
+      privateNetworkHosts: string[]
+    }
   | { ok: false; issues: ValidationIssue[] }
 
 /** Toutes les clés de traduction référencées par le manifeste, sans le @. */
@@ -251,10 +299,16 @@ function preflight(raw: unknown): ValidationIssue[] {
           message: 'un hôte réseau doit déclarer ses méthodes et ses préfixes de chemin, sinon l\'écran de permissions est illisible',
         })
       }
-      if (!isDeclarableHost(host)) {
+      const klass = classifyHost(host)
+      if (klass === 'invalid') {
         issues.push({
           code: 'NETWORK_HOST_INVALID', path: `permissions.network.${host}`,
-          message: 'hôte invalide : nom de domaine attendu, sans schéma, sans port, sans chemin, et jamais une adresse IP',
+          message: 'hôte invalide : nom de domaine ou adresse IPv4 attendu, sans schéma, sans port, sans chemin',
+        })
+      } else if (klass === 'forbidden') {
+        issues.push({
+          code: 'NETWORK_HOST_FORBIDDEN', path: `permissions.network.${host}`,
+          message: 'cette cible est la machine de l\'instance elle même (boucle locale, lien local, métadonnées d\'hébergeur) : elle n\'est jamais déclarable',
         })
       }
     }
@@ -355,5 +409,14 @@ export function validateManifest(raw: unknown): ValidationResult {
   const late = [...early, ...postflight(parsed.data)]
   if (late.length) return { ok: false, issues: late }
 
-  return { ok: true, manifest: parsed.data, messageKeys: collectMessageKeys(parsed.data) }
+  const privateNetworkHosts = Object.keys(parsed.data.permissions?.network ?? {})
+    .filter(h => classifyHost(h) === 'private')
+    .sort()
+
+  return {
+    ok: true,
+    manifest: parsed.data,
+    messageKeys: collectMessageKeys(parsed.data),
+    privateNetworkHosts,
+  }
 }

--- a/nodyx-core/src/extensions/manifest.ts
+++ b/nodyx-core/src/extensions/manifest.ts
@@ -1,0 +1,359 @@
+// Validation du manifeste d'extension, contrat `api: 1`.
+//
+// Référence normative : SPECS/NODYX_SDK_REFERENCE.md §3.
+// Ce module est PUR : pas de base, pas de disque, pas de réseau. Il sert au
+// même endroit trois fois, et c'est voulu :
+//   1. l'installation côté core,
+//   2. la commande `nodyx-ext check` des développeurs,
+//   3. la CI du dépôt de registre.
+// Un paquet accepté ici est accepté partout, sans surprise à l'upload.
+//
+// Deux principes de conduite :
+//   - Un manifeste inconnu est REFUSÉ, jamais nettoyé. Une faute de frappe sur
+//     `permissions` ne doit pas produire une extension qui tourne avec moins de
+//     droits que prévu et échoue à l'usage.
+//   - Chaque refus porte un code stable en majuscules. Le message est pour
+//     l'humain, le code est pour la machine.
+
+import { z } from 'zod'
+import { API_VERSION, STORAGE } from './limits'
+import { isReservedExtensionId } from './reserved'
+
+// ── Formes ────────────────────────────────────────────────────────────────────
+
+export const RE_EXTENSION_ID = /^[a-z][a-z0-9-]{2,38}$/
+export const RE_SURFACE_ID   = /^[a-z][a-z0-9-]{0,30}$/
+export const RE_PAGE_PATH    = /^[a-z][a-z0-9-]{1,30}$/
+export const RE_FIELD_KEY    = /^[a-z][a-z0-9_]{0,39}$/
+export const RE_SEMVER       = /^\d+\.\d+\.\d+$/
+export const RE_LOCALE       = /^[a-z]{2}(-[A-Za-z]{2})?$/
+export const RE_MESSAGE_KEY  = /^@[A-Za-z0-9_][A-Za-z0-9_.-]*$/
+export const RE_HOST         = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/
+
+/**
+ * Un hôte déclarable : un nom de domaine, jamais une adresse IP littérale.
+ *
+ * Le proxy refuse déjà les adresses privées au moment de la connexion, après
+ * résolution (NODYX_SDK_SECURITY.md §4.4). Mais une IP littérale n'a aucune
+ * raison d'apparaître dans un manifeste : elle ne veut rien dire pour l'admin
+ * qui lit l'écran de permissions, et elle ne sert qu'à viser une machine
+ * précise. On la refuse à la déclaration, pas seulement à l'usage.
+ */
+export function isDeclarableHost(host: string): boolean {
+  if (!RE_HOST.test(host)) return false
+  const last = host.slice(host.lastIndexOf('.') + 1)
+  return /[a-z]/.test(last)          // un TLD tout en chiffres = adresse IPv4
+}
+export const RE_RATE         = /^\d+\/(s|min|h)$/
+export const RE_SIZE         = /^\d+(kb|mb)$/
+
+export const FIELD_TYPES = ['text', 'textarea', 'url', 'number', 'boolean', 'select', 'color', 'image'] as const
+export const IDENTITY_FIELDS = ['id', 'username', 'avatar', 'locale'] as const
+export const CORE_SCOPES = ['members:read', 'forum:read', 'instance:read'] as const
+export const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const
+
+/** Un chemin de paquet sûr : relatif, sans remontée, sans antislash. */
+export function isSafePackagePath(p: string): boolean {
+  if (!p || p.startsWith('/') || p.includes('\\') || p.includes('\0')) return false
+  if (/(^|\/)\.\.(\/|$)/.test(p)) return false
+  return /^[A-Za-z0-9][A-Za-z0-9._\/-]*$/.test(p)
+}
+
+/** "512kb" | "8mb" -> octets. Rend null si la forme est invalide. */
+export function parseSize(raw: string): number | null {
+  const m = RE_SIZE.exec(raw)
+  if (!m) return null
+  const n = parseInt(raw, 10)
+  return raw.endsWith('mb') ? n * 1024 * 1024 : n * 1024
+}
+
+// ── Schéma ────────────────────────────────────────────────────────────────────
+
+const messageKey = z.string().regex(RE_MESSAGE_KEY, 'doit être une clé de traduction commençant par @')
+const entryPath  = z.string().refine(p => isSafePackagePath(p) && p.endsWith('.js'), 'chemin de paquet invalide, ou ne finit pas par .js')
+
+const fieldOption = z.object({
+  value: z.string().min(1),
+  label: messageKey,
+}).strict()
+
+const fieldSchema = z.object({
+  key:         z.string().regex(RE_FIELD_KEY),
+  type:        z.enum(FIELD_TYPES),
+  label:       messageKey,
+  hint:        messageKey.optional(),
+  details:     messageKey.optional(),
+  placeholder: z.string().optional(),
+  required:    z.boolean().optional(),
+  default:     z.unknown().optional(),
+  options:     z.array(fieldOption).min(1).optional(),
+  min:         z.number().optional(),
+  max:         z.number().optional(),
+}).strict().superRefine((f, ctx) => {
+  if (f.type === 'select' && !f.options) {
+    ctx.addIssue({ code: 'custom', message: 'un champ select exige `options`', params: { nodyx: 'SELECT_WITHOUT_OPTIONS' } })
+  }
+  if (f.type !== 'select' && f.options) {
+    ctx.addIssue({ code: 'custom', message: '`options` n\'a de sens que sur un champ select', params: { nodyx: 'OPTIONS_ON_NON_SELECT' } })
+  }
+})
+
+const navSchema = z.object({
+  label:    messageKey,
+  icon:     z.string().min(1).optional(),
+  position: z.enum(['main', 'community']).optional(),
+}).strict()
+
+const widgetSurface = z.object({
+  type:           z.literal('widget'),
+  id:             z.string().regex(RE_SURFACE_ID),
+  entry:          entryPath,
+  label:          messageKey,
+  description:    messageKey.optional(),
+  schema:         z.array(fieldSchema).optional(),
+  default_height: z.number().int().positive().max(2000).optional(),
+}).strict()
+
+const pageSurface = z.object({
+  type:        z.literal('page'),
+  path:        z.string().regex(RE_PAGE_PATH),
+  entry:       entryPath,
+  label:       messageKey.optional(),
+  description: messageKey.optional(),
+  nav:         navSchema.optional(),
+}).strict()
+
+const surface = z.discriminatedUnion('type', [widgetSurface, pageSurface])
+
+const networkRule = z.object({
+  methods: z.array(z.enum(HTTP_METHODS)).min(1),
+  paths:   z.array(z.string().startsWith('/')).min(1),
+  secret:  z.string().regex(/^[A-Z][A-Z0-9_]{2,63}$/).optional(),
+  rate:    z.string().regex(RE_RATE).optional(),
+}).strict()
+
+const storagePermission = z.object({
+  user:           z.string().regex(RE_SIZE).optional(),
+  instance:       z.string().regex(RE_SIZE).optional(),
+  // L'écriture partagée est une capacité distincte de la lecture partagée, et
+  // ne s'obtient jamais par défaut (cf NODYX_SDK_SECURITY.md §4.5).
+  instance_write: z.boolean().optional(),
+}).strict()
+
+const permissions = z.object({
+  identity: z.array(z.enum(IDENTITY_FIELDS)).min(1).optional(),
+  storage:  storagePermission.optional(),
+  core:     z.array(z.enum(CORE_SCOPES)).min(1).optional(),
+  network:  z.record(z.string(), networkRule).optional(),
+}).strict()
+
+const manifestSchema = z.object({
+  api:            z.literal(API_VERSION),
+  id:             z.string().regex(RE_EXTENSION_ID),
+  version:        z.string().regex(RE_SEMVER),
+  nodyx_min:      z.string().regex(RE_SEMVER).optional(),
+  license:        z.string().min(1),
+  author:         z.object({ name: z.string().min(1), url: z.string().url().optional() }).strict().optional(),
+  source:         z.string().url().optional(),
+  default_locale: z.string().regex(RE_LOCALE),
+  label:          messageKey,
+  description:    messageKey,
+  icon:           z.string().refine(isSafePackagePath, 'chemin de paquet invalide').optional(),
+  family:         z.enum(['media', 'gaming', 'community', 'esport', 'social', 'content']).optional(),
+  surfaces:       z.array(surface).min(1),
+  permissions:    permissions.optional(),
+}).strict()
+
+export type ExtensionManifest = z.infer<typeof manifestSchema>
+
+// ── Résultat ──────────────────────────────────────────────────────────────────
+
+export interface ValidationIssue {
+  code:    string
+  path:    string
+  message: string
+}
+
+export type ValidationResult =
+  | { ok: true;  manifest: ExtensionManifest; messageKeys: string[] }
+  | { ok: false; issues: ValidationIssue[] }
+
+/** Toutes les clés de traduction référencées par le manifeste, sans le @. */
+export function collectMessageKeys(m: ExtensionManifest): string[] {
+  const keys = new Set<string>()
+  const add = (v?: string) => { if (v) keys.add(v.slice(1)) }
+  add(m.label); add(m.description)
+  for (const s of m.surfaces) {
+    add(s.label); add(s.description)
+    if (s.type === 'page') { add(s.nav?.label) }
+    if (s.type === 'widget') {
+      for (const f of s.schema ?? []) {
+        add(f.label); add(f.hint); add(f.details)
+        for (const o of f.options ?? []) add(o.label)
+      }
+    }
+  }
+  return [...keys].sort()
+}
+
+// ── Contrôles à message dédié ─────────────────────────────────────────────────
+//
+// Ces cas passeraient dans le filet générique de zod, mais avec un message
+// illisible pour un auteur d'extension. Ils méritent leur propre code, parce
+// que ce sont les erreurs que les gens font vraiment.
+
+function preflight(raw: unknown): ValidationIssue[] {
+  const issues: ValidationIssue[] = []
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return [{ code: 'MANIFEST_NOT_AN_OBJECT', path: '', message: 'le manifeste doit être un objet JSON' }]
+  }
+  const o = raw as Record<string, unknown>
+
+  if (o.api === undefined) {
+    issues.push({
+      code: 'API_VERSION_MISSING', path: 'api',
+      message: `manifeste sans champ "api". Le format antérieur (Web Component, customElements.define) n'est pas supporté : voir le guide de migration, SPECS/NODYX_SDK_REFERENCE.md §16`,
+    })
+  } else if (o.api !== API_VERSION) {
+    issues.push({
+      code: 'API_VERSION_UNSUPPORTED', path: 'api',
+      message: `cette instance implémente api ${API_VERSION}, le manifeste demande ${JSON.stringify(o.api)}`,
+    })
+  }
+
+  if (typeof o.id === 'string' && isReservedExtensionId(o.id)) {
+    issues.push({
+      code: 'RESERVED_ID', path: 'id',
+      message: `"${o.id}" appartient au domaine réservé aux composants livrés avec Nodyx`,
+    })
+  }
+
+  // `checkbox` était toléré par l'ancien catalogue, le SDK v1 impose `boolean`.
+  for (const [si, s] of (Array.isArray(o.surfaces) ? o.surfaces : []).entries()) {
+    const sch = (s as Record<string, unknown>)?.schema
+    for (const [fi, f] of (Array.isArray(sch) ? sch : []).entries()) {
+      if ((f as Record<string, unknown>)?.type === 'checkbox') {
+        issues.push({
+          code: 'FIELD_TYPE_CHECKBOX', path: `surfaces[${si}].schema[${fi}].type`,
+          message: 'le type "checkbox" n\'existe pas dans le SDK v1, utiliser "boolean"',
+        })
+      }
+    }
+  }
+
+  // Un hôte réseau nu ne dit rien à l'admin : on exige méthodes et chemins.
+  const net = (o.permissions as Record<string, unknown> | undefined)?.network
+  if (net && typeof net === 'object' && !Array.isArray(net)) {
+    for (const [host, rule] of Object.entries(net as Record<string, unknown>)) {
+      if (typeof rule !== 'object' || rule === null || Array.isArray(rule)) {
+        issues.push({
+          code: 'NETWORK_HOST_WITHOUT_RULE', path: `permissions.network.${host}`,
+          message: 'un hôte réseau doit déclarer ses méthodes et ses préfixes de chemin, sinon l\'écran de permissions est illisible',
+        })
+      }
+      if (!isDeclarableHost(host)) {
+        issues.push({
+          code: 'NETWORK_HOST_INVALID', path: `permissions.network.${host}`,
+          message: 'hôte invalide : nom de domaine attendu, sans schéma, sans port, sans chemin, et jamais une adresse IP',
+        })
+      }
+    }
+  }
+
+  return issues
+}
+
+function postflight(m: ExtensionManifest): ValidationIssue[] {
+  const issues: ValidationIssue[] = []
+
+  const widgetIds = new Set<string>()
+  const pagePaths = new Set<string>()
+  for (const [i, s] of m.surfaces.entries()) {
+    if (s.type === 'widget') {
+      if (widgetIds.has(s.id)) {
+        issues.push({ code: 'DUPLICATE_SURFACE_ID', path: `surfaces[${i}].id`, message: `deux surfaces widget portent l'identifiant "${s.id}"` })
+      }
+      widgetIds.add(s.id)
+      const keys = new Set<string>()
+      for (const [j, f] of (s.schema ?? []).entries()) {
+        if (keys.has(f.key)) {
+          issues.push({ code: 'DUPLICATE_FIELD_KEY', path: `surfaces[${i}].schema[${j}].key`, message: `la clé de configuration "${f.key}" est déclarée deux fois` })
+        }
+        keys.add(f.key)
+      }
+    } else {
+      if (pagePaths.has(s.path)) {
+        issues.push({ code: 'DUPLICATE_PAGE_PATH', path: `surfaces[${i}].path`, message: `deux surfaces page portent le chemin "${s.path}"` })
+      }
+      pagePaths.add(s.path)
+    }
+  }
+
+  const st = m.permissions?.storage
+  if (st) {
+    for (const scope of ['user', 'instance'] as const) {
+      const raw = st[scope]
+      if (!raw) continue
+      const bytes = parseSize(raw)
+      if (bytes === null || bytes > STORAGE.maxQuotaBytes) {
+        issues.push({
+          code: 'STORAGE_QUOTA_TOO_LARGE', path: `permissions.storage.${scope}`,
+          message: `quota au dessus du plafond de l'instance (${STORAGE.maxQuotaBytes / 1024 / 1024} Mo)`,
+        })
+      }
+    }
+    if (st.instance_write && !st.instance) {
+      issues.push({
+        code: 'STORAGE_WRITE_WITHOUT_SCOPE', path: 'permissions.storage.instance_write',
+        message: 'l\'écriture partagée exige de déclarer aussi un quota `instance`',
+      })
+    }
+  }
+
+  for (const [host, rule] of Object.entries(m.permissions?.network ?? {})) {
+    if (rule.secret && !rule.methods.length) {
+      issues.push({ code: 'SECRET_WITHOUT_METHOD', path: `permissions.network.${host}.secret`, message: 'un secret exige au moins une méthode déclarée' })
+    }
+  }
+
+  return issues
+}
+
+const ZOD_CODE_MAP: Record<string, string> = {
+  unrecognized_keys: 'UNKNOWN_FIELD',
+  invalid_type:      'INVALID_TYPE',
+  invalid_format:    'INVALID_FORMAT',
+  too_small:         'TOO_SMALL',
+  too_big:           'TOO_BIG',
+  invalid_value:     'INVALID_VALUE',
+  invalid_union:     'INVALID_SURFACE',
+}
+
+/**
+ * Valide un manifeste déjà parsé en JSON.
+ * Ne touche ni au disque ni à la base : le contenu des bundles de traduction
+ * est vérifié à l'étape paquet, avec `messageKeys` comme entrée.
+ */
+export function validateManifest(raw: unknown): ValidationResult {
+  const early = preflight(raw)
+  const parsed = manifestSchema.safeParse(raw)
+
+  if (!parsed.success) {
+    const fromZod = parsed.error.issues.map((i): ValidationIssue => {
+      const custom = (i as { params?: { nodyx?: string } }).params?.nodyx
+      return {
+        code:    custom ?? ZOD_CODE_MAP[i.code] ?? 'INVALID_MANIFEST',
+        path:    i.path.join('.'),
+        message: i.message,
+      }
+    })
+    // Les contrôles dédiés d'abord : ce sont eux qui expliquent vraiment.
+    const seen = new Set(early.map(e => e.code + '|' + e.path))
+    return { ok: false, issues: [...early, ...fromZod.filter(i => !seen.has(i.code + '|' + i.path))] }
+  }
+
+  const late = [...early, ...postflight(parsed.data)]
+  if (late.length) return { ok: false, issues: late }
+
+  return { ok: true, manifest: parsed.data, messageKeys: collectMessageKeys(parsed.data) }
+}

--- a/nodyx-core/src/extensions/package.ts
+++ b/nodyx-core/src/extensions/package.ts
@@ -1,0 +1,205 @@
+// Lecture et vérification d'un paquet d'extension .nyx (une archive zip).
+//
+// Ce module ne touche PAS au disque : il travaille sur un tampon et rend un
+// paquet vérifié en mémoire. L'écriture appartient à l'installateur, qui n'a
+// plus qu'à poser des fichiers déjà jugés sûrs.
+//
+// Toutes les défenses d'extraction vivent ici, et pas ailleurs :
+// zip slip, chemin absolu, lien symbolique, plafonds de taille et de nombre,
+// ratio de décompression, liste blanche d'extensions, assainissement SVG.
+// cf NODYX_SDK_SECURITY.md §4.6 et §4.7
+
+import AdmZip from 'adm-zip'
+import path from 'path'
+import { PACKAGE } from './limits'
+import { validateManifest, isSafePackagePath, type ExtensionManifest, type ValidationIssue } from './manifest'
+import { sanitizeSvg, SvgRejected } from './svg'
+
+export interface PackageFile {
+  /** Chemin relatif normalisé, séparateurs en barre oblique. */
+  path:    string
+  content: Buffer
+}
+
+export interface ExtensionPackage {
+  manifest:            ExtensionManifest
+  files:               PackageFile[]
+  /** Locale -> dictionnaire plat. */
+  messages:            Record<string, Record<string, string>>
+  privateNetworkHosts: string[]
+  /** Éléments retirés d'un SVG, par chemin de fichier. */
+  sanitized:           Record<string, string[]>
+}
+
+export type PackageResult =
+  | { ok: true;  pkg: ExtensionPackage }
+  | { ok: false; issues: ValidationIssue[] }
+
+const fail = (code: string, message: string, p = ''): ValidationIssue => ({ code, path: p, message })
+
+/** Le mode POSIX d'une entrée zip vit dans les 16 bits de poids fort. */
+function isSymlink(entry: AdmZip.IZipEntry): boolean {
+  const mode = (entry.header.attr >>> 16) & 0xf000
+  return mode === 0xa000
+}
+
+function depthOf(p: string): number {
+  return p.split('/').length - 1
+}
+
+export function readExtensionPackage(archive: Buffer): PackageResult {
+  const issues: ValidationIssue[] = []
+
+  if (archive.length > PACKAGE.maxArchiveBytes) {
+    return { ok: false, issues: [fail('ARCHIVE_TOO_LARGE', `archive au dessus du plafond de ${PACKAGE.maxArchiveBytes / 1024 / 1024} Mo`)] }
+  }
+
+  let zip: AdmZip
+  let entries: AdmZip.IZipEntry[]
+  try {
+    zip = new AdmZip(archive)
+    entries = zip.getEntries()
+  } catch {
+    return { ok: false, issues: [fail('ARCHIVE_UNREADABLE', 'archive illisible, ce n\'est pas un zip valide')] }
+  }
+
+  const files: PackageFile[] = []
+  let unpacked = 0
+  let fileCount = 0
+
+  for (const entry of entries) {
+    const raw = entry.entryName
+
+    // Le lien symbolique se refuse AVANT toute lecture : c'est une évasion,
+    // pas un fichier. Un lien vers /etc/passwd ressemble à un .json innocent.
+    if (isSymlink(entry)) {
+      issues.push(fail('SYMLINK_REFUSED', 'lien symbolique refusé', raw))
+      continue
+    }
+    if (entry.isDirectory) continue
+
+    const normalized = raw.replace(/\\/g, '/')
+    if (!isSafePackagePath(normalized)) {
+      issues.push(fail('UNSAFE_PATH', 'chemin absolu, remontant, ou porteur de caractères refusés', raw))
+      continue
+    }
+    if (depthOf(normalized) > PACKAGE.maxDepth) {
+      issues.push(fail('PATH_TOO_DEEP', `arborescence au delà de ${PACKAGE.maxDepth} niveaux`, raw))
+      continue
+    }
+
+    const ext = path.extname(normalized).toLowerCase()
+    if (!(PACKAGE.allowedExtensions as readonly string[]).includes(ext)) continue   // ignoré, pas fatal
+
+    if (++fileCount > PACKAGE.maxFiles) {
+      issues.push(fail('TOO_MANY_FILES', `plus de ${PACKAGE.maxFiles} fichiers dans l'archive`))
+      break
+    }
+
+    const declared = entry.header.size
+    if (declared > PACKAGE.maxFileBytes) {
+      issues.push(fail('FILE_TOO_LARGE', `fichier au dessus du plafond de ${PACKAGE.maxFileBytes / 1024 / 1024} Mo`, raw))
+      continue
+    }
+
+    // Bombe de décompression : on juge sur la taille DÉCLARÉE avant de
+    // décompresser, sinon la défense arrive après le dégât.
+    const compressed = entry.header.compressedSize || 1
+    if (declared / compressed > PACKAGE.maxCompressionRatio && declared > 64 * 1024) {
+      issues.push(fail('COMPRESSION_RATIO', 'ratio de décompression anormal, archive refusée', raw))
+      continue
+    }
+
+    unpacked += declared
+    if (unpacked > PACKAGE.maxUnpackedBytes) {
+      issues.push(fail('UNPACKED_TOO_LARGE', `contenu décompressé au dessus du plafond de ${PACKAGE.maxUnpackedBytes / 1024 / 1024} Mo`))
+      break
+    }
+
+    files.push({ path: normalized, content: entry.getData() })
+  }
+
+  if (issues.length) return { ok: false, issues }
+
+  const byPath = new Map(files.map(f => [f.path, f]))
+
+  // ── Manifeste ───────────────────────────────────────────────────────────
+  const manifestFile = byPath.get('manifest.json')
+  if (!manifestFile) {
+    return { ok: false, issues: [fail('MANIFEST_MISSING', 'manifest.json absent de la racine de l\'archive. Piège classique : les fichiers sont dans un sous-dossier, il faut zipper le CONTENU du dossier, pas le dossier')] }
+  }
+
+  let rawManifest: unknown
+  try {
+    rawManifest = JSON.parse(manifestFile.content.toString('utf8'))
+  } catch (e) {
+    return { ok: false, issues: [fail('MANIFEST_MALFORMED', 'manifest.json n\'est pas du JSON valide : ' + (e as Error).message, 'manifest.json')] }
+  }
+
+  const validated = validateManifest(rawManifest)
+  if (!validated.ok) return { ok: false, issues: validated.issues }
+  const { manifest, messageKeys, privateNetworkHosts } = validated
+
+  // ── Points d'entrée et icône ────────────────────────────────────────────
+  for (const [i, s] of manifest.surfaces.entries()) {
+    if (!byPath.has(s.entry)) {
+      issues.push(fail('ENTRY_MISSING', `le point d'entrée "${s.entry}" est déclaré mais absent de l'archive`, `surfaces[${i}].entry`))
+    }
+  }
+  if (manifest.icon && !byPath.has(manifest.icon)) {
+    issues.push(fail('ICON_MISSING', `l'icône "${manifest.icon}" est déclarée mais absente de l'archive`, 'icon'))
+  }
+
+  // ── Traductions ─────────────────────────────────────────────────────────
+  const messages: Record<string, Record<string, string>> = {}
+  for (const f of files) {
+    const m = /^i18n\/([a-z]{2}(?:-[A-Za-z]{2})?)\.json$/.exec(f.path)
+    if (!m) continue
+    try {
+      const parsed = JSON.parse(f.content.toString('utf8'))
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        issues.push(fail('BUNDLE_MALFORMED', 'un dictionnaire de traduction doit être un objet plat', f.path))
+        continue
+      }
+      const flat: Record<string, string> = {}
+      for (const [k, v] of Object.entries(parsed)) {
+        if (typeof v !== 'string') {
+          issues.push(fail('BUNDLE_NOT_FLAT', `la clé "${k}" ne vaut pas une chaîne. Les dictionnaires sont plats, les clés portent des points`, f.path))
+          continue
+        }
+        flat[k] = v
+      }
+      messages[m[1]] = flat
+    } catch (e) {
+      issues.push(fail('BUNDLE_MALFORMED', 'JSON invalide : ' + (e as Error).message, f.path))
+    }
+  }
+
+  const source = messages[manifest.default_locale]
+  if (!source) {
+    issues.push(fail('DEFAULT_BUNDLE_MISSING', `default_locale vaut "${manifest.default_locale}" mais i18n/${manifest.default_locale}.json est absent`, 'default_locale'))
+  } else {
+    const missing = messageKeys.filter(k => !(k in source))
+    if (missing.length) {
+      issues.push(fail('MESSAGE_KEY_MISSING', `le manifeste référence des clés absentes de i18n/${manifest.default_locale}.json : ${missing.slice(0, 8).join(', ')}${missing.length > 8 ? `, et ${missing.length - 8} autres` : ''}`, 'i18n'))
+    }
+  }
+
+  // ── SVG ─────────────────────────────────────────────────────────────────
+  const sanitized: Record<string, string[]> = {}
+  for (const f of files) {
+    if (!f.path.endsWith('.svg')) continue
+    try {
+      const { svg, stripped } = sanitizeSvg(f.content.toString('utf8'))
+      f.content = Buffer.from(svg, 'utf8')
+      if (stripped.length) sanitized[f.path] = stripped
+    } catch (e) {
+      const why = e instanceof SvgRejected ? e.reason : 'SVG illisible'
+      issues.push(fail('SVG_REJECTED', why, f.path))
+    }
+  }
+
+  if (issues.length) return { ok: false, issues }
+
+  return { ok: true, pkg: { manifest, files, messages, privateNetworkHosts, sanitized } }
+}

--- a/nodyx-core/src/extensions/reserved.ts
+++ b/nodyx-core/src/extensions/reserved.ts
@@ -1,0 +1,32 @@
+// Identifiants réservés au domaine natif.
+//
+// Une extension portant l'un de ces identifiants est REFUSÉE à l'installation.
+// Ce n'est pas « le natif gagne à l'affichage » (comportement actuel de
+// catalog.ts, qui masque la collision sans l'empêcher) : c'est un refus net,
+// pour qu'un widget installé ne puisse jamais prendre l'identité d'un widget
+// livré avec Nodyx.
+//
+// Miroir de PLUGIN_REGISTRY côté frontend
+// (nodyx-frontend/src/lib/components/homepage/plugins/index.ts).
+// Toute addition là bas doit être répercutée ici.
+
+export const RESERVED_EXTENSION_IDS: ReadonlySet<string> = new Set([
+  'hero-banner',
+  'header',
+  'stats-bar',
+  'join-card',
+  'announcement-banner',
+  'article-slideshow',
+  'articles-showcase',
+  'recent-threads',
+  'social-links-bar',
+  'twitch-stream',
+  // Préfixes de service, réservés pour éviter toute confusion d'origine
+  'nodyx',
+  'core',
+  'admin',
+])
+
+export function isReservedExtensionId(id: string): boolean {
+  return RESERVED_EXTENSION_IDS.has(id) || id.startsWith('nodyx-')
+}

--- a/nodyx-core/src/extensions/svg.ts
+++ b/nodyx-core/src/extensions/svg.ts
@@ -1,0 +1,84 @@
+// Assainissement des SVG livrés par une extension.
+//
+// Pourquoi ce module existe : l'icône et l'aperçu d'une extension sont
+// affichés par la page d'administration et par le magasin, donc HORS du bac à
+// sable, sur l'origine principale. Un SVG n'est pas une image : il peut porter
+// <script>, des attributs on*, des <foreignObject>, des références externes.
+// Sans traitement, l'icône d'une extension devient une XSS sur la page
+// d'administration, indépendamment de toute l'isolation de la frame.
+// cf NODYX_SDK_SECURITY.md §4.7
+
+import sanitizeHtml from 'sanitize-html'
+
+/** Sous-ensemble SVG considéré comme sûr : du dessin, rien d'exécutable. */
+const ALLOWED_TAGS = [
+  'svg', 'g', 'defs', 'title', 'desc', 'symbol', 'use',
+  'path', 'rect', 'circle', 'ellipse', 'line', 'polyline', 'polygon',
+  'linearGradient', 'radialGradient', 'stop', 'clipPath', 'mask', 'pattern',
+  'text', 'tspan',
+]
+
+const ALLOWED_ATTRS = [
+  'viewBox', 'xmlns', 'width', 'height', 'fill', 'fill-rule', 'fill-opacity',
+  'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin', 'stroke-dasharray',
+  'stroke-opacity', 'opacity', 'transform', 'd', 'x', 'y', 'x1', 'y1', 'x2', 'y2',
+  'cx', 'cy', 'r', 'rx', 'ry', 'points', 'offset', 'stop-color', 'stop-opacity',
+  'gradientUnits', 'gradientTransform', 'clip-path', 'mask', 'id', 'class', 'style',
+  'font-family', 'font-size', 'font-weight', 'text-anchor', 'dominant-baseline',
+  'preserveAspectRatio',
+]
+
+export interface SvgSanitizeResult {
+  /** Le SVG réécrit, sûr à servir. */
+  svg:      string
+  /** Ce qui a été retiré, pour le dire à l'auteur plutôt que de le taire. */
+  stripped: string[]
+}
+
+export class SvgRejected extends Error {
+  constructor(public readonly reason: string) {
+    super(reason)
+    this.name = 'SvgRejected'
+  }
+}
+
+/**
+ * Réécrit un SVG vers un sous-ensemble sûr.
+ *
+ * Lève `SvgRejected` si le fichier ne survit pas : on ne sert jamais un SVG
+ * silencieusement vidé de sa substance, l'auteur doit savoir que son icône est
+ * refusée plutôt que découvrir un carré blanc en production.
+ */
+export function sanitizeSvg(raw: string): SvgSanitizeResult {
+  if (!/<svg[\s>]/i.test(raw)) throw new SvgRejected('ce fichier ne contient pas de balise <svg>')
+
+  const stripped: string[] = []
+  const note = (what: string) => { if (!stripped.includes(what)) stripped.push(what) }
+
+  // Repérage AVANT nettoyage : on veut nommer ce qui a été retiré.
+  if (/<script[\s>]/i.test(raw))             note('<script>')
+  if (/<foreignObject[\s>]/i.test(raw))      note('<foreignObject>')
+  if (/\son[a-z]+\s*=/i.test(raw))           note('attributs de gestionnaire on*')
+  if (/(href|xlink:href)\s*=\s*["']?\s*(https?:|\/\/)/i.test(raw)) note('références externes')
+  if (/javascript:/i.test(raw))              note('URL javascript:')
+  if (/<(iframe|object|embed|animate|set)[\s>]/i.test(raw))        note('éléments actifs')
+
+  const svg = sanitizeHtml(raw, {
+    allowedTags:       ALLOWED_TAGS,
+    allowedAttributes: { '*': ALLOWED_ATTRS },
+    // Aucun schéma d'URL n'est autorisé : un SVG d'icône n'a rien à aller
+    // chercher ailleurs, et une référence externe est un traceur.
+    allowedSchemes:    [],
+    parser:            { lowerCaseTags: false, lowerCaseAttributeNames: false },
+    disallowedTagsMode: 'discard',
+  }).trim()
+
+  if (!/<svg[\s>]/i.test(svg))  throw new SvgRejected('le fichier ne survit pas à l\'assainissement, la racine <svg> a disparu')
+  if (!/<\/svg>/i.test(svg))    throw new SvgRejected('SVG malformé, balise racine non fermée')
+
+  // Un SVG réduit à sa racine ne dessine plus rien : autant le dire.
+  const hasDrawing = /<(path|rect|circle|ellipse|line|polyline|polygon|text|use|g)[\s>]/i.test(svg)
+  if (!hasDrawing) throw new SvgRejected('le fichier ne survit pas à l\'assainissement, il ne reste aucun élément de dessin')
+
+  return { svg, stripped }
+}

--- a/nodyx-core/src/extensions/token.ts
+++ b/nodyx-core/src/extensions/token.ts
@@ -1,0 +1,148 @@
+// Jeton d'extension : la seule identité acceptée par les routes /extensions/*.
+//
+// Une frame d'extension vit dans une origine opaque. Son `Origin` vaut donc
+// `null`, et n'importe qui peut produire ça : ce n'est PAS une
+// authentification. L'identité vient de ce jeton, et de lui seul.
+// cf NODYX_SDK_SECURITY.md §4.3
+//
+// Chaque claim ferme un rejeu précis. Un jeton frappé pour une extension, une
+// surface, un utilisateur et une instance ne vaut nulle part ailleurs.
+
+import jwt from 'jsonwebtoken'
+import { createHmac } from 'crypto'
+import { SURFACE } from './limits'
+
+export interface ExtensionTokenClaims {
+  /** Origine de l'instance émettrice. */
+  iss: string
+  /** Toujours `nodyx-extension` : un jeton utilisateur ne peut pas s'y substituer. */
+  aud: 'nodyx-extension'
+  /** Instance : un jeton ne traverse pas d'une instance à l'autre. */
+  ins: string
+  /** Extension destinataire. */
+  ext: string
+  /** Surface destinataire, `page` ou `widget:<id>`. */
+  sur: string
+  /** Utilisateur, ou null pour un visiteur. */
+  sub: string | null
+  /** Permissions ACCORDÉES par l'admin, pas celles demandées au manifeste. */
+  prm: string[]
+  jti: string
+  iat: number
+  exp: number
+}
+
+export interface MintInput {
+  issuer:      string
+  instanceId:  string
+  extensionId: string
+  surface:     string
+  userId:      string | null
+  permissions: string[]
+  jti:         string
+  ttlSeconds?: number
+}
+
+export interface ExpectedAudience {
+  instanceId:  string
+  extensionId: string
+  surface:     string
+}
+
+export type VerifyResult =
+  | { ok: true;  claims: ExtensionTokenClaims }
+  | { ok: false; code: VerifyErrorCode; message: string }
+
+export type VerifyErrorCode =
+  | 'TOKEN_INVALID'
+  | 'SESSION_EXPIRED'
+  | 'TOKEN_WRONG_AUDIENCE'
+  | 'TOKEN_WRONG_INSTANCE'
+  | 'TOKEN_WRONG_EXTENSION'
+  | 'TOKEN_WRONG_SURFACE'
+  | 'TOKEN_REVOKED'
+
+/**
+ * Secret dédié, dérivé du secret applicatif.
+ *
+ * Le claim `aud` suffirait en théorie à séparer les deux familles de jetons.
+ * On dérive quand même une clé distincte : ainsi un jeton de session
+ * d'utilisateur ne peut pas valider ici, et un jeton d'extension ne peut pas
+ * valider ailleurs, même si un jour quelqu'un oublie de vérifier `aud`. Une
+ * frontière qui tient sans dépendre d'un contrôle applicatif vaut mieux qu'une
+ * frontière qui en dépend.
+ */
+export function deriveExtensionSecret(appSecret: string): string {
+  return createHmac('sha256', appSecret).update('nodyx-extension-token-v1').digest('hex')
+}
+
+export function mintExtensionToken(input: MintInput, appSecret: string): string {
+  const now = Math.floor(Date.now() / 1000)
+  const ttl = input.ttlSeconds ?? SURFACE.tokenTtlSeconds
+  const claims: ExtensionTokenClaims = {
+    iss: input.issuer,
+    aud: 'nodyx-extension',
+    ins: input.instanceId,
+    ext: input.extensionId,
+    sur: input.surface,
+    sub: input.userId,
+    prm: [...input.permissions].sort(),
+    jti: input.jti,
+    iat: now,
+    exp: now + ttl,
+  }
+  // Pas de `noTimestamp` : l'option supprimerait le `iat` que l'on pose ici.
+  return jwt.sign(claims, deriveExtensionSecret(appSecret), { algorithm: 'HS256' })
+}
+
+/**
+ * Vérifie un jeton CONTRE la cible réellement appelée.
+ *
+ * `expected` n'est pas décoratif : sans lui, un jeton légitime obtenu pour un
+ * widget servirait à appeler au nom d'une page, ou d'une autre extension. La
+ * vérification cryptographique dit seulement que nous avons émis ce jeton,
+ * pas qu'il vaut pour cet appel là.
+ */
+export function verifyExtensionToken(
+  token: string,
+  expected: ExpectedAudience,
+  appSecret: string,
+  isRevoked?: (jti: string) => boolean,
+): VerifyResult {
+  let claims: ExtensionTokenClaims
+  try {
+    claims = jwt.verify(token, deriveExtensionSecret(appSecret), {
+      algorithms: ['HS256'],          // jamais `none`, jamais de négociation
+      audience:   'nodyx-extension',
+    }) as ExtensionTokenClaims
+  } catch (e) {
+    const name = (e as Error).name
+    if (name === 'TokenExpiredError') {
+      return { ok: false, code: 'SESSION_EXPIRED', message: 'jeton d\'extension expiré' }
+    }
+    if (name === 'JsonWebTokenError' && /audience/i.test((e as Error).message)) {
+      return { ok: false, code: 'TOKEN_WRONG_AUDIENCE', message: 'ce jeton n\'est pas un jeton d\'extension' }
+    }
+    return { ok: false, code: 'TOKEN_INVALID', message: 'jeton d\'extension invalide' }
+  }
+
+  if (claims.ins !== expected.instanceId) {
+    return { ok: false, code: 'TOKEN_WRONG_INSTANCE', message: 'jeton émis pour une autre instance' }
+  }
+  if (claims.ext !== expected.extensionId) {
+    return { ok: false, code: 'TOKEN_WRONG_EXTENSION', message: 'jeton émis pour une autre extension' }
+  }
+  if (claims.sur !== expected.surface) {
+    return { ok: false, code: 'TOKEN_WRONG_SURFACE', message: 'jeton émis pour une autre surface' }
+  }
+  if (isRevoked?.(claims.jti)) {
+    return { ok: false, code: 'TOKEN_REVOKED', message: 'jeton révoqué : extension désactivée, désinstallée, ou permission retirée' }
+  }
+
+  return { ok: true, claims }
+}
+
+/** L'extension détient elle cette capacité, telle qu'accordée par l'admin ? */
+export function tokenGrants(claims: ExtensionTokenClaims, capability: string): boolean {
+  return claims.prm.includes(capability)
+}

--- a/nodyx-core/src/tests/extensionManifest.test.ts
+++ b/nodyx-core/src/tests/extensionManifest.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateManifest, collectMessageKeys, parseSize, isSafePackagePath,
+  type ExtensionManifest,
+} from '../extensions/manifest'
+
+// Manifeste minimal valide : le socle de tous les cas négatifs ci dessous.
+function base(): Record<string, unknown> {
+  return {
+    api: 1,
+    id: 'my-widget',
+    version: '1.0.0',
+    license: 'MIT',
+    default_locale: 'en',
+    label: '@label',
+    description: '@description',
+    surfaces: [
+      { type: 'widget', id: 'main', entry: 'ui/widget.js', label: '@label' },
+    ],
+  }
+}
+
+function issues(raw: unknown): string[] {
+  const r = validateManifest(raw)
+  return r.ok ? [] : r.issues.map(i => i.code)
+}
+
+describe('validateManifest, cas nominal', () => {
+  it('accepte le manifeste minimal', () => {
+    const r = validateManifest(base())
+    expect(r.ok).toBe(true)
+  })
+
+  it('accepte un manifeste complet, deux surfaces et toutes les permissions', () => {
+    const m = {
+      ...base(),
+      id: 'library',
+      nodyx_min: '2.13.0',
+      author: { name: 'Nodyx', url: 'https://nodyx.org' },
+      source: 'https://github.com/Pokled/nodyx',
+      icon: 'icon.svg',
+      family: 'content',
+      surfaces: [
+        {
+          type: 'page', path: 'library', entry: 'ui/page.js',
+          nav: { label: '@nav.label', icon: 'twemoji:clapper-board', position: 'main' },
+        },
+        {
+          type: 'widget', id: 'tonight', entry: 'ui/tonight.js', label: '@widget.tonight',
+          default_height: 320,
+          schema: [
+            { key: 'mood', type: 'select', label: '@field.mood', options: [{ value: 'learn', label: '@mood.learn' }] },
+            { key: 'compact', type: 'boolean', label: '@field.compact', default: true },
+          ],
+        },
+      ],
+      permissions: {
+        identity: ['id', 'username'],
+        storage: { user: '1mb', instance: '8mb', instance_write: true },
+        core: ['members:read'],
+        network: {
+          'api.themoviedb.org': { methods: ['GET'], paths: ['/3/movie/*'], secret: 'TMDB_API_KEY', rate: '60/min' },
+        },
+      },
+    }
+    const r = validateManifest(m)
+    if (!r.ok) throw new Error('refusé à tort : ' + JSON.stringify(r.issues, null, 2))
+    expect(r.manifest.id).toBe('library')
+  })
+})
+
+describe('rupture avec le format antérieur', () => {
+  it('refuse un manifeste sans api, avec un code dédié', () => {
+    const { api, ...noApi } = base()
+    expect(issues(noApi)).toContain('API_VERSION_MISSING')
+  })
+
+  it('refuse une version d api que cette instance n implémente pas', () => {
+    expect(issues({ ...base(), api: 2 })).toContain('API_VERSION_UNSUPPORTED')
+  })
+
+  it('refuse le type de champ checkbox et nomme le remplacement', () => {
+    const m = base()
+    ;(m.surfaces as Record<string, unknown>[])[0].schema = [{ key: 'on', type: 'checkbox', label: '@f' }]
+    const r = validateManifest(m)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    const issue = r.issues.find(i => i.code === 'FIELD_TYPE_CHECKBOX')
+    expect(issue).toBeDefined()
+    expect(issue!.message).toContain('boolean')
+  })
+})
+
+describe('domaine réservé', () => {
+  it.each(['hero-banner', 'twitch-stream', 'stats-bar', 'nodyx', 'nodyx-quoi-que-ce-soit'])(
+    'refuse l identifiant réservé %s', (id) => {
+      expect(issues({ ...base(), id })).toContain('RESERVED_ID')
+    })
+
+  it('laisse passer video-player, qui reste une extension', () => {
+    // D7 révisé le 2026-08-14 : le lecteur est l'exemple de référence du SDK,
+    // il n'est pas passé natif, donc son identifiant n'est PAS réservé.
+    const r = validateManifest({ ...base(), id: 'video-player' })
+    expect(r.ok).toBe(true)
+  })
+})
+
+describe('rien n est nettoyé en silence', () => {
+  it('refuse un champ racine inconnu', () => {
+    expect(issues({ ...base(), permision: {} })).toContain('UNKNOWN_FIELD')
+  })
+
+  it('refuse une permission inconnue plutôt que de l ignorer', () => {
+    expect(issues({ ...base(), permissions: { filesystem: true } })).toContain('UNKNOWN_FIELD')
+  })
+
+  it('refuse une portée core hors de la liste', () => {
+    expect(issues({ ...base(), permissions: { core: ['members:write'] } }).length).toBeGreaterThan(0)
+  })
+
+  it('refuse un champ de surface inconnu', () => {
+    const m = base()
+    ;(m.surfaces as Record<string, unknown>[])[0].height = 300
+    expect(issues(m).length).toBeGreaterThan(0)
+  })
+})
+
+describe('identité et forme', () => {
+  it.each(['A-widget', 'ab', 'my_widget', '1widget', 'x'.repeat(40)])('refuse l identifiant %s', (id) => {
+    expect(issues({ ...base(), id })).not.toHaveLength(0)
+  })
+
+  it.each(['1.0', 'v1.0.0', '1.0.0-beta'])('refuse la version %s', (version) => {
+    expect(issues({ ...base(), version })).not.toHaveLength(0)
+  })
+
+  it('exige une licence', () => {
+    const { license, ...noLicense } = base()
+    expect(issues(noLicense).length).toBeGreaterThan(0)
+  })
+
+  it('exige au moins une surface', () => {
+    expect(issues({ ...base(), surfaces: [] }).length).toBeGreaterThan(0)
+  })
+})
+
+describe('i18n : toute chaîne visible est une clé', () => {
+  it('refuse un libellé écrit en dur', () => {
+    expect(issues({ ...base(), label: 'Mon widget' }).length).toBeGreaterThan(0)
+  })
+
+  it('refuse un libellé de champ écrit en dur', () => {
+    const m = base()
+    ;(m.surfaces as Record<string, unknown>[])[0].schema = [{ key: 'a', type: 'text', label: 'Titre' }]
+    expect(issues(m).length).toBeGreaterThan(0)
+  })
+
+  it('exige une locale par défaut bien formée', () => {
+    expect(issues({ ...base(), default_locale: 'anglais' }).length).toBeGreaterThan(0)
+  })
+
+  it('collecte toutes les clés référencées, sans le @, dédoublonnées et triées', () => {
+    const m = base()
+    ;(m.surfaces as Record<string, unknown>[])[0].schema = [
+      { key: 'mood', type: 'select', label: '@field.mood', hint: '@field.mood.hint', options: [{ value: 'a', label: '@mood.a' }] },
+    ]
+    const r = validateManifest(m)
+    if (!r.ok) throw new Error('refusé à tort')
+    expect(r.messageKeys).toEqual(['description', 'field.mood', 'field.mood.hint', 'label', 'mood.a'])
+  })
+})
+
+describe('surfaces', () => {
+  it('refuse un widget sans identifiant', () => {
+    expect(issues({ ...base(), surfaces: [{ type: 'widget', entry: 'ui/w.js', label: '@l' }] }).length).toBeGreaterThan(0)
+  })
+
+  it('refuse une page sans chemin', () => {
+    expect(issues({ ...base(), surfaces: [{ type: 'page', entry: 'ui/p.js' }] }).length).toBeGreaterThan(0)
+  })
+
+  it('refuse un schéma de configuration sur une page', () => {
+    expect(issues({ ...base(), surfaces: [{ type: 'page', path: 'x', entry: 'ui/p.js', schema: [] }] }).length).toBeGreaterThan(0)
+  })
+
+  it('refuse deux widgets de même identifiant', () => {
+    const s = { type: 'widget', id: 'main', entry: 'ui/w.js', label: '@l' }
+    expect(issues({ ...base(), surfaces: [s, { ...s }] })).toContain('DUPLICATE_SURFACE_ID')
+  })
+
+  it('refuse deux clés de configuration identiques', () => {
+    const m = base()
+    ;(m.surfaces as Record<string, unknown>[])[0].schema = [
+      { key: 'a', type: 'text', label: '@a' },
+      { key: 'a', type: 'text', label: '@b' },
+    ]
+    expect(issues(m)).toContain('DUPLICATE_FIELD_KEY')
+  })
+
+  it('refuse un select sans options', () => {
+    const m = base()
+    ;(m.surfaces as Record<string, unknown>[])[0].schema = [{ key: 'a', type: 'select', label: '@a' }]
+    expect(issues(m)).toContain('SELECT_WITHOUT_OPTIONS')
+  })
+})
+
+describe('points d entrée, aucune remontée de chemin', () => {
+  it.each([
+    '../../etc/passwd.js',
+    '/absolute/widget.js',
+    'ui\\widget.js',
+    'ui/../../escape.js',
+    'ui/widget.mjs',
+    'widget.js.png',
+  ])('refuse le point d entrée %s', (entry) => {
+    expect(issues({ ...base(), surfaces: [{ type: 'widget', id: 'a', entry, label: '@l' }] }).length).toBeGreaterThan(0)
+  })
+
+  it('accepte un point d entrée sain', () => {
+    expect(validateManifest({ ...base(), surfaces: [{ type: 'widget', id: 'a', entry: 'ui/widget.js', label: '@l' }] }).ok).toBe(true)
+  })
+})
+
+describe('permissions réseau', () => {
+  it('refuse un hôte nu, sans méthodes ni chemins', () => {
+    expect(issues({ ...base(), permissions: { network: { 'api.example.com': true } } })).toContain('NETWORK_HOST_WITHOUT_RULE')
+  })
+
+  it('refuse une liste d hôtes, forme de l ancien format', () => {
+    expect(issues({ ...base(), permissions: { network: ['api.example.com'] } }).length).toBeGreaterThan(0)
+  })
+
+  it.each([
+    'https://api.example.com',
+    'api.example.com:8443',
+    'api.example.com/v1',
+    '127.0.0.1',
+  ])('refuse l hôte %s', (host) => {
+    expect(issues({ ...base(), permissions: { network: { [host]: { methods: ['GET'], paths: ['/'] } } } })).toContain('NETWORK_HOST_INVALID')
+  })
+
+  it('refuse une méthode inconnue', () => {
+    expect(issues({ ...base(), permissions: { network: { 'a.example.com': { methods: ['FETCH'], paths: ['/'] } } } }).length).toBeGreaterThan(0)
+  })
+
+  it('refuse un chemin qui ne commence pas par une barre', () => {
+    expect(issues({ ...base(), permissions: { network: { 'a.example.com': { methods: ['GET'], paths: ['v1/x'] } } } }).length).toBeGreaterThan(0)
+  })
+})
+
+describe('permissions de stockage', () => {
+  it('refuse un quota au dessus du plafond de l instance', () => {
+    expect(issues({ ...base(), permissions: { storage: { user: '999mb' } } })).toContain('STORAGE_QUOTA_TOO_LARGE')
+  })
+
+  it('refuse une taille mal formée', () => {
+    expect(issues({ ...base(), permissions: { storage: { user: '1 Mo' } } }).length).toBeGreaterThan(0)
+  })
+
+  it('refuse l écriture partagée sans portée partagée déclarée', () => {
+    expect(issues({ ...base(), permissions: { storage: { user: '1mb', instance_write: true } } })).toContain('STORAGE_WRITE_WITHOUT_SCOPE')
+  })
+})
+
+describe('outils', () => {
+  it('parseSize comprend kb et mb, et refuse le reste', () => {
+    expect(parseSize('512kb')).toBe(524288)
+    expect(parseSize('8mb')).toBe(8388608)
+    expect(parseSize('8 mb')).toBeNull()
+    expect(parseSize('8gb')).toBeNull()
+  })
+
+  it('isSafePackagePath refuse les remontées et les chemins absolus', () => {
+    expect(isSafePackagePath('ui/widget.js')).toBe(true)
+    expect(isSafePackagePath('../x.js')).toBe(false)
+    expect(isSafePackagePath('/x.js')).toBe(false)
+    expect(isSafePackagePath('a/../../b.js')).toBe(false)
+  })
+})
+
+describe('le manifeste n est pas un objet', () => {
+  it.each([null, 42, 'texte', []])('refuse %p', (raw) => {
+    expect(issues(raw)).toContain('MANIFEST_NOT_AN_OBJECT')
+  })
+})
+
+describe('cumul des refus', () => {
+  it('rend plusieurs problèmes d un coup, pour ne pas faire corriger un par un', () => {
+    const r = validateManifest({ api: 1, id: 'A', version: 'x', label: 'dur', surfaces: [] })
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.issues.length).toBeGreaterThan(3)
+  })
+})
+
+describe('typage', () => {
+  it('rend un manifeste typé après validation', () => {
+    const r = validateManifest(base())
+    if (!r.ok) throw new Error('refusé à tort')
+    const m: ExtensionManifest = r.manifest
+    expect(collectMessageKeys(m)).toContain('label')
+  })
+})

--- a/nodyx-core/src/tests/extensionManifest.test.ts
+++ b/nodyx-core/src/tests/extensionManifest.test.ts
@@ -234,9 +234,31 @@ describe('permissions réseau', () => {
     'https://api.example.com',
     'api.example.com:8443',
     'api.example.com/v1',
-    '127.0.0.1',
-  ])('refuse l hôte %s', (host) => {
+    '10.0.0.999',
+  ])('refuse l hôte mal formé %s', (host) => {
     expect(issues({ ...base(), permissions: { network: { [host]: { methods: ['GET'], paths: ['/'] } } } })).toContain('NETWORK_HOST_INVALID')
+  })
+
+  // Une instance peut vivre en intranet, sur un reseau domestique, ou sur une
+  // simple adresse IP sans nom de domaine. On ne ferme pas la porte, on
+  // demande l'accord de l'admin. Seule la machine de l'instance elle meme
+  // reste hors de portee.
+  it.each(['10.0.0.5', '192.168.1.50', '172.16.4.4', '100.64.0.9', 'inventaire.local', 'srv.internal', 'nas.lan'])(
+    'accepte l hôte privé %s, en le signalant a l admin', (host) => {
+      const r = validateManifest({ ...base(), permissions: { network: { [host]: { methods: ['GET'], paths: ['/api'] } } } })
+      if (!r.ok) throw new Error('refusé à tort : ' + JSON.stringify(r.issues))
+      expect(r.privateNetworkHosts).toEqual([host])
+    })
+
+  it.each(['127.0.0.1', '127.1.2.3', 'localhost', 'app.localhost', '169.254.169.254', '0.0.0.0', '224.0.0.1'])(
+    'refuse toujours %s, qui vise la machine de l instance', (host) => {
+      expect(issues({ ...base(), permissions: { network: { [host]: { methods: ['GET'], paths: ['/'] } } } })).toContain('NETWORK_HOST_FORBIDDEN')
+    })
+
+  it('ne signale rien quand tous les hôtes sont publics', () => {
+    const r = validateManifest({ ...base(), permissions: { network: { 'api.themoviedb.org': { methods: ['GET'], paths: ['/3/'] } } } })
+    if (!r.ok) throw new Error('refusé à tort')
+    expect(r.privateNetworkHosts).toEqual([])
   })
 
   it('refuse une méthode inconnue', () => {

--- a/nodyx-core/src/tests/extensionPackage.test.ts
+++ b/nodyx-core/src/tests/extensionPackage.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from 'vitest'
+import AdmZip from 'adm-zip'
+import { readExtensionPackage } from '../extensions/package'
+import { sanitizeSvg, SvgRejected } from '../extensions/svg'
+
+const MANIFEST = {
+  api: 1,
+  id: 'demo-ext',
+  version: '1.0.0',
+  license: 'MIT',
+  default_locale: 'en',
+  label: '@label',
+  description: '@description',
+  surfaces: [{ type: 'widget', id: 'main', entry: 'ui/widget.js', label: '@label' }],
+}
+
+const EN = { label: 'Demo', description: 'A demo extension.' }
+const ICON = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M4 4h16v16H4z"/></svg>'
+
+interface BuildOpts {
+  manifest?: unknown
+  en?: unknown
+  files?: Record<string, string | Buffer>
+  omit?: string[]
+}
+
+function build(opts: BuildOpts = {}): Buffer {
+  const zip = new AdmZip()
+  const put = (p: string, c: string | Buffer) => {
+    if (opts.omit?.includes(p)) return
+    zip.addFile(p, Buffer.isBuffer(c) ? c : Buffer.from(c, 'utf8'))
+  }
+  put('manifest.json', JSON.stringify(opts.manifest ?? MANIFEST, null, 2))
+  put('i18n/en.json',  JSON.stringify(opts.en ?? EN))
+  put('ui/widget.js',  'export function mount({ root, nodyx }) { root.textContent = nodyx.t("label") }')
+  for (const [p, c] of Object.entries(opts.files ?? {})) put(p, c)
+  return zip.toBuffer()
+}
+
+function codes(buf: Buffer): string[] {
+  const r = readExtensionPackage(buf)
+  return r.ok ? [] : r.issues.map(i => i.code)
+}
+
+describe('paquet valide', () => {
+  it('lit un paquet minimal', () => {
+    const r = readExtensionPackage(build())
+    if (!r.ok) throw new Error('refusé à tort : ' + JSON.stringify(r.issues, null, 2))
+    expect(r.pkg.manifest.id).toBe('demo-ext')
+    expect(r.pkg.messages.en.label).toBe('Demo')
+    expect(r.pkg.files.map(f => f.path).sort()).toEqual(['i18n/en.json', 'manifest.json', 'ui/widget.js'])
+  })
+
+  it('ignore un fichier de type non autorisé sans faire échouer l installation', () => {
+    const r = readExtensionPackage(build({ files: { 'notes.txt': 'coucou', 'build.sh': '#!/bin/sh' } }))
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.pkg.files.some(f => f.path.endsWith('.sh') || f.path.endsWith('.txt'))).toBe(false)
+  })
+
+  it('remonte les hôtes privés pour que l admin les voie à part', () => {
+    const m = { ...MANIFEST, permissions: { network: { '10.0.0.5': { methods: ['GET'], paths: ['/api'] } } } }
+    const r = readExtensionPackage(build({ manifest: m }))
+    if (!r.ok) throw new Error('refusé à tort')
+    expect(r.pkg.privateNetworkHosts).toEqual(['10.0.0.5'])
+  })
+})
+
+describe('structure du paquet', () => {
+  it('refuse une archive sans manifeste et explique le piège du sous-dossier', () => {
+    const zip = new AdmZip()
+    zip.addFile('demo-ext/manifest.json', Buffer.from(JSON.stringify(MANIFEST)))
+    const r = readExtensionPackage(zip.toBuffer())
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.issues[0].code).toBe('MANIFEST_MISSING')
+    expect(r.issues[0].message).toContain('sous-dossier')
+  })
+
+  it('refuse un manifeste au JSON malformé', () => {
+    const zip = new AdmZip()
+    zip.addFile('manifest.json', Buffer.from('{ "api": 1, '))
+    expect(codes(zip.toBuffer())).toContain('MANIFEST_MALFORMED')
+  })
+
+  it('refuse ce qui n est pas un zip', () => {
+    expect(codes(Buffer.from('bonjour'))).toContain('ARCHIVE_UNREADABLE')
+  })
+
+  it('refuse un point d entrée déclaré mais absent', () => {
+    expect(codes(build({ omit: ['ui/widget.js'] }))).toContain('ENTRY_MISSING')
+  })
+
+  it('refuse une icône déclarée mais absente', () => {
+    expect(codes(build({ manifest: { ...MANIFEST, icon: 'icon.svg' } }))).toContain('ICON_MISSING')
+  })
+})
+
+describe('défenses d extraction', () => {
+  it('refuse une remontée de chemin, le zip slip', () => {
+    // adm-zip normalise les remontées à l'ajout, donc on force le nom d'entrée
+    // après coup : c'est exactement ce que contient une archive fabriquée pour
+    // sortir du dossier de destination.
+    const zip = new AdmZip()
+    zip.addFile('manifest.json', Buffer.from(JSON.stringify(MANIFEST)))
+    zip.addFile('ui/widget.js', Buffer.from('export function mount() {}'))
+    zip.addFile('placeholder.json', Buffer.from('{}'))
+    zip.getEntries().find(e => e.entryName === 'placeholder.json')!.entryName = '../../../etc/cron.d/pwn.json'
+    expect(codes(zip.toBuffer())).toContain('UNSAFE_PATH')
+  })
+
+  it('refuse un chemin absolu', () => {
+    // adm-zip normalise la barre oblique de tête à l'ajout : on force le nom
+    // d'entrée après coup, comme le ferait une archive fabriquée à la main.
+    const zip = new AdmZip()
+    zip.addFile('manifest.json', Buffer.from(JSON.stringify(MANIFEST)))
+    zip.addFile('ui/widget.js', Buffer.from('export function mount() {}'))
+    zip.addFile('placeholder.json', Buffer.from('{}'))
+    zip.getEntries().find(e => e.entryName === 'placeholder.json')!.entryName = '/etc/passwd.json'
+    expect(codes(zip.toBuffer())).toContain('UNSAFE_PATH')
+  })
+
+  it('refuse un chemin à antislash, remontée à la mode Windows', () => {
+    const zip = new AdmZip()
+    zip.addFile('manifest.json', Buffer.from(JSON.stringify(MANIFEST)))
+    zip.addFile('ui/widget.js', Buffer.from('export function mount() {}'))
+    zip.addFile('placeholder.json', Buffer.from('{}'))
+    zip.getEntries().find(e => e.entryName === 'placeholder.json')!.entryName = '..\\..\\evil.json'
+    expect(codes(zip.toBuffer())).toContain('UNSAFE_PATH')
+  })
+
+  it('refuse un lien symbolique, avant même de le lire', () => {
+    const zip = new AdmZip()
+    zip.addFile('manifest.json', Buffer.from(JSON.stringify(MANIFEST)))
+    zip.addFile('secrets.json', Buffer.from('/etc/shadow'))
+    const entry = zip.getEntries().find(e => e.entryName === 'secrets.json')!
+    entry.header.attr = (0xa1ff << 16) >>> 0            // S_IFLNK
+    expect(codes(zip.toBuffer())).toContain('SYMLINK_REFUSED')
+  })
+
+  it('refuse une arborescence trop profonde', () => {
+    expect(codes(build({ files: { 'a/b/c/d/e/f/g/deep.json': '{}' } }))).toContain('PATH_TOO_DEEP')
+  })
+
+  it('refuse un fichier au dessus du plafond', () => {
+    expect(codes(build({ files: { 'data/big.json': Buffer.alloc(9 * 1024 * 1024, 0x41) } }))).toContain('FILE_TOO_LARGE')
+  })
+
+  it('refuse une bombe de décompression', () => {
+    // 4 Mo de zéros se compressent à quelques kilo-octets : ratio énorme.
+    expect(codes(build({ files: { 'data/bomb.json': Buffer.alloc(4 * 1024 * 1024, 0) } }))).toContain('COMPRESSION_RATIO')
+  })
+})
+
+describe('traductions', () => {
+  it('refuse un paquet sans dictionnaire pour la locale par défaut', () => {
+    expect(codes(build({ omit: ['i18n/en.json'] }))).toContain('DEFAULT_BUNDLE_MISSING')
+  })
+
+  it('refuse une clé référencée par le manifeste mais absente du dictionnaire', () => {
+    const r = readExtensionPackage(build({ en: { label: 'Demo' } }))
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    const issue = r.issues.find(i => i.code === 'MESSAGE_KEY_MISSING')
+    expect(issue).toBeDefined()
+    expect(issue!.message).toContain('description')
+  })
+
+  it('refuse un dictionnaire imbriqué, les clés sont plates', () => {
+    expect(codes(build({ en: { label: 'Demo', description: 'x', nav: { label: 'y' } } }))).toContain('BUNDLE_NOT_FLAT')
+  })
+
+  it('accepte des locales supplémentaires, même incomplètes', () => {
+    const r = readExtensionPackage(build({ files: { 'i18n/fr.json': JSON.stringify({ label: 'Démo' }) } }))
+    if (!r.ok) throw new Error('refusé à tort : ' + JSON.stringify(r.issues))
+    expect(r.pkg.messages.fr.label).toBe('Démo')
+  })
+})
+
+describe('assainissement SVG, la XSS hors du bac à sable', () => {
+  it('conserve un SVG sain tel quel', () => {
+    const { svg, stripped } = sanitizeSvg(ICON)
+    expect(svg).toContain('<path')
+    expect(stripped).toEqual([])
+  })
+
+  it.each([
+    ['<script>', `<svg xmlns="http://www.w3.org/2000/svg"><script>fetch('//evil')</script><path d="M0 0h1v1H0z"/></svg>`],
+    ['attributs de gestionnaire on*', `<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h1v1H0z" onload="alert(1)"/></svg>`],
+    ['<foreignObject>', `<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><body xmlns="http://www.w3.org/1999/xhtml"><img src=x onerror="alert(1)"></body></foreignObject><path d="M0 0h1v1H0z"/></svg>`],
+    ['références externes', `<svg xmlns="http://www.w3.org/2000/svg"><image href="https://evil.example/pixel.png"/><path d="M0 0h1v1H0z"/></svg>`],
+  ])('retire %s et le signale', (label, raw) => {
+    const { svg, stripped } = sanitizeSvg(raw)
+    expect(stripped).toContain(label)
+    expect(svg).not.toMatch(/<script|on[a-z]+\s*=|foreignObject|<image|javascript:/i)
+    // Seule URL tolérée : la déclaration d'espace de noms SVG.
+    for (const url of svg.match(/https?:\/\/[^"']+/gi) ?? []) {
+      expect(url).toBe('http://www.w3.org/2000/svg')
+    }
+    expect(svg).toContain('<path')
+  })
+
+  it('refuse plutôt que de servir un SVG vidé de sa substance', () => {
+    expect(() => sanitizeSvg('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>')).toThrow(SvgRejected)
+  })
+
+  it('refuse un fichier qui n est pas un SVG', () => {
+    expect(() => sanitizeSvg('<html><body>coucou</body></html>')).toThrow(SvgRejected)
+  })
+
+  it('assainit le SVG DANS le paquet, et remonte ce qui a été retiré', () => {
+    const evil = `<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script><path d="M0 0h1v1H0z"/></svg>`
+    const r = readExtensionPackage(build({ manifest: { ...MANIFEST, icon: 'icon.svg' }, files: { 'icon.svg': evil } }))
+    if (!r.ok) throw new Error('refusé à tort : ' + JSON.stringify(r.issues))
+    const icon = r.pkg.files.find(f => f.path === 'icon.svg')!
+    expect(icon.content.toString('utf8')).not.toContain('script')
+    expect(r.pkg.sanitized['icon.svg']).toContain('<script>')
+  })
+
+  it('fait échouer l installation quand un SVG ne survit pas', () => {
+    const dead = `<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>`
+    expect(codes(build({ files: { 'preview.svg': dead } }))).toContain('SVG_REJECTED')
+  })
+})

--- a/nodyx-core/src/tests/extensionToken.test.ts
+++ b/nodyx-core/src/tests/extensionToken.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest'
+import jwt from 'jsonwebtoken'
+import {
+  mintExtensionToken, verifyExtensionToken, deriveExtensionSecret, tokenGrants,
+  type MintInput, type ExpectedAudience,
+} from '../extensions/token'
+
+const SECRET = 'secret-applicatif-de-test'
+
+const MINT: MintInput = {
+  issuer:      'https://instance.example',
+  instanceId:  'inst-1',
+  extensionId: 'library',
+  surface:     'page',
+  userId:      'user-42',
+  permissions: ['storage.user', 'identity'],
+  jti:         'jti-1',
+}
+
+const EXPECTED: ExpectedAudience = { instanceId: 'inst-1', extensionId: 'library', surface: 'page' }
+
+function ok(token: string, expected = EXPECTED, revoked?: (j: string) => boolean) {
+  return verifyExtensionToken(token, expected, SECRET, revoked)
+}
+
+describe('aller-retour', () => {
+  it('frappe puis vérifie un jeton, en conservant ses claims', () => {
+    const r = ok(mintExtensionToken(MINT, SECRET))
+    if (!r.ok) throw new Error('refusé à tort : ' + r.code)
+    expect(r.claims).toMatchObject({
+      iss: 'https://instance.example',
+      aud: 'nodyx-extension',
+      ins: 'inst-1',
+      ext: 'library',
+      sur: 'page',
+      sub: 'user-42',
+      jti: 'jti-1',
+    })
+    expect(r.claims.exp - r.claims.iat).toBe(600)
+  })
+
+  it('accepte un visiteur, sans utilisateur rattaché', () => {
+    const r = ok(mintExtensionToken({ ...MINT, userId: null }, SECRET))
+    if (!r.ok) throw new Error('refusé à tort')
+    expect(r.claims.sub).toBeNull()
+  })
+
+  it('porte les permissions ACCORDÉES, triées', () => {
+    const r = ok(mintExtensionToken({ ...MINT, permissions: ['identity', 'storage.user', 'core'] }, SECRET))
+    if (!r.ok) throw new Error('refusé à tort')
+    expect(r.claims.prm).toEqual(['core', 'identity', 'storage.user'])
+    expect(tokenGrants(r.claims, 'storage.user')).toBe(true)
+    expect(tokenGrants(r.claims, 'storage.instance.write')).toBe(false)
+  })
+})
+
+describe('rejeu croisé : chaque claim ferme une porte', () => {
+  const token = mintExtensionToken(MINT, SECRET)
+
+  it('refuse le rejeu sur une autre instance', () => {
+    const r = ok(token, { ...EXPECTED, instanceId: 'inst-2' })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('TOKEN_WRONG_INSTANCE')
+  })
+
+  it('refuse le rejeu par une autre extension', () => {
+    const r = ok(token, { ...EXPECTED, extensionId: 'autre-ext' })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('TOKEN_WRONG_EXTENSION')
+  })
+
+  it('refuse le rejeu sur une autre surface de la même extension', () => {
+    const r = ok(token, { ...EXPECTED, surface: 'widget:tonight' })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('TOKEN_WRONG_SURFACE')
+  })
+
+  it('refuse un jeton expiré', () => {
+    const expired = mintExtensionToken({ ...MINT, ttlSeconds: -10 }, SECRET)
+    const r = ok(expired)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('SESSION_EXPIRED')
+  })
+
+  it('refuse un jeton révoqué, même valide par ailleurs', () => {
+    const r = ok(token, EXPECTED, (j) => j === 'jti-1')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('TOKEN_REVOKED')
+  })
+})
+
+describe('séparation des familles de jetons', () => {
+  it('refuse un jeton de session d utilisateur signé avec le secret applicatif', () => {
+    // Le cas qui compte : le secret est le même, seule la dérivation diffère.
+    const userToken = jwt.sign({ userId: 'user-42' }, SECRET, { algorithm: 'HS256' })
+    const r = ok(userToken)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('TOKEN_INVALID')
+  })
+
+  it('refuse un jeton d extension présenté avec la bonne forme mais la mauvaise clé', () => {
+    const forged = jwt.sign(
+      { iss: 'x', aud: 'nodyx-extension', ins: 'inst-1', ext: 'library', sur: 'page', sub: null, prm: ['storage.user'], jti: 'j', iat: 1, exp: 9999999999 },
+      SECRET,                                  // secret applicatif brut, pas le dérivé
+      { algorithm: 'HS256' },
+    )
+    const r = ok(forged)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('TOKEN_INVALID')
+  })
+
+  it('la clé dérivée n est pas le secret applicatif', () => {
+    expect(deriveExtensionSecret(SECRET)).not.toBe(SECRET)
+    expect(deriveExtensionSecret(SECRET)).toHaveLength(64)
+  })
+
+  it('deux secrets applicatifs donnent deux clés dérivées différentes', () => {
+    expect(deriveExtensionSecret('a')).not.toBe(deriveExtensionSecret('b'))
+  })
+})
+
+describe('formes malveillantes', () => {
+  it('refuse un jeton dont la charge a été retouchée', () => {
+    const token = mintExtensionToken(MINT, SECRET)
+    const [h, p, s] = token.split('.')
+    const payload = JSON.parse(Buffer.from(p, 'base64url').toString())
+    payload.prm = ['storage.instance.write', 'core']
+    const tampered = [h, Buffer.from(JSON.stringify(payload)).toString('base64url'), s].join('.')
+    const r = ok(tampered)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('TOKEN_INVALID')
+  })
+
+  it('refuse l algorithme none', () => {
+    const none = jwt.sign(
+      { iss: 'x', aud: 'nodyx-extension', ins: 'inst-1', ext: 'library', sur: 'page', sub: null, prm: [], jti: 'j', exp: 9999999999 },
+      '', { algorithm: 'none' },
+    )
+    const r = ok(none)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('TOKEN_INVALID')
+  })
+
+  it.each(['', 'pas-un-jeton', 'a.b.c'])('refuse la chaîne %p', (raw) => {
+    expect(ok(raw).ok).toBe(false)
+  })
+
+  it('refuse un jeton d extension destiné à une autre audience', () => {
+    const other = jwt.sign(
+      { aud: 'autre-chose', ins: 'inst-1', ext: 'library', sur: 'page', exp: 9999999999 },
+      deriveExtensionSecret(SECRET), { algorithm: 'HS256' },
+    )
+    const r = ok(other)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('TOKEN_WRONG_AUDIENCE')
+  })
+})

--- a/nodyx-frontend/svelte.config.js
+++ b/nodyx-frontend/svelte.config.js
@@ -38,6 +38,17 @@ const config = {
                     'https://www.youtube-nocookie.com',
                     'https://player.vimeo.com',
                     'https://www.openstreetmap.org',
+                    // Plateformes du lecteur multimédia. Ces six hôtes sont DEJA autorisés par la
+                    // politique servie en production (posée par le proxy en mode set, qui remplace
+                    // celle-ci) : sans eux ici, un rapprochement de la config du proxy avec le disque
+                    // casserait Twitch, Dailymotion, SoundCloud et Spotify. Alignement sur l'existant,
+                    // pas un élargissement. cf SPECS/NODYX_SDK_CDC.md §13.1
+                    'https://player.twitch.tv',
+                    'https://www.twitch.tv',
+                    'https://clips.twitch.tv',
+                    'https://geo.dailymotion.com',
+                    'https://w.soundcloud.com',
+                    'https://open.spotify.com',
                 ],
                 'object-src':   ['none'],
                 'base-uri':     ['self'],


### PR DESCRIPTION
Brouillon. Ouverte tot pour que la CI valide le socle avant que les routes du coeur s'empilent dessus.

## Ce que contient cette branche

**Trois specifications normatives**, ecrites avant tout code et validees.

- `SPECS/NODYX_SDK_CDC.md` : architecture, decisions, phasage, plan de non-regression.
- `SPECS/NODYX_SDK_REFERENCE.md` : le manuel developpeur, contrat que P0 doit satisfaire.
- `SPECS/NODYX_SDK_SECURITY.md` : modele de menace, dix garanties et six non-garanties assumees.

**Le substrat de securite de P0-A**, quatre modules purs (ni base, ni disque, ni reseau), 122 tests dedies.

- `extensions/manifest.ts` : validation du contrat api 1. Un manifeste inconnu est refuse, jamais nettoye, et chaque refus porte un code stable.
- `extensions/package.ts` : lecture du paquet .nyx. Zip slip, chemin absolu, antislash, lien symbolique refuse avant lecture, profondeur, plafonds, bombe de decompression jugee sur la taille declaree.
- `extensions/svg.ts` : assainissement des SVG. Seule attaque du modele qui frappe hors du bac a sable, l'icone s'affichant sur la page d'administration.
- `extensions/token.ts` : jeton lie a l'instance, l'extension et la surface. Cle derivee du secret applicatif, donc un jeton de session ne peut pas valider ici.

## Le pourquoi, en une ligne

Le chargement actuel des widgets injecte le JavaScript tiers dans le document principal, or le jeton de session est dans la charge SSR de chaque page. Installer un widget revient donc aujourd'hui a confier son instance a son auteur. Acceptable tant qu'on ecrit soi meme ses widgets, intenable des l'ouverture d'une place de marche.

## Deux trouvailles en cours de route

**La politique de securite de contenu de production ne vient pas de l'application** mais du proxy, en mode `set`, y compris sur les reponses d'API. Une CSP de frame posee en en-tete seul serait effacee. Elle sera donc posee en en-tete ET en balise meta. Au passage, le depot ne listait pas six hotes d'embarquement que la production autorise deja, d'ou le seul commit non additif de cette branche.

**Mesure au navigateur** : dans un bac a sable, cinq fournisseurs video sur six meurent, et Twitch refuse avant meme de charger, sa politique frame-ancestors ne pouvant pas etre satisfaite depuis une origine opaque. Consequence actee, l'embarquement passera par une primitive rendue par l'hote, en v1.

## Perimetre et risque

Treize fichiers, 3698 lignes ajoutees, zero suppression. Aucune route, aucune migration, aucun appelant : rien de ce code n'est encore branche. Le seul fichier non nouveau est `svelte.config.js`, aligne sur la politique deja servie en production, sans reintroduire le `unsafe-inline` retire volontairement du depot.

591 tests verts sur le coeur, tsc propre, production non touchee.

## Suite

Migration et installation par fichier, puis document de frame et sa CSP, puis protocole et MessageChannel.
