### PR TITLE
SDK d'extensions : projection de l'identite cote serveur (P0-B, 2/3)

### DIFF
--- a/nodyx-core/src/extensions/identity.ts
+++ b/nodyx-core/src/extensions/identity.ts
@@ -1,0 +1,63 @@
+// Projection de l'identite d'un membre vers une extension.
+//
+// `nodyx.user` n'est PAS une copie de la session : c'est une projection
+// autorisee, champ par champ, de ce que l'admin a accepte de montrer.
+//
+// La projection se fait ICI, cote serveur, et pas dans la page qui monte la
+// surface. C'est deliberе : si le frontend devait filtrer, il suffirait d'un
+// composant distrait passant l'objet utilisateur entier pour que l'adresse de
+// courriel d'un membre parte dans une extension tierce. Le serveur ne rend que
+// ce qui est accorde, et la question ne se pose plus.
+//
+// cf SPECS/NODYX_SDK_REFERENCE.md §5.2, NODYX_SDK_SECURITY.md §4.2
+
+/** Les seuls champs projetables. L'adresse de courriel n'en fait PAS partie. */
+export const PROJECTABLE_FIELDS = ['id', 'username', 'avatar', 'locale'] as const
+
+export type ProjectableField = typeof PROJECTABLE_FIELDS[number]
+
+export interface UserRow {
+  id?:       string
+  username?: string
+  avatar?:   string | null
+  locale?:   string | null
+  /** Volontairement present dans le type : c'est ce qui NE DOIT PAS sortir. */
+  email?:    string
+  [k: string]: unknown
+}
+
+/**
+ * Rend l'objet `user` que verra l'extension, ou null.
+ *
+ * Trois cas rendent null, et ils sont distincts :
+ *   - aucun membre connecte : une vue publique est vue par des gens sans compte ;
+ *   - la capacite `identity` n'a pas ete accordee ;
+ *   - aucun champ individuel n'a ete accorde.
+ * Dans les trois cas l'extension doit fonctionner, et le manuel le dit.
+ */
+export function projectUser(user: UserRow | null | undefined, granted: string[]): Record<string, unknown> | null {
+  if (!user) return null
+  if (!granted.includes('identity')) return null
+
+  const out: Record<string, unknown> = {}
+  for (const field of PROJECTABLE_FIELDS) {
+    if (!granted.includes(`identity:${field}`)) continue
+    const value = user[field]
+    if (value === undefined) continue
+    out[field] = value ?? null
+  }
+
+  return Object.keys(out).length ? out : null
+}
+
+/**
+ * Colonnes a lire en base pour honorer une projection.
+ *
+ * On ne lit que ce qu'on a le droit de rendre : une requete qui ramene
+ * l'adresse de courriel pour la jeter ensuite finit toujours par la laisser
+ * fuir dans un journal ou une trace d'erreur.
+ */
+export function columnsFor(granted: string[]): ProjectableField[] {
+  if (!granted.includes('identity')) return []
+  return PROJECTABLE_FIELDS.filter(f => granted.includes(`identity:${f}`))
+}

--- a/nodyx-core/src/routes/extensions.ts
+++ b/nodyx-core/src/routes/extensions.ts
@@ -18,6 +18,7 @@ import { sensitiveCapabilities } from '../extensions/capabilities'
 import { validateManifest }      from '../extensions/manifest'
 import { mintExtensionToken, verifyExtensionToken, type ExtensionTokenClaims } from '../extensions/token'
 import { storageGet, storageSet, storageDelete, storageList } from '../extensions/storage'
+import { projectUser, columnsFor } from '../extensions/identity'
 import { parseSize } from '../extensions/manifest'
 import { STORAGE } from '../extensions/limits'
 import { PACKAGE, SURFACE }      from '../extensions/limits'
@@ -259,13 +260,30 @@ export async function extensionRoutes(app: FastifyInstance) {
     )
     if (!known) return reply.code(404).send({ error: 'Surface inconnue', code: 'SURFACE_NOT_FOUND' })
 
