### PR TITLE
SDK d'extensions : stockage cle/valeur cloisonne (P0-B, 1/3)

### DIFF
--- a/nodyx-core/src/extensions/storage.ts
+++ b/nodyx-core/src/extensions/storage.ts
@@ -1,0 +1,186 @@
+// Stockage clé/valeur des extensions.
+//
+// Deux règles portent tout le reste.
+//
+// 1. L'extension ne nomme JAMAIS son propre espace. La clé d'extension vient
+//    du jeton, la portée est validée ici, et l'identifiant d'utilisateur vient
+//    de la session portée par le jeton. Une requête ne peut pas designer
+//    l'espace d'une autre extension ni d'un autre membre.
+//
+// 2. Un quota en octets ne suffit pas. Sans limites fines, une extension épuise
+//    le processeur et la base sans jamais approcher son mégaoctet : des clés
+//    interminables, du JSON profond, des écritures en rafale.
+//
+// Module sans import de base : il reçoit sa fonction de requête, comme
+// l'installateur. cf SPECS/NODYX_SDK_REFERENCE.md §9, NODYX_SDK_SECURITY.md §4.5
+
+import { STORAGE } from './limits'
+
+export type Scope = 'user' | 'instance'
+
+export type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
+
+export interface StorageCaller {
+  extensionId: string
+  /** Utilisateur de la session portée par le jeton, ou null pour un visiteur. */
+  userId:      string | null
+  /** Capacités ACCORDÉES par l'admin, telles qu'elles voyagent dans le jeton. */
+  granted:     string[]
+  /** Quota en octets accordé pour cette portée. */
+  quotaBytes:  number
+}
+
+export type StorageError =
+  | 'PERMISSION_DENIED' | 'NOT_AUTHENTICATED' | 'INVALID_ARGUMENT'
+  | 'KEY_TOO_LONG' | 'VALUE_TOO_LARGE' | 'TOO_MANY_KEYS' | 'JSON_TOO_DEEP'
+  | 'QUOTA_EXCEEDED' | 'NOT_FOUND'
+
+export type StorageResult<T> =
+  | { ok: true;  value: T }
+  | { ok: false; code: StorageError; message: string }
+
+const RE_KEY = /^[A-Za-z0-9_.:-]+$/
+
+function fail(code: StorageError, message: string): StorageResult<never> {
+  return { ok: false, code, message }
+}
+
+/** Profondeur d'une valeur JSON, tableaux compris. */
+export function jsonDepth(value: unknown, depth = 1): number {
+  if (value === null || typeof value !== 'object') return depth
+  if (depth > STORAGE.maxJsonDepth) return depth
+  let max = depth
+  for (const v of Object.values(value as Record<string, unknown>)) {
+    max = Math.max(max, jsonDepth(v, depth + 1))
+  }
+  return max
+}
+
+/** Taille sérialisée, en octets, telle qu'elle sera stockée. */
+export function valueBytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value ?? null), 'utf8')
+}
+
+export function validateKey(key: unknown): StorageResult<string> {
+  if (typeof key !== 'string' || key.length === 0) return fail('INVALID_ARGUMENT', 'clé absente')
+  if (key.length > STORAGE.maxKeyLength)           return fail('KEY_TOO_LONG', `clé au delà de ${STORAGE.maxKeyLength} caractères`)
+  if (!RE_KEY.test(key))                           return fail('INVALID_ARGUMENT', 'clé aux caractères refusés')
+  return { ok: true, value: key }
+}
+
+/**
+ * Résout la portée demandée en droit effectif.
+ *
+ * Règle des deux axes : la capacité de l'extension et les droits de
+ * l'utilisateur sont deux dimensions distinctes, et le droit effectif est leur
+ * intersection. Une extension qui détient l'écriture partagée n'écrit pas
+ * parce qu'un membre a ouvert son interface.
+ */
+export function resolveScope(
+  raw: unknown,
+  caller: StorageCaller,
+  intent: 'read' | 'write',
+): StorageResult<{ scope: Scope; userId: string | null }> {
+  const scope = raw === undefined ? 'user' : raw
+  if (scope !== 'user' && scope !== 'instance') return fail('INVALID_ARGUMENT', 'portée inconnue')
+
+  if (scope === 'user') {
+    if (!caller.granted.includes('storage.user')) return fail('PERMISSION_DENIED', 'la capacité storage.user n\'a pas été accordée')
+    if (!caller.userId)                           return fail('NOT_AUTHENTICATED', 'la portée utilisateur exige une session : gardez l\'état en mémoire pour un visiteur')
+    return { ok: true, value: { scope, userId: caller.userId } }
+  }
+
+  const needed = intent === 'write' ? 'storage.instance.write' : 'storage.instance.read'
+  if (!caller.granted.includes(needed)) return fail('PERMISSION_DENIED', `la capacité ${needed} n'a pas été accordée`)
+  return { ok: true, value: { scope, userId: null } }
+}
+
+// ── Opérations ───────────────────────────────────────────────────────────────
+
+export async function storageGet(caller: StorageCaller, rawKey: unknown, rawScope: unknown, query: QueryFn): Promise<StorageResult<unknown>> {
+  const key = validateKey(rawKey)
+  if (!key.ok) return key
+  const scope = resolveScope(rawScope, caller, 'read')
+  if (!scope.ok) return scope
+
+  const { rows } = await query(
+    `SELECT value FROM extension_storage
+      WHERE extension_id = $1 AND scope = $2 AND user_id IS NOT DISTINCT FROM $3 AND key = $4`,
+    [caller.extensionId, scope.value.scope, scope.value.userId, key.value],
+  )
+  const row = rows[0] as { value: unknown } | undefined
+  return { ok: true, value: row ? row.value : undefined }
+}
+
+export async function storageSet(caller: StorageCaller, rawKey: unknown, value: unknown, rawScope: unknown, query: QueryFn): Promise<StorageResult<{ bytes: number }>> {
+  const key = validateKey(rawKey)
+  if (!key.ok) return key
+  const scope = resolveScope(rawScope, caller, 'write')
+  if (!scope.ok) return scope
+
+  if (value === undefined) return fail('INVALID_ARGUMENT', 'valeur absente : utilisez delete pour retirer une clé')
+
+  let bytes: number
+  try {
+    bytes = valueBytes(value)
+  } catch {
+    return fail('INVALID_ARGUMENT', 'valeur non sérialisable : pas de référence circulaire, pas de Map, pas de Date')
+  }
+  if (bytes > STORAGE.maxValueBytes)              return fail('VALUE_TOO_LARGE', `valeur au delà de ${STORAGE.maxValueBytes / 1024} Ko`)
+  if (jsonDepth(value) > STORAGE.maxJsonDepth)    return fail('JSON_TOO_DEEP', `imbrication au delà de ${STORAGE.maxJsonDepth} niveaux`)
+
+  // On mesure l'espace occupé SANS la clé visée : une réécriture ne doit pas
+  // se faire refuser au motif de la place qu'elle libère.
+  const { rows } = await query(
+    `SELECT count(*)::int AS n, coalesce(sum(bytes), 0)::int AS total
+       FROM extension_storage
+      WHERE extension_id = $1 AND scope = $2 AND user_id IS NOT DISTINCT FROM $3 AND key <> $4`,
+    [caller.extensionId, scope.value.scope, scope.value.userId, key.value],
+  )
+  const { n, total } = (rows[0] ?? { n: 0, total: 0 }) as { n: number; total: number }
+
+  if (n + 1 > STORAGE.maxKeysPerScope)     return fail('TOO_MANY_KEYS', `au delà de ${STORAGE.maxKeysPerScope} clés pour cette portée`)
+  if (total + bytes > caller.quotaBytes)   return fail('QUOTA_EXCEEDED', `quota de ${Math.round(caller.quotaBytes / 1024)} Ko atteint`)
+
+  await query(
+    `INSERT INTO extension_storage (extension_id, scope, user_id, key, value, bytes, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, now(), now())
+     ON CONFLICT (extension_id, scope, user_id, key)
+     DO UPDATE SET value = $5, bytes = $6, updated_at = now()`,
+    [caller.extensionId, scope.value.scope, scope.value.userId, key.value, JSON.stringify(value), bytes],
+  )
+  return { ok: true, value: { bytes } }
+}
+
+export async function storageDelete(caller: StorageCaller, rawKey: unknown, rawScope: unknown, query: QueryFn): Promise<StorageResult<{ deleted: boolean }>> {
+  const key = validateKey(rawKey)
+  if (!key.ok) return key
+  const scope = resolveScope(rawScope, caller, 'write')
+  if (!scope.ok) return scope
+
+  const { rows } = await query(
+    `DELETE FROM extension_storage
+      WHERE extension_id = $1 AND scope = $2 AND user_id IS NOT DISTINCT FROM $3 AND key = $4
+      RETURNING key`,
+    [caller.extensionId, scope.value.scope, scope.value.userId, key.value],
+  )
+  return { ok: true, value: { deleted: rows.length > 0 } }
+}
+
+export async function storageList(caller: StorageCaller, rawScope: unknown, query: QueryFn): Promise<StorageResult<Array<{ key: string; bytes: number; updatedAt: string }>>> {
+  const scope = resolveScope(rawScope, caller, 'read')
+  if (!scope.ok) return scope
+
+  const { rows } = await query(
+    `SELECT key, bytes, updated_at FROM extension_storage
+      WHERE extension_id = $1 AND scope = $2 AND user_id IS NOT DISTINCT FROM $3
+      ORDER BY key`,
+    [caller.extensionId, scope.value.scope, scope.value.userId],
+  )
+  return {
+    ok: true,
+    value: (rows as Array<{ key: string; bytes: number; updated_at: string | Date }>).map(r => ({
+      key: r.key, bytes: r.bytes, updatedAt: new Date(r.updated_at).toISOString(),
+    })),
+  }
+}

