### PR TITLE
SDK d'extensions : liste publique et entree au catalogue (P0-C, 1/2)

### DIFF
--- a/nodyx-core/src/routes/extensions.ts
+++ b/nodyx-core/src/routes/extensions.ts
@@ -154,6 +154,70 @@ export async function extensionRoutes(app: FastifyInstance) {
     return reply.send({ success: true })
   })
 
+  // ── GET /extensions/public ──────────────────────────────────────────────
+  //
+  // Ce que le frontend a besoin de savoir pour AFFICHER des extensions, et
+  // rien de plus : ni permissions accordees, ni empreinte, ni qui a installe.
+  //
+  // Les libelles sont resolus ICI, dans la langue demandee. Le frontend n'a
+  // donc aucune logique de cles a porter, et une extension ne peut pas lui
+  // faire afficher une chaine qui n'est pas dans ses dictionnaires.
+  app.get('/extensions/public', { preHandler: [rateLimit] }, async (request, reply) => {
+    const asked = String((request.query as { locale?: string }).locale ?? '').slice(0, 5)
+
+    const { rows } = await db.query(
+      `SELECT id, manifest, messages, version
+         FROM installed_extensions
+        WHERE enabled = true
+        ORDER BY id`,
+    )
+
+    const extensions = (rows as Array<{ id: string; manifest: Record<string, unknown>; messages: Record<string, Record<string, string>>; version: string }>)
+      .map((row) => {
+        const parsed = validateManifest(row.manifest)
+        if (!parsed.ok) return null                 // manifeste corrompu : on l'ignore plutot que de servir n'importe quoi
+
+        const m = parsed.manifest
+        const dict = { ...(row.messages?.[m.default_locale] ?? {}), ...(asked ? row.messages?.[asked] ?? {} : {}) }
+        const tr = (v?: string) => (v?.startsWith('@') ? dict[v.slice(1)] ?? v.slice(1) : v)
+
+        return {
+          id:          m.id,
+          version:     row.version,
+          label:       tr(m.label),
+          description: tr(m.description),
+          icon:        m.icon ? `/api/v1/extensions/${m.id}/${row.version}/assets/${m.icon}` : null,
+          family:      m.family ?? 'content',
+          messages:    dict,
+          surfaces:    m.surfaces.map((s) => s.type === 'widget'
+            ? {
+                type:  'widget' as const,
+                id:    s.id,
+                entry: s.entry,
+                label: tr(s.label),
+                defaultHeight: s.default_height ?? null,
+                schema: (s.schema ?? []).map((f) => ({
+                  ...f,
+                  label:   tr(f.label),
+                  hint:    tr(f.hint),
+                  details: tr(f.details),
+                  options: f.options?.map((o) => ({ ...o, label: tr(o.label) })),
+                })),
+              }
+            : {
+                type:  'page' as const,
+                path:  s.path,
+                entry: s.entry,
+                label: tr(s.label) ?? tr(m.label),
+                nav:   s.nav ? { label: tr(s.nav.label), icon: s.nav.icon ?? null } : null,
+              }),
+        }
+      })
+      .filter((e) => e !== null)
+
+    return reply.send({ extensions })
+  })
+
   // ── POST /extensions/:id/storage ────────────────────────────────────────
   //
   // Authentifiee par le JETON D'EXTENSION, jamais par le cookie de session :

--- a/nodyx-core/src/tests/extensionRoutes.test.ts
+++ b/nodyx-core/src/tests/extensionRoutes.test.ts
@@ -317,3 +317,70 @@ describe('stockage', () => {
     expect(r.statusCode).toBe(400)
   })
 })
