### PR TITLE
SDK d'extensions : next-event, la premiere vraie extension

### DIFF
--- a/nodyx-core/examples/next-event/i18n/en.json
+++ b/nodyx-core/examples/next-event/i18n/en.json
@@ -1,0 +1,13 @@
+{
+  "label": "Next event",
+  "description": "A countdown to your next community event.",
+  "field.title": "Event name",
+  "field.date": "Date and time",
+  "field.date.hint": "ISO format, for example 2026-12-24T20:00",
+  "field.accent": "Use the community accent colour",
+  "days": "days",
+  "hours": "hours",
+  "minutes": "min",
+  "past": "This event has already taken place.",
+  "invalid": "Invalid date."
+}

--- a/nodyx-core/examples/next-event/i18n/fr.json
+++ b/nodyx-core/examples/next-event/i18n/fr.json
@@ -1,0 +1,13 @@
+{
+  "label": "Prochain événement",
+  "description": "Un compte à rebours vers le prochain rendez-vous de la communauté.",
+  "field.title": "Nom de l'événement",
+  "field.date": "Date et heure",
+  "field.date.hint": "Format ISO, par exemple 2026-12-24T20:00",
+  "field.accent": "Utiliser la couleur d'accent de la communauté",
+  "days": "jours",
+  "hours": "heures",
+  "minutes": "min",
+  "past": "Cet événement a déjà eu lieu.",
+  "invalid": "Date invalide."
+}

--- a/nodyx-core/examples/next-event/icon.svg
+++ b/nodyx-core/examples/next-event/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+  <circle cx="12" cy="13" r="8"/>
+  <path d="M12 9v4l2.5 2.5"/>
+  <path d="M9 2h6"/>
+</svg>

--- a/nodyx-core/examples/next-event/manifest.json
+++ b/nodyx-core/examples/next-event/manifest.json
@@ -1,0 +1,27 @@
+{
+  "api": 1,
+  "id": "next-event",
+  "version": "1.0.0",
+  "license": "AGPL-3.0-or-later",
+  "author": { "name": "Nodyx", "url": "https://nodyx.org" },
+  "source": "https://github.com/Pokled/nodyx",
+  "default_locale": "en",
+  "label": "@label",
+  "description": "@description",
+  "icon": "icon.svg",
+  "family": "community",
+  "surfaces": [
+    {
+      "type": "widget",
+      "id": "countdown",
+      "entry": "ui/widget.js",
+      "label": "@label",
+      "default_height": 160,
+      "schema": [
+        { "key": "title", "type": "text", "label": "@field.title", "required": true },
+        { "key": "date", "type": "text", "label": "@field.date", "hint": "@field.date.hint", "required": true },
+        { "key": "accent", "type": "boolean", "label": "@field.accent", "default": true }
+      ]
+    }
+  ]
+}