--- a/nodyx-core/src/routes/extensions.ts
+++ b/nodyx-core/src/routes/extensions.ts
@@ -9,14 +9,17 @@
 
 import type { FastifyInstance } from 'fastify'
 import { randomUUID } from 'crypto'
-import { db }           from '../config/database'
+import { db, redis }    from '../config/database'
 import { adminOnly }    from '../middleware/adminOnly'
 import { optionalAuth } from '../middleware/auth'
 import { rateLimit }    from '../middleware/rateLimit'
 import { installExtension, uninstallExtension } from '../extensions/installer'
 import { sensitiveCapabilities } from '../extensions/capabilities'
 import { validateManifest }      from '../extensions/manifest'
-import { mintExtensionToken }    from '../extensions/token'
+import { mintExtensionToken, verifyExtensionToken, type ExtensionTokenClaims } from '../extensions/token'
+import { storageGet, storageSet, storageDelete, storageList } from '../extensions/storage'
+import { parseSize } from '../extensions/manifest'
+import { STORAGE } from '../extensions/limits'
 import { PACKAGE, SURFACE }      from '../extensions/limits'
 
 const RE_ID      = /^[a-z][a-z0-9-]{2,38}$/
@@ -148,6 +151,82 @@ export async function extensionRoutes(app: FastifyInstance) {
     if (!RE_ID.test(id)) return reply.code(400).send({ error: 'Identifiant invalide', code: 'INVALID_ID' })
     await uninstallExtension(id, { query })
     return reply.send({ success: true })
+  })
+
+  // ── POST /extensions/:id/storage ────────────────────────────────────────
+  //
+  // Authentifiee par le JETON D'EXTENSION, jamais par le cookie de session :
+  // la frame n'a pas de session, et c'est tout l'interet. Origin: null est
+  // accepte, parce que c'est ce qu'envoie une origine opaque, mais il ne vaut
+  // strictement rien comme preuve : l'identite vient du jeton.
+  app.post('/extensions/:id/storage', { preHandler: [rateLimit] }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const surface = request.headers['x-nodyx-surface']
+    const header  = request.headers.authorization
+
+    if (!RE_ID.test(id) || typeof surface !== 'string' || !RE_SURFACE.test(surface)) {
+      return reply.code(400).send({ error: 'Requête invalide', code: 'INVALID_REQUEST' })
+    }
+    if (!header?.startsWith('Bearer ')) {
+      return reply.code(401).send({ error: 'Jeton absent', code: 'TOKEN_MISSING' })
+    }
+    if (!appSecret) return reply.code(500).send({ error: 'Instance mal configurée', code: 'MISSING_SECRET' })
+
+    const revoked = await redis.exists(`ext:revoked:${id}`).catch(() => 0)
+    const verified = verifyExtensionToken(
+      header.slice(7),
+      { instanceId, extensionId: id, surface },
+      appSecret,
+      () => revoked === 1,
+    )
+    if (!verified.ok) {
+      const status = verified.code === 'SESSION_EXPIRED' ? 401 : 403
+      return reply.code(status).send({ error: verified.message, code: verified.code })
+    }
+    const claims: ExtensionTokenClaims = verified.claims
+
+    const body = (request.body ?? {}) as { op?: string; key?: unknown; value?: unknown; scope?: unknown }
+
+    // Les ecritures sont plafonnees par membre et par extension : sans ca, une
+    // extension martele la base sans jamais approcher son quota d'octets.
+    if (body.op === 'set' || body.op === 'delete') {
+      const bucket = `ext:writes:${id}:${claims.sub ?? 'anon'}`
+      const hits = await redis.incr(bucket).catch(() => 0)
+      if (hits === 1) await redis.expire(bucket, 60).catch(() => {})
+      if (hits > STORAGE.writesPerMinute) {
+        return reply.code(429).send({ error: 'Trop d\'écritures', code: 'RATE_LIMITED' })
+      }
+    }
+
+    // Le quota vient du manifeste INSTALLE, jamais de la requete.
+    const { rows } = await db.query(
+      `SELECT manifest, enabled FROM installed_extensions WHERE id = $1`, [id],
+    )
+    const row = rows[0] as { manifest: Record<string, unknown>; enabled: boolean } | undefined
+    if (!row)         return reply.code(404).send({ error: 'Extension introuvable', code: 'EXTENSION_NOT_FOUND' })
+    if (!row.enabled) return reply.code(403).send({ error: 'Extension désactivée', code: 'EXTENSION_DISABLED' })
+
+    const declared = (row.manifest as { permissions?: { storage?: Record<string, string> } }).permissions?.storage ?? {}
+    const scopeKey = body.scope === 'instance' ? 'instance' : 'user'
+    const quotaBytes = Math.min(parseSize(declared[scopeKey] ?? '') ?? 0, STORAGE.maxQuotaBytes)
+
+    const caller = { extensionId: id, userId: claims.sub, granted: claims.prm, quotaBytes }
+    const query  = (sql: string, params?: unknown[]) => db.query(sql, params) as Promise<{ rows: unknown[] }>
+
+    const result = body.op === 'get'    ? await storageGet(caller, body.key, body.scope, query)
+                 : body.op === 'set'    ? await storageSet(caller, body.key, body.value, body.scope, query)
+                 : body.op === 'delete' ? await storageDelete(caller, body.key, body.scope, query)
+                 : body.op === 'list'   ? await storageList(caller, body.scope, query)
+                 : { ok: false as const, code: 'INVALID_ARGUMENT' as const, message: 'operation inconnue' }
+
+    if (!result.ok) {
+      const status = result.code === 'PERMISSION_DENIED'  ? 403
+                   : result.code === 'NOT_AUTHENTICATED'  ? 401
+                   : result.code === 'QUOTA_EXCEEDED'     ? 507
+                   : 400
+      return reply.code(status).send({ error: result.message, code: result.code })
+    }
+    return reply.send({ result: result.value })
   })
 
   // ── POST /extensions/:id/session ────────────────────────────────────────

