### PR TITLE
SDK d'extensions : cote serveur de P0-A (migration, installateur, routes, protocole)

### DIFF
--- a/nodyx-core/src/extensions/capabilities.ts
+++ b/nodyx-core/src/extensions/capabilities.ts
@@ -1,0 +1,77 @@
+// Traduction des permissions du manifeste en capacités.
+//
+// Le manifeste DEMANDE, l'admin ACCORDE, le jeton PORTE. Ce module fait la
+// jonction, et la distinction n'est pas cosmétique : une extension n'obtient
+// jamais que ce qu'un humain a vu et accepté.
+//
+// Une capacité est une chaîne plate, parce que c'est ce qui voyage dans le
+// jeton et ce qui se compare sans ambiguïté à l'exécution.
+// cf SPECS/NODYX_SDK_SECURITY.md §4.5
+
+import type { ExtensionManifest } from './manifest'
+import { classifyHost } from './manifest'
+
+/** Ce que le manifeste demande, sous forme de capacités plates. */
+export function requestedCapabilities(m: ExtensionManifest): string[] {
+  const caps = new Set<string>()
+  const p = m.permissions
+  if (!p) return []
+
+  if (p.identity?.length) {
+    caps.add('identity')
+    for (const f of p.identity) caps.add(`identity:${f}`)
+  }
+  if (p.storage?.user)           caps.add('storage.user')
+  if (p.storage?.instance)       caps.add('storage.instance.read')
+  if (p.storage?.instance_write) caps.add('storage.instance.write')
+  for (const scope of p.core ?? []) caps.add(`core:${scope}`)
+  for (const host of Object.keys(p.network ?? {})) caps.add(`net:${host}`)
+
+  return [...caps].sort()
+}
+
+/**
+ * Ce qui exige un consentement DISTINCT, montré à part sur l'écran de
+ * permissions plutôt que noyé dans la liste ordinaire.
+ *
+ * Deux familles : l'écriture sur les données partagées de l'instance, et les
+ * appels vers un réseau privé. La seconde existe parce qu'une instance en
+ * intranet est un usage normal, pas une anomalie : on ne l'interdit pas, on la
+ * fait remarquer.
+ */
+export function sensitiveCapabilities(m: ExtensionManifest): string[] {
+  const out: string[] = []
+  if (m.permissions?.storage?.instance_write) out.push('storage.instance.write')
+  for (const host of Object.keys(m.permissions?.network ?? {})) {
+    if (classifyHost(host) === 'private') out.push(`net:${host}`)
+  }
+  return out.sort()
+}
+
+export interface GrantDecision {
+  /** Capacités que l'admin accepte. Absent vaut « tout ce qui est demandé ». */
+  accept?: string[]
+}
+
+export interface GrantResult {
+  granted: string[]
+  /** Demandé mais refusé par l'admin, pour le dire à l'extension plutôt qu'échouer plus tard. */
+  denied:  string[]
+}
+
+/**
+ * Applique la décision de l'admin.
+ *
+ * Une capacité accordée qui n'a pas été demandée est ignorée : l'accord ne
+ * peut pas élargir ce que le manifeste déclare, sinon l'écran de permissions
+ * cesserait d'être la vérité.
+ */
+export function applyGrant(m: ExtensionManifest, decision: GrantDecision = {}): GrantResult {
+  const requested = requestedCapabilities(m)
+  if (!decision.accept) return { granted: requested, denied: [] }
+
+  const accepted = new Set(decision.accept)
+  const granted  = requested.filter(c => accepted.has(c))
+  const denied   = requested.filter(c => !accepted.has(c))
+  return { granted, denied }
+}

--- a/nodyx-core/src/extensions/installer.ts
+++ b/nodyx-core/src/extensions/installer.ts
@@ -1,0 +1,132 @@
+// Installation d'un paquet d'extension.
+//
+// Le lecteur (package.ts) a déjà tout jugé : ce module ne fait que POSER des
+// fichiers déjà sûrs et enregistrer la décision de l'admin. Il ne revalide
+// rien, et il ne doit jamais devenir l'endroit où l'on ajoute une garde
+// oubliée ailleurs.
+//
+// Aucun import de `../config/database` ici, volontairement : ce module reçoit
+// sa fonction de requête. Cela le rend testable sans monter la moitié de
+// l'application, et évite qu'un test touche par accident une base ou un cache
+// de production.
+
+import fs from 'fs/promises'
+import path from 'path'
+import { createHash } from 'crypto'
+import { readExtensionPackage } from './package'
+import { applyGrant, type GrantDecision } from './capabilities'
+import type { ValidationIssue } from './manifest'
+
+export type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
+
+export interface InstallContext {
+  query: QueryFn
+  /** Racine des extensions installées, `uploads/extensions` par défaut. */
+  dir?:  string
+}
+
+export interface InstallInput {
+  archive:      Buffer
+  /** `file` pour un téléversement, `registry:<hôte>` pour une installation depuis un index. */
+  origin:       string
+  installedBy?: string | null
+  grant?:       GrantDecision
+}
+
+export interface InstallSuccess {
+  id:        string
+  version:   string
+  sha256:    string
+  granted:   string[]
+  denied:    string[]
+  /** Éléments retirés d'un SVG, par chemin, pour le dire à l'auteur. */
+  sanitized: Record<string, string[]>
+  dir:       string
+}
+
+export type InstallResult =
+  | { ok: true;  result: InstallSuccess }
+  | { ok: false; issues: ValidationIssue[] }
+
+export function defaultExtensionsDir(): string {
+  return path.join(process.cwd(), 'uploads', 'extensions')
+}
+
+/**
+ * Pose les fichiers, puis enregistre.
+ *
+ * L'écriture passe par un dossier temporaire renommé à la fin : une
+ * installation interrompue ne laisse pas une version à moitié écrite que la
+ * route d'assets servirait ensuite. Le dossier est nommé par version, donc
+ * deux versions ne se marchent jamais dessus et le cache du navigateur se
+ * périme tout seul.
+ */
+export async function installExtension(input: InstallInput, ctx: InstallContext): Promise<InstallResult> {
+  const read = readExtensionPackage(input.archive)
+  if (!read.ok) return { ok: false, issues: read.issues }
+
+  const { manifest, files, messages, sanitized } = read.pkg
+  const { granted, denied } = applyGrant(manifest, input.grant)
+
+  const sha256 = createHash('sha256').update(input.archive).digest('hex')
+  const root    = ctx.dir ?? defaultExtensionsDir()
+  const target  = path.join(root, manifest.id, manifest.version)
+  const staging = `${target}.tmp-${process.pid}-${Date.now()}`
+
+  try {
+    await fs.rm(staging, { recursive: true, force: true })
+    for (const f of files) {
+      const dest = path.join(staging, f.path)
+      // Ceinture : le chemin a déjà été jugé sûr par le lecteur, on vérifie
+      // quand même qu'il reste sous la racine. Une garde de pose coûte trois
+      // lignes et couvre une régression future du lecteur.
+      if (!dest.startsWith(staging + path.sep)) {
+        throw new Error(`chemin hors du dossier de destination : ${f.path}`)
+      }
+      await fs.mkdir(path.dirname(dest), { recursive: true })
+      await fs.writeFile(dest, f.content)
+    }
+
+    await fs.rm(target, { recursive: true, force: true })
+    await fs.mkdir(path.dirname(target), { recursive: true })
+    await fs.rename(staging, target)
+  } catch (e) {
+    await fs.rm(staging, { recursive: true, force: true }).catch(() => {})
+    return { ok: false, issues: [{ code: 'INSTALL_WRITE_FAILED', path: '', message: (e as Error).message }] }
+  }
+
+  await ctx.query(
+    `INSERT INTO installed_extensions
+       (id, manifest, messages, version, origin, sha256, enabled, granted, installed_by, installed_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, true, $7, $8, now(), now())
+     ON CONFLICT (id) DO UPDATE SET
+       manifest = $2, messages = $3, version = $4, origin = $5, sha256 = $6,
+       enabled = true, granted = $7, updated_at = now()`,
+    [
+      manifest.id,
+      JSON.stringify(manifest),
+      JSON.stringify(messages),
+      manifest.version,
+      input.origin,
+      sha256,
+      JSON.stringify(granted),
+      input.installedBy ?? null,
+    ],
+  )
+
+  return { ok: true, result: { id: manifest.id, version: manifest.version, sha256, granted, denied, sanitized, dir: target } }
+}
+
+/**
+ * Retire une extension : la base d'abord, le disque ensuite.
+ *
+ * Cet ordre est délibéré. Si la suppression des fichiers échoue, il reste des
+ * octets orphelins sur le disque, ce qui est bénin. L'ordre inverse laisserait
+ * une extension enregistrée dont les fichiers ont disparu, donc une surface
+ * cassée pour les membres.
+ */
+export async function uninstallExtension(id: string, ctx: InstallContext): Promise<void> {
+  await ctx.query(`DELETE FROM installed_extensions WHERE id = $1`, [id])
+  const root = ctx.dir ?? defaultExtensionsDir()
+  await fs.rm(path.join(root, id), { recursive: true, force: true }).catch(() => {})
+}

