### PR TITLE
SDK d'extensions : les surfaces entrent dans le builder d'accueil

### DIFF
--- a/nodyx-frontend/src/lib/components/homepage/catalog.extensions.test.ts
+++ b/nodyx-frontend/src/lib/components/homepage/catalog.extensions.test.ts
@@ -81,3 +81,39 @@ describe('entrees du catalogue', () => {
 		expect(Object.keys(extensionIndex([EXT]))).toEqual(['ext:library:tonight'])
 	})
 })
+
+// Le catalogue complet vit dans catalog.ts, qui importe des composants Svelte
+// et n'est donc pas transformable ici. On verifie la partie qui compte et qui
+// est pure : un identifiant d'extension ne peut pas entrer en collision avec
+// un identifiant natif, quel que soit l'ordre d'assemblage.
+describe('cohabitation avec les widgets natifs', () => {
+	const NATIFS = [
+		'hero-banner', 'header', 'stats-bar', 'join-card', 'announcement-banner',
+		'article-slideshow', 'articles-showcase', 'recent-threads',
+		'social-links-bar', 'twitch-stream', 'video-player',
+	]
+
+	it('aucun identifiant d extension ne peut valoir un identifiant natif', () => {
+		const ids = extensionWidgetEntries([EXT]).map(e => e.id)
+		for (const id of ids) expect(NATIFS).not.toContain(id)
+	})
+
+	it('aucun identifiant natif ne se decompose comme une extension', () => {
+		for (const id of NATIFS) expect(parseExtensionWidgetId(id)).toBeNull()
+	})
+
+	it('deux extensions differentes ne se marchent pas dessus', () => {
+		const autre = { ...EXT, id: 'autre', surfaces: [{ ...EXT.surfaces[0] }] }
+		const index = extensionIndex([EXT, autre as PublicExtension])
+		expect(Object.keys(index).sort()).toEqual(['ext:autre:tonight', 'ext:library:tonight'])
+	})
+
+	it('deux surfaces de la meme extension ne se marchent pas dessus', () => {
+		const deux = { ...EXT, surfaces: [
+			EXT.surfaces[0],
+			{ ...EXT.surfaces[0], id: 'shelf', label: 'Etagere' },
+		] }
+		expect(Object.keys(extensionIndex([deux as PublicExtension])).sort())
+			.toEqual(['ext:library:shelf', 'ext:library:tonight'])
+	})
+})

--- a/nodyx-frontend/src/lib/components/homepage/catalog.ts
+++ b/nodyx-frontend/src/lib/components/homepage/catalog.ts
@@ -13,7 +13,7 @@
 
 import { PLUGIN_LIST, PLUGIN_REGISTRY } from './plugins'
 import type { WidgetPlugin, FieldSchema, WidgetFamily } from './plugins/_types'