+
+// ── Liste publique, ce que le frontend a le droit de savoir ────────────────
+
+describe('liste publique', () => {
+  const M = {
+    ...MANIFEST,
+    icon: 'icon.svg',
+    label: '@label',
+    description: '@desc',
+    surfaces: [
+      { type: 'widget', id: 'main', entry: 'ui/widget.js', label: '@w.label',
+        default_height: 200,
+        schema: [{ key: 'mood', type: 'select', label: '@f.mood', options: [{ value: 'a', label: '@o.a' }] }] },
+      { type: 'page', path: 'demo', entry: 'ui/page.js', nav: { label: '@nav.label', icon: 'twemoji:star' } },
+    ],
+  }
+  const MESSAGES = {
+    en: { label: 'Demo', desc: 'A demo.', 'w.label': 'Widget', 'f.mood': 'Mood', 'o.a': 'A', 'nav.label': 'Demo page' },
+    fr: { label: 'Démo', 'w.label': 'Widget FR' },
+  }
+
+  const publicList = (locale?: string) => app.inject({
+    method: 'GET', url: `/api/v1/extensions/public${locale ? `?locale=${locale}` : ''}`,
+  })
+
+  beforeEach(() => {
+    dbQuery.mockResolvedValue({ rows: [{ id: 'demo-ext', manifest: M, messages: MESSAGES, version: '1.0.0' }] })
+  })
+
+  it('resout les libelles cote serveur, dans la langue demandee', async () => {
+    const r = await publicList('fr')
+    const e = JSON.parse(r.body).extensions[0]
+    expect(e.label).toBe('Démo')                       // traduit en francais
+    expect(e.description).toBe('A demo.')              // repli sur la locale par defaut
+    expect(e.surfaces[0].label).toBe('Widget FR')
+  })
+
+  it('resout aussi les libelles du schema et de ses options', async () => {
+    const e = JSON.parse((await publicList()).body).extensions[0]
+    expect(e.surfaces[0].schema[0].label).toBe('Mood')
+    expect(e.surfaces[0].schema[0].options[0].label).toBe('A')
+  })
+
+  it('ne divulgue ni permissions accordees, ni empreinte, ni installateur', async () => {
+    const body = (await publicList()).body
+    for (const secret of ['granted', 'sha256', 'installed_by', 'permissions']) {
+      expect(body).not.toContain(secret)
+    }
+  })
+
+  it('pointe l icone vers la route d assets versionnee', async () => {
+    const e = JSON.parse((await publicList()).body).extensions[0]
+    expect(e.icon).toBe('/api/v1/extensions/demo-ext/1.0.0/assets/icon.svg')
+  })
+
+  it('ne liste que les extensions activees', async () => {
+    await publicList()
+    expect(dbQuery.mock.calls[0][0]).toContain('WHERE enabled = true')
+  })
+
+  it('ignore un manifeste corrompu plutot que de servir n importe quoi', async () => {
+    dbQuery.mockResolvedValue({ rows: [{ id: 'x', manifest: { api: 99 }, messages: {}, version: '1.0.0' }] })
+    const r = await publicList()
+    expect(r.statusCode).toBe(200)
+    expect(JSON.parse(r.body).extensions).toEqual([])
+  })
+})