--- a/nodyx-core/src/extensions/protocol.ts
+++ b/nodyx-core/src/extensions/protocol.ts
@@ -1,0 +1,123 @@
+// Le protocole hôte <-> frame.
+//
+// C'est le contrat réel : le SDK n'est qu'une commodité posée dessus. Il est
+// versionné par `p`, indépendamment de `api` du manifeste, parce que les deux
+// évoluent pour des raisons différentes.
+//
+// Toute enveloppe entrante est validée ici avant d'atteindre quoi que ce soit
+// d'autre. Le message vient d'une frame qui exécute du code tiers : c'est une
+// entrée hostile par défaut, au même titre qu'un corps de requête HTTP.
+// cf SPECS/NODYX_SDK_CDC.md §4.6
+
+import { PROTOCOL_VERSION } from './limits'
+
+export const REQUEST_TYPES = [
+  'session.renew',
+  'storage.get', 'storage.set', 'storage.delete', 'storage.list',
+  'net.fetch',
+  'core.get',
+  'ui.toast', 'ui.confirm', 'ui.modal',
+  'router.push', 'router.replace',
+  'nav.go', 'nav.external',
+  'surface.resize',
+] as const
+
+export type RequestType = typeof REQUEST_TYPES[number]
+
+export const EVENT_TYPES = ['theme', 'locale', 'config', 'route', 'visible', 'session'] as const
+export type EventType = typeof EVENT_TYPES[number]
+
+export interface ProtocolRequest {
+  p:        number
+  id:       string
+  ext:      string
+  surface:  string
+  type:     RequestType
+  payload?: unknown
+}
+
+export type ProtocolResponse =
+  | { p: number; id: string; ok: true;  result: unknown }
+  | { p: number; id: string; ok: false; error: { code: string; message: string } }
+
+export interface ProtocolEvent {
+  p:        number
+  event:    EventType
+  payload?: unknown
+}
+
+const RE_ID      = /^[A-Za-z0-9_-]{1,64}$/
+const RE_EXT     = /^[a-z][a-z0-9-]{2,38}$/
+const RE_SURFACE = /^(page|widget:[a-z][a-z0-9-]{0,30})$/
+
+export type ParseResult =
+  | { ok: true;  request: ProtocolRequest }
+  | { ok: false; code: string; message: string }
+
+/**
+ * Valide une enveloppe reçue de la frame.
+ *
+ * `expected` verrouille l'extension et la surface : une frame ne parle que
+ * pour elle même. Sans ce contrôle, une extension pourrait se présenter sous
+ * l'identité d'une autre dans ses propres messages, et le pont ferait foi.
+ */
+export function parseRequest(raw: unknown, expected: { ext: string; surface: string }): ParseResult {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, code: 'PROTOCOL_MALFORMED', message: 'enveloppe absente ou non objet' }
+  }
+  const m = raw as Record<string, unknown>
+
+  if (m.p !== PROTOCOL_VERSION) {
+    return { ok: false, code: 'PROTOCOL_VERSION', message: `protocole ${String(m.p)} non supporté, cette instance parle ${PROTOCOL_VERSION}` }
+  }
+  if (typeof m.id !== 'string' || !RE_ID.test(m.id)) {
+    return { ok: false, code: 'PROTOCOL_MALFORMED', message: 'identifiant de requête absent ou invalide' }
+  }
+  if (typeof m.type !== 'string' || !(REQUEST_TYPES as readonly string[]).includes(m.type)) {
+    return { ok: false, code: 'PROTOCOL_UNKNOWN_TYPE', message: `type de requête inconnu : ${String(m.type)}` }
+  }
+  if (typeof m.ext !== 'string' || !RE_EXT.test(m.ext) || m.ext !== expected.ext) {
+    return { ok: false, code: 'PROTOCOL_WRONG_EXTENSION', message: 'cette frame ne parle pas pour cette extension' }
+  }
+  if (typeof m.surface !== 'string' || !RE_SURFACE.test(m.surface) || m.surface !== expected.surface) {
+    return { ok: false, code: 'PROTOCOL_WRONG_SURFACE', message: 'cette frame ne parle pas pour cette surface' }
+  }
+
+  return { ok: true, request: { p: m.p, id: m.id, ext: m.ext, surface: m.surface, type: m.type as RequestType, payload: m.payload } }
+}
+
+export function ok(id: string, result: unknown): ProtocolResponse {
+  return { p: PROTOCOL_VERSION, id, ok: true, result }
+}
+
+export function err(id: string, code: string, message: string): ProtocolResponse {
+  return { p: PROTOCOL_VERSION, id, ok: false, error: { code, message } }
+}
+
+export function event(name: EventType, payload?: unknown): ProtocolEvent {
+  return { p: PROTOCOL_VERSION, event: name, payload }
+}
+
+/**
+ * Suit les identifiants déjà consommés, pour refuser un rejeu.
+ *
+ * Borné : une frame malveillante qui envoie des millions d'identifiants ne
+ * doit pas faire grossir la mémoire de l'hôte indéfiniment. Au delà du
+ * plafond, les plus anciens sortent, ce qui est sans danger puisqu'un rejeu
+ * tardif d'une requête déjà répondue n'a pas d'intérêt.
+ */
+export class RequestLedger {
+  private readonly seen = new Set<string>()
+  constructor(private readonly max = 512) {}
+
+  /** Vrai si l'identifiant est neuf, faux si c'est un rejeu. */
+  accept(id: string): boolean {
+    if (this.seen.has(id)) return false
+    this.seen.add(id)
+    if (this.seen.size > this.max) {
+      const oldest = this.seen.values().next().value as string
+      this.seen.delete(oldest)
+    }
+    return true
+  }
+}

--- a/nodyx-core/src/index.ts
+++ b/nodyx-core/src/index.ts
@@ -32,6 +32,7 @@ import wikiRoutes            from './routes/wiki'
 import socialRoutes          from './routes/social'
 import memberRoutes          from './routes/members'
 import { widgetStoreRoutes } from './routes/widgetStore'
+import { extensionFrameRoutes } from './routes/extensionFrame'
 import { widgetDemoRoutes }  from './routes/widgetDemo'
 import { adminBackupRoutes } from './routes/admin_backups'
 import canvasRoutes          from './routes/canvas'
@@ -173,6 +174,9 @@ server.register(wikiRoutes,           { prefix: '/api/v1/wiki' })
 server.register(socialRoutes,         { prefix: '/api/v1/social' })
 server.register(memberRoutes,         { prefix: '/api/v1/members' })
 server.register(widgetStoreRoutes,    { prefix: '/api/v1' })
+// SDK d'extensions (P0-A) : document de frame et assets versionnés.
+// Additif : l'ancien chemin widget reste servi jusqu'à la fin de P0-C.
+server.register(extensionFrameRoutes, { prefix: '/api/v1' })
 server.register(widgetDemoRoutes,     { prefix: '/api/v1' })
 server.register(adminBackupRoutes,    { prefix: '/api/v1' })
 server.register(canvasRoutes,         { prefix: '/api/v1/canvas' })

--- a/nodyx-core/src/index.ts
+++ b/nodyx-core/src/index.ts
@@ -33,6 +33,7 @@ import socialRoutes          from './routes/social'
 import memberRoutes          from './routes/members'
 import { widgetStoreRoutes } from './routes/widgetStore'
 import { extensionFrameRoutes } from './routes/extensionFrame'
+import { extensionRoutes }      from './routes/extensions'
 import { widgetDemoRoutes }  from './routes/widgetDemo'
 import { adminBackupRoutes } from './routes/admin_backups'
 import canvasRoutes          from './routes/canvas'
@@ -177,6 +178,7 @@ server.register(widgetStoreRoutes,    { prefix: '/api/v1' })
 // SDK d'extensions (P0-A) : document de frame et assets versionnés.
 // Additif : l'ancien chemin widget reste servi jusqu'à la fin de P0-C.
 server.register(extensionFrameRoutes, { prefix: '/api/v1' })
+server.register(extensionRoutes,      { prefix: '/api/v1' })
 server.register(widgetDemoRoutes,     { prefix: '/api/v1' })
 server.register(adminBackupRoutes,    { prefix: '/api/v1' })
 server.register(canvasRoutes,         { prefix: '/api/v1/canvas' })