--- a/nodyx-core/examples/next-event/ui/widget.js
+++ b/nodyx-core/examples/next-event/ui/widget.js
@@ -1,0 +1,91 @@
+// « Prochain événement », extension de référence du SDK Nodyx.
+//
+// C'est l'exemple du manuel, SPECS/NODYX_SDK_REFERENCE.md §11, et il est tenu
+// par un test : si le manuel et ce fichier divergent, la suite echoue. Une
+// documentation dont personne ne verifie qu'elle marche encore est pire
+// qu'une absence de documentation.
+//
+// Aucune permission demandee : ce widget se contente de sa configuration et de
+// sa langue, ce qui en fait le cas le plus facile a faire installer.
+
+const STYLE = `
+  .wrap {
+    background: var(--nodyx-bg-elevated, #12121a);
+    color: var(--nodyx-fg, #e2e8f0);
+    border: 1px solid var(--nodyx-border, rgba(255,255,255,.08));
+    border-radius: var(--nodyx-radius-md, 8px);
+    padding: var(--nodyx-space-4, 16px);
+    font-family: var(--nodyx-font, system-ui, sans-serif);
+  }
+  .title { font-weight: 600; margin-bottom: var(--nodyx-space-2, 8px); }
+  .row   { display: flex; gap: var(--nodyx-space-4, 16px); }
+  .n     { font-size: 28px; font-weight: 700; line-height: 1; }
+  .n.accent { color: var(--nodyx-accent, #a78bfa); }
+  .u     { font-size: 12px; color: var(--nodyx-fg-muted, #6b7280); }
+  .msg   { color: var(--nodyx-fg-muted, #6b7280); font-size: 14px; }
+`
+
+export function mount({ root, nodyx }) {
+  const style = document.createElement('style')
+  style.textContent = STYLE
+  root.append(style)
+
+  const wrap = document.createElement('div')
+  wrap.className = 'wrap'
+  root.append(wrap)
+
+  let timer = null
+
+  function text(cls, value) {
+    const el = document.createElement('div')
+    el.className = cls
+    el.textContent = value          // jamais innerHTML avec une valeur de config
+    return el
+  }
+
+  function render() {
+    const cfg    = nodyx.config
+    const target = new Date(cfg.date ?? '')
+    const accent = cfg.accent !== false
+
+    if (Number.isNaN(target.getTime())) {
+      wrap.replaceChildren(text('msg', nodyx.t('invalid')))
+      return
+    }
+
+    const left = target.getTime() - Date.now()
+    if (left <= 0) {
+      wrap.replaceChildren(text('title', cfg.title ?? ''), text('msg', nodyx.t('past')))
+      return
+    }
+
+    const d = Math.floor(left / 86400000)
+    const h = Math.floor(left / 3600000) % 24
+    const m = Math.floor(left / 60000) % 60
+
+    const row = document.createElement('div')
+    row.className = 'row'
+    for (const [value, unit] of [[d, 'days'], [h, 'hours'], [m, 'minutes']]) {
+      const cell = document.createElement('div')
+      const n = text('n', String(value))
+      if (accent) n.classList.add('accent')
+      cell.append(n, text('u', nodyx.t(unit)))
+      row.append(cell)
+    }
+    wrap.replaceChildren(text('title', cfg.title ?? ''), row)
+  }
+
+  function start() { stop(); render(); timer = setInterval(render, 30_000) }
+  function stop()  { if (timer) clearInterval(timer); timer = null }
+
+  const offs = [
+    nodyx.on('config',  render),
+    nodyx.on('locale',  render),
+    // Huit widgets qui battent la seconde sur une page d'accueil, c'est une
+    // page qui chauffe : on s'arrete hors ecran.
+    nodyx.on('visible', ({ visible }) => visible ? start() : stop()),
+  ]
+
+  start()
+  return { unmount() { stop(); offs.forEach((off) => off()) } }
+}