--- a/nodyx-frontend/src/lib/components/homepage/catalog.extensions.test.ts
+++ b/nodyx-frontend/src/lib/components/homepage/catalog.extensions.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import {
+	extensionWidgetEntries, extensionIndex, extensionWidgetId, parseExtensionWidgetId,
+	type PublicExtension,
+} from './extensionCatalog'
+
+const EXT: PublicExtension = {
+	id: 'library', version: '1.0.0',
+	label: 'Médiathèque', description: 'Des films choisis à la main.',
+	icon: '/api/v1/extensions/library/1.0.0/assets/icon.svg', family: 'content',
+	messages: { label: 'Médiathèque' },
+	surfaces: [
+		{ type: 'widget', id: 'tonight', entry: 'ui/tonight.js', label: 'Ce soir', defaultHeight: 320,
+		  schema: [{ key: 'mood', type: 'select', label: 'Humeur', options: [{ value: 'a', label: 'A' }] }] },
+		{ type: 'page', path: 'library', entry: 'ui/page.js', label: 'Médiathèque' },
+	],
+}
+
+describe('identifiants de mise en page', () => {
+	it('prefixe, pour qu une extension ne prenne jamais l identite d un natif', () => {
+		expect(extensionWidgetId('library', 'tonight')).toBe('ext:library:tonight')
+	})
+
+	it('se decompose', () => {
+		expect(parseExtensionWidgetId('ext:library:tonight')).toEqual({ extensionId: 'library', surfaceId: 'tonight' })
+	})
+
+	it.each(['hero-banner', 'ext:', 'ext:library', 'library:tonight', ''])(
+		'refuse de decomposer %p', (raw) => {
+			expect(parseExtensionWidgetId(raw)).toBeNull()
+		})
+
+	it('ne peut pas se confondre avec un identifiant natif', () => {
+		// Les identifiants natifs n'ont pas de deux-points : la collision est
+		// impossible par construction, pas par convention.
+		expect(parseExtensionWidgetId('video-player')).toBeNull()
+	})
+})
+
+describe('entrees du catalogue', () => {
+	it('ne retient que les surfaces widget', () => {
+		const entries = extensionWidgetEntries([EXT])
+		expect(entries).toHaveLength(1)
+		expect(entries[0].surfaceId).toBe('tonight')
+	})
+
+	it('porte tout ce qu il faut pour monter la surface', () => {
+		const e = extensionWidgetEntries([EXT])[0]
+		expect(e).toMatchObject({
+			kind: 'extension', id: 'ext:library:tonight',
+			extensionId: 'library', version: '1.0.0',
+			entry: 'ui/tonight.js', label: 'Ce soir', defaultHeight: 320,
+		})
+		expect(e.messages.label).toBe('Médiathèque')
+	})
+
+	it('retombe sur le libelle de l extension quand la surface n en a pas', () => {
+		const sans = { ...EXT, surfaces: [{ ...EXT.surfaces[0], label: '' }] }
+		expect(extensionWidgetEntries([sans])[0].label).toBe('Médiathèque')
+	})
+
+	it('normalise le schema comme celui d un widget natif', () => {
+		const e = extensionWidgetEntries([EXT])[0]
+		expect(e.schema[0]).toMatchObject({ key: 'mood', type: 'select' })
+		expect(e.schema[0].options?.[0].label).toBe('A')
+	})
+
+	it('accepte checkbox a la lecture, sans le legitimer au manifeste', () => {
+		// Le validateur du coeur refuse checkbox a l'installation ; ici on
+		// canonise ce qui viendrait d'ailleurs plutot que de casser le rendu.
+		const ext = { ...EXT, surfaces: [{ ...EXT.surfaces[0], schema: [{ key: 'on', type: 'checkbox', label: 'On' }] }] }
+		expect(extensionWidgetEntries([ext as PublicExtension])[0].schema[0].type).toBe('boolean')
+	})
+
+	it('rend une liste vide sans extension', () => {
+		expect(extensionWidgetEntries()).toEqual([])
+		expect(extensionWidgetEntries([{ ...EXT, surfaces: [] }])).toEqual([])
+	})
+
+	it('indexe par identifiant de mise en page', () => {
+		expect(Object.keys(extensionIndex([EXT]))).toEqual(['ext:library:tonight'])
+	})
+})

--- a/nodyx-frontend/src/lib/components/homepage/catalog.ts
+++ b/nodyx-frontend/src/lib/components/homepage/catalog.ts
@@ -12,7 +12,8 @@
 // vue de surface (CatalogEntry) qui sera vraiment unifiée en Phase 2.
 
 import { PLUGIN_LIST, PLUGIN_REGISTRY } from './plugins'
-import type { WidgetPlugin, FieldSchema, FieldType, WidgetFamily } from './plugins/_types'
+import type { WidgetPlugin, FieldSchema, WidgetFamily } from './plugins/_types'
+import { canonField } from './extensionCatalog'
 
 // Manifest d'un widget installé tel que renvoyé par /api/v1/widget-store-public.
 export interface InstalledWidgetManifest {
@@ -53,33 +54,6 @@ export type CatalogEntry =
 			version: string
 			author?: string
 		}
