### PR TITLE
SDK d'extensions : une surface s'affiche sur la page d'accueil (P0-C, 2/2)

### DIFF
--- a/nodyx-frontend/src/lib/components/homepage/GridRenderer.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/GridRenderer.svelte
@@ -4,6 +4,8 @@
 	import { DEFAULT_THEME, autoSpanMd, autoSpanSm } from '$lib/types/homepage'
 	import { PLUGIN_REGISTRY } from './plugins'
 	import DynamicWidget from './DynamicWidget.svelte'
+	import ExtensionSurface from '$lib/components/ExtensionSurface.svelte'
+	import { extensionIndex, type PublicExtension } from './extensionCatalog'
 	import { t as i18n } from '$lib/i18n'   // `t` est déjà utilisé pour le thème
 
 	const tFn = $derived($i18n)
@@ -14,6 +16,7 @@
 		instance?:        Record<string, unknown>
 		user?:            Record<string, unknown> | null
 		installedWidgets?: Record<string, { entry: string; [k: string]: unknown }>
+		extensions?:       PublicExtension[]
 		// Mode édition : affiche overlays, handles, slots vides
 		editMode?:         boolean
 		// Callbacks édition
@@ -34,6 +37,7 @@
 		instance = {},
 		user = null,
 		installedWidgets = {},
+		extensions = [],
 		editMode = false,
 		onRowDragStart,
 		onColClick,
@@ -86,6 +90,12 @@
 		return installedWidgets[widgetType] ?? null
 	}
 
+	// Surfaces d'extension, resolues par identifiant prefixe `ext:<ext>:<surface>`.
+	const extIndex = $derived(extensionIndex(extensions))
+	function getExtension(widgetType: string) {
+		return extIndex[widgetType] ?? null
+	}
+
 	function colKey(row: GridRow, col: GridColumn) {
 		return `${row.id}:${col.id}`
 	}
