### PR TITLE
SDK d'extensions : stockage branche dans le pont (P0-B, 3/3)

### DIFF
--- a/nodyx-frontend/src/lib/components/ExtensionSurface.svelte
+++ b/nodyx-frontend/src/lib/components/ExtensionSurface.svelte
@@ -12,7 +12,7 @@
 	import { onMount, onDestroy } from 'svelte'
 	import { browser } from '$app/environment'
 	import { t } from '$lib/i18n'
-	import { createHostHandler, buildBootPayload, frameUrl, type HostSurface } from '$lib/extensions/host'
+	import { createHostHandler, buildBootPayload, frameUrl, createStorageCaller, type HostSurface } from '$lib/extensions/host'
 
 	const tFn = $derived($t)
 
@@ -29,7 +29,6 @@
 		locale?:     string
 		theme?:      Record<string, string>
 		instance?:   Record<string, unknown>
-		user?:       Record<string, unknown> | null
 		defaultHeight?: number
 		/** Une page occupe la zone de contenu, un widget suit sa hauteur. */
 		fill?:       boolean
@@ -38,8 +37,14 @@
 	let {
 		extensionId, version, surface, entry, label,
 		config = {}, messages = {}, locale = 'fr', theme = {},
-		instance = {}, user = null, defaultHeight = 160, fill = false,
+		instance = {}, defaultHeight = 160, fill = false,
 	}: Props = $props()
+
+	// L'identite N'EST PAS une propriete : elle vient de la route de session,
+	// projetee cote serveur selon ce que l'admin a accorde. Un composant ne
+	// peut donc pas passer par erreur l'objet utilisateur entier.
+	let token: string | null = null
+	let grantedUser: Record<string, unknown> | null = null
 
 	let frame:  HTMLIFrameElement | null = $state(null)
 	let status: 'loading' | 'ready' | 'error' = $state('loading')
@@ -55,11 +60,30 @@
 		{
 			resize: (h) => { if (!fill) height = h },
 			toast:  (message) => { console.info('[extension]', extensionId, message) },
-			// Les autres actions arrivent avec l'API de runtime : le pont répond
+			// Les autres actions arrivent avec les lots suivants : le pont répond
 			// déjà « pas encore » avec un code explicite, ce qui vaut mieux qu'un
 			// silence pour qui développe une extension.
 		},
+		{ storage: createStorageCaller({ extensionId, version, surface }, () => token) },
 	)
+
+	/** Frappe le jeton de surface et récupère l'identité projetée. */
+	async function openSession(): Promise<boolean> {
+		try {
+			const res = await fetch(`/api/v1/extensions/${extensionId}/session`, {
+				method:  'POST',
+				headers: { 'content-type': 'application/json' },
+				body:    JSON.stringify({ surface }),
+			})
+			if (!res.ok) return false
+			const body = await res.json()
+			token       = body.token ?? null
+			grantedUser = body.user  ?? null
+			return Boolean(token)
+		} catch {
+			return false
+		}
+	}
 
 	function onWindowMessage(e: MessageEvent) {
 		// `e.origin` vaut "null" pour une frame en origine opaque, donc il ne
@@ -77,7 +101,7 @@
 		channel.port1.start()
 
 		const boot = buildBootPayload(ref, window.location.origin, entry, {
-			config, messages, locale, theme, instance, user, route: '/',
+			config, messages, locale, theme, instance, user: grantedUser, route: '/',
 		})
 		// Cible '*' : la frame est en origine opaque, aucune autre valeur ne
 		// correspondrait. Ce n'est pas une faiblesse, le message ne contient rien
@@ -93,6 +117,9 @@
 		if (!browser) return
 		window.addEventListener('message', onWindowMessage)
 		bootTimer = setTimeout(() => { if (status === 'loading') status = 'error' }, 5000)
+		// Sans jeton la surface s'affiche quand même : elle n'aura simplement
+		// aucune capacité, ce que le pont lui dira avec un code explicite.
+		void openSession()
 	})
 
 	onDestroy(() => {

--- a/nodyx-frontend/src/lib/extensions/host.test.ts
+++ b/nodyx-frontend/src/lib/extensions/host.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
-	createHostHandler, buildBootPayload, frameUrl,
+	createHostHandler, buildBootPayload, frameUrl, createStorageCaller, RuntimeCallError,
 	isSafeInternalPath, isSafeExternalUrl, RequestLedger, PROTOCOL,
 	type HostSurface,
 } from './host'
@@ -115,8 +115,76 @@ describe('navigation : une extension reste chez elle', () => {
 	})
 })
 