+    // L'identite est projetee ICI, cote serveur, et pas dans la page qui monte
+    // la surface : si le frontend devait filtrer, un composant distrait passant
+    // l'objet utilisateur entier suffirait a faire partir une adresse de
+    // courriel dans une extension tierce.
+    const granted = Array.isArray(row.granted) ? row.granted : []
+    let projectedUser: Record<string, unknown> | null = null
+    if (request.user?.userId) {
+      const cols = columnsFor(granted)
+      if (cols.length) {
+        const { rows: userRows } = await db.query(
+          `SELECT ${cols.join(', ')} FROM users WHERE id = $1`,
+          [request.user.userId],
+        )
+        projectedUser = projectUser(userRows[0] as Record<string, unknown> | undefined, granted)
+      }
+    }
+
     const token = mintExtensionToken({
       issuer:      origin,
       instanceId,
       extensionId: id,
       surface,
       userId:      request.user?.userId ?? null,
-      permissions: Array.isArray(row.granted) ? row.granted : [],
+      permissions: granted,
       jti:         randomUUID(),
     }, appSecret)
 
@@ -274,6 +292,8 @@ export async function extensionRoutes(app: FastifyInstance) {
       expiresIn: SURFACE.tokenTtlSeconds,
       version:   row.version,
       surface,
+      granted,
+      user: projectedUser,
     })
   })
 }

--- a/nodyx-core/src/tests/extensionIdentity.test.ts
+++ b/nodyx-core/src/tests/extensionIdentity.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { projectUser, columnsFor, PROJECTABLE_FIELDS } from '../extensions/identity'
+
+const USER = {
+  id:       'user-42',
+  username: 'ada',
+  avatar:   'https://instance.example/a.png',
+  locale:   'fr',
+  email:    'prive@example.org',
+  password_hash: '$argon2id$...',
+  is_admin: true,
+}
+
+const ALL = ['identity', ...PROJECTABLE_FIELDS.map(f => `identity:${f}`)]
+
+describe('ce qui ne doit jamais sortir', () => {
+  it('ne rend jamais l adresse de courriel, meme avec tout accorde', () => {
+    const p = projectUser(USER, ALL)!
+    expect(p.email).toBeUndefined()
+    expect(JSON.stringify(p)).not.toContain('prive@example.org')
+  })
+
+  it('ne rend aucun champ non projetable, meme si l appelant les demande', () => {
+    const p = projectUser(USER, [...ALL, 'identity:email', 'identity:password_hash', 'identity:is_admin'])!
+    expect(Object.keys(p).sort()).toEqual(['avatar', 'id', 'locale', 'username'])
+  })
+
+  it('la liste des champs projetables ne contient pas email', () => {
+    expect(PROJECTABLE_FIELDS).not.toContain('email')
+  })
+})
+
+describe('projection champ par champ', () => {
+  it('rend exactement ce qui est accorde', () => {
+    expect(projectUser(USER, ['identity', 'identity:id', 'identity:username']))
+      .toEqual({ id: 'user-42', username: 'ada' })
+  })
+
+  it('un champ absent en base ne fabrique pas de cle', () => {
+    expect(projectUser({ id: 'u', username: 'ada' }, ALL)).toEqual({ id: 'u', username: 'ada' })
+  })
+
+  it('un champ vide en base rend null, pas undefined', () => {
+    expect(projectUser({ id: 'u', avatar: null }, ['identity', 'identity:avatar']))
+      .toEqual({ avatar: null })
+  })
+})
+
+describe('les trois facons de ne rien rendre', () => {
+  it('aucun membre connecte', () => {
+    expect(projectUser(null, ALL)).toBeNull()
+    expect(projectUser(undefined, ALL)).toBeNull()
+  })
+
+  it('capacite identity non accordee', () => {
+    // Meme avec les champs listes : sans la capacite, rien ne sort.
+    expect(projectUser(USER, ['identity:id', 'identity:username'])).toBeNull()
+  })
+
+  it('capacite accordee mais aucun champ', () => {
+    expect(projectUser(USER, ['identity'])).toBeNull()
+  })
+})
+
+describe('colonnes a lire en base', () => {
+  it('ne lit que ce qu on a le droit de rendre', () => {
+    // Une requete qui ramene le courriel pour le jeter finit par le laisser
+    // fuir dans un journal ou une trace d'erreur.
+    expect(columnsFor(['identity', 'identity:id', 'identity:locale'])).toEqual(['id', 'locale'])
+  })
+
+  it('ne lit rien sans la capacite', () => {
+    expect(columnsFor(['identity:id'])).toEqual([])
+    expect(columnsFor([])).toEqual([])
+  })
+
+  it('ignore une colonne inventee par l appelant', () => {
+    expect(columnsFor(['identity', 'identity:email', 'identity:id'])).toEqual(['id'])
+  })
+})