--- a/nodyx-core/src/migrations/112_extensions.sql
+++ b/nodyx-core/src/migrations/112_extensions.sql
@@ -1,0 +1,84 @@
+-- 112 — Extensions Nodyx (SDK api 1)
+--
+-- Remplace le systeme `installed_widgets` (071), qui reste en place une
+-- release de plus : tant que la bascule n'est pas verifiee sur les quatre
+-- instances, le repli est le retour arriere du frontend seul.
+-- cf SPECS/NODYX_SDK_CDC.md §6.1 et §13.1
+
+CREATE TABLE IF NOT EXISTS installed_extensions (
+  id            TEXT        PRIMARY KEY,          -- manifest.id, valide par le SDK
+  manifest      JSONB       NOT NULL,
+  messages      JSONB       NOT NULL DEFAULT '{}',-- locale -> dictionnaire plat
+  version       TEXT        NOT NULL,
+  origin        TEXT        NOT NULL,             -- 'file' | 'registry:<hote>'
+  sha256        TEXT        NOT NULL,             -- empreinte de l'archive installee
+  enabled       BOOLEAN     NOT NULL DEFAULT true,
+  -- Permissions ACCORDEES par l'admin, pas celles demandees au manifeste.
+  -- La difference est le coeur du modele : une extension n'obtient que ce que
+  -- l'admin a vu et accepte.
+  granted       JSONB       NOT NULL DEFAULT '{}',
+  installed_by  UUID        REFERENCES users(id) ON DELETE SET NULL,
+  installed_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS installed_extensions_enabled_idx
+  ON installed_extensions (enabled);
+
+-- Stockage cle/valeur cloisonne par extension.
+--
+-- L'extension ne nomme jamais son propre espace : la cle d'extension vient du
+-- jeton, pas de la requete. Deux portees, `user` et `instance`, l'ecriture
+-- partagee etant une capacite distincte de la lecture partagee.
+--
+-- UNIQUE NULLS NOT DISTINCT exige PostgreSQL 15 ou plus (prod en 16) : sans
+-- lui, deux lignes de portee instance avec user_id NULL ne seraient pas
+-- dedoublonnees, NULL etant distinct de NULL dans une contrainte d'unicite.
+CREATE TABLE IF NOT EXISTS extension_storage (
+  extension_id TEXT        NOT NULL REFERENCES installed_extensions(id) ON DELETE CASCADE,
+  scope        TEXT        NOT NULL CHECK (scope IN ('instance', 'user')),
+  user_id      UUID        REFERENCES users(id) ON DELETE CASCADE,
+  key          TEXT        NOT NULL,
+  value        JSONB       NOT NULL,
+  bytes        INTEGER     NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE NULLS NOT DISTINCT (extension_id, scope, user_id, key),
+  -- Une ligne de portee user sans utilisateur, ou de portee instance avec un
+  -- utilisateur, serait une donnee orpheline : la base refuse les deux.
+  CONSTRAINT extension_storage_scope_coherent CHECK (
+    (scope = 'user'     AND user_id IS NOT NULL) OR
+    (scope = 'instance' AND user_id IS NULL)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS extension_storage_lookup_idx
+  ON extension_storage (extension_id, scope, user_id);
+
+-- Secrets d'instance utilises par le proxy reseau.
+--
+-- La valeur n'est JAMAIS renvoyee par une API : elle est injectee cote serveur
+-- selon une recette que le serveur possede. L'extension nomme le secret, elle
+-- ne choisit ni l'en-tete ni sa destination, sinon elle le recuperait
+-- indirectement en le faisant envoyer vers un hote qu'elle controle.
+-- cf SPECS/NODYX_SDK_SECURITY.md §4.4
+CREATE TABLE IF NOT EXISTS extension_secrets (
+  extension_id TEXT        NOT NULL REFERENCES installed_extensions(id) ON DELETE CASCADE,
+  name         TEXT        NOT NULL,
+  value        TEXT        NOT NULL,
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (extension_id, name)
+);
+
+-- Jetons d'extension revoques avant leur expiration naturelle.
+--
+-- Un jeton vit dix minutes. Cette table sert la fenetre entre une
+-- desactivation, une desinstallation ou un retrait de permission, et
+-- l'expiration du dernier jeton emis. Purge par `expires_at`.
+CREATE TABLE IF NOT EXISTS extension_revoked_tokens (
+  jti        TEXT        PRIMARY KEY,
+  expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS extension_revoked_tokens_expiry_idx
+  ON extension_revoked_tokens (expires_at);

--- a/nodyx-core/src/routes/extensionFrame.ts
+++ b/nodyx-core/src/routes/extensionFrame.ts
@@ -1,0 +1,171 @@
+// Le document de frame, et les assets d'une extension.
+//
+// C'est la seule surface publique du bac à sable. Tout ce qui est servi ici
+// est destiné à vivre dans une iframe à origine opaque, montée par l'hôte avec
+// `sandbox="allow-scripts"` et rien d'autre.
+// cf SPECS/NODYX_SDK_CDC.md §4 et NODYX_SDK_SECURITY.md §4.1
+
+import type { FastifyInstance, FastifyReply } from 'fastify'
+import { randomBytes } from 'crypto'
+import fs from 'fs/promises'
+import path from 'path'
+import { rateLimit } from '../middleware/rateLimit'
+import { defaultExtensionsDir } from '../extensions/installer'
+import { isSafePackagePath } from '../extensions/manifest'
+import { PACKAGE } from '../extensions/limits'
+
+/** Types servis, déterminés par le serveur, jamais devinés depuis le contenu. */
+const CONTENT_TYPES: Record<string, string> = {
+  '.js':    'application/javascript; charset=utf-8',
+  '.css':   'text/css; charset=utf-8',
+  '.json':  'application/json; charset=utf-8',
+  '.svg':   'image/svg+xml',
+  '.png':   'image/png',
+  '.jpg':   'image/jpeg',
+  '.jpeg':  'image/jpeg',
+  '.webp':  'image/webp',
+  '.woff2': 'font/woff2',
+  '.md':    'text/markdown; charset=utf-8',
+}
+
+const RE_ID      = /^[a-z][a-z0-9-]{2,38}$/
+const RE_VERSION = /^\d+\.\d+\.\d+$/
+
+/**
+ * La politique de sécurité de la frame.
+ *
+ * L'origine est écrite EN CLAIR : dans une origine opaque, `'self'` ne
+ * correspond à rien. `frame-src 'none'` interdit toute iframe imbriquée, donc
+ * tout embarquement de tiers, qui passera par une primitive de l'hôte.
+ *
+ * `style-src-attr 'unsafe-inline'` est délibéré et borné aux attributs
+ * `style=""`, qui sont réels dans du code d'interface. Il n'y a PAS de
+ * `'unsafe-inline'` dans `style-src` ni dans `script-src` : un nonce le
+ * neutraliserait de toute façon, l'écrire ne ferait que masquer l'intention.
+ */
+export function frameCsp(origin: string, nonce: string): string {
+  return [
+    `default-src 'none'`,
+    `script-src 'nonce-${nonce}' ${origin}`,
+    `style-src 'nonce-${nonce}' ${origin}`,
+    `style-src-attr 'unsafe-inline'`,
+    `img-src ${origin} data: blob:`,
+    `media-src ${origin} blob:`,
+    `connect-src ${origin}`,
+    `frame-src 'none'`,
+    `form-action 'none'`,
+    `base-uri 'none'`,
+  ].join('; ')
+}
+
+function frameHtml(origin: string, nonce: string, csp: string, sdkUrl: string, entryUrl: string): string {
+  // La politique est posée DEUX FOIS, en en-tête et ici.
+  //
+  // Vérifié sur notre propre production : le proxy pose la politique du site
+  // en mode `set`, donc il REMPLACE celle que l'application envoie, y compris
+  // sur les réponses d'API. Un en-tête seul serait effacé et la frame
+  // hériterait d'une politique permissive, ce qui rouvrirait le réseau sortant
+  // direct depuis une extension. Une balise n'est pas réécrite par un proxy, et
+  // deux politiques présentes valent leur intersection, donc la plus stricte
+  // gagne. Règle générale : une frontière de sécurité ne dépend jamais d'un
+  // en-tête qu'un intermédiaire peut réécrire.
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="${csp.replace(/"/g, '&quot;')}">
+<meta name="referrer" content="no-referrer">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Nodyx extension surface</title>
+<style nonce="${nonce}">
+  html, body { margin: 0; padding: 0; background: transparent; }
+  #root { min-height: 1px; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script nonce="${nonce}" type="module" src="${sdkUrl}" data-entry="${entryUrl}"></script>
+</body>
+</html>`
+}
+
+function harden(reply: FastifyReply): FastifyReply {
+  return reply
+    .header('X-Content-Type-Options', 'nosniff')
+    .header('Referrer-Policy', 'no-referrer')
+    .header('Cross-Origin-Resource-Policy', 'same-origin')
+}
+
+export async function extensionFrameRoutes(app: FastifyInstance) {
+  const root   = defaultExtensionsDir()
+  const origin = process.env.FRONTEND_URL?.replace(/\/+$/, '') || 'http://localhost:5173'
+
+  // ── GET /extensions/:id/:version/frame ──────────────────────────────────
+  // Le document hôte de la surface. Public : une page d'accueil est vue par
+  // des visiteurs, et c'est le jeton, transmis plus tard par le port privé,
+  // qui porte l'identité. Rien de sensible n'est rendu ici.
+  app.get('/extensions/:id/:version/frame', { preHandler: [rateLimit] }, async (request, reply) => {
+    const { id, version } = request.params as { id: string; version: string }
+    const { surface }     = request.query  as { surface?: string }
+
+    if (!RE_ID.test(id) || !RE_VERSION.test(version)) {
+      return harden(reply).code(400).send({ error: 'Invalid extension reference', code: 'INVALID_EXTENSION_REF' })
+    }
+    if (surface && !/^(page|widget:[a-z][a-z0-9-]{0,30})$/.test(surface)) {
+      return harden(reply).code(400).send({ error: 'Invalid surface', code: 'INVALID_SURFACE' })
+    }
+
+    const nonce = randomBytes(16).toString('base64')
+    const csp   = frameCsp(origin, nonce)
+    const base  = `${origin}/api/v1/extensions/${id}/${version}`
+
+    return harden(reply)
+      .header('Content-Security-Policy', csp)
+      .header('Cache-Control', 'no-store')
+      .type('text/html; charset=utf-8')
+      .send(frameHtml(origin, nonce, csp, `${origin}/api/v1/extensions/sdk.js`, `${base}/assets/`))
+  })
+
+  // ── GET /extensions/:id/:version/assets/* ───────────────────────────────
+  // La version est dans le chemin : une mise à jour invalide le cache d'elle
+  // même, et une frame ouverte ne mélange jamais deux générations de code.
+  app.get('/extensions/:id/:version/assets/*', { preHandler: [rateLimit] }, async (request, reply) => {
+    const { id, version } = request.params as { id: string; version: string }
+    const rel = ((request.params as Record<string, string>)['*'] ?? '').replace(/\\/g, '/')
+
+    if (!RE_ID.test(id) || !RE_VERSION.test(version) || !isSafePackagePath(rel)) {
+      return harden(reply).code(400).send({ error: 'Invalid asset reference', code: 'INVALID_ASSET_REF' })
+    }
+
+    const ext = path.extname(rel).toLowerCase()
+    if (!(PACKAGE.allowedExtensions as readonly string[]).includes(ext)) {
+      return harden(reply).code(403).send({ error: 'Asset type not served', code: 'ASSET_TYPE_REFUSED' })
+    }
+
+    const versionDir = path.join(root, id, version)
+    const target     = path.resolve(versionDir, rel)
+
+    // Ceinture, après la bretelle : même si `isSafePackagePath` régressait, un
+    // chemin qui sort du dossier de version ne serait pas servi.
+    if (target !== versionDir && !target.startsWith(versionDir + path.sep)) {
+      return harden(reply).code(403).send({ error: 'Forbidden', code: 'ASSET_PATH_ESCAPE' })
+    }
+
+    let content: Buffer
+    try {
+      content = await fs.readFile(target)
+    } catch {
+      return harden(reply).code(404).send({ error: 'Asset not found', code: 'ASSET_NOT_FOUND' })
+    }
+
+    const r = harden(reply)
+      .header('Content-Type', CONTENT_TYPES[ext] ?? 'application/octet-stream')
+      .header('Cache-Control', 'public, max-age=31536000, immutable')
+
+    // Un SVG est assaini à l'installation, mais il est servi sur notre origine
+    // et affiché hors du bac à sable : on le sert inerte, par principe.
+    if (ext === '.svg') r.header('Content-Security-Policy', "default-src 'none'; style-src 'unsafe-inline'")
+
+    return r.send(content)
+  })
+}

--- a/nodyx-core/src/routes/extensions.ts
+++ b/nodyx-core/src/routes/extensions.ts
@@ -1,0 +1,200 @@
+// Administration des extensions, et frappe des jetons de surface.
+//
+// Deux publics dans un seul fichier, mais deux régimes bien séparés :
+//   - `/admin/extensions/*` : réservé à l'administration, c'est là que
+//     l'installation et les permissions se décident ;
+//   - `/extensions/:id/session` : appelé par l'hôte pour frapper le jeton
+//     court d'une surface, avec la session réelle de l'utilisateur.
+// cf SPECS/NODYX_SDK_CDC.md §4 et §6
+
+import type { FastifyInstance } from 'fastify'
+import { randomUUID } from 'crypto'
+import { db }           from '../config/database'
+import { adminOnly }    from '../middleware/adminOnly'
+import { optionalAuth } from '../middleware/auth'
+import { rateLimit }    from '../middleware/rateLimit'
+import { installExtension, uninstallExtension } from '../extensions/installer'
+import { sensitiveCapabilities } from '../extensions/capabilities'
+import { validateManifest }      from '../extensions/manifest'
+import { mintExtensionToken }    from '../extensions/token'
+import { PACKAGE, SURFACE }      from '../extensions/limits'
+
+const RE_ID      = /^[a-z][a-z0-9-]{2,38}$/
+const RE_SURFACE = /^(page|widget:[a-z][a-z0-9-]{0,30})$/
+
+interface InstalledRow {
+  id:       string
+  manifest: Record<string, unknown>
+  version:  string
+  enabled:  boolean
+  granted:  string[]
+}
+
+export async function extensionRoutes(app: FastifyInstance) {
+  const query = (sql: string, params?: unknown[]) => db.query(sql, params) as Promise<{ rows: unknown[] }>
+  const origin     = process.env.FRONTEND_URL?.replace(/\/+$/, '') || 'http://localhost:5173'
+  const instanceId = origin
+  const appSecret  = process.env.JWT_SECRET ?? ''
+
+  // ── GET /admin/extensions ───────────────────────────────────────────────
+  app.get('/admin/extensions', { preHandler: [rateLimit, adminOnly] }, async (_req, reply) => {
+    const { rows } = await db.query(
+      `SELECT id, manifest, version, origin, sha256, enabled, granted, installed_at, updated_at
+         FROM installed_extensions
+        ORDER BY installed_at DESC`,
+    )
+    return reply.send({ extensions: rows })
+  })
+
+  // ── POST /admin/extensions/install ──────────────────────────────────────
+  // Téléversement d'un .nyx. Tout le jugement appartient au lecteur de paquet :
+  // cette route ne fait que lire le corps, appliquer la décision de l'admin, et
+  // rendre un compte rendu exploitable par l'interface.
+  app.post('/admin/extensions/install', { preHandler: [rateLimit, adminOnly] }, async (request, reply) => {
+    const data = await request.file({ limits: { fileSize: PACKAGE.maxArchiveBytes } })
+    if (!data) {
+      return reply.code(400).send({ error: 'Aucun fichier reçu', code: 'NO_FILE' })
+    }
+
+    const archive = await data.toBuffer()
+    if (data.file.truncated) {
+      return reply.code(413).send({
+        error: `Archive au dessus du plafond de ${PACKAGE.maxArchiveBytes / 1024 / 1024} Mo`,
+        code:  'ARCHIVE_TOO_LARGE',
+      })
+    }
+
+    // Les capacités acceptées arrivent en champ de formulaire : l'écran de
+    // permissions est côté interface, la décision voyage explicitement.
+    let accept: string[] | undefined
+    const raw = (data.fields?.accept as { value?: string } | undefined)?.value
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw)
+        if (Array.isArray(parsed) && parsed.every(v => typeof v === 'string')) accept = parsed
+      } catch { /* décision illisible : on retombe sur « tout ce qui est demandé » */ }
+    }
+
+    const result = await installExtension(
+      { archive, origin: 'file', installedBy: request.user?.userId ?? null, grant: accept ? { accept } : undefined },
+      { query },
+    )
+
+    if (!result.ok) {
+      return reply.code(400).send({
+        error:  'Paquet refusé',
+        code:   'PACKAGE_REJECTED',
+        issues: result.issues,
+      })
+    }
+    return reply.code(201).send(result.result)
+  })
+
+  // ── POST /admin/extensions/inspect ──────────────────────────────────────
+  // Lit un paquet SANS l'installer, pour alimenter l'écran de permissions.
+  // L'admin doit pouvoir voir ce qu'une extension demande avant de dire oui.
+  app.post('/admin/extensions/inspect', { preHandler: [rateLimit, adminOnly] }, async (request, reply) => {
+    const data = await request.file({ limits: { fileSize: PACKAGE.maxArchiveBytes } })
+    if (!data) return reply.code(400).send({ error: 'Aucun fichier reçu', code: 'NO_FILE' })
+
+    const { readExtensionPackage } = await import('../extensions/package')
+    const { requestedCapabilities } = await import('../extensions/capabilities')
+
+    const read = readExtensionPackage(await data.toBuffer())
+    if (!read.ok) return reply.code(400).send({ error: 'Paquet refusé', code: 'PACKAGE_REJECTED', issues: read.issues })
+
+    return reply.send({
+      manifest:            read.pkg.manifest,
+      messages:            read.pkg.messages[read.pkg.manifest.default_locale] ?? {},
+      requested:           requestedCapabilities(read.pkg.manifest),
+      sensitive:           sensitiveCapabilities(read.pkg.manifest),
+      privateNetworkHosts: read.pkg.privateNetworkHosts,
+      sanitized:           read.pkg.sanitized,
+    })
+  })
+
+  // ── PATCH /admin/extensions/:id ─────────────────────────────────────────
+  app.patch('/admin/extensions/:id', { preHandler: [rateLimit, adminOnly] }, async (request, reply) => {
+    const { id }      = request.params as { id: string }
+    const { enabled } = request.body   as { enabled?: boolean }
+    if (!RE_ID.test(id) || typeof enabled !== 'boolean') {
+      return reply.code(400).send({ error: 'Requête invalide', code: 'INVALID_REQUEST' })
+    }
+
+    const { rowCount } = await db.query(
+      `UPDATE installed_extensions SET enabled = $1, updated_at = now() WHERE id = $2`,
+      [enabled, id],
+    )
+    if (!rowCount) return reply.code(404).send({ error: 'Extension introuvable', code: 'EXTENSION_NOT_FOUND' })
+
+    // Désactiver doit couper tout de suite. Les jetons déjà émis vivent dix
+    // minutes : sans révocation, une surface continuerait d'appeler pendant ce
+    // temps là, ce qui viderait le bouton de son sens.
+    if (!enabled) {
+      await db.query(
+        `INSERT INTO extension_revoked_tokens (jti, expires_at)
+         SELECT $1, now() + interval '${SURFACE.tokenTtlSeconds} seconds'
+         ON CONFLICT (jti) DO NOTHING`,
+        [`ext:${id}:*`],
+      ).catch(() => { /* la révocation fine arrive avec le suivi des jti émis */ })
+    }
+
+    return reply.send({ success: true })
+  })
+
+  // ── DELETE /admin/extensions/:id ────────────────────────────────────────
+  app.delete('/admin/extensions/:id', { preHandler: [rateLimit, adminOnly] }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    if (!RE_ID.test(id)) return reply.code(400).send({ error: 'Identifiant invalide', code: 'INVALID_ID' })
+    await uninstallExtension(id, { query })
+    return reply.send({ success: true })
+  })
+
+  // ── POST /extensions/:id/session ────────────────────────────────────────
+  // Frappe le jeton court d'une surface. Appelé par l'HÔTE, avec la session
+  // réelle de l'utilisateur, jamais par la frame : la frame n'a pas de session
+  // et c'est tout l'intérêt.
+  app.post('/extensions/:id/session', { preHandler: [rateLimit, optionalAuth] }, async (request, reply) => {
+    const { id }      = request.params as { id: string }
+    const { surface } = (request.body ?? {}) as { surface?: string }
+
+    if (!RE_ID.test(id))                  return reply.code(400).send({ error: 'Identifiant invalide', code: 'INVALID_ID' })
+    if (!surface || !RE_SURFACE.test(surface)) return reply.code(400).send({ error: 'Surface invalide', code: 'INVALID_SURFACE' })
+    if (!appSecret)                       return reply.code(500).send({ error: 'Instance mal configurée', code: 'MISSING_SECRET' })
+
+    const { rows } = await db.query(
+      `SELECT id, manifest, version, enabled, granted FROM installed_extensions WHERE id = $1`,
+      [id],
+    )
+    const row = rows[0] as InstalledRow | undefined
+    if (!row)          return reply.code(404).send({ error: 'Extension introuvable', code: 'EXTENSION_NOT_FOUND' })
+    if (!row.enabled)  return reply.code(403).send({ error: 'Extension désactivée', code: 'EXTENSION_DISABLED' })
+
+    // La surface demandée doit exister dans le manifeste installé, sinon un
+    // jeton serait frappé pour quelque chose qui n'existe pas.
+    const parsed = validateManifest(row.manifest)
+    if (!parsed.ok) return reply.code(500).send({ error: 'Manifeste installé invalide', code: 'MANIFEST_CORRUPT' })
+
+    const known = parsed.manifest.surfaces.some(s =>
+      s.type === 'page' ? surface === 'page' : surface === `widget:${s.id}`,
+    )
+    if (!known) return reply.code(404).send({ error: 'Surface inconnue', code: 'SURFACE_NOT_FOUND' })
+
+    const token = mintExtensionToken({
+      issuer:      origin,
+      instanceId,
+      extensionId: id,
+      surface,
+      userId:      request.user?.userId ?? null,
+      permissions: Array.isArray(row.granted) ? row.granted : [],
+      jti:         randomUUID(),
+    }, appSecret)
+
+    return reply.send({
+      token,
+      expiresIn: SURFACE.tokenTtlSeconds,
+      version:   row.version,
+      surface,
+    })
+  })
+}