+describe('stockage, proxy par l hote', () => {
+	it('transmet l operation et la charge au runtime', async () => {
+		const storage = vi.fn().mockResolvedValue([603])
+		const handle = createHostHandler(SURFACE, {}, { storage })
+		const r = await handle(req({ type: 'storage.get', payload: { key: 'watched', scope: 'user' } }))
+		expect(storage).toHaveBeenCalledWith('get', { key: 'watched', scope: 'user' })
+		expect(r).toMatchObject({ ok: true, result: [603] })
+	})
+
+	it.each(['get', 'set', 'delete', 'list'])('route l operation %s', async (op) => {
+		const storage = vi.fn().mockResolvedValue(null)
+		const handle = createHostHandler(SURFACE, {}, { storage })
+		await handle(req({ type: `storage.${op}` }))
+		expect(storage.mock.calls[0][0]).toBe(op)
+	})
+
+	it('retransmet le code du coeur tel quel', async () => {
+		// Une extension doit distinguer un quota atteint d'une permission
+		// refusee : le manuel promet des codes stables.
+		const storage = vi.fn().mockRejectedValue(new RuntimeCallError('QUOTA_EXCEEDED', 'quota atteint'))
+		const handle = createHostHandler(SURFACE, {}, { storage })
+		const r = await handle(req({ type: 'storage.set', payload: { key: 'k', value: 1 } }))
+		expect(r).toMatchObject({ ok: false, error: { code: 'QUOTA_EXCEEDED' } })
+	})
+
+	it('repond « pas branche » quand l hote n a pas de runtime', async () => {
+		const handle = createHostHandler(SURFACE)
+		expect(await handle(req({ type: 'storage.get' }))).toMatchObject({ ok: false, error: { code: 'NOT_IMPLEMENTED' } })
+	})
+})
+
+describe('appel de stockage vers le coeur', () => {
+	it('porte le jeton et la surface en en-tetes, pas dans le corps', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true, json: async () => ({ result: 'ok' }),
+		})
+		vi.stubGlobal('fetch', fetchMock)
+
+		const call = createStorageCaller(SURFACE, () => 'JETON')
+		expect(await call('get', { key: 'k' })).toBe('ok')
+
+		const [url, init] = fetchMock.mock.calls[0]
+		expect(url).toBe('/api/v1/extensions/library/storage')
+		expect(init.headers.authorization).toBe('Bearer JETON')
+		expect(init.headers['x-nodyx-surface']).toBe('widget:tonight')
+		expect(JSON.parse(init.body)).toEqual({ op: 'get', key: 'k' })
+		vi.unstubAllGlobals()
+	})
+
+	it('leve avec le code du coeur quand l appel est refuse', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+			ok: false, json: async () => ({ code: 'PERMISSION_DENIED', error: 'refuse' }),
+		}))
+		const call = createStorageCaller(SURFACE, () => 'JETON')
+		await expect(call('get', { key: 'k' })).rejects.toMatchObject({ code: 'PERMISSION_DENIED' })
+		vi.unstubAllGlobals()
+	})
+
+	it('leve sans jeton plutot que d appeler dans le vide', async () => {
+		const fetchMock = vi.fn()
+		vi.stubGlobal('fetch', fetchMock)
+		const call = createStorageCaller(SURFACE, () => null)
+		await expect(call('get', { key: 'k' })).rejects.toMatchObject({ code: 'SESSION_EXPIRED' })
+		expect(fetchMock).not.toHaveBeenCalled()
+		vi.unstubAllGlobals()
+	})
+})
+
 describe('ce qui appartient au lot suivant', () => {
-	it.each(['storage.get', 'storage.set', 'net.fetch', 'core.get', 'session.renew'])(
+	it.each(['net.fetch', 'core.get', 'session.renew'])(
 		'%s repond « pas encore », pas un refus muet', async (type) => {
 			// Une extension doit pouvoir distinguer « pas encore » de « refuse ».
 			const handle = createHostHandler(SURFACE)

--- a/nodyx-frontend/src/lib/extensions/host.ts
+++ b/nodyx-frontend/src/lib/extensions/host.ts
@@ -34,6 +34,17 @@ export interface BootPayload {
 	route:     string
 }
 
+/**
+ * Acces au runtime, cote hote.
+ *
+ * L'hote proxie vers le coeur avec le jeton d'extension : la frame ne peut pas
+ * appeler l'API elle meme, elle n'a ni session ni jeton. C'est ce passage
+ * oblige qui rend les capacites verifiables.
+ */
+export interface HostRuntime {
+	storage?: (op: 'get' | 'set' | 'delete' | 'list', payload: Record<string, unknown>) => Promise<unknown>
+}
+
 export interface HostActions {
 	resize?:     (height: number) => void
 	toast?:      (message: string) => void
@@ -106,11 +117,46 @@ export class RequestLedger {
  * et un développeur doit le lire dans la console au lieu de le deviner.
  */
 const RUNTIME_API_TYPES = new Set([
-	'storage.get', 'storage.set', 'storage.delete', 'storage.list',
 	'net.fetch', 'core.get', 'session.renew',
 ])
 
-export function createHostHandler(surface: HostSurface, actions: HostActions = {}) {
+/** Erreur portant le code rendu par le coeur, pour le retransmettre tel quel. */
+export class RuntimeCallError extends Error {
+	constructor(public readonly code: string, message: string) {
+		super(message)
+		this.name = 'RuntimeCallError'
+	}
+}
+
+/**
+ * Appelle le stockage du coeur au nom d'une surface.
+ *
+ * Le jeton et la surface voyagent en en-tetes : le corps ne porte que
+ * l'operation. Une frame qui mentirait sur sa surface se ferait refuser par le
+ * coeur, dont le jeton est lie a une surface precise.
+ */
+export function createStorageCaller(surface: HostSurface, getToken: () => string | null) {
+	return async function callStorage(op: string, payload: Record<string, unknown>): Promise<unknown> {
+		const token = getToken()
+		if (!token) throw new RuntimeCallError('SESSION_EXPIRED', 'aucun jeton d\'extension')
+
+		const res = await fetch(`/api/v1/extensions/${surface.extensionId}/storage`, {
+			method:  'POST',
+			headers: {
+				'content-type':    'application/json',
+				'authorization':   `Bearer ${token}`,
+				'x-nodyx-surface': surface.surface,
+			},
+			body: JSON.stringify({ op, ...payload }),
+		})
+
+		const body = await res.json().catch(() => ({}))
+		if (!res.ok) throw new RuntimeCallError(body?.code ?? 'UNKNOWN', body?.error ?? 'appel refusé')
+		return body?.result
+	}
+}
+
+export function createHostHandler(surface: HostSurface, actions: HostActions = {}, runtime: HostRuntime = {}) {
 	const ledger = new RequestLedger()
 
 	return async function handle(raw: unknown): Promise<Envelope | null> {
@@ -170,6 +216,23 @@ export function createHostHandler(surface: HostSurface, actions: HostActions = {
 				if (!isSafeExternalUrl(payload.url)) return err(id, 'INVALID_ARGUMENT', 'URL externe invalide')
 				actions.external?.(payload.url)
 				return null
+			}
+
+			case 'storage.get':
+			case 'storage.set':
+			case 'storage.delete':
+			case 'storage.list': {
+				if (!runtime.storage) return err(id, 'NOT_IMPLEMENTED', 'le stockage n\'est pas branché sur cet hôte')
+				const op = type.slice('storage.'.length) as 'get' | 'set' | 'delete' | 'list'
+				try {
+					return ok(id, await runtime.storage(op, payload))
+				} catch (e) {
+					// Le code du coeur traverse tel quel : une extension doit pouvoir
+					// distinguer un quota atteint d'une permission refusée, et le
+					// manuel promet des codes stables.
+					const code = (e as { code?: string })?.code ?? 'UNKNOWN'
+					return err(id, code, (e as Error)?.message ?? 'appel de stockage en échec')
+				}
 			}
 
 			default:


### PR DESCRIPTION
Derniere piece de P0-B, apres #519 (stockage cote coeur) et #520 (projection de l'identite). Une extension peut desormais lire et ecrire ses donnees pour de vrai.

## Le passage oblige

Le pont proxie `storage.*` vers le coeur avec le jeton d'extension : la frame n'a ni session ni jeton propre, elle ne peut pas appeler l'API elle meme. C'est ce passage oblige qui rend les capacites verifiables.

Le jeton et la surface voyagent en **en-tetes**, le corps ne portant que l'operation. Une frame qui mentirait sur sa surface se ferait refuser par le coeur, dont le jeton est lie a une surface precise.

## Les codes traversent tels quels

Une extension doit pouvoir distinguer un quota atteint d'une permission refusee, et le manuel promet des codes stables. Les aplatir en une erreur generique aurait rendu la promesse fausse des le premier lot qui s'en sert.

## Changement de contrat du composant

`user` n'est plus une propriete de `ExtensionSurface`. L'identite vient de la route de session, projetee cote serveur selon ce que l'admin a accorde. Un composant ne peut donc plus passer par erreur l'objet utilisateur entier, et la garantie tient meme si le code d'interface change plus tard.

Sans jeton, la surface s'affiche quand meme : elle n'a simplement aucune capacite, et le pont le lui dit avec un code explicite plutot qu'un silence.

## Perimetre

Additif, frontend seul. Le composant reste livre mais non branche : aucune page ne rend encore de surface d'extension.

40 tests sur le pont, 67 sur le frontend, svelte-check 0 erreur.