--- a/nodyx-core/src/tests/extensionRoutes.test.ts
+++ b/nodyx-core/src/tests/extensionRoutes.test.ts
@@ -126,6 +126,38 @@ describe('frappe du jeton de surface', () => {
     expect(r.statusCode).toBe(404)
   })
 
+  it('projette l identite cote SERVEUR, jamais l objet utilisateur entier', async () => {
+    dbQuery.mockReset()
+    dbQuery
+      .mockResolvedValueOnce({ rows: [installedRow({ granted: ['identity', 'identity:id', 'identity:username'] })] })
+      .mockResolvedValueOnce({ rows: [{ id: 'user-42', username: 'ada' }] })
+    const r = await session({ surface: 'page' }, 'Bearer membre')
+    const body = JSON.parse(r.body)
+    expect(body.user).toEqual({ id: 'user-42', username: 'ada' })
+
+    // La requete ne LIT que les colonnes accordees : ramener le courriel pour
+    // le jeter ensuite finirait par le laisser fuir dans un journal.
+    const sql = dbQuery.mock.calls[1][0] as string
+    expect(sql).toContain('SELECT id, username FROM users')
+    expect(sql).not.toContain('email')
+  })
+
+  it('ne lit meme pas la table users quand identity n est pas accorde', async () => {
+    dbQuery.mockReset()
+    dbQuery.mockResolvedValue({ rows: [installedRow({ granted: ['storage.user'] })] })
+    const r = await session({ surface: 'page' }, 'Bearer membre')
+    expect(JSON.parse(r.body).user).toBeNull()
+    expect(dbQuery).toHaveBeenCalledOnce()
+  })
+
+  it('rend un utilisateur nul pour un visiteur, sans echouer', async () => {
+    dbQuery.mockReset()
+    dbQuery.mockResolvedValue({ rows: [installedRow({ granted: ['identity', 'identity:id'] })] })
+    const r = await session({ surface: 'page' })
+    expect(r.statusCode).toBe(200)
+    expect(JSON.parse(r.body).user).toBeNull()
+  })
+
   it('le jeton frappé ne vaut pas pour une autre surface', async () => {
     dbQuery.mockResolvedValue({ rows: [installedRow()] })
     const { token } = JSON.parse((await session({ surface: 'page' }, 'Bearer membre')).body)


### PR DESCRIPTION
Suite de #519. `nodyx.user` n'est pas une copie de la session : c'est une projection autorisee, champ par champ, de ce que l'admin a accepte de montrer.

## Le point du lot : ou se fait le filtrage

La projection se fait **cote serveur**, dans la route de session, et pas dans la page qui monte la surface. Si le frontend devait filtrer, il suffirait d'un composant distrait passant l'objet utilisateur entier pour qu'une adresse de courriel parte dans une extension tierce. Le serveur ne rend que ce qui est accorde, et la question ne se pose plus.

Deuxieme precaution du meme ordre : on ne **lit** en base que les colonnes accordees. Une requete qui ramene le courriel pour le jeter ensuite finit toujours par le laisser fuir dans un journal ou une trace d'erreur. Quand `identity` n'est pas accorde, la table `users` n'est meme pas interrogee, et un test le verifie en comptant les appels.

## Ce qui ne sort jamais

L'adresse de courriel n'est pas projetable, et trois tests le verrouillent : elle ne sort pas avec tout accorde, elle ne sort pas si l'appelant invente `identity:email`, et elle n'est pas dans la liste des champs projetables.

## Trois facons distinctes de ne rien rendre

Aucun membre connecte, capacite non accordee, aucun champ accorde. Dans les trois cas l'extension doit fonctionner, parce qu'une vue publique est vue par des gens sans compte, et c'est souvent leur premier contact avec la communaute.

## Perimetre

Additif. La reponse de la route de session gagne deux champs, `granted` et `user`. Rien de neuf n'est appele par le frontend.

12 tests sur la projection, 3 de plus sur la route, 728 sur le coeur, tsc propre.