--- a/nodyx-core/src/tests/extensionFrame.test.ts
+++ b/nodyx-core/src/tests/extensionFrame.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import type { FastifyInstance } from 'fastify'
+import { buildApp } from './helpers/buildApp'
+
+vi.mock('../middleware/rateLimit', () => ({ rateLimit: vi.fn(async () => {}) }))
+
+let app: FastifyInstance
+let cwd: string
+const ORIGIN = 'https://instance.example'
+
+beforeAll(async () => {
+  cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'nodyx-frame-'))
+  const dir = path.join(cwd, 'uploads', 'extensions', 'demo-ext', '1.0.0')
+  await fs.mkdir(path.join(dir, 'ui'), { recursive: true })
+  await fs.writeFile(path.join(dir, 'ui', 'widget.js'), 'export function mount() {}')
+  await fs.writeFile(path.join(dir, 'icon.svg'), '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h1v1H0z"/></svg>')
+  await fs.writeFile(path.join(cwd, 'secret.txt'), 'ceci ne doit jamais sortir')
+
+  vi.spyOn(process, 'cwd').mockReturnValue(cwd)
+  process.env.FRONTEND_URL = ORIGIN
+
+  const { extensionFrameRoutes } = await import('../routes/extensionFrame')
+  app = await buildApp(async (a) => { await a.register(extensionFrameRoutes, { prefix: '/api/v1' }) })
+})
+
+afterAll(async () => {
+  await app?.close()
+  await fs.rm(cwd, { recursive: true, force: true })
+})
+
+const frame = (q = '') => app.inject({ method: 'GET', url: `/api/v1/extensions/demo-ext/1.0.0/frame${q}` })
+const asset = (p: string) => app.inject({ method: 'GET', url: `/api/v1/extensions/demo-ext/1.0.0/assets/${p}` })
+
+describe('document de frame', () => {
+  it('sert un document HTML avec une politique stricte', async () => {
+    const r = await frame()
+    expect(r.statusCode).toBe(200)
+    const csp = r.headers['content-security-policy'] as string
+    expect(csp).toContain("default-src 'none'")
+    expect(csp).toContain("frame-src 'none'")
+    expect(csp).toContain(`connect-src ${ORIGIN}`)
+    expect(csp).toContain(`form-action 'none'`)
+  })
+
+  it('pose la politique DEUX FOIS, en en-tête et en balise', async () => {
+    // Le proxy de production remplace l'en-tête. Sans la balise, la frame
+    // hériterait d'une politique permissive et le réseau sortant direct
+    // redeviendrait possible.
+    const r = await frame()
+    const header = r.headers['content-security-policy'] as string
+    const meta   = /<meta http-equiv="Content-Security-Policy" content="([^"]+)">/.exec(r.body)
+    expect(meta).not.toBeNull()
+    expect(meta![1]).toBe(header)
+  })
+
+  it('écrit l origine en clair, jamais self', async () => {
+    // Dans une origine opaque, 'self' ne correspond à rien.
+    const csp = (await frame()).headers['content-security-policy'] as string
+    expect(csp).not.toContain("'self'")
+    expect(csp).toContain(ORIGIN)
+  })
+
+  it('n autorise pas unsafe-inline pour les scripts ni les styles', async () => {
+    const csp = (await frame()).headers['content-security-policy'] as string
+    expect(/script-src[^;]*unsafe-inline/.test(csp)).toBe(false)
+    expect(/style-src '[^;]*unsafe-inline/.test(csp)).toBe(false)
+    expect(csp).toContain("style-src-attr 'unsafe-inline'")   // borné aux attributs, délibéré
+  })
+
+  it('utilise un nonce neuf à chaque requête', async () => {
+    const [a, b] = await Promise.all([frame(), frame()])
+    const nonceOf = (r: { headers: Record<string, unknown> }) =>
+      /nonce-([^' ]+)/.exec(r.headers['content-security-policy'] as string)![1]
+    expect(nonceOf(a)).not.toBe(nonceOf(b))
+  })
+
+  it('durcit la réponse et ne la met pas en cache', async () => {
+    const r = await frame()
+    expect(r.headers['x-content-type-options']).toBe('nosniff')
+    expect(r.headers['referrer-policy']).toBe('no-referrer')
+    expect(r.headers['cross-origin-resource-policy']).toBe('same-origin')
+    expect(r.headers['cache-control']).toBe('no-store')
+  })
+
+  it('accepte une surface bien formée et refuse le reste', async () => {
+    expect((await frame('?surface=page')).statusCode).toBe(200)
+    expect((await frame('?surface=widget:tonight')).statusCode).toBe(200)
+    expect((await frame('?surface=../../evil')).statusCode).toBe(400)
+  })
+
+  it('refuse une référence d extension ou de version mal formée', async () => {
+    expect((await app.inject({ url: '/api/v1/extensions/Demo/1.0.0/frame' })).statusCode).toBe(400)
+    expect((await app.inject({ url: '/api/v1/extensions/demo-ext/latest/frame' })).statusCode).toBe(400)
+  })
+})
+
+describe('assets', () => {
+  it('sert un fichier de la version demandée', async () => {
+    const r = await asset('ui/widget.js')
+    expect(r.statusCode).toBe(200)
+    expect(r.headers['content-type']).toContain('application/javascript')
+    expect(r.body).toContain('mount')
+  })
+
+  it('met en cache immuablement, la version étant dans le chemin', async () => {
+    expect((await asset('ui/widget.js')).headers['cache-control']).toContain('immutable')
+  })
+
+  it('sert un SVG inerte, parce qu il s affiche hors du bac à sable', async () => {
+    const r = await asset('icon.svg')
+    expect(r.statusCode).toBe(200)
+    expect(r.headers['content-type']).toBe('image/svg+xml')
+    expect(r.headers['content-security-policy']).toContain("default-src 'none'")
+    expect(r.headers['x-content-type-options']).toBe('nosniff')
+  })
+
+  it.each([
+    '../../../secret.txt',
+    '../../secret.txt',
+    '..%2f..%2fsecret.txt',
+    '/etc/passwd',
+  ])('ne sort jamais du dossier de version : %s', async (p) => {
+    const r = await asset(p)
+    expect(r.statusCode).not.toBe(200)
+    expect(r.body).not.toContain('ne doit jamais sortir')
+  })
+
+  it('refuse un type de fichier non servi', async () => {
+    const r = await asset('notes.txt')
+    expect(r.statusCode).toBe(403)
+    expect(JSON.parse(r.body).code).toBe('ASSET_TYPE_REFUSED')
+  })
+
+  it('rend 404 pour un fichier absent, sans divulguer le chemin', async () => {
+    const r = await asset('ui/absent.js')
+    expect(r.statusCode).toBe(404)
+    expect(r.body).not.toContain(cwd)
+  })
+
+  it('ne sert pas la version voisine', async () => {
+    const r = await app.inject({ url: '/api/v1/extensions/demo-ext/9.9.9/assets/ui/widget.js' })
+    expect(r.statusCode).toBe(404)
+  })
+})

--- a/nodyx-core/src/tests/extensionInstaller.test.ts
+++ b/nodyx-core/src/tests/extensionInstaller.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import AdmZip from 'adm-zip'
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { installExtension, uninstallExtension, type QueryFn } from '../extensions/installer'
+import { requestedCapabilities, sensitiveCapabilities, applyGrant } from '../extensions/capabilities'
+import { validateManifest, type ExtensionManifest } from '../extensions/manifest'
+
+const MANIFEST = {
+  api: 1,
+  id: 'demo-ext',
+  version: '1.0.0',
+  license: 'MIT',
+  default_locale: 'en',
+  label: '@label',
+  description: '@description',
+  surfaces: [{ type: 'widget', id: 'main', entry: 'ui/widget.js', label: '@label' }],
+}
+
+function zipOf(manifest: unknown = MANIFEST, extra: Record<string, string> = {}): Buffer {
+  const zip = new AdmZip()
+  zip.addFile('manifest.json', Buffer.from(JSON.stringify(manifest)))
+  zip.addFile('i18n/en.json',  Buffer.from(JSON.stringify({ label: 'Demo', description: 'Une demo.' })))
+  zip.addFile('ui/widget.js',  Buffer.from('export function mount() {}'))
+  for (const [p, c] of Object.entries(extra)) zip.addFile(p, Buffer.from(c))
+  return zip.toBuffer()
+}
+
+function parse(m: unknown): ExtensionManifest {
+  const r = validateManifest(m)
+  if (!r.ok) throw new Error('manifeste de test invalide : ' + JSON.stringify(r.issues))
+  return r.manifest
+}
+
+let dir: string
+let query: QueryFn & ReturnType<typeof vi.fn>
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'nodyx-ext-'))
+  query = vi.fn().mockResolvedValue({ rows: [] }) as never
+})
+afterEach(async () => { await fs.rm(dir, { recursive: true, force: true }) })
+
+describe('installation', () => {
+  it('pose les fichiers dans un dossier par version et enregistre', async () => {
+    const r = await installExtension({ archive: zipOf(), origin: 'file', installedBy: 'user-1' }, { query, dir })
+    if (!r.ok) throw new Error('refusé à tort : ' + JSON.stringify(r.issues))
+
+    expect(r.result.dir).toBe(path.join(dir, 'demo-ext', '1.0.0'))
+    expect(await fs.readFile(path.join(r.result.dir, 'ui/widget.js'), 'utf8')).toContain('mount')
+    expect(await fs.readFile(path.join(r.result.dir, 'manifest.json'), 'utf8')).toContain('demo-ext')
+
+    expect(query).toHaveBeenCalledOnce()
+    const [sql, params] = query.mock.calls[0]
+    expect(sql).toContain('INSERT INTO installed_extensions')
+    expect(params[0]).toBe('demo-ext')
+    expect(params[3]).toBe('1.0.0')
+    expect(params[4]).toBe('file')
+    expect(params[5]).toHaveLength(64)              // sha256 de l'archive
+  })
+
+  it('ne laisse aucun dossier temporaire derrière elle', async () => {
+    await installExtension({ archive: zipOf(), origin: 'file' }, { query, dir })
+    const entries = await fs.readdir(path.join(dir, 'demo-ext'))
+    expect(entries).toEqual(['1.0.0'])
+  })
+
+  it('installe deux versions côte à côte, sans qu elles se marchent dessus', async () => {
+    await installExtension({ archive: zipOf(), origin: 'file' }, { query, dir })
+    await installExtension({ archive: zipOf({ ...MANIFEST, version: '1.1.0' }), origin: 'file' }, { query, dir })
+    const entries = (await fs.readdir(path.join(dir, 'demo-ext'))).sort()
+    expect(entries).toEqual(['1.0.0', '1.1.0'])
+  })
+
+  it('remplace proprement une réinstallation de la même version', async () => {
+    await installExtension({ archive: zipOf(MANIFEST, { 'data/a.json': '{"v":1}' }) }, { query, dir } as never)
+    await installExtension({ archive: zipOf(MANIFEST, { 'data/b.json': '{"v":2}' }), origin: 'file' }, { query, dir })
+    const files = await fs.readdir(path.join(dir, 'demo-ext', '1.0.0', 'data'))
+    expect(files).toEqual(['b.json'])                // l'ancien contenu ne survit pas
+  })
+
+  it('n écrit rien en base quand le paquet est refusé', async () => {
+    const r = await installExtension({ archive: Buffer.from('pas un zip'), origin: 'file' }, { query, dir })
+    expect(r.ok).toBe(false)
+    expect(query).not.toHaveBeenCalled()
+    await expect(fs.readdir(dir)).resolves.toEqual([])
+  })
+
+  it('remonte ce qui a été retiré d un SVG', async () => {
+    const evil = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script><path d="M0 0h1v1H0z"/></svg>'
+    const r = await installExtension({ archive: zipOf({ ...MANIFEST, icon: 'icon.svg' }, { 'icon.svg': evil }), origin: 'file' }, { query, dir })
+    if (!r.ok) throw new Error('refusé à tort')
+    expect(r.result.sanitized['icon.svg']).toContain('<script>')
+    expect(await fs.readFile(path.join(r.result.dir, 'icon.svg'), 'utf8')).not.toContain('script')
+  })
+})
+
+describe('désinstallation', () => {
+  it('efface la base d abord, puis le disque', async () => {
+    await installExtension({ archive: zipOf(), origin: 'file' }, { query, dir })
+    query.mockClear()
+
+    await uninstallExtension('demo-ext', { query, dir })
+
+    expect(query.mock.calls[0][0]).toContain('DELETE FROM installed_extensions')
+    await expect(fs.readdir(path.join(dir, 'demo-ext'))).rejects.toThrow()
+  })
+})
+
+describe('capacités : le manifeste demande, l admin accorde', () => {
+  const full = parse({
+    ...MANIFEST,
+    permissions: {
+      identity: ['id', 'username'],
+      storage: { user: '1mb', instance: '2mb', instance_write: true },
+      core: ['members:read'],
+      network: {
+        'api.themoviedb.org': { methods: ['GET'], paths: ['/3/'] },
+        '10.0.0.5':           { methods: ['GET'], paths: ['/api'] },
+      },
+    },
+  })
+
+  it('traduit les permissions en capacités plates', () => {
+    expect(requestedCapabilities(full)).toEqual([
+      'core:members:read',
+      'identity', 'identity:id', 'identity:username',
+      'net:10.0.0.5', 'net:api.themoviedb.org',
+      'storage.instance.read', 'storage.instance.write', 'storage.user',
+    ])
+  })
+
+  it('isole ce qui exige un consentement distinct', () => {
+    expect(sensitiveCapabilities(full)).toEqual(['net:10.0.0.5', 'storage.instance.write'])
+  })
+
+  it('un manifeste sans permission ne demande rien', () => {
+    expect(requestedCapabilities(parse(MANIFEST))).toEqual([])
+    expect(sensitiveCapabilities(parse(MANIFEST))).toEqual([])
+  })
+
+  it('sans décision, tout ce qui est demandé est accordé', () => {
+    const { granted, denied } = applyGrant(full)
+    expect(granted).toEqual(requestedCapabilities(full))
+    expect(denied).toEqual([])
+  })
+
+  it('un refus partiel se lit dans le résultat, il n échoue pas plus tard', () => {
+    const { granted, denied } = applyGrant(full, { accept: ['identity', 'identity:id', 'storage.user'] })
+    expect(granted).toEqual(['identity', 'identity:id', 'storage.user'])
+    expect(denied).toContain('net:10.0.0.5')
+    expect(denied).toContain('storage.instance.write')
+  })
+
+  it('accorder ce qui n a pas été demandé n élargit rien', () => {
+    // Sinon l'écran de permissions cesserait d'être la vérité.
+    const { granted } = applyGrant(full, { accept: ['storage.user', 'core:forum:read', 'net:evil.example'] })
+    expect(granted).toEqual(['storage.user'])
+  })
+
+  it('les capacités accordées sont enregistrées telles quelles', async () => {
+    const manifest = { ...MANIFEST, permissions: { identity: ['id'], storage: { user: '1mb' } } }
+    await installExtension(
+      { archive: zipOf(manifest), origin: 'file', grant: { accept: ['identity', 'identity:id'] } },
+      { query, dir },
+    )
+    const granted = JSON.parse(query.mock.calls[0][1][6] as string)
+    expect(granted).toEqual(['identity', 'identity:id'])
+    expect(granted).not.toContain('storage.user')     // demandé, mais non accordé
+  })
+})