--- a/nodyx-core/src/tests/extensionRoutes.test.ts
+++ b/nodyx-core/src/tests/extensionRoutes.test.ts
@@ -22,9 +22,17 @@ const MANIFEST = {
 
 const dbQuery = vi.fn()
 
+const redisIncr = vi.fn().mockResolvedValue(1)
 vi.mock('../config/database', () => ({
   db:    { query: (...a: unknown[]) => dbQuery(...a) },
-  redis: { exists: vi.fn().mockResolvedValue(0), setex: vi.fn(), incr: vi.fn().mockResolvedValue(1), expire: vi.fn() },
+  redis: {
+    exists: vi.fn().mockResolvedValue(0),
+    setex:  vi.fn().mockResolvedValue('OK'),
+    incr:   (...a: unknown[]) => redisIncr(...a),
+    // Doit rendre une promesse : le vrai ioredis en rend une, et la route y
+    // enchaine un .catch(). Un mock qui rend undefined fabrique un faux 500.
+    expire: vi.fn().mockResolvedValue(1),
+  },
 }))
 vi.mock('../middleware/rateLimit', () => ({ rateLimit: vi.fn(async () => {}) }))
 vi.mock('../middleware/adminOnly', () => ({
@@ -171,5 +179,109 @@ describe('administration', () => {
   it('exige une authentification pour installer', async () => {
     const r = await app.inject({ method: 'POST', url: '/api/v1/admin/extensions/install' })
     expect(r.statusCode).toBe(401)
+  })
+})
+
+// ── Stockage, authentifie par le jeton d'extension ─────────────────────────
+
+describe('stockage', () => {
+  const MANIFEST_STORAGE = {
+    ...MANIFEST,
+    permissions: { storage: { user: '1mb' } },
+  }
+
+  async function tokenFor(granted: string[] = ['storage.user']) {
+    dbQuery.mockResolvedValue({ rows: [installedRow({ granted, manifest: MANIFEST_STORAGE })] })
+    const r = await session({ surface: 'page' }, 'Bearer membre')
+    return JSON.parse(r.body).token as string
+  }
+
+  const call = (token: string, body: unknown, surface = 'page') => app.inject({
+    method: 'POST', url: '/api/v1/extensions/demo-ext/storage',
+    headers: { authorization: `Bearer ${token}`, 'x-nodyx-surface': surface },
+    payload: body,
+  })
+
+  it('lit une cle avec un jeton valide', async () => {
+    const token = await tokenFor()
+    dbQuery.mockReset()
+    dbQuery
+      .mockResolvedValueOnce({ rows: [{ manifest: MANIFEST_STORAGE, enabled: true }] })
+      .mockResolvedValueOnce({ rows: [{ value: [603] }] })
+    const r = await call(token, { op: 'get', key: 'watched' })
+    expect(r.statusCode).toBe(200)
+    expect(JSON.parse(r.body).result).toEqual([603])
+  })
+
+  it('refuse sans jeton', async () => {
+    const r = await app.inject({
+      method: 'POST', url: '/api/v1/extensions/demo-ext/storage',
+      headers: { 'x-nodyx-surface': 'page' }, payload: { op: 'get', key: 'k' },
+    })
+    expect(r.statusCode).toBe(401)
+    expect(JSON.parse(r.body).code).toBe('TOKEN_MISSING')
+  })
+
+  it('refuse un jeton frappe pour une AUTRE surface', async () => {
+    const token = await tokenFor()
+    const r = await call(token, { op: 'get', key: 'k' }, 'widget:main')
+    expect(r.statusCode).toBe(403)
+    expect(JSON.parse(r.body).code).toBe('TOKEN_WRONG_SURFACE')
+  })
+
+  it('refuse une capacite non accordee, meme avec un jeton valide', async () => {
+    const token = await tokenFor([])            // aucune capacite accordee
+    dbQuery.mockReset()
+    dbQuery.mockResolvedValue({ rows: [{ manifest: MANIFEST_STORAGE, enabled: true }] })
+    const r = await call(token, { op: 'get', key: 'k' })
+    expect(r.statusCode).toBe(403)
+    expect(JSON.parse(r.body).code).toBe('PERMISSION_DENIED')
+  })
+
+  it('refuse quand l extension a ete desactivee entre temps', async () => {
+    const token = await tokenFor()
+    dbQuery.mockReset()
+    dbQuery.mockResolvedValue({ rows: [{ manifest: MANIFEST_STORAGE, enabled: false }] })
+    const r = await call(token, { op: 'get', key: 'k' })
+    expect(r.statusCode).toBe(403)
+    expect(JSON.parse(r.body).code).toBe('EXTENSION_DISABLED')
+  })
+
+  it('plafonne les ecritures par membre', async () => {
+    const token = await tokenFor()
+    redisIncr.mockResolvedValueOnce(31)
+    const r = await call(token, { op: 'set', key: 'k', value: 1 })
+    expect(r.statusCode).toBe(429)
+    expect(JSON.parse(r.body).code).toBe('RATE_LIMITED')
+  })
+
+  it('ne plafonne PAS les lectures', async () => {
+    const token = await tokenFor()
+    redisIncr.mockClear()
+    dbQuery.mockReset()
+    dbQuery
+      .mockResolvedValueOnce({ rows: [{ manifest: MANIFEST_STORAGE, enabled: true }] })
+      .mockResolvedValueOnce({ rows: [] })
+    await call(token, { op: 'get', key: 'k' })
+    expect(redisIncr).not.toHaveBeenCalled()
+  })
+
+  it('rend 507 quand le quota est atteint', async () => {
+    const token = await tokenFor()
+    dbQuery.mockReset()
+    dbQuery
+      .mockResolvedValueOnce({ rows: [{ manifest: MANIFEST_STORAGE, enabled: true }] })
+      .mockResolvedValueOnce({ rows: [{ n: 1, total: 1024 * 1024 }] })
+    const r = await call(token, { op: 'set', key: 'k', value: 'x'.repeat(100) })
+    expect(r.statusCode).toBe(507)
+    expect(JSON.parse(r.body).code).toBe('QUOTA_EXCEEDED')
+  })
+
+  it('refuse une operation inconnue', async () => {
+    const token = await tokenFor()
+    dbQuery.mockReset()
+    dbQuery.mockResolvedValue({ rows: [{ manifest: MANIFEST_STORAGE, enabled: true }] })
+    const r = await call(token, { op: 'truncate' })
+    expect(r.statusCode).toBe(400)
   })
 })

--- a/nodyx-core/src/tests/extensionStorage.test.ts
+++ b/nodyx-core/src/tests/extensionStorage.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  storageGet, storageSet, storageDelete, storageList,
+  resolveScope, validateKey, jsonDepth, valueBytes,
+  type StorageCaller,
+} from '../extensions/storage'
+
+const CALLER: StorageCaller = {
+  extensionId: 'library',
+  userId:      'user-42',
+  granted:     ['storage.user', 'storage.instance.read'],
+  quotaBytes:  1024 * 1024,
+}
+
+let query: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  query = vi.fn().mockResolvedValue({ rows: [] })
+})
+
+/** Reponse par defaut de la mesure d'occupation. */
+function usage(n: number, total: number) {
+  query.mockResolvedValueOnce({ rows: [{ n, total }] }).mockResolvedValueOnce({ rows: [] })
+}
+
+describe('l extension ne nomme jamais son propre espace', () => {
+  it('la requete porte l extension du JETON, pas celle de l appel', async () => {
+    usage(0, 0)
+    await storageSet(CALLER, 'k', { a: 1 }, undefined, query)
+    for (const call of query.mock.calls) {
+      expect(call[1][0]).toBe('library')       // toujours l'extension de l'appelant
+    }
+  })
+
+  it('la portee utilisateur vise l utilisateur de la session', async () => {
+    await storageGet(CALLER, 'k', 'user', query)
+    expect(query.mock.calls[0][1]).toEqual(['library', 'user', 'user-42', 'k'])
+  })
+
+  it('la portee instance ne porte aucun utilisateur', async () => {
+    await storageGet(CALLER, 'k', 'instance', query)
+    expect(query.mock.calls[0][1]).toEqual(['library', 'instance', null, 'k'])
+  })
+})
+
+describe('les deux axes : capacite accordee et droits utilisateur', () => {
+  it('refuse la portee utilisateur sans la capacite', async () => {
+    const r = await storageGet({ ...CALLER, granted: [] }, 'k', 'user', query)
+    expect(r).toMatchObject({ ok: false, code: 'PERMISSION_DENIED' })
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it('refuse la portee utilisateur a un visiteur, avec un conseil utile', async () => {
+    const r = await storageGet({ ...CALLER, userId: null }, 'k', 'user', query)
+    expect(r).toMatchObject({ ok: false, code: 'NOT_AUTHENTICATED' })
+    if (!r.ok) expect(r.message).toContain('mémoire')
+  })
+
+  it('lire le partage ne donne pas le droit d y ecrire', async () => {
+    expect(resolveScope('instance', CALLER, 'read')).toMatchObject({ ok: true })
+    expect(resolveScope('instance', CALLER, 'write')).toMatchObject({ ok: false, code: 'PERMISSION_DENIED' })
+  })
+
+  it('accorde l ecriture partagee quand la capacite est la', () => {
+    const c = { ...CALLER, granted: [...CALLER.granted, 'storage.instance.write'] }
+    expect(resolveScope('instance', c, 'write')).toMatchObject({ ok: true })
+  })
+
+  it('refuse une portee inconnue', () => {
+    expect(resolveScope('global', CALLER, 'read')).toMatchObject({ ok: false, code: 'INVALID_ARGUMENT' })
+  })
+
+  it('la portee par defaut est utilisateur', () => {
+    const r = resolveScope(undefined, CALLER, 'read')
+    expect(r).toMatchObject({ ok: true })
+    if (r.ok) expect(r.value.scope).toBe('user')
+  })
+})
+
+describe('un quota en octets ne suffit pas', () => {
+  it('refuse une cle interminable', async () => {
+    const r = await storageSet(CALLER, 'k'.repeat(200), 1, undefined, query)
+    expect(r).toMatchObject({ ok: false, code: 'KEY_TOO_LONG' })
+  })
+
+  it('refuse une cle aux caracteres douteux', async () => {
+    for (const key of ['a b', 'a/b', '../x', 'é']) {
+      expect(await storageSet(CALLER, key, 1, undefined, query)).toMatchObject({ ok: false, code: 'INVALID_ARGUMENT' })
+    }
+  })
+
+  it('refuse une valeur trop grosse', async () => {
+    const r = await storageSet(CALLER, 'k', 'x'.repeat(70_000), undefined, query)
+    expect(r).toMatchObject({ ok: false, code: 'VALUE_TOO_LARGE' })
+  })
+
+  it('refuse un JSON trop profond, sans exploser en le mesurant', async () => {
+    let deep: unknown = 'fond'
+    for (let i = 0; i < 40; i++) deep = { n: deep }
+    const r = await storageSet(CALLER, 'k', deep, undefined, query)
+    expect(r).toMatchObject({ ok: false, code: 'JSON_TOO_DEEP' })
+  })
+
+  it('refuse au dela du nombre de cles', async () => {
+    usage(500, 100)
+    const r = await storageSet(CALLER, 'nouvelle', 1, undefined, query)
+    expect(r).toMatchObject({ ok: false, code: 'TOO_MANY_KEYS' })
+  })
+
+  it('refuse au dela du quota d octets', async () => {
+    usage(3, 1024 * 1024)
+    const r = await storageSet(CALLER, 'k', { gros: 'x'.repeat(100) }, undefined, query)
+    expect(r).toMatchObject({ ok: false, code: 'QUOTA_EXCEEDED' })
+  })
+
+  it('une reecriture ne se fait pas refuser pour la place qu elle libere', async () => {
+    // La mesure exclut la cle visee : sans ca, remplacer une grosse valeur par
+    // une petite echouerait alors qu'elle fait de la place.
+    usage(2, 500)
+    const r = await storageSet({ ...CALLER, quotaBytes: 600 }, 'k', { a: 1 }, undefined, query)
+    expect(r.ok).toBe(true)
+    expect(query.mock.calls[0][0]).toContain('key <> $4')
+  })
+
+  it('refuse une valeur non serialisable plutot que de planter', async () => {
+    const cyclique: Record<string, unknown> = {}
+    cyclique.moi = cyclique
+    const r = await storageSet(CALLER, 'k', cyclique, undefined, query)
+    expect(r).toMatchObject({ ok: false, code: 'INVALID_ARGUMENT' })
+  })
+
+  it('refuse une ecriture sans valeur, en orientant vers delete', async () => {
+    const r = await storageSet(CALLER, 'k', undefined, undefined, query)
+    expect(r).toMatchObject({ ok: false, code: 'INVALID_ARGUMENT' })
+    if (!r.ok) expect(r.message).toContain('delete')
+  })
+})
+
+describe('operations', () => {
+  it('rend undefined pour une cle absente, pas une erreur', async () => {
+    const r = await storageGet(CALLER, 'absente', undefined, query)
+    expect(r).toEqual({ ok: true, value: undefined })
+  })
+
+  it('rend la valeur stockee', async () => {
+    query.mockResolvedValue({ rows: [{ value: [603, 27205] }] })
+    const r = await storageGet(CALLER, 'watched', undefined, query)
+    expect(r).toEqual({ ok: true, value: [603, 27205] })
+  })
+
+  it('ecrit et rend la taille occupee', async () => {
+    usage(1, 20)
+    const r = await storageSet(CALLER, 'k', { a: 1 }, undefined, query)
+    expect(r).toEqual({ ok: true, value: { bytes: valueBytes({ a: 1 }) } })
+    expect(query.mock.calls[1][0]).toContain('ON CONFLICT')
+  })
+
+  it('dit si la suppression a touche quelque chose', async () => {
+    query.mockResolvedValue({ rows: [{ key: 'k' }] })
+    expect(await storageDelete(CALLER, 'k', undefined, query)).toEqual({ ok: true, value: { deleted: true } })
+    query.mockResolvedValue({ rows: [] })
+    expect(await storageDelete(CALLER, 'k', undefined, query)).toEqual({ ok: true, value: { deleted: false } })
+  })
+
+  it('liste les cles avec leur taille et leur date', async () => {
+    query.mockResolvedValue({ rows: [{ key: 'a', bytes: 12, updated_at: '2026-08-14T10:00:00.000Z' }] })
+    const r = await storageList(CALLER, undefined, query)
+    expect(r).toEqual({ ok: true, value: [{ key: 'a', bytes: 12, updatedAt: '2026-08-14T10:00:00.000Z' }] })
+  })
+})
+
+describe('outils de mesure', () => {
+  it('mesure la profondeur sans partir a l infini', () => {
+    expect(jsonDepth('a')).toBe(1)
+    expect(jsonDepth({ a: { b: { c: 1 } } })).toBe(4)
+    expect(jsonDepth([[[1]]])).toBe(4)
+    let deep: unknown = 1
+    for (let i = 0; i < 5000; i++) deep = [deep]
+    expect(jsonDepth(deep)).toBeGreaterThan(16)      // s'arrete, ne deborde pas la pile
+  })
+
+  it('mesure les octets reellement stockes', () => {
+    expect(valueBytes('é')).toBe(4)                  // guillemets compris
+    expect(valueBytes(null)).toBe(4)
+  })
+
+  it('valide les cles', () => {
+    expect(validateKey('a.b:c-d_e')).toMatchObject({ ok: true })
+    expect(validateKey('')).toMatchObject({ ok: false })
+    expect(validateKey(42)).toMatchObject({ ok: false })
+  })
+})


### PR DESCRIPTION
Premiere piece de P0-B, l'API de runtime. Ouverte apres que le banc de confinement soit passe au vert (#517) : c'etait la porte que la specification pose elle meme.

## Deux regles, et leurs tests

**L'extension ne nomme JAMAIS son propre espace.** La cle d'extension vient du jeton, la portee est validee, l'identifiant d'utilisateur vient de la session portee par le jeton. Un test verifie que toutes les requetes SQL emises portent l'extension de l'appelant, quoi que dise le corps de l'appel.

**Un quota en octets ne suffit pas.** Sans limites fines, une extension epuise le processeur et la base sans jamais approcher son megaoctet : longueur de cle, taille de valeur, profondeur JSON, nombre de cles, frequence d'ecriture.

## Un detail qui aurait fait un bug agacant

La mesure d'occupation **exclut la cle visee**. Sinon remplacer une grosse valeur par une petite echouerait pour depassement de quota, alors qu'elle fait de la place. Le test le verrouille en verifiant le `key <> $4` dans le SQL.

## Regle des deux axes

Lire le partage ne donne pas le droit d'y ecrire, et une capacite accordee a l'installation n'est jamais une elevation de privilege pour l'utilisateur courant. Le quota vient du manifeste INSTALLE, jamais de la requete.

La route est authentifiee par le JETON D'EXTENSION et jamais par le cookie de session : la frame n'a pas de session, et c'est tout l'interet. `Origin: null` est accepte parce que c'est ce qu'envoie une origine opaque, mais il ne vaut rien comme preuve.

## Cas limites traites plutot que subis

Une cle absente rend `undefined` et non une erreur. Une valeur cyclique est refusee proprement. Une ecriture sans valeur oriente vers `delete`. Un visiteur qui demande la portee utilisateur recoit un conseil utile, garder l'etat en memoire, plutot qu'un refus sec.

## Note de banc

Un test de route a demande une correction de MOCK et non de code : ioredis rend des promesses, un mock qui rend `undefined` fait planter un `.catch()` et fabrique un faux 500 qui ressemble a un bug de quota.

## Perimetre

Additif. Le module est pur, sans import de base, il recoit sa fonction de requete. La route s'ajoute au fichier d'extensions existant. Rien de neuf n'est appele par le frontend : le pont repond encore `NOT_IMPLEMENTED` pour `storage.*`, le cablage vient dans le lot suivant.

26 tests sur le module, 10 de plus sur la route, 713 sur le coeur, tsc propre.