-
-// Les SDK externes utilisent souvent `checkbox` là où le builder attend
-// `boolean`. On accepte les deux à l'entrée pour ne pas casser les widgets
-// déjà publiés (le SDK officiel devra à terme imposer `boolean`).
-function canonFieldType(raw: string): FieldType {
-	if (raw === 'checkbox') return 'boolean'
-	return raw as FieldType
-}
-
-function canonField(raw: unknown): FieldSchema | null {
-	if (!raw || typeof raw !== 'object') return null
-	const r = raw as Record<string, unknown>
-	if (typeof r.key !== 'string' || typeof r.label !== 'string' || typeof r.type !== 'string') return null
-	return {
-		key:         r.key,
-		label:       r.label,
-		type:        canonFieldType(r.type),
-		placeholder: typeof r.placeholder === 'string' ? r.placeholder : undefined,
-		default:     r.default,
-		required:    typeof r.required === 'boolean' ? r.required : undefined,
-		options:     Array.isArray(r.options) ? r.options as { value: string; label: string }[] : undefined,
-		min:         typeof r.min === 'number' ? r.min : undefined,
-		max:         typeof r.max === 'number' ? r.max : undefined,
-		hint:        typeof r.hint === 'string' ? r.hint : undefined,
-		details:     typeof r.details === 'string' ? r.details : undefined,
-	}
-}
 
 function manifestToEntry(m: InstalledWidgetManifest): CatalogEntry {
 	const schema = (m.schema ?? [])

--- a/nodyx-frontend/src/lib/components/homepage/extensionCatalog.ts
+++ b/nodyx-frontend/src/lib/components/homepage/extensionCatalog.ts
@@ -1,0 +1,126 @@
+// Catalogue des surfaces d'extension, et normalisation des champs de config.
+//
+// Module PUR : il n'importe aucun composant Svelte, uniquement des types. C'est
+// ce qui le rend testable dans le harnais node du depot, et ce qui permet de le
+// relire comme une frontiere plutot que comme du code d'interface.
+
+import type { FieldSchema, FieldType } from './plugins/_types'
+
+// Les SDK externes utilisent souvent `checkbox` là où le builder attend
+// `boolean`. On accepte les deux à l'entrée pour ne pas casser les widgets
+// déjà publiés (le SDK officiel devra à terme imposer `boolean`).
+export function canonFieldType(raw: string): FieldType {
+	if (raw === 'checkbox') return 'boolean'
+	return raw as FieldType
+}
+
+export function canonField(raw: unknown): FieldSchema | null {
+	if (!raw || typeof raw !== 'object') return null
+	const r = raw as Record<string, unknown>
+	if (typeof r.key !== 'string' || typeof r.label !== 'string' || typeof r.type !== 'string') return null
+	return {
+		key:         r.key,
+		label:       r.label,
+		type:        canonFieldType(r.type),
+		placeholder: typeof r.placeholder === 'string' ? r.placeholder : undefined,
+		default:     r.default,
+		required:    typeof r.required === 'boolean' ? r.required : undefined,
+		options:     Array.isArray(r.options) ? r.options as { value: string; label: string }[] : undefined,
+		min:         typeof r.min === 'number' ? r.min : undefined,
+		max:         typeof r.max === 'number' ? r.max : undefined,
+		hint:        typeof r.hint === 'string' ? r.hint : undefined,
+		details:     typeof r.details === 'string' ? r.details : undefined,
+	}
+}
+
+// ── Extensions installees (SDK api 1) ────────────────────────────────────────
+//
+// Une surface d'extension entre dans le catalogue du builder comme n'importe
+// quel widget, avec un identifiant PREFIXE : `ext:<extension>:<surface>`. Le
+// prefixe n'est pas cosmetique, il garantit qu'une extension ne peut jamais
+// prendre l'identite d'un widget natif dans une mise en page enregistree.
+
+export const EXTENSION_WIDGET_PREFIX = 'ext:'
+
+export interface PublicExtensionSurface {
+	type:          'widget' | 'page'
+	id?:           string
+	path?:         string
+	entry:         string
+	label:         string
+	defaultHeight?: number | null
+	schema?:       FieldSchema[]
+}
+
+export interface PublicExtension {
+	id:          string
+	version:     string
+	label:       string
+	description: string
+	icon:        string | null
+	family:      string
+	messages:    Record<string, string>
+	surfaces:    PublicExtensionSurface[]
+}
+
+/** Identifiant de mise en page d'une surface widget d'extension. */
+export function extensionWidgetId(extensionId: string, surfaceId: string): string {
+	return `${EXTENSION_WIDGET_PREFIX}${extensionId}:${surfaceId}`
+}
+
+/** Decompose un identifiant, ou rend null si ce n'en est pas un. */
+export function parseExtensionWidgetId(raw: string): { extensionId: string; surfaceId: string } | null {
+	if (!raw.startsWith(EXTENSION_WIDGET_PREFIX)) return null
+	const [extensionId, surfaceId] = raw.slice(EXTENSION_WIDGET_PREFIX.length).split(':')
+	if (!extensionId || !surfaceId) return null
+	return { extensionId, surfaceId }
+}
+
+export interface ExtensionSurfaceEntry {
+	kind:        'extension'
+	id:          string          // identifiant de mise en page, prefixe
+	extensionId: string
+	surfaceId:   string
+	version:     string
+	entry:       string
+	label:       string
+	icon:        string | null
+	family:      string
+	desc:        string
+	schema:      FieldSchema[]
+	messages:    Record<string, string>
+	defaultHeight: number
+}
+
+/** Surfaces widget de toutes les extensions activees, pretes pour le builder. */
+export function extensionWidgetEntries(extensions: PublicExtension[] = []): ExtensionSurfaceEntry[] {
+	const out: ExtensionSurfaceEntry[] = []
+	for (const ext of extensions) {
+		for (const s of ext.surfaces) {
+			if (s.type !== 'widget' || !s.id) continue
+			out.push({
+				kind:          'extension',
+				id:            extensionWidgetId(ext.id, s.id),
+				extensionId:   ext.id,
+				surfaceId:     s.id,
+				version:       ext.version,
+				entry:         s.entry,
+				label:         s.label || ext.label,
+				icon:          ext.icon,
+				family:        ext.family,
+				desc:          ext.description,
+				schema:        (s.schema ?? []).map(canonField).filter((f): f is FieldSchema => f !== null),
+				messages:      ext.messages,
+				defaultHeight: s.defaultHeight ?? 160,
+			})
+		}
+	}
+	return out
+}
+
+/** Index par identifiant de mise en page, pour la resolution au rendu. */
+export function extensionIndex(extensions: PublicExtension[] = []): Record<string, ExtensionSurfaceEntry> {
+	const out: Record<string, ExtensionSurfaceEntry> = {}
+	for (const e of extensionWidgetEntries(extensions)) out[e.id] = e
+	return out
+}


### PR DESCRIPTION
Prepare le branchement du composant. Deux pieces.

## Liste publique

Elle ne rend QUE ce dont le frontend a besoin pour afficher : ni permissions accordees, ni empreinte, ni qui a installe. Un test verifie l'absence de ces quatre mots dans la reponse, parce qu'une liste publique qui grossit finit toujours par laisser passer un champ de trop.

Les libelles sont resolus **cote serveur**, dans la langue demandee, avec repli sur la locale par defaut de l'extension. Le frontend ne porte donc aucune logique de cles, et une extension ne peut pas lui faire afficher une chaine absente de ses propres dictionnaires. Un manifeste corrompu est ignore plutot que servi a moitie.

## Identifiant prefixe

Une surface widget entre au catalogue sous `ext:<extension>:<surface>`. Le prefixe n'est pas cosmetique : les identifiants natifs n'ont pas de deux-points, donc une extension **ne peut pas** prendre l'identite d'un widget natif dans une mise en page enregistree. Impossible par construction, pas par convention.

## Un decoupage impose par le harnais

`catalog.ts` importe des composants Svelte, que le harnais de test du depot (environnement node) ne sait pas transformer. Les helpers purs sortent donc dans `extensionCatalog.ts`, que `catalog.ts` importe desormais. Le module devient testable, et la dependance va dans le bon sens : le fichier de rendu importe le module pur, jamais l'inverse.

## Perimetre

Additif. Aucune page ne consomme encore la liste publique : le rendu vient dans le lot suivant.

15 tests sur le catalogue, 6 de plus sur la route, 743 coeur, 82 frontend, svelte-check 0 erreur.