--- a/nodyx-core/src/tests/extensionProtocol.test.ts
+++ b/nodyx-core/src/tests/extensionProtocol.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { parseRequest, ok, err, event, RequestLedger, REQUEST_TYPES } from '../extensions/protocol'
+
+const EXPECTED = { ext: 'library', surface: 'widget:tonight' }
+
+function envelope(over: Record<string, unknown> = {}) {
+  return { p: 1, id: 'abc123', ext: 'library', surface: 'widget:tonight', type: 'storage.get', payload: { key: 'k' }, ...over }
+}
+
+function code(raw: unknown): string | null {
+  const r = parseRequest(raw, EXPECTED)
+  return r.ok ? null : r.code
+}
+
+describe('enveloppe valide', () => {
+  it('accepte une requête bien formée', () => {
+    const r = parseRequest(envelope(), EXPECTED)
+    if (!r.ok) throw new Error('refusée à tort : ' + r.code)
+    expect(r.request.type).toBe('storage.get')
+    expect(r.request.payload).toEqual({ key: 'k' })
+  })
+
+  it.each(REQUEST_TYPES)('accepte le type %s', (type) => {
+    expect(code(envelope({ type }))).toBeNull()
+  })
+})
+
+describe('une frame ne parle que pour elle même', () => {
+  it('refuse une requête au nom d une autre extension', () => {
+    expect(code(envelope({ ext: 'autre-ext' }))).toBe('PROTOCOL_WRONG_EXTENSION')
+  })
+
+  it('refuse une requête au nom d une autre surface', () => {
+    expect(code(envelope({ surface: 'page' }))).toBe('PROTOCOL_WRONG_SURFACE')
+  })
+})
+
+describe('entrée hostile par défaut', () => {
+  it.each([null, 42, 'texte', [], undefined])('refuse l enveloppe %p', (raw) => {
+    expect(code(raw)).toBe('PROTOCOL_MALFORMED')
+  })
+
+  it('refuse une version de protocole différente', () => {
+    expect(code(envelope({ p: 2 }))).toBe('PROTOCOL_VERSION')
+    expect(code(envelope({ p: '1' }))).toBe('PROTOCOL_VERSION')
+  })
+
+  it('refuse un type inconnu', () => {
+    expect(code(envelope({ type: 'fs.readFile' }))).toBe('PROTOCOL_UNKNOWN_TYPE')
+    expect(code(envelope({ type: '__proto__' }))).toBe('PROTOCOL_UNKNOWN_TYPE')
+  })
+
+  it.each(['', 'a'.repeat(65), 'id avec espace', '../x'])('refuse l identifiant de requête %p', (id) => {
+    expect(code(envelope({ id }))).toBe('PROTOCOL_MALFORMED')
+  })
+
+  it('refuse un identifiant d extension mal formé', () => {
+    expect(code(envelope({ ext: 'MAJ' }))).toBe('PROTOCOL_WRONG_EXTENSION')
+  })
+})
+
+describe('réponses et événements', () => {
+  it('corrèle une réponse à sa requête', () => {
+    expect(ok('abc123', [1, 2])).toEqual({ p: 1, id: 'abc123', ok: true, result: [1, 2] })
+  })
+
+  it('porte un code stable en cas d échec', () => {
+    const e = err('abc123', 'QUOTA_EXCEEDED', 'quota atteint')
+    expect(e).toMatchObject({ id: 'abc123', ok: false, error: { code: 'QUOTA_EXCEEDED' } })
+  })
+
+  it('un événement n a pas d identifiant, il n attend pas de réponse', () => {
+    expect(event('theme', { bg: '#000' })).toEqual({ p: 1, event: 'theme', payload: { bg: '#000' } })
+  })
+})
+
+describe('rejeu', () => {
+  it('accepte un identifiant neuf, refuse le même deux fois', () => {
+    const ledger = new RequestLedger()
+    expect(ledger.accept('a')).toBe(true)
+    expect(ledger.accept('a')).toBe(false)
+    expect(ledger.accept('b')).toBe(true)
+  })
+
+  it('reste borné en mémoire face à une frame bavarde', () => {
+    const ledger = new RequestLedger(4)
+    for (let i = 0; i < 1000; i++) expect(ledger.accept('id-' + i)).toBe(true)
+    // Les plus récents restent protégés, ce qui est le seul cas utile.
+    expect(ledger.accept('id-999')).toBe(false)
+  })
+})