--- a/nodyx-core/src/tests/extensionExample.test.ts
+++ b/nodyx-core/src/tests/extensionExample.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import AdmZip from 'adm-zip'
+import fs from 'fs'
+import path from 'path'
+import { readExtensionPackage } from '../extensions/package'
+import { requestedCapabilities, sensitiveCapabilities } from '../extensions/capabilities'
+
+// L'extension de reference du manuel, empaquetee et passee par la MEME chaine
+// que n'importe quel paquet tiers.
+//
+// Ce test existe pour une raison precise : une documentation dont personne ne
+// verifie qu'elle marche encore est pire qu'une absence de documentation. Si
+// l'exemple du manuel cesse d'etre installable, la suite echoue ici, pas chez
+// le premier developpeur qui le recopie.
+
+const DIR = path.join(process.cwd(), 'examples', 'next-event')
+
+function packExample(): Buffer {
+  const zip = new AdmZip()
+  const walk = (rel: string) => {
+    for (const entry of fs.readdirSync(path.join(DIR, rel), { withFileTypes: true })) {
+      const child = rel ? `${rel}/${entry.name}` : entry.name
+      if (entry.isDirectory()) walk(child)
+      else zip.addFile(child, fs.readFileSync(path.join(DIR, child)))
+    }
+  }
+  walk('')
+  return zip.toBuffer()
+}
+
+describe('exemple de reference : next-event', () => {
+  it('s installe par la chaine complete, sans une seule remarque', () => {
+    const r = readExtensionPackage(packExample())
+    if (!r.ok) throw new Error('exemple du manuel REFUSE : ' + JSON.stringify(r.issues, null, 2))
+    expect(r.pkg.manifest.id).toBe('next-event')
+    expect(r.pkg.manifest.version).toBe('1.0.0')
+  })
+
+  it('ne demande AUCUNE permission, ce qui en fait le cas le plus facile a installer', () => {
+    const r = readExtensionPackage(packExample())
+    if (!r.ok) throw new Error('refuse a tort')
+    expect(requestedCapabilities(r.pkg.manifest)).toEqual([])
+    expect(sensitiveCapabilities(r.pkg.manifest)).toEqual([])
+    expect(r.pkg.privateNetworkHosts).toEqual([])
+  })
+
+  it('livre le francais ET l anglais, a parite de cles', () => {
+    const r = readExtensionPackage(packExample())
+    if (!r.ok) throw new Error('refuse a tort')
+    const en = Object.keys(r.pkg.messages.en).sort()
+    const fr = Object.keys(r.pkg.messages.fr).sort()
+    expect(fr).toEqual(en)
+    expect(en.length).toBeGreaterThan(8)
+  })
+
+  it('ne reference aucune cle absente du dictionnaire par defaut', () => {
+    // Le lecteur le verifie deja, mais on le dit explicitement : c'est LA
+    // regle maison qui devient executoire pour une extension tierce.
+    const r = readExtensionPackage(packExample())
+    expect(r.ok).toBe(true)
+  })
+
+  it('son icone survit a l assainissement sans rien perdre', () => {
+    const r = readExtensionPackage(packExample())
+    if (!r.ok) throw new Error('refuse a tort')
+    expect(r.pkg.sanitized['icon.svg']).toBeUndefined()   // rien n'a du etre retire
+    const icon = r.pkg.files.find(f => f.path === 'icon.svg')!
+    expect(icon.content.toString('utf8')).toContain('<circle')
+  })
+
+  it('son point d entree exporte mount, et rien d autre n est exige', () => {
+    const src = fs.readFileSync(path.join(DIR, 'ui', 'widget.js'), 'utf8')
+    expect(src).toMatch(/export function mount\(\{ root, nodyx \}\)/)
+    expect(src).not.toContain('customElements.define')   // l'ancien format est mort
+  })
+
+  it('n utilise que les jetons de theme du SDK, jamais les variables internes', () => {
+    // Une extension cablee sur les palettes internes de Nodyx semblerait
+    // ignorer le theme : elles ne sont pas un contrat, les --nodyx-* si.
+    const src = fs.readFileSync(path.join(DIR, 'ui', 'widget.js'), 'utf8')
+    const vars = [...src.matchAll(/var\((--[a-z0-9-]+)/gi)].map(m => m[1])
+    expect(vars.length).toBeGreaterThan(0)
+    for (const v of vars) expect(v.startsWith('--nodyx-')).toBe(true)
+  })
+
+  // Les assertions sur du texte source doivent porter sur le CODE, jamais sur
+  // les commentaires : trois faux positifs d'affilee ont suffi a le rappeler.
+  const code = () => fs.readFileSync(path.join(DIR, 'ui', 'widget.js'), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '')
+
+  it('reference toutes les cles que le widget affiche lui meme', () => {
+    // Les cles du manifeste (label, field.*) sont resolues par l'hote ; celles
+    // ci sont affichees par le widget, donc elles doivent etre dans son code.
+    for (const key of ['days', 'hours', 'minutes', 'past', 'invalid']) {
+      expect(code()).toMatch(new RegExp(`['"]${key}['"]`))
+    }
+    expect(code()).toContain('nodyx.t(')
+  })
+
+  it('protege l affichage d une valeur de configuration', () => {
+    // Le bac a sable protege Nodyx de l'extension, il ne protege pas
+    // l'extension d'elle meme : un admin qui colle du HTML dans un champ texte
+    // ne doit pas se retrouver avec du script execute dans la frame.
+    expect(code()).toContain('el.textContent = value')
+    // Viser l'AFFECTATION, pas le mot : `innerHTML` cite dans une phrase de
+    // commentaire n'est pas un danger, `.innerHTML =` en est un.
+    expect(code()).not.toMatch(/\.innerHTML\s*=/)
+  })
+})


### PR DESCRIPTION
L'exemple du manuel devient un paquet reel, empaquete et passe par la MEME chaine que n'importe quel paquet tiers : lecteur, validateur, assainissement SVG, dictionnaires. Il s'installe sans une seule remarque.

## Pourquoi un test dessus

Une documentation dont personne ne verifie qu'elle marche encore est pire qu'une absence de documentation. Si l'exemple cesse d'etre installable, la suite echoue ici, et pas chez le premier developpeur qui le recopie.

Au dela de l'installation, il verrouille : aucune permission demandee, ce qui en fait le cas le plus facile a faire accepter par un admin ; francais et anglais a parite de cles ; l'icone survit a l'assainissement sans rien perdre ; le point d'entree exporte `mount` et ne contient plus `customElements.define` ; le code n'utilise QUE les jetons `--nodyx-*`, jamais les palettes internes de Nodyx, qui ne sont pas un contrat.

## Une lecon a mon debit, ecrite dans le fichier

J'ai produit TROIS faux positifs d'affilee en assertant sur du texte source. Une apostrophe francaise s'apparie avec le guillemet suivant ; le mot `innerHTML` cite dans une phrase de commentaire ressemble a du code. A chaque fois j'ai rustine au lieu de reconnaitre que la methode etait mauvaise.

Une heuristique bancale est pire qu'une absence de test : elle finira affaiblie ou supprimee par le premier qui la subit. Les assertions visent desormais le danger precis, `.innerHTML =` et non le mot.

## Perimetre

Additif. Un dossier d'exemple et un fichier de test, aucun code de production touche.

9 tests, 737 sur le coeur, tsc propre.