@@ -125,6 +135,7 @@
 			{#each row.columns as col, colIdx (col.id)}
 				{@const plugin  = col.widget ? getPlugin(col.widget) : null}
 				{@const dynamic = col.widget ? getDynamic(col.widget) : null}
+				{@const ext     = col.widget ? getExtension(col.widget) : null}
 				{@const isSelected = selectedColKey === colKey(row, col)}
 
 				<!-- ── COLUMN ──────────────────────────────────────────────── -->
@@ -149,6 +160,18 @@
 							{instance}
 							{user}
 							title={col.title}
+						/>
+					{:else if ext}
+						<ExtensionSurface
+							extensionId={ext.extensionId}
+							version={ext.version}
+							surface={`widget:${ext.surfaceId}`}
+							entry={ext.entry}
+							label={ext.label}
+							config={col.config ?? {}}
+							messages={ext.messages}
+							defaultHeight={ext.defaultHeight}
+							{instance}
 						/>
 					{:else if dynamic}
 						<DynamicWidget

--- a/nodyx-frontend/src/lib/components/homepage/WidgetZone.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/WidgetZone.svelte
@@ -2,6 +2,8 @@
 	import type { HomepageWidget } from '$lib/types/homepage';
 	import { PLUGIN_REGISTRY } from './plugins';
 	import DynamicWidget from './DynamicWidget.svelte';
+	import ExtensionSurface from '$lib/components/ExtensionSurface.svelte';
+	import { extensionIndex, type PublicExtension } from './extensionCatalog';
 
 	interface Props {
 		widgets:          HomepageWidget[];
@@ -9,9 +11,12 @@
 		user:             Record<string, unknown> | null;
 		layout?:          string;
 		installedWidgets?: Record<string, { entry: string; [k: string]: unknown }>;
+		extensions?:       PublicExtension[];
 	}
 
-	let { widgets, instance, user, layout = 'full', installedWidgets = {} }: Props = $props();
+	let { widgets, instance, user, layout = 'full', installedWidgets = {}, extensions = [] }: Props = $props();
+
+	const extIndex = $derived(extensionIndex(extensions));
 
 	function isVisible(w: HomepageWidget): boolean {
 		const v = w.visibility ?? { audience: 'all' };
@@ -31,7 +36,8 @@
 		{#each visibleWidgets as widget (widget.id)}
 			{@const nativePlugin  = PLUGIN_REGISTRY[widget.widget_type]}
 			{@const dynamicManifest = installedWidgets[widget.widget_type]}
-			{#if nativePlugin || dynamicManifest}
+			{@const extSurface = extIndex[widget.widget_type]}
+			{#if nativePlugin || dynamicManifest || extSurface}
 				<div
 					class="widget-wrapper"
 					class:hide-mobile={widget.hide_mobile}
@@ -46,6 +52,19 @@
 							{instance}
 							{user}
 							title={widget.title}
+						/>
+					{:else if extSurface}
+						<!-- Surface d'extension, montée en frame isolée -->
+						<ExtensionSurface
+							extensionId={extSurface.extensionId}
+							version={extSurface.version}
+							surface={`widget:${extSurface.surfaceId}`}
+							entry={extSurface.entry}
+							label={extSurface.label}
+							config={widget.config ?? {}}
+							messages={extSurface.messages}
+							defaultHeight={extSurface.defaultHeight}
+							{instance}
 						/>
 					{:else}
 						<!-- Widget installé — Web Component chargé dynamiquement -->

--- a/nodyx-frontend/src/routes/+page.server.ts
+++ b/nodyx-frontend/src/routes/+page.server.ts
@@ -2,9 +2,9 @@ import type { PageServerLoad } from './$types';
 import { apiFetch } from '$lib/api';
 
 export const load: PageServerLoad = async ({ fetch, parent }) => {
-	const { modules } = await parent()
+	const { modules, ssrLocale } = await parent()
 
-	const [infoRes, catRes, threadsRes, featuredRes, eventsRes, homepageRes, widgetStoreRes, gridRes] = await Promise.all([
+	const [infoRes, catRes, threadsRes, featuredRes, eventsRes, homepageRes, widgetStoreRes, gridRes, extensionsRes] = await Promise.all([
 		apiFetch(fetch, '/instance/info'),
 		apiFetch(fetch, '/instance/categories'),
 		apiFetch(fetch, '/instance/threads/recent'),
@@ -13,10 +13,14 @@ export const load: PageServerLoad = async ({ fetch, parent }) => {
 		apiFetch(fetch, '/instance/homepage'),
 		apiFetch(fetch, '/widget-store-public'),
 		apiFetch(fetch, '/instance/homepage/grid'),
+		// Extensions activees (SDK api 1). Tolerante : une instance qui n'a pas
+		// encore la table repond en erreur, la page d'accueil ne doit pas tomber
+		// pour autant.
+		apiFetch(fetch, `/extensions/public?locale=${encodeURIComponent(ssrLocale ?? '')}`).catch(() => null),
 	]);
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const [infoJson, catJson, threadsJson, featuredJson, eventsJson, homepageJson, widgetStoreJson, gridJson]: any[] = await Promise.all([
+	const [infoJson, catJson, threadsJson, featuredJson, eventsJson, homepageJson, widgetStoreJson, gridJson, extensionsJson]: any[] = await Promise.all([
 		infoRes.ok          ? infoRes.json()          : {},
 		catRes.ok           ? catRes.json()           : {},
 		threadsRes.ok       ? threadsRes.json()       : {},
@@ -25,6 +29,7 @@ export const load: PageServerLoad = async ({ fetch, parent }) => {
 		homepageRes.ok      ? homepageRes.json()      : { positions: [] },
 		widgetStoreRes?.ok  ? widgetStoreRes.json()   : { widgets: [] },
 		gridRes?.ok         ? gridRes.json()          : { layout: null, theme: {} },
+		extensionsRes?.ok   ? extensionsRes.json()    : { extensions: [] },
 	]);
 
 	// Resolve hero-banner dynamic variant server-side (live > event > night > default)
@@ -96,6 +101,8 @@ export const load: PageServerLoad = async ({ fetch, parent }) => {
 		installedWidgets: Object.fromEntries(
 			(widgetStoreJson.widgets ?? []).map((w: any) => [w.id, w.manifest])
 		),
+		// Extensions activées (SDK api 1) : surfaces widget montées en frame isolée
+		extensions: extensionsJson?.extensions ?? [],
 		// Grid Builder v2 — layout publié + thème
 		// Si layout est non-null → GridRenderer prend le relais sur la homepage
 		gridLayout: gridJson.layout ?? null,

--- a/nodyx-frontend/src/routes/+page.svelte
+++ b/nodyx-frontend/src/routes/+page.svelte
@@ -4,6 +4,7 @@
 	import { t } from '$lib/i18n';
 	import WidgetZone from '$lib/components/homepage/WidgetZone.svelte';
 	import GridRenderer from '$lib/components/homepage/GridRenderer.svelte';
+	import type { PublicExtension } from '$lib/components/homepage/extensionCatalog';
 	import type { HomepagePosition, GridLayout, GridTheme } from '$lib/types/homepage';
 	import { GRID_GOOGLE_FONTS_URL } from '$lib/types/homepage';
 	const tFn = $derived($t)
@@ -18,6 +19,7 @@
 	const hpPositions      = $derived((data as any).homepagePositions as HomepagePosition[] ?? []);
 	const user             = $derived((data as any).user ?? null);
 	const installedWidgets = $derived((data as any).installedWidgets as Record<string, { entry: string }> ?? {});
+	const extensions = $derived(((data as { extensions?: PublicExtension[] }).extensions ?? []) satisfies PublicExtension[])
 	const gridLayout       = $derived((data as any).gridLayout as GridLayout | null ?? null);
 	const gridTheme        = $derived((data as any).gridTheme as Partial<GridTheme> ?? {});
 	const hasGrid          = $derived(gridLayout !== null && (gridLayout as GridLayout)?.rows?.length > 0);
@@ -213,6 +215,7 @@
 		{instance}
 		{user}
 		{installedWidgets}
+		{extensions}
 	/>
 {:else}
 
@@ -222,14 +225,14 @@
 
 <!-- BANNER -->
 {#if hasPos('banner')}
-	<WidgetZone widgets={posWidgets('banner')} {instance} {user} layout="full" {installedWidgets} />
+	<WidgetZone widgets={posWidgets('banner')} {instance} {user} layout="full" {installedWidgets} {extensions} />
 {/if}
 
 <!-- ═══════════════════════════════════════════════════════════════════
      HERO — position 'hero' (WidgetZone) ou fallback hardcodé
 ════════════════════════════════════════════════════════════════════════ -->
 {#if hasPos('hero')}
-	<WidgetZone widgets={posWidgets('hero')} {instance} {user} layout="full" {installedWidgets} />
+	<WidgetZone widgets={posWidgets('hero')} {instance} {user} layout="full" {installedWidgets} {extensions} />
 {:else}
 <!-- Fallback hero hardcodé (tant qu'aucun widget n'est configuré) -->
 <section class="relative overflow-hidden noise" style="background: #0a0a0f; border-bottom: 1px solid rgba(255,255,255,.05); min-height: 220px">
@@ -326,7 +329,7 @@
 ════════════════════════════════════════════════════════════════════════ -->
 {#if hasPos('stats-bar')}
 	<div class="flex flex-wrap px-8 py-3 gap-0.5" style="background:#0d0d12; border-bottom:1px solid rgba(255,255,255,.05)">
-		<WidgetZone widgets={posWidgets('stats-bar')} {instance} {user} layout="full" {installedWidgets} />
+		<WidgetZone widgets={posWidgets('stats-bar')} {instance} {user} layout="full" {installedWidgets} {extensions} />
 	</div>
 {/if}
 
@@ -334,7 +337,7 @@
      MAIN — position 'main' (WidgetZone) — above main content
 ════════════════════════════════════════════════════════════════════════ -->
 {#if hasPos('main')}
-	<WidgetZone widgets={posWidgets('main')} {instance} {user} layout="full" {installedWidgets} />
+	<WidgetZone widgets={posWidgets('main')} {instance} {user} layout="full" {installedWidgets} {extensions} />
 {/if}
 
 <!-- ═══════════════════════════════════════════════════════════════════
@@ -581,7 +584,7 @@
 {#if hasPos('sidebar')}
 	<div class="px-6 py-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
 	     style="border-bottom:1px solid rgba(255,255,255,.05); background:#08080d">
-		<WidgetZone widgets={posWidgets('sidebar')} {instance} {user} layout="grid-3" {installedWidgets} />
+		<WidgetZone widgets={posWidgets('sidebar')} {instance} {user} layout="grid-3" {installedWidgets} {extensions} />
 	</div>
 {/if}
 
@@ -825,19 +828,19 @@
 ════════════════════════════════════════════════════════════════════════ -->
 {#if hasPos('wide-1')}
 	<section style="border-bottom:1px solid rgba(255,255,255,.05)">
-		<WidgetZone widgets={posWidgets('wide-1')} {instance} {user} layout="full" {installedWidgets} />
+		<WidgetZone widgets={posWidgets('wide-1')} {instance} {user} layout="full" {installedWidgets} {extensions} />
 	</section>
 {/if}
 {#if hasPos('half-1') || hasPos('half-2')}
 	<div class="grid grid-cols-1 md:grid-cols-2 gap-0" style="border-bottom:1px solid rgba(255,255,255,.05)">
 		{#if hasPos('half-1')}
 			<div style="border-right:1px solid rgba(255,255,255,.05)">
-				<WidgetZone widgets={posWidgets('half-1')} {instance} {user} layout="full" {installedWidgets} />
+				<WidgetZone widgets={posWidgets('half-1')} {instance} {user} layout="full" {installedWidgets} {extensions} />
 			</div>
 		{/if}
 		{#if hasPos('half-2')}
 			<div>
-				<WidgetZone widgets={posWidgets('half-2')} {instance} {user} layout="full" {installedWidgets} />
+				<WidgetZone widgets={posWidgets('half-2')} {instance} {user} layout="full" {installedWidgets} {extensions} />
 			</div>
 		{/if}
 	</div>
@@ -845,7 +848,7 @@
 
 {#if hasPos('wide-2')}
 	<section style="border-bottom:1px solid rgba(255,255,255,.05)">
-		<WidgetZone widgets={posWidgets('wide-2')} {instance} {user} layout="full" {installedWidgets} />
+		<WidgetZone widgets={posWidgets('wide-2')} {instance} {user} layout="full" {installedWidgets} {extensions} />
 	</section>
 {/if}
 
@@ -853,17 +856,17 @@
 	<div class="grid grid-cols-1 md:grid-cols-3 gap-0" style="border-bottom:1px solid rgba(255,255,255,.05)">
 		{#if hasPos('trio-1')}
 			<div style="border-right:1px solid rgba(255,255,255,.05)">
-				<WidgetZone widgets={posWidgets('trio-1')} {instance} {user} layout="full" {installedWidgets} />
+				<WidgetZone widgets={posWidgets('trio-1')} {instance} {user} layout="full" {installedWidgets} {extensions} />
 			</div>
 		{/if}
 		{#if hasPos('trio-2')}
 			<div style="border-right:1px solid rgba(255,255,255,.05)">
-				<WidgetZone widgets={posWidgets('trio-2')} {instance} {user} layout="full" {installedWidgets} />
+				<WidgetZone widgets={posWidgets('trio-2')} {instance} {user} layout="full" {installedWidgets} {extensions} />
 			</div>
 		{/if}
 		{#if hasPos('trio-3')}
 			<div>
-				<WidgetZone widgets={posWidgets('trio-3')} {instance} {user} layout="full" {installedWidgets} />
+				<WidgetZone widgets={posWidgets('trio-3')} {instance} {user} layout="full" {installedWidgets} {extensions} />
 			</div>
 		{/if}
 	</div>
@@ -876,24 +879,24 @@
 	<div class="grid grid-cols-1 md:grid-cols-3 gap-0" style="border-top:1px solid rgba(255,255,255,.05)">
 		{#if hasPos('footer-1')}
 			<div style="border-right:1px solid rgba(255,255,255,.05)">
-				<WidgetZone widgets={posWidgets('footer-1')} {instance} {user} layout="full" {installedWidgets} />
+				<WidgetZone widgets={posWidgets('footer-1')} {instance} {user} layout="full" {installedWidgets} {extensions} />
 			</div>
 		{/if}
 		{#if hasPos('footer-2')}
 			<div style="border-right:1px solid rgba(255,255,255,.05)">
-				<WidgetZone widgets={posWidgets('footer-2')} {instance} {user} layout="full" {installedWidgets} />
+				<WidgetZone widgets={posWidgets('footer-2')} {instance} {user} layout="full" {installedWidgets} {extensions} />
 			</div>
 		{/if}
 		{#if hasPos('footer-3')}
 			<div>
-				<WidgetZone widgets={posWidgets('footer-3')} {instance} {user} layout="full" {installedWidgets} />
+				<WidgetZone widgets={posWidgets('footer-3')} {instance} {user} layout="full" {installedWidgets} {extensions} />
 			</div>
 		{/if}
 	</div>
 {/if}
 {#if hasPos('footer-bar')}
 	<div style="border-top:1px solid rgba(255,255,255,.05)">
-		<WidgetZone widgets={posWidgets('footer-bar')} {instance} {user} layout="full" {installedWidgets} />
+		<WidgetZone widgets={posWidgets('footer-bar')} {instance} {user} layout="full" {installedWidgets} {extensions} />
 	</div>
 {/if}
 


### PR DESCRIPTION
Le dernier fil. Les deux renderers montent `ExtensionSurface` quand l'identifiant de mise en page est prefixe, et la page charge la liste publique des extensions activees dans la langue negociee au SSR.

## Trois choix

**Le chargement est tolerant.** Une instance dont la table n'existe pas encore repond en erreur, et la page d'accueil ne doit pas tomber pour autant. C'est la premiere fois de ce chantier qu'un appel neuf se retrouve sur le chemin d'une page PUBLIQUE : il ne peut pas etre celui qui la casse.

**L'ordre de resolution est natif, puis extension, puis ancien widget installe.** Le natif garde la priorite comme avant, l'ancien chemin reste servi jusqu'a la fin de P0-C, et un identifiant prefixe ne peut pas se confondre avec un natif. La cohabitation est donc sure pendant la transition.

**Rien n'est visible tant qu'aucune extension n'est installee.** Sur les quatre instances, la liste est vide, donc le rendu est strictement identique a aujourd'hui.

## Un piege a mon debit

Un de mes remplacements de source n'a pas pris, faute d'indentation identique, et mon script a rapporte « ok » sans l'avoir fait : je n'avais pas mis d'assertion sur celui la. C'est `svelte-check` qui l'a rattrape, avec un « Cannot find name 'ext' » bien concret.

Regle sans exception : toute substitution automatique doit etre assertee, sinon elle ment.

## Perimetre

82 tests frontend, 743 coeur, svelte-check 0 erreur.