-import { canonField } from './extensionCatalog'
+import { canonField, extensionWidgetEntries, type PublicExtension } from './extensionCatalog'
 
 // Manifest d'un widget installé tel que renvoyé par /api/v1/widget-store-public.
 export interface InstalledWidgetManifest {
@@ -41,6 +41,21 @@ export type CatalogEntry =
 			desc:   string
 			schema: FieldSchema[]
 			plugin: WidgetPlugin
+		}
+	| {
+			kind:        'extension'
+			id:          string      // identifiant de mise en page, prefixe `ext:`
+			label:       string
+			icon:        string
+			family:      WidgetFamily | string
+			desc:        string
+			schema:      FieldSchema[]
+			extensionId: string
+			surfaceId:   string
+			version:     string
+			entry:       string
+			messages:    Record<string, string>
+			defaultHeight: number
 		}
 	| {
 			kind:    'installed'
@@ -88,14 +103,34 @@ function pluginToEntry(p: WidgetPlugin): CatalogEntry {
 
 // Catalogue complet pour le picker du builder. Natifs phase 1 d'abord
 // (toujours disponibles), puis widgets installés non-shadowés par un natif.
-export function buildCatalog(installed: InstalledWidgetManifest[] = []): CatalogEntry[] {
+export function buildCatalog(
+	installed: InstalledWidgetManifest[] = [],
+	extensions: PublicExtension[] = [],
+): CatalogEntry[] {
 	const natives = PLUGIN_LIST
 		.filter(p => p.phase === 1)
 		.map(pluginToEntry)
 	const dyns = installed
 		.filter(m => !PLUGIN_REGISTRY[m.id]) // un installed ne masque jamais un natif
 		.map(manifestToEntry)
-	return [...natives, ...dyns]
+	// Les surfaces d'extension ne peuvent masquer personne : leur identifiant
+	// est prefixe, et aucun identifiant natif ne contient de deux-points.
+	const exts = extensionWidgetEntries(extensions).map((e): CatalogEntry => ({
+		kind:          'extension',
+		id:            e.id,
+		label:         e.label,
+		icon:          e.icon ?? '🧩',
+		family:        e.family,
+		desc:          e.desc,
+		schema:        e.schema,
+		extensionId:   e.extensionId,
+		surfaceId:     e.surfaceId,
+		version:       e.version,
+		entry:         e.entry,
+		messages:      e.messages,
+		defaultHeight: e.defaultHeight,
+	}))
+	return [...natives, ...dyns, ...exts]
 }
 
 // Index par id pour la résolution O(1) (icône, schema, etc.) côté UI.

--- a/nodyx-frontend/src/routes/admin/homepage/builder/+page.server.ts
+++ b/nodyx-frontend/src/routes/admin/homepage/builder/+page.server.ts
@@ -2,13 +2,16 @@ import type { PageServerLoad } from './$types';
 import { apiFetch } from '$lib/api';
 
 export const load: PageServerLoad = async ({ fetch, parent }) => {
-	const { token } = await parent();
+	const { token, ssrLocale } = await parent();
 
-	const [gridRes, widgetsRes] = await Promise.all([
+	const [gridRes, widgetsRes, extensionsRes] = await Promise.all([
 		apiFetch(fetch, '/admin/homepage/grid', {
 			headers: { Authorization: `Bearer ${token}` },
 		}),
 		apiFetch(fetch, '/widget-store-public'),
+		// Tolerant : un builder ne doit pas devenir inaccessible parce que la
+		// liste des extensions repond mal.
+		apiFetch(fetch, `/extensions/public?locale=${encodeURIComponent(ssrLocale ?? '')}`).catch(() => null),
 	]);
 
 	const grid = gridRes.ok
@@ -19,10 +22,13 @@ export const load: PageServerLoad = async ({ fetch, parent }) => {
 	const installedWidgets = (widgetsJson.widgets ?? [])
 		.map((w: { manifest: unknown }) => w.manifest);
 
+	const extensionsJson = extensionsRes?.ok ? await extensionsRes.json() : { extensions: [] };
+
 	return {
 		draft:            grid.draft     ?? null,
 		published:        grid.published ?? null,
 		theme:            grid.theme     ?? {},
 		installedWidgets,
+		extensions:       extensionsJson.extensions ?? [],
 	};
 };

--- a/nodyx-frontend/src/routes/admin/homepage/builder/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/homepage/builder/+page.svelte
@@ -8,6 +8,7 @@
 		buildCatalog, buildCatalogIndex, toInstalledWidgetsMap,
 		type CatalogEntry, type InstalledWidgetManifest,
 	} from '$lib/components/homepage/catalog'
+	import type { PublicExtension } from '$lib/components/homepage/extensionCatalog'
 	import type {
 		GridLayout, GridRow, GridColumn, GridTheme,
 	} from '$lib/types/homepage'
@@ -79,7 +80,10 @@
 	)
 
 	// Catalogue widgets (natifs phase 1 + widgets installés depuis l'admin store)
-	const catalog       = $derived(buildCatalog((data.installedWidgets ?? []) as InstalledWidgetManifest[]))
+	const catalog       = $derived(buildCatalog(
+		(data.installedWidgets ?? []) as InstalledWidgetManifest[],
+		(data.extensions ?? []) as PublicExtension[],
+	))
 	const catalogIndex  = $derived(buildCatalogIndex(catalog))
 	const installedMap  = $derived(toInstalledWidgetsMap((data.installedWidgets ?? []) as InstalledWidgetManifest[]))
 
@@ -1705,6 +1709,7 @@
 						instance={{}}
 						user={null}
 						installedWidgets={installedMap}
+						extensions={(data.extensions ?? []) as PublicExtension[]}
 						editMode={true}
 						{selectedColKey}
 						dragOverRowId={dragOverIdx !== null && dragRowId !== null ? (draft.rows[dragOverIdx]?.id ?? null) : null}


### PR DESCRIPTION
Un admin peut desormais poser une extension sur sa grille comme n'importe quel widget : elle apparait au picker, son formulaire de configuration est genere depuis le schema declare au manifeste, et l'apercu la monte en frame isolee, donc exactement comme la page publique la rendra.

## Le builder ne connait ni cles ni dictionnaires

Les libelles du picker et du formulaire arrivent deja resolus par le serveur dans la langue de l'admin. Toute la logique i18n d'une extension reste chez elle et chez le coeur, jamais dans le code d'interface.

## Cohabitation verrouillee

Les surfaces d'extension ne peuvent masquer personne : leur identifiant est prefixe et aucun identifiant natif ne contient de deux-points. Quatre tests le tiennent, dont un qui passe les onze identifiants natifs en revue, et deux qui verifient que deux extensions distinctes, ou deux surfaces d'une meme extension, ne se marchent pas dessus.

## Tolerance

Le chargement de la liste est tolerant ici aussi : un builder ne doit pas devenir inaccessible parce que la liste des extensions repond mal.

## Perimetre

Sur les quatre instances aucune extension n'est installee, donc le picker est identique a aujourd'hui.

86 tests frontend, svelte-check 0 erreur.