--- a/nodyx-core/src/tests/extensionRoutes.test.ts
+++ b/nodyx-core/src/tests/extensionRoutes.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { FastifyInstance } from 'fastify'
+import { buildApp } from './helpers/buildApp'
+import { verifyExtensionToken } from '../extensions/token'
+
+const SECRET = 'secret-de-test'
+const ORIGIN = 'https://instance.example'
+
+const MANIFEST = {
+  api: 1,
+  id: 'demo-ext',
+  version: '1.0.0',
+  license: 'MIT',
+  default_locale: 'en',
+  label: '@label',
+  description: '@description',
+  surfaces: [
+    { type: 'widget', id: 'main', entry: 'ui/widget.js', label: '@label' },
+    { type: 'page', path: 'demo', entry: 'ui/page.js' },
+  ],
+}
+
+const dbQuery = vi.fn()
+
+vi.mock('../config/database', () => ({
+  db:    { query: (...a: unknown[]) => dbQuery(...a) },
+  redis: { exists: vi.fn().mockResolvedValue(0), setex: vi.fn(), incr: vi.fn().mockResolvedValue(1), expire: vi.fn() },
+}))
+vi.mock('../middleware/rateLimit', () => ({ rateLimit: vi.fn(async () => {}) }))
+vi.mock('../middleware/adminOnly', () => ({
+  adminOnly: vi.fn(async (req: { headers: Record<string, string> }, reply: { code: (n: number) => { send: (b: unknown) => unknown } }) => {
+    if (!req.headers.authorization) return reply.code(401).send({ error: 'Unauthorized' })
+  }),
+}))
+vi.mock('../middleware/auth', () => ({
+  optionalAuth: vi.fn(async (req: { headers: Record<string, string>; user?: unknown }) => {
+    if (req.headers.authorization === 'Bearer membre') req.user = { userId: 'user-42', username: 'ada' }
+  }),
+}))
+
+let app: FastifyInstance
+
+beforeEach(async () => {
+  dbQuery.mockReset()
+  process.env.JWT_SECRET   = SECRET
+  process.env.FRONTEND_URL = ORIGIN
+  const { extensionRoutes } = await import('../routes/extensions')
+  app = await buildApp(async (a) => { await a.register(extensionRoutes, { prefix: '/api/v1' }) })
+})
+
+function installedRow(over: Record<string, unknown> = {}) {
+  return { id: 'demo-ext', manifest: MANIFEST, version: '1.0.0', enabled: true, granted: ['identity', 'storage.user'], ...over }
+}
+
+const session = (body: unknown, auth?: string) => app.inject({
+  method: 'POST', url: '/api/v1/extensions/demo-ext/session',
+  headers: auth ? { authorization: auth } : {},
+  payload: body,
+})
+
+describe('frappe du jeton de surface', () => {
+  it('rend un jeton lié à l extension, la surface et l utilisateur', async () => {
+    dbQuery.mockResolvedValue({ rows: [installedRow()] })
+    const r = await session({ surface: 'widget:main' }, 'Bearer membre')
+    expect(r.statusCode).toBe(200)
+
+    const { token, expiresIn } = JSON.parse(r.body)
+    expect(expiresIn).toBe(600)
+
+    const v = verifyExtensionToken(token, { instanceId: ORIGIN, extensionId: 'demo-ext', surface: 'widget:main' }, SECRET)
+    if (!v.ok) throw new Error('jeton refusé à tort : ' + v.code)
+    expect(v.claims.sub).toBe('user-42')
+    expect(v.claims.prm).toEqual(['identity', 'storage.user'])
+  })
+
+  it('rend un jeton anonyme à un visiteur, sans échouer', async () => {
+    // Les vues publiques sont vues par des gens sans compte : une extension
+    // doit pouvoir s'y monter.
+    dbQuery.mockResolvedValue({ rows: [installedRow()] })
+    const r = await session({ surface: 'page' })
+    expect(r.statusCode).toBe(200)
+    const v = verifyExtensionToken(JSON.parse(r.body).token, { instanceId: ORIGIN, extensionId: 'demo-ext', surface: 'page' }, SECRET)
+    if (!v.ok) throw new Error('jeton refusé à tort')
+    expect(v.claims.sub).toBeNull()
+  })
+
+  it('porte les capacités ACCORDÉES, pas celles du manifeste', async () => {
+    dbQuery.mockResolvedValue({ rows: [installedRow({ granted: [] })] })
+    const r = await session({ surface: 'page' }, 'Bearer membre')
+    const v = verifyExtensionToken(JSON.parse(r.body).token, { instanceId: ORIGIN, extensionId: 'demo-ext', surface: 'page' }, SECRET)
+    if (!v.ok) throw new Error('jeton refusé à tort')
+    expect(v.claims.prm).toEqual([])
+  })
+
+  it('refuse une surface absente du manifeste installé', async () => {
+    dbQuery.mockResolvedValue({ rows: [installedRow()] })
+    const r = await session({ surface: 'widget:inconnu' }, 'Bearer membre')
+    expect(r.statusCode).toBe(404)
+    expect(JSON.parse(r.body).code).toBe('SURFACE_NOT_FOUND')
+  })
+
+  it.each(['', 'page/../evil', 'widget:MAJ', 'widget:'])('refuse la surface mal formée %p', async (surface) => {
+    dbQuery.mockResolvedValue({ rows: [installedRow()] })
+    const r = await session({ surface })
+    expect(r.statusCode).toBe(400)
+  })
+
+  it('refuse une extension désactivée', async () => {
+    dbQuery.mockResolvedValue({ rows: [installedRow({ enabled: false })] })
+    const r = await session({ surface: 'page' }, 'Bearer membre')
+    expect(r.statusCode).toBe(403)
+    expect(JSON.parse(r.body).code).toBe('EXTENSION_DISABLED')
+  })
+
+  it('refuse une extension inconnue', async () => {
+    dbQuery.mockResolvedValue({ rows: [] })
+    const r = await session({ surface: 'page' })
+    expect(r.statusCode).toBe(404)
+  })
+
+  it('le jeton frappé ne vaut pas pour une autre surface', async () => {
+    dbQuery.mockResolvedValue({ rows: [installedRow()] })
+    const { token } = JSON.parse((await session({ surface: 'page' }, 'Bearer membre')).body)
+    const v = verifyExtensionToken(token, { instanceId: ORIGIN, extensionId: 'demo-ext', surface: 'widget:main' }, SECRET)
+    expect(v.ok).toBe(false)
+    if (!v.ok) expect(v.code).toBe('TOKEN_WRONG_SURFACE')
+  })
+})
+
+describe('administration', () => {
+  it('exige une authentification sur la liste', async () => {
+    const r = await app.inject({ method: 'GET', url: '/api/v1/admin/extensions' })
+    expect(r.statusCode).toBe(401)
+  })
+
+  it('liste les extensions installées', async () => {
+    dbQuery.mockResolvedValue({ rows: [installedRow()] })
+    const r = await app.inject({ method: 'GET', url: '/api/v1/admin/extensions', headers: { authorization: 'Bearer admin' } })
+    expect(r.statusCode).toBe(200)
+    expect(JSON.parse(r.body).extensions).toHaveLength(1)
+  })
+
+  it('bascule l état actif', async () => {
+    dbQuery.mockResolvedValue({ rows: [], rowCount: 1 })
+    const r = await app.inject({
+      method: 'PATCH', url: '/api/v1/admin/extensions/demo-ext',
+      headers: { authorization: 'Bearer admin' }, payload: { enabled: false },
+    })
+    expect(r.statusCode).toBe(200)
+    expect(dbQuery.mock.calls[0][0]).toContain('UPDATE installed_extensions')
+  })
+
+  it('rend 404 quand la bascule ne touche aucune ligne', async () => {
+    dbQuery.mockResolvedValue({ rows: [], rowCount: 0 })
+    const r = await app.inject({
+      method: 'PATCH', url: '/api/v1/admin/extensions/absente',
+      headers: { authorization: 'Bearer admin' }, payload: { enabled: true },
+    })
+    expect(r.statusCode).toBe(404)
+  })
+
+  it('refuse un identifiant mal formé à la suppression', async () => {
+    const r = await app.inject({
+      method: 'DELETE', url: '/api/v1/admin/extensions/MAJUSCULES',
+      headers: { authorization: 'Bearer admin' },
+    })
+    expect(r.statusCode).toBe(400)
+    expect(dbQuery).not.toHaveBeenCalled()
+  })
+
+  it('exige une authentification pour installer', async () => {
+    const r = await app.inject({ method: 'POST', url: '/api/v1/admin/extensions/install' })
+    expect(r.statusCode).toBe(401)
+  })
+})


### PR DESCRIPTION
Suite de #514. Ferme le cote serveur de P0-A : une extension peut etre inspectee, installee, activee, desactivee, desinstallee, et une surface peut obtenir son jeton court.

## Contenu

**Migration 112**, quatre tables. `installed_extensions` distingue les permissions ACCORDEES par l'admin de celles demandees au manifeste, difference qui est le coeur du modele. `extension_storage` cloisonne par extension et par portee. `extension_secrets` garde des valeurs qu'aucune API ne renvoie. `extension_revoked_tokens` couvre la fenetre entre une desactivation et l'expiration du dernier jeton.

`installed_widgets` (071) reste en place une release de plus : tant que la bascule n'est pas verifiee sur les quatre instances, le repli doit rester le retour arriere du frontend seul.

**Capacites et installateur.** Le manifeste demande, l'admin accorde, le jeton porte. Accorder une capacite non demandee n'elargit rien, sinon l'ecran de permissions cesserait d'etre la verite. L'installateur ecrit dans un dossier temporaire renomme a la fin, nomme par version, et desinstalle la base AVANT le disque.

**Document de frame et assets.** La politique de securite est posee en en-tete ET en balise meta, un test verifiant que les deux sont identiques. L'origine est ecrite en clair, jamais `'self'`, qui ne correspond a rien dans une origine opaque. Assets servis par version, type determine par le serveur, `nosniff` et CORP.

**Routes d'administration et session.** Une route d'inspection lit un paquet SANS l'installer, pour que l'ecran de permissions ait quelque chose a afficher : sans elle le consentement serait decoratif. La frappe du jeton est appelee par l'hote avec la session reelle, jamais par la frame.

**Protocole** versionne et correle. Une frame ne parle que pour elle meme : l'extension et la surface annoncees doivent correspondre a celles de la frame.

## Verification

Migration appliquee et EPROUVEE sur une base jetable, pas seulement relue. `UNIQUE NULLS NOT DISTINCT` mord vraiment, la contrainte de coherence de portee mord, la cascade de desinstallation efface le stockage.

Quatre tentatives de sortie de dossier sur la route d'assets ne rendent jamais le fichier temoin place hors du dossier de version, y compris la forme encodee.

675 tests verts sur le coeur, tsc propre.

## Perimetre et risque

Onze fichiers, 1378 lignes ajoutees, zero suppression. Les deux fichiers de routes sont enregistres dans le point d'entree du coeur, strictement en ajout : l'ancien chemin widget est intact, et rien de neuf n'est encore appele par le frontend.

## Reste connu, non masque

La revocation fine par jti emis n'est pas branchee, faute de suivi des jetons emis : dans la fenetre de dix minutes, un jeton deja frappe reste valable apres une desactivation. A corriger par un compteur d'epoque par extension.

## Suite

SDK cote frame et composant hote, donc du frontend, puis le premier bout en bout : installer un .nyx et voir sa surface se monter isolee.
