### PR TITLE
SDK d'extensions : le proxy reseau, avec epinglage d'adresse

### DIFF
--- a/nodyx-core/src/extensions/manifest.ts
+++ b/nodyx-core/src/extensions/manifest.ts
@@ -165,6 +165,10 @@ const surface = z.discriminatedUnion('type', [widgetSurface, pageSurface])
 const networkRule = z.object({
   methods: z.array(z.enum(HTTP_METHODS)).min(1),
   paths:   z.array(z.string().startsWith('/')).min(1),
+  // Un service d'intranet vit rarement sur 443. Le port se DECLARE, donc il
+  // reste visible sur l'ecran de permissions : declarer un hote n'ouvre pas
+  // toutes ses portes, mais on ne rend pas l'intranet indeclarable.
+  port:    z.number().int().min(1).max(65535).optional(),
   secret:  z.string().regex(/^[A-Z][A-Z0-9_]{2,63}$/).optional(),
   rate:    z.string().regex(RE_RATE).optional(),
 }).strict()

--- a/nodyx-core/src/extensions/net.ts
+++ b/nodyx-core/src/extensions/net.ts
@@ -1,0 +1,234 @@
+// Le proxy réseau des extensions.
+//
+// Ce n'est PAS un `fetch` générique derrière une liste blanche. C'est une porte
+// bornée par ce que le manifeste déclare et que l'admin a accepté, et la
+// différence se voit à l'écran de permissions : « peut lire les fiches
+// publiques TMDB (GET /3/movie/...) » plutôt que « accès réseau ».
+//
+// Deux principes portent tout le module.
+//
+// 1. On valide l'ADRESSE OBTENUE, pas le nom demandé. Vérifier le nom avant de
+//    résoudre ne protège de rien : le rebinding DNS est l'attaque de référence,
+//    et un nom public qui résout en adresse privée est le contournement
+//    classique. On résout, on juge l'adresse, puis on se connecte À CETTE
+//    ADRESSE.
+//
+// 2. Le SERVEUR possède la recette d'injection du secret. L'extension nomme le
+//    secret, elle ne choisit ni l'en-tête ni sa destination : sinon elle
+//    demanderait `X-Peu-Importe: <secret>` vers un hôte qu'elle contrôle et le
+//    récupérerait indirectement.
+//
+// cf SPECS/NODYX_SDK_CDC.md §6.4, NODYX_SDK_SECURITY.md §4.4
+
+import { NETWORK } from './limits'
+import { classifyHost } from './manifest'
+
+export type NetError =
+  | 'HOST_NOT_ALLOWED' | 'HOST_FORBIDDEN' | 'METHOD_NOT_ALLOWED' | 'PATH_NOT_ALLOWED'
+  | 'PORT_NOT_ALLOWED' | 'SCHEME_NOT_ALLOWED' | 'PRIVATE_ADDRESS' | 'INVALID_ARGUMENT'
+  | 'TOO_MANY_REDIRECTS' | 'RESPONSE_TOO_LARGE' | 'UPSTREAM_TIMEOUT' | 'UPSTREAM_ERROR'
+
+export interface NetRule {
+  methods: string[]
+  paths:   string[]
+  /** Port non standard declare au manifeste. Absent = port par defaut du schema. */
+  port?:   number
+  secret?: string
+  rate?:   string
+}
+
+/** Ce que l'admin a accordé, hôte par hôte. */
+export type GrantedNetwork = Record<string, NetRule>
+
+export type NetCheck<T> =
+  | { ok: true;  value: T }
+  | { ok: false; code: NetError; message: string }
+
+const fail = (code: NetError, message: string): NetCheck<never> => ({ ok: false, code, message })
+
+/** Un préfixe de chemin déclaré, avec `*` en fin, autorise ses descendants. */
+export function pathAllowed(pathname: string, patterns: string[]): boolean {
+  return patterns.some((p) => {
+    if (p.endsWith('*')) return pathname.startsWith(p.slice(0, -1))
+    return pathname === p
+  })
+}
+
+export interface AllowedTarget {
+  url:    URL
+  host:   string
+  rule:   NetRule
+  method: string
+}
+
+/**
+ * Vérifie une cible contre ce que l'admin a accordé.
+ *
+ * Purement lexical : aucune résolution ici. La vérification d'adresse se fait
+ * juste avant la connexion, et à chaque redirection.
+ */
+export function checkTarget(rawUrl: unknown, rawMethod: unknown, granted: GrantedNetwork): NetCheck<AllowedTarget> {
+  if (typeof rawUrl !== 'string' || rawUrl.length > 2048) return fail('INVALID_ARGUMENT', 'URL absente ou trop longue')
+
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    return fail('INVALID_ARGUMENT', 'URL invalide')
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    return fail('SCHEME_NOT_ALLOWED', 'seuls http et https sortent')
+  }
+
+  const host = url.hostname.toLowerCase()
+  const rule = granted[host]
+  if (!rule) return fail('HOST_NOT_ALLOWED', `l'hôte ${host} n'a pas été accordé à cette extension`)
+
+  // Un port non declare est refuse : declarer un hote n'ouvre pas toutes ses
+  // portes, et un service d'administration vit souvent juste a cote. Mais un
+  // port PEUT se declarer, sinon un service d'intranet serait injoignable.
+  const defaultPort = url.protocol === 'https:' ? '443' : '80'
+  const allowedPort = rule.port ? String(rule.port) : defaultPort
+  if ((url.port || defaultPort) !== allowedPort) {
+    return fail('PORT_NOT_ALLOWED', `le port ${url.port || defaultPort} n'a pas été déclaré pour ${host}`)
+  }
+
+  const klass = classifyHost(host)
+  if (klass === 'forbidden') {
+    return fail('HOST_FORBIDDEN', 'cette cible est la machine de l\'instance elle même')
+  }
+
+  const method = String(rawMethod ?? 'GET').toUpperCase()
+  if (!rule.methods.map((m) => m.toUpperCase()).includes(method)) {
+    return fail('METHOD_NOT_ALLOWED', `la méthode ${method} n'a pas été déclarée pour ${host}`)
+  }
+
+  if (!pathAllowed(url.pathname, rule.paths)) {
+    return fail('PATH_NOT_ALLOWED', `le chemin ${url.pathname} sort de ce qui a été déclaré pour ${host}`)
+  }
+
+  return { ok: true, value: { url, host, rule, method } }
+}
+
+// ── Adresses ─────────────────────────────────────────────────────────────────
+
+/** Une adresse IPv4 privée, de bouclage, de lien local, ou réservée. */
+export function isPrivateIPv4(ip: string): boolean {
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(ip)
+  if (!m) return false
+  const [a, b] = m.slice(1).map(Number)
+  if (a === 10 || a === 127 || a === 0) return true
+  if (a === 172 && b >= 16 && b <= 31) return true
+  if (a === 192 && b === 168) return true
+  if (a === 169 && b === 254) return true            // lien local, métadonnées d'hébergeur
+  if (a === 100 && b >= 64 && b <= 127) return true  // partage d'adresse opérateur
+  if (a >= 224) return true                          // multicast, réservé, diffusion
+  return false
+}
+
+/** Une adresse IPv6 de bouclage, de lien local, unique locale, ou mappée. */
+export function isPrivateIPv6(ip: string): boolean {
+  const a = ip.toLowerCase().replace(/^\[|\]$/g, '')
+  if (a === '::1' || a === '::') return true
+  if (a.startsWith('fe80:') || a.startsWith('fc') || a.startsWith('fd')) return true
+  // Une IPv4 mappée cache une adresse v4 derrière une écriture v6.
+  const mapped = /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.exec(a)
+  if (mapped) return isPrivateIPv4(mapped[1])
+  if (a.startsWith('ff')) return true                // multicast
+  return false
+}
+
+export function isPrivateAddress(ip: string): boolean {
+  return ip.includes(':') ? isPrivateIPv6(ip) : isPrivateIPv4(ip)
+}
+
+/**
+ * Décide si une adresse résolue est joignable.
+ *
+ * `allowPrivate` vient de l'accord EXPLICITE de l'admin pour cet hôte : une
+ * instance en intranet est un usage normal, pas une anomalie. La boucle locale
+ * et le lien local, eux, restent refusés même avec cet accord, parce qu'ils
+ * visent la machine de l'instance et ses identifiants d'hébergeur.
+ */
+export function addressAllowed(ip: string, allowPrivate: boolean): NetCheck<string> {
+  const v6 = ip.includes(':')
+  const loopbackOrLinkLocal = v6
+    ? (ip === '::1' || ip === '::' || ip.toLowerCase().startsWith('fe80:'))
+    : /^(127\.|169\.254\.|0\.)/.test(ip)
+
+  if (loopbackOrLinkLocal) {
+    return fail('PRIVATE_ADDRESS', 'la boucle locale et le lien local ne sont joignables en aucun cas')
+  }
+  if (isPrivateAddress(ip) && !allowPrivate) {
+    return fail('PRIVATE_ADDRESS', `l'adresse ${ip} est privée et cet accès n'a pas été accordé`)
+  }
+  return { ok: true, value: ip }
+}
+
+// ── En-têtes ─────────────────────────────────────────────────────────────────
+
+/** Ce qu'une extension peut envoyer. Court, et volontairement. */
+const REQUEST_HEADER_ALLOWLIST = new Set(['accept', 'accept-language', 'content-type'])
+
+/** Ce qu'on rend. Tout le reste est retiré, à commencer par les cookies. */
+const RESPONSE_HEADER_ALLOWLIST = new Set([
+  'content-type', 'content-length', 'cache-control', 'etag', 'last-modified', 'expires',
+])
+
+export function filterRequestHeaders(raw: unknown): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (!raw || typeof raw !== 'object') return out
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    const key = k.toLowerCase()
+    if (!REQUEST_HEADER_ALLOWLIST.has(key)) continue
+    if (typeof v !== 'string' || v.length > 512) continue
+    out[key] = v
+  }
+  return out
+}
+
+export function filterResponseHeaders(headers: Iterable<[string, string]>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [k, v] of headers) {
+    const key = k.toLowerCase()
+    if (RESPONSE_HEADER_ALLOWLIST.has(key)) out[key] = v
+  }
+  return out
+}
+
+/**
+ * Injecte le secret, selon une recette que le SERVEUR possède.
+ *
+ * L'extension a nommé le secret au manifeste, elle ne dit ni où il va ni sous
+ * quel nom. Aujourd'hui : un en-tête `Authorization: Bearer`, ou un paramètre
+ * de requête `api_key` quand l'hôte l'exige. Le choix appartient à la recette,
+ * jamais à l'appelant.
+ */
+export interface SecretRecipe {
+  mode:  'bearer' | 'query'
+  param?: string
+}
+
+export const DEFAULT_RECIPE: SecretRecipe = { mode: 'bearer' }
+
+export function applySecret(
+  url: URL,
+  headers: Record<string, string>,
+  secret: string | undefined,
+  recipe: SecretRecipe = DEFAULT_RECIPE,
+): void {
+  if (!secret) return
+  if (recipe.mode === 'query') {
+    url.searchParams.set(recipe.param || 'api_key', secret)
+    return
+  }
+  headers.authorization = `Bearer ${secret}`
+}
+
+/** Une réponse dont la taille annoncée dépasse déjà le plafond. */
+export function declaredTooLarge(contentLength: string | null): boolean {
+  if (!contentLength) return false
+  const n = Number(contentLength)
+  return Number.isFinite(n) && n > NETWORK.maxResponseBytes
+}

--- a/nodyx-core/src/extensions/netFetch.ts
+++ b/nodyx-core/src/extensions/netFetch.ts
@@ -1,0 +1,217 @@
+// Exécution d'un appel sortant d'extension.
+//
+// La partie délicate est l'épinglage : entre le moment où l'on juge une adresse
+// et celui où l'on s'y connecte, un serveur DNS hostile peut changer d'avis.
+// C'est le rebinding, et la parade est de faire les deux dans le même geste :
+// on fournit à la pile réseau notre propre fonction de résolution, qui valide
+// l'adresse et la rend. La connexion part donc vers l'adresse jugée, jamais
+// vers une seconde résolution.
+//
+// Écrit sur `node:http`/`node:https` plutôt que sur `fetch` : la bibliothèque
+// standard accepte une fonction `lookup`, ce que `fetch` n'expose pas.
+//
+// cf SPECS/NODYX_SDK_SECURITY.md §4.4
+
+import http from 'node:http'
+import https from 'node:https'
+import { lookup as dnsLookup, type LookupOptions } from 'node:dns'
+import type { LookupFunction } from 'node:net'
+import { NETWORK } from './limits'
+import {
+  checkTarget, addressAllowed, filterRequestHeaders, filterResponseHeaders,
+  applySecret, declaredTooLarge, type GrantedNetwork, type NetError, type SecretRecipe,
+} from './net'
+
+export interface ProxyRequest {
+  url:     unknown
+  method?: unknown
+  headers?: unknown
+  body?:   unknown
+}
+
+export interface ProxyContext {
+  granted: GrantedNetwork
+  /** Hôtes pour lesquels l'admin a explicitement accepté le réseau privé. */
+  allowPrivate: Set<string>
+  /** Secrets de l'instance, jamais transmis à l'extension. */
+  secrets: Record<string, string>
+  recipes?: Record<string, SecretRecipe>
+}
+
+export interface ProxyResponse {
+  status:  number
+  headers: Record<string, string>
+  body:    string
+}
+
+export type ProxyResult =
+  | { ok: true;  response: ProxyResponse }
+  | { ok: false; code: NetError; message: string }
+
+const fail = (code: NetError, message: string): ProxyResult => ({ ok: false, code, message })
+
+/**
+ * Résolution gardée, passée à la pile réseau.
+ *
+ * Elle refuse en rendant une erreur, donc la connexion n'est jamais tentée.
+ */
+function guardedLookup(allowPrivate: boolean): LookupFunction {
+  return function lookup(
+    hostname: string,
+    _options: LookupOptions,
+    callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void,
+  ) {
+    dnsLookup(hostname, { all: false }, (err, address, family) => {
+      if (err) return callback(err, '', 0)
+      const verdict = addressAllowed(address, allowPrivate)
+      if (!verdict.ok) {
+        const e = new Error(verdict.message) as NodeJS.ErrnoException
+        e.code = 'EPRIVATEADDR'
+        return callback(e, '', 0)
+      }
+      callback(null, address, family)
+    })
+  }
+}
+
+export interface RawResponse {
+  status:  number
+  headers: Record<string, string | string[] | undefined>
+  body:    string
+}
+
+/** L'en-tete de redirection, lu a UN SEUL endroit. */
+function locationOf(raw: RawResponse): string | null {
+  const v = raw.headers.location
+  const s = Array.isArray(v) ? v[0] : v
+  return typeof s === 'string' && s ? s : null
+}
+
+/**
+ * Le transport, isole pour etre remplacable EN TEST.
+ *
+ * La couture est ici, et pas sur le garde d'adresse : remplacer le garde
+ * reviendrait a tester un systeme qui n'est pas celui qu'on livre. En
+ * remplacant le transport, on eprouve toute l'orchestration (revalidation des
+ * redirections, plafond de sauts, injection du secret par saut, traduction des
+ * erreurs) pendant que le garde reste exactement celui de production.
+ *
+ * Ce qui reste non couvert par un test portable : la traversee d'une vraie
+ * socket. C'est assume et ecrit, plutot que simule par un faux garde. La
+ * machine n'a que la boucle locale et une adresse publique, et la boucle locale
+ * est refusee en toute circonstance : c'est precisement la garantie voulue.
+ */
+export type Transport = (
+  url: URL, method: string, headers: Record<string, string>, body: string | null, allowPrivate: boolean,
+) => Promise<RawResponse>
+
+export const once: Transport = function once(url, method, headers, body, allowPrivate) {
+  return new Promise((resolve, reject) => {
+    const mod = url.protocol === 'https:' ? https : http
+    const req = mod.request(
+      {
+        protocol: url.protocol,
+        hostname: url.hostname,
+        port:     url.port || (url.protocol === 'https:' ? 443 : 80),
+        path:     url.pathname + url.search,
+        method,
+        headers:  { ...headers, host: url.host },
+        // L'epinglage vit ici : la pile appelle NOTRE resolution.
+        lookup:   guardedLookup(allowPrivate),
+        servername: url.hostname,          // SNI correct malgre la resolution custom
+        timeout:  NETWORK.timeoutMs,
+      },
+      (res) => {
+        if (declaredTooLarge(String(res.headers['content-length'] ?? ''))) {
+          res.destroy()
+          return reject(Object.assign(new Error('réponse trop grosse'), { code: 'ERESPTOOBIG' }))
+        }
+
+        // On coupe DES QU'ON DEPASSE, sans attendre la fin : une réponse sans
+        // taille annoncée pourrait couler indéfiniment.
+        let size = 0
+        const chunks: Buffer[] = []
+        res.on('data', (c: Buffer) => {
+          size += c.length
+          if (size > NETWORK.maxResponseBytes) {
+            res.destroy()
+            return reject(Object.assign(new Error('réponse trop grosse'), { code: 'ERESPTOOBIG' }))
+          }
+          chunks.push(c)
+        })
+        res.on('end', () => resolve({
+          status:  res.statusCode ?? 0,
+          headers: res.headers,
+          body:    Buffer.concat(chunks).toString('utf8'),
+        }))
+        res.on('error', reject)
+      },
+    )
+
+    req.on('timeout', () => { req.destroy(Object.assign(new Error('délai dépassé'), { code: 'ETIMEDOUT' })) })
+    req.on('error', reject)
+    if (body) req.write(body)
+    req.end()
+  })
+}
+
+/**
+ * Appelle un service tiers au nom d'une extension.
+ *
+ * Chaque redirection est REVALIDEE intégralement, hôte, méthode, chemin et
+ * adresse comprises : une redirection est une nouvelle cible, pas la suite de
+ * la précédente. C'est le contournement le plus simple d'une liste blanche.
+ */
+export async function proxyFetch(input: ProxyRequest, ctx: ProxyContext, transport: Transport = once): Promise<ProxyResult> {
+  let target = checkTarget(input.url, input.method, ctx.granted)
+  if (!target.ok) return target
+
+  const headers = filterRequestHeaders(input.headers)
+  const body = typeof input.body === 'string' ? input.body : null
+  if (body && body.length > 64 * 1024) return fail('INVALID_ARGUMENT', 'corps de requête trop gros')
+
+  let hops = 0
+  for (;;) {
+    const { url, host, rule, method } = target.value
+
+    // Le secret est injecte a CHAQUE saut valide, et seulement pour l'hote qui
+    // l'a declare : une redirection vers un autre hote ne l'emporte pas.
+    const call = new URL(url.toString())
+    const callHeaders = { ...headers }
+    applySecret(call, callHeaders, rule.secret ? ctx.secrets[rule.secret] : undefined, ctx.recipes?.[host])
+
+    let raw: RawResponse
+    try {
+      raw = await transport(call, method, callHeaders, body, ctx.allowPrivate.has(host))
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException).code
+      if (code === 'EPRIVATEADDR')  return fail('PRIVATE_ADDRESS', (e as Error).message)
+      if (code === 'ERESPTOOBIG')   return fail('RESPONSE_TOO_LARGE', `réponse au delà de ${NETWORK.maxResponseBytes / 1024 / 1024} Mo`)
+      if (code === 'ETIMEDOUT')     return fail('UPSTREAM_TIMEOUT', 'le service distant n\'a pas répondu à temps')
+      return fail('UPSTREAM_ERROR', 'le service distant est injoignable')
+    }
+
+    // Un seul endroit decide qu'il y a redirection : dupliquer l'information
+    // dans le transport aurait laisse un champ que tout transport doit penser
+    // a remplir, donc un oubli silencieux.
+    const location = raw.status >= 300 && raw.status < 400 ? locationOf(raw) : null
+    if (!location) {
+      return {
+        ok: true,
+        response: {
+          status:  raw.status,
+          headers: filterResponseHeaders(Object.entries(raw.headers).map(([k, v]) => [k, Array.isArray(v) ? v.join(', ') : String(v ?? '')])),
+          body:    raw.body,
+        },
+      }
+    }
+
+    if (++hops > NETWORK.maxRedirects) return fail('TOO_MANY_REDIRECTS', `plus de ${NETWORK.maxRedirects} redirections`)
+
+    const next = new URL(location, call).toString()
+    target = checkTarget(next, method, ctx.granted)
+    if (!target.ok) {
+      return fail(target.code, `redirection refusée : ${target.message}`)
+    }
+  }
+}

--- a/nodyx-core/src/routes/extensions.ts
+++ b/nodyx-core/src/routes/extensions.ts
@@ -21,6 +21,9 @@ import { storageGet, storageSet, storageDelete, storageList } from '../extension
 import { projectUser, columnsFor } from '../extensions/identity'
 import { parseSize } from '../extensions/manifest'
 import { STORAGE } from '../extensions/limits'
+import { proxyFetch } from '../extensions/netFetch'
+import { classifyHost } from '../extensions/manifest'
+import type { GrantedNetwork } from '../extensions/net'
 import { PACKAGE, SURFACE }      from '../extensions/limits'
 
 const RE_ID      = /^[a-z][a-z0-9-]{2,38}$/
@@ -292,6 +295,76 @@ export async function extensionRoutes(app: FastifyInstance) {
       return reply.code(status).send({ error: result.message, code: result.code })
     }
     return reply.send({ result: result.value })
+  })
+
+  // ── POST /extensions/:id/fetch ──────────────────────────────────────────
+  //
+  // Le seul chemin par lequel une extension atteint un service tiers. Le
+  // navigateur du visiteur ne parle jamais directement a personne d'autre qu'a
+  // sa communaute : c'est la traduction technique du « zero analytics ».
+  app.post('/extensions/:id/fetch', { preHandler: [rateLimit] }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const surface = request.headers['x-nodyx-surface']
+    const header  = request.headers.authorization
+
+    if (!RE_ID.test(id) || typeof surface !== 'string' || !RE_SURFACE.test(surface)) {
+      return reply.code(400).send({ error: 'Requête invalide', code: 'INVALID_REQUEST' })
+    }
+    if (!header?.startsWith('Bearer ')) return reply.code(401).send({ error: 'Jeton absent', code: 'TOKEN_MISSING' })
+    if (!appSecret) return reply.code(500).send({ error: 'Instance mal configurée', code: 'MISSING_SECRET' })
+
+    const revoked = await redis.exists(`ext:revoked:${id}`).catch(() => 0)
+    const verified = verifyExtensionToken(header.slice(7), { instanceId, extensionId: id, surface }, appSecret, () => revoked === 1)
+    if (!verified.ok) {
+      return reply.code(verified.code === 'SESSION_EXPIRED' ? 401 : 403).send({ error: verified.message, code: verified.code })
+    }
+
+    const { rows } = await db.query(
+      `SELECT manifest, enabled, granted FROM installed_extensions WHERE id = $1`, [id],
+    )
+    const row = rows[0] as { manifest: Record<string, unknown>; enabled: boolean; granted: string[] } | undefined
+    if (!row)         return reply.code(404).send({ error: 'Extension introuvable', code: 'EXTENSION_NOT_FOUND' })
+    if (!row.enabled) return reply.code(403).send({ error: 'Extension désactivée', code: 'EXTENSION_DISABLED' })
+
+    // Ce qui est joignable = ce que le manifeste declare ET que l'admin a
+    // accorde. L'intersection, jamais l'un des deux seul.
+    const declared = (row.manifest as { permissions?: { network?: GrantedNetwork } }).permissions?.network ?? {}
+    const grantedCaps = new Set(Array.isArray(row.granted) ? row.granted : [])
+    const granted: GrantedNetwork = {}
+    const allowPrivate = new Set<string>()
+    for (const [host, rule] of Object.entries(declared)) {
+      if (!grantedCaps.has(`net:${host}`)) continue
+      granted[host] = rule
+      // Un reseau prive n'est joignable que parce que l'admin a accepte CET
+      // hote la, ce que l'ecran de permissions lui a montre a part.
+      if (classifyHost(host) === 'private') allowPrivate.add(host)
+    }
+    if (Object.keys(granted).length === 0) {
+      return reply.code(403).send({ error: 'Aucun accès réseau accordé', code: 'PERMISSION_DENIED' })
+    }
+
+    // Les secrets ne quittent JAMAIS le serveur : ils sont injectes par le
+    // proxy selon une recette que l'extension ne choisit pas.
+    const { rows: secretRows } = await db.query(
+      `SELECT name, value FROM extension_secrets WHERE extension_id = $1`, [id],
+    )
+    const secrets: Record<string, string> = {}
+    for (const r of secretRows as Array<{ name: string; value: string }>) secrets[r.name] = r.value
+
+    const body = (request.body ?? {}) as Record<string, unknown>
+    const result = await proxyFetch(
+      { url: body.url, method: body.method, headers: body.headers, body: body.body },
+      { granted, allowPrivate, secrets },
+    )
+
+    if (!result.ok) {
+      const status = result.code === 'UPSTREAM_TIMEOUT'   ? 504
+                   : result.code === 'RESPONSE_TOO_LARGE' ? 502
+                   : result.code === 'UPSTREAM_ERROR'     ? 502
+                   : 403
+      return reply.code(status).send({ error: result.message, code: result.code })
+    }
+    return reply.send({ result: result.response })
   })
 
   // ── POST /extensions/:id/session ────────────────────────────────────────

--- a/nodyx-core/src/tests/extensionNet.test.ts
+++ b/nodyx-core/src/tests/extensionNet.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest'
+import {
+  checkTarget, pathAllowed, addressAllowed, isPrivateAddress, isPrivateIPv4, isPrivateIPv6,
+  filterRequestHeaders, filterResponseHeaders, applySecret, declaredTooLarge,
+  type GrantedNetwork,
+} from '../extensions/net'
+
+const GRANTED: GrantedNetwork = {
+  'api.themoviedb.org': { methods: ['GET'], paths: ['/3/movie/*', '/3/search/movie'], secret: 'TMDB_API_KEY' },
+  'inventaire.local':   { methods: ['GET', 'POST'], paths: ['/api/*'] },
+}
+
+const check = (url: string, method = 'GET') => checkTarget(url, method, GRANTED)
+const code  = (url: string, method = 'GET') => { const r = check(url, method); return r.ok ? null : r.code }
+
+describe('ce qui a ete accorde, et rien d autre', () => {
+  it('laisse passer une cible declaree', () => {
+    const r = check('https://api.themoviedb.org/3/movie/603')
+    if (!r.ok) throw new Error('refuse a tort : ' + r.code)
+    expect(r.value.host).toBe('api.themoviedb.org')
+    expect(r.value.method).toBe('GET')
+  })
+
+  it('refuse un hote non accorde', () => {
+    expect(code('https://evil.example/collecte')).toBe('HOST_NOT_ALLOWED')
+  })
+
+  it('refuse une methode non declaree', () => {
+    expect(code('https://api.themoviedb.org/3/movie/603', 'DELETE')).toBe('METHOD_NOT_ALLOWED')
+  })
+
+  it('refuse un chemin hors des prefixes declares', () => {
+    expect(code('https://api.themoviedb.org/3/account/secret')).toBe('PATH_NOT_ALLOWED')
+    expect(code('https://api.themoviedb.org/4/list')).toBe('PATH_NOT_ALLOWED')
+  })
+
+  it('accepte un descendant d un prefixe en etoile', () => {
+    expect(code('https://api.themoviedb.org/3/movie/603/credits')).toBeNull()
+  })
+
+  it('exige le chemin EXACT quand il n y a pas d etoile', () => {
+    expect(code('https://api.themoviedb.org/3/search/movie')).toBeNull()
+    expect(code('https://api.themoviedb.org/3/search/movie/extra')).toBe('PATH_NOT_ALLOWED')
+  })
+
+  it('declarer un hote n ouvre pas toutes ses portes', () => {
+    // Un service d'administration vit souvent sur un port voisin.
+    expect(code('https://api.themoviedb.org:8443/3/movie/1')).toBe('PORT_NOT_ALLOWED')
+    expect(code('https://api.themoviedb.org:443/3/movie/1')).toBeNull()   // port par defaut, explicite
+  })
+
+  it('mais un port PEUT se declarer, sinon l intranet serait injoignable', () => {
+    // Un service maison vit rarement sur 443. Le port declare reste visible
+    // sur l'ecran de permissions.
+    const g = { 'inventaire.local': { methods: ['GET'], paths: ['/api/*'], port: 8080 } }
+    const ok = checkTarget('http://inventaire.local:8080/api/stock', 'GET', g)
+    expect(ok.ok).toBe(true)
+    const ko = checkTarget('http://inventaire.local:9090/api/stock', 'GET', g)
+    expect(ko.ok).toBe(false)
+    if (!ko.ok) expect(ko.code).toBe('PORT_NOT_ALLOWED')
+    // Le port par defaut ne passe plus si un autre est declare.
+    expect(checkTarget('http://inventaire.local/api/stock', 'GET', g).ok).toBe(false)
+  })
+
+  it.each(['file:///etc/passwd', 'ftp://a.example/x', 'javascript:alert(1)', 'data:text/html,x'])(
+    'refuse le schema de %s', (url) => {
+      expect(['SCHEME_NOT_ALLOWED', 'INVALID_ARGUMENT', 'HOST_NOT_ALLOWED']).toContain(code(url))
+    })
+
+  it('refuse la machine de l instance meme si quelqu un l accordait', () => {
+    const granted = { localhost: { methods: ['GET'], paths: ['/'] } } as GrantedNetwork
+    const r = checkTarget('http://localhost/admin', 'GET', granted)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('HOST_FORBIDDEN')
+  })
+
+  it.each([null, 42, '', 'pas-une-url', 'x'.repeat(3000)])('refuse l URL %p', (url) => {
+    const r = checkTarget(url, 'GET', GRANTED)
+    expect(r.ok).toBe(false)
+  })
+})
+
+describe('prefixes de chemin', () => {
+  it('etoile finale, sinon egalite stricte', () => {
+    expect(pathAllowed('/a/b', ['/a/*'])).toBe(true)
+    expect(pathAllowed('/a', ['/a'])).toBe(true)
+    expect(pathAllowed('/ab', ['/a'])).toBe(false)
+    expect(pathAllowed('/b', ['/a/*'])).toBe(false)
+  })
+})
+
+describe('adresses : c est l adresse RESOLUE qui decide', () => {
+  it.each(['10.0.0.5', '172.16.0.1', '192.168.1.1', '127.0.0.1', '169.254.169.254', '100.64.0.1', '224.0.0.1', '0.0.0.0'])(
+    '%s est privee ou reservee', (ip) => {
+      expect(isPrivateIPv4(ip)).toBe(true)
+      expect(isPrivateAddress(ip)).toBe(true)
+    })
+
+  it.each(['8.8.8.8', '1.1.1.1', '203.0.113.10'])('%s est publique', (ip) => {
+    expect(isPrivateIPv4(ip)).toBe(false)
+  })
+
+  it.each(['::1', 'fe80::1', 'fc00::1', 'fd12::3', 'ff02::1'])('%s est privee en v6', (ip) => {
+    expect(isPrivateIPv6(ip)).toBe(true)
+  })
+
+  it('demasque une IPv4 privee cachee derriere une ecriture v6', () => {
+    // ::ffff:10.0.0.5 est une adresse privee deguisee.
+    expect(isPrivateIPv6('::ffff:10.0.0.5')).toBe(true)
+    expect(isPrivateIPv6('::ffff:8.8.8.8')).toBe(false)
+  })
+
+  it('une adresse publique passe', () => {
+    expect(addressAllowed('8.8.8.8', false)).toMatchObject({ ok: true })
+  })
+
+  it('une adresse privee passe SEULEMENT avec l accord explicite', () => {
+    // Une instance en intranet est un usage normal, pas une anomalie.
+    expect(addressAllowed('10.0.0.5', false)).toMatchObject({ ok: false, code: 'PRIVATE_ADDRESS' })
+    expect(addressAllowed('10.0.0.5', true)).toMatchObject({ ok: true })
+  })
+
+  it.each(['127.0.0.1', '127.1.2.3', '169.254.169.254', '::1', 'fe80::1', '0.0.0.0'])(
+    '%s reste refusee MEME avec l accord de l admin', (ip) => {
+      // Ces cibles sont la machine de l'instance et ses identifiants
+      // d'hebergeur : un admin n'y gagne rien de legitime.
+      const r = addressAllowed(ip, true)
+      expect(r.ok).toBe(false)
+      if (!r.ok) expect(r.code).toBe('PRIVATE_ADDRESS')
+    })
+})
+
+describe('en-tetes', () => {
+  it('ne laisse sortir qu une liste courte', () => {
+    const out = filterRequestHeaders({
+      'Accept': 'application/json',
+      'Cookie': 'session=vole',
+      'Authorization': 'Bearer vole',
+      'X-Forwarded-For': '1.2.3.4',
+      'content-type': 'application/json',
+    })
+    expect(Object.keys(out).sort()).toEqual(['accept', 'content-type'])
+  })
+
+  it('refuse une valeur demesuree', () => {
+    expect(filterRequestHeaders({ accept: 'x'.repeat(600) })).toEqual({})
+  })
+
+  it('ne rend jamais un Set-Cookie', () => {
+    const out = filterResponseHeaders([
+      ['content-type', 'application/json'],
+      ['set-cookie', 'a=b'],
+      ['x-powered-by', 'php'],
+      ['cache-control', 'max-age=60'],
+    ])
+    expect(Object.keys(out).sort()).toEqual(['cache-control', 'content-type'])
+  })
+
+  it('supporte une entree vide', () => {
+    expect(filterRequestHeaders(null)).toEqual({})
+    expect(filterRequestHeaders('texte')).toEqual({})
+  })
+})
+
+describe('secrets : le serveur possede la recette', () => {
+  it('injecte en en-tete par defaut', () => {
+    const url = new URL('https://api.themoviedb.org/3/movie/1')
+    const h: Record<string, string> = {}
+    applySecret(url, h, 'SECRET')
+    expect(h.authorization).toBe('Bearer SECRET')
+    expect(url.search).toBe('')
+  })
+
+  it('injecte en parametre quand la recette le dit', () => {
+    const url = new URL('https://api.themoviedb.org/3/movie/1')
+    const h: Record<string, string> = {}
+    applySecret(url, h, 'SECRET', { mode: 'query', param: 'api_key' })
+    expect(url.searchParams.get('api_key')).toBe('SECRET')
+    expect(h.authorization).toBeUndefined()
+  })
+
+  it('ne fait rien sans secret', () => {
+    const url = new URL('https://a.example/')
+    const h: Record<string, string> = {}
+    applySecret(url, h, undefined)
+    expect(h).toEqual({})
+  })
+
+  it('l extension ne peut pas choisir la destination du secret', () => {
+    // Elle nomme le secret au manifeste, elle n'ecrit ni l'en-tete ni le
+    // parametre : sinon elle le ferait envoyer vers un hote qu'elle controle.
+    const h = filterRequestHeaders({ 'X-Peu-Importe': 'donne-moi-le-secret', authorization: 'a-moi' })
+    expect(h).toEqual({})
+  })
+})
+
+describe('taille de reponse', () => {
+  it('refuse ce qui s annonce deja trop gros', () => {
+    expect(declaredTooLarge(String(6 * 1024 * 1024))).toBe(true)
+    expect(declaredTooLarge('1024')).toBe(false)
+    expect(declaredTooLarge(null)).toBe(false)
+    expect(declaredTooLarge('pas-un-nombre')).toBe(false)
+  })
+})

--- a/nodyx-core/src/tests/extensionNetFetch.test.ts
+++ b/nodyx-core/src/tests/extensionNetFetch.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi } from 'vitest'
+import { proxyFetch, type ProxyContext, type Transport, type RawResponse } from '../extensions/netFetch'
+
+// Le TRANSPORT est remplace, jamais le garde d'adresse.
+//
+// Remplacer le garde reviendrait a tester un systeme qui n'est pas celui qu'on
+// livre. En remplacant le transport, on eprouve toute l'orchestration pendant
+// que le garde reste exactement celui de production, et deux tests le montrent
+// en le laissant refuser pour de vrai.
+//
+// Ce qui reste non couvert par un test portable : la traversee d'une vraie
+// socket. Assume et ecrit, plutot que simule.
+
+function ctx(over: Partial<ProxyContext> = {}): ProxyContext {
+  return {
+    granted: over.granted ?? {
+      'api.tmdb.example': { methods: ['GET'], paths: ['/3/*'], secret: 'TMDB' },
+      'cdn.tmdb.example': { methods: ['GET'], paths: ['/*'] },
+    },
+    allowPrivate: over.allowPrivate ?? new Set(),
+    secrets:      over.secrets      ?? { TMDB: 'SECRET-DE-L-INSTANCE' },
+    recipes:      over.recipes,
+  }
+}
+
+function transportOf(...responses: Array<Partial<RawResponse>>): { t: Transport; calls: Array<{ url: string; headers: Record<string, string> }> } {
+  const calls: Array<{ url: string; headers: Record<string, string> }> = []
+  let i = 0
+  const t: Transport = async (url, _m, headers) => {
+    calls.push({ url: url.toString(), headers: { ...headers } })
+    const r = responses[Math.min(i++, responses.length - 1)]
+    return { status: 200, headers: {}, body: '', ...r }
+  }
+  return { t, calls }
+}
+
+describe('appel nominal', () => {
+  it('rend le corps et filtre les en-tetes de reponse', async () => {
+    const { t } = transportOf({
+      status: 200, body: '{"ok":true}',
+      headers: { 'content-type': 'application/json', 'set-cookie': 'trace=1', 'x-powered-by': 'php' },
+    })
+    const r = await proxyFetch({ url: 'https://api.tmdb.example/3/movie/603' }, ctx(), t)
+    if (!r.ok) throw new Error('refuse a tort : ' + r.code)
+    expect(r.response.body).toBe('{"ok":true}')
+    expect(r.response.headers).toEqual({ 'content-type': 'application/json' })
+  })
+
+  it('injecte le secret sans que l extension ait pu le nommer ni le placer', async () => {
+    const { t, calls } = transportOf({})
+    await proxyFetch({ url: 'https://api.tmdb.example/3/movie/1', headers: { 'X-Vole': 'donne' } }, ctx(), t)
+    expect(calls[0].headers.authorization).toBe('Bearer SECRET-DE-L-INSTANCE')
+    expect(calls[0].headers['x-vole']).toBeUndefined()
+  })
+
+  it('place le secret en parametre quand la recette de l instance le dit', async () => {
+    const { t, calls } = transportOf({})
+    await proxyFetch(
+      { url: 'https://api.tmdb.example/3/movie/1' },
+      ctx({ recipes: { 'api.tmdb.example': { mode: 'query', param: 'api_key' } } }),
+      t,
+    )
+    expect(calls[0].url).toContain('api_key=SECRET-DE-L-INSTANCE')
+    expect(calls[0].headers.authorization).toBeUndefined()
+  })
+})
+
+describe('redirections : chaque saut est une nouvelle cible', () => {
+  it('suit une redirection vers un hote lui aussi accorde', async () => {
+    const { t, calls } = transportOf(
+      { status: 302, headers: { location: 'https://cdn.tmdb.example/img/a.jpg' } },
+      { status: 200, body: 'IMAGE' },
+    )
+    const r = await proxyFetch({ url: 'https://api.tmdb.example/3/movie/1' }, ctx(), t)
+    if (!r.ok) throw new Error('refuse a tort : ' + r.code)
+    expect(r.response.body).toBe('IMAGE')
+    expect(calls).toHaveLength(2)
+  })
+
+  it('refuse une redirection vers un hote NON accorde', async () => {
+    // Le contournement le plus simple d'une liste blanche.
+    const { t } = transportOf({ status: 302, headers: { location: 'https://evil.example/vole' } })
+    const r = await proxyFetch({ url: 'https://api.tmdb.example/3/movie/1' }, ctx(), t)
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.code).toBe('HOST_NOT_ALLOWED')
+      expect(r.message).toContain('redirection refusée')
+    }
+  })
+
+  it('refuse une redirection vers un chemin hors des prefixes du meme hote', async () => {
+    const { t } = transportOf({ status: 302, headers: { location: '/4/account/secret' } })
+    const r = await proxyFetch({ url: 'https://api.tmdb.example/3/movie/1' }, ctx(), t)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('PATH_NOT_ALLOWED')
+  })
+
+  it('N EMPORTE PAS le secret vers l autre hote', async () => {
+    // Le secret appartient a l'hote qui l'a declare, pas au voyage.
+    const { t, calls } = transportOf(
+      { status: 302, headers: { location: 'https://cdn.tmdb.example/img/a.jpg' } },
+      { status: 200, body: 'IMAGE' },
+    )
+    await proxyFetch({ url: 'https://api.tmdb.example/3/movie/1' }, ctx(), t)
+    expect(calls[0].headers.authorization).toBe('Bearer SECRET-DE-L-INSTANCE')
+    expect(calls[1].headers.authorization).toBeUndefined()
+  })
+
+  it('coupe une boucle de redirection', async () => {
+    const { t } = transportOf({ status: 302, headers: { location: 'https://api.tmdb.example/3/loop' } })
+    const r = await proxyFetch({ url: 'https://api.tmdb.example/3/loop' }, ctx(), t)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('TOO_MANY_REDIRECTS')
+  })
+})
+
+describe('traduction des erreurs de transport', () => {
+  it.each([
+    ['EPRIVATEADDR', 'PRIVATE_ADDRESS'],
+    ['ERESPTOOBIG',  'RESPONSE_TOO_LARGE'],
+    ['ETIMEDOUT',    'UPSTREAM_TIMEOUT'],
+    ['ECONNREFUSED', 'UPSTREAM_ERROR'],
+  ])('%s devient %s', async (nodeCode, expected) => {
+    const t: Transport = async () => { throw Object.assign(new Error('boum'), { code: nodeCode }) }
+    const r = await proxyFetch({ url: 'https://api.tmdb.example/3/movie/1' }, ctx(), t)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe(expected)
+  })
+
+  it('ne divulgue pas le detail interne d une panne distante', async () => {
+    const t: Transport = async () => { throw new Error('getaddrinfo ENOTFOUND interne.vpc.local') }
+    const r = await proxyFetch({ url: 'https://api.tmdb.example/3/movie/1' }, ctx(), t)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.message).not.toContain('vpc.local')
+  })
+})
+
+describe('le garde de production, laisse a l oeuvre', () => {
+  it('refuse la boucle locale AVANT tout transport', async () => {
+    const t = vi.fn()
+    const granted = { localhost: { methods: ['GET'], paths: ['/*'] } }
+    const r = await proxyFetch({ url: 'http://localhost/admin' }, ctx({ granted, allowPrivate: new Set(['localhost']) }), t as never)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('HOST_FORBIDDEN')
+    expect(t).not.toHaveBeenCalled()          // aucune socket n'a ete ouverte
+  })
+
+  it('refuse un hote non accorde AVANT tout transport', async () => {
+    const t = vi.fn()
+    const r = await proxyFetch({ url: 'https://ailleurs.example/x' }, ctx(), t as never)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('HOST_NOT_ALLOWED')
+    expect(t).not.toHaveBeenCalled()
+  })
+
+  it('refuse un corps demesure AVANT tout transport', async () => {
+    const t = vi.fn()
+    const r = await proxyFetch({ url: 'https://api.tmdb.example/3/movie/1', body: 'x'.repeat(100_000) }, ctx(), t as never)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('INVALID_ARGUMENT')
+    expect(t).not.toHaveBeenCalled()
+  })
+})

--- a/nodyx-core/src/tests/extensionRoutes.test.ts
+++ b/nodyx-core/src/tests/extensionRoutes.test.ts
@@ -384,3 +384,90 @@ describe('liste publique', () => {
     expect(JSON.parse(r.body).extensions).toEqual([])
   })
 })
+
+// ── Proxy reseau ───────────────────────────────────────────────────────────
+
+describe('proxy reseau', () => {
+  const M = {
+    ...MANIFEST,
+    permissions: {
+      network: {
+        'api.tmdb.example': { methods: ['GET'], paths: ['/3/*'], secret: 'TMDB' },
+        '10.0.0.5':         { methods: ['GET'], paths: ['/api/*'] },
+      },
+    },
+  }
+
+  async function tokenFor(granted: string[]) {
+    dbQuery.mockResolvedValue({ rows: [installedRow({ granted, manifest: M })] })
+    const r = await session({ surface: 'page' }, 'Bearer membre')
+    return JSON.parse(r.body).token as string
+  }
+
+  const call = (token: string, body: unknown) => app.inject({
+    method: 'POST', url: '/api/v1/extensions/demo-ext/fetch',
+    headers: { authorization: `Bearer ${token}`, 'x-nodyx-surface': 'page' },
+    payload: body,
+  })
+
+  it('refuse sans jeton', async () => {
+    const r = await app.inject({
+      method: 'POST', url: '/api/v1/extensions/demo-ext/fetch',
+      headers: { 'x-nodyx-surface': 'page' }, payload: { url: 'https://api.tmdb.example/3/movie/1' },
+    })
+    expect(r.statusCode).toBe(401)
+  })
+
+  it('refuse quand aucun acces reseau n a ete accorde', async () => {
+    const token = await tokenFor(['storage.user'])
+    dbQuery.mockReset()
+    dbQuery.mockResolvedValue({ rows: [{ manifest: M, enabled: true, granted: ['storage.user'] }] })
+    const r = await call(token, { url: 'https://api.tmdb.example/3/movie/1' })
+    expect(r.statusCode).toBe(403)
+    expect(JSON.parse(r.body).code).toBe('PERMISSION_DENIED')
+  })
+
+  it('refuse un hote declare au manifeste mais NON accorde par l admin', async () => {
+    // L'intersection, jamais l'un des deux seul : le manifeste demande deux
+    // hotes, l'admin n'en a accorde qu'un.
+    const token = await tokenFor(['net:api.tmdb.example'])
+    dbQuery.mockReset()
+    dbQuery
+      .mockResolvedValueOnce({ rows: [{ manifest: M, enabled: true, granted: ['net:api.tmdb.example'] }] })
+      .mockResolvedValueOnce({ rows: [] })
+    const r = await call(token, { url: 'http://10.0.0.5/api/stock' })
+    expect(r.statusCode).toBe(403)
+    expect(JSON.parse(r.body).code).toBe('HOST_NOT_ALLOWED')
+  })
+
+  it('refuse un chemin hors des prefixes declares', async () => {
+    const token = await tokenFor(['net:api.tmdb.example'])
+    dbQuery.mockReset()
+    dbQuery
+      .mockResolvedValueOnce({ rows: [{ manifest: M, enabled: true, granted: ['net:api.tmdb.example'] }] })
+      .mockResolvedValueOnce({ rows: [] })
+    const r = await call(token, { url: 'https://api.tmdb.example/4/account' })
+    expect(r.statusCode).toBe(403)
+    expect(JSON.parse(r.body).code).toBe('PATH_NOT_ALLOWED')
+  })
+
+  it('refuse une extension desactivee', async () => {
+    const token = await tokenFor(['net:api.tmdb.example'])
+    dbQuery.mockReset()
+    dbQuery.mockResolvedValue({ rows: [{ manifest: M, enabled: false, granted: ['net:api.tmdb.example'] }] })
+    const r = await call(token, { url: 'https://api.tmdb.example/3/movie/1' })
+    expect(r.statusCode).toBe(403)
+    expect(JSON.parse(r.body).code).toBe('EXTENSION_DISABLED')
+  })
+
+  it('ne renvoie JAMAIS la valeur d un secret', async () => {
+    const token = await tokenFor(['net:api.tmdb.example'])
+    dbQuery.mockReset()
+    dbQuery
+      .mockResolvedValueOnce({ rows: [{ manifest: M, enabled: true, granted: ['net:api.tmdb.example'] }] })
+      .mockResolvedValueOnce({ rows: [{ name: 'TMDB', value: 'SECRET-ULTRA' }] })
+    const r = await call(token, { url: 'https://api.tmdb.example/3/movie/1' })
+    // L'appel sortant echoue (hote inexistant), mais rien ne doit fuir.
+    expect(r.body).not.toContain('SECRET-ULTRA')
+  })
+})

--- a/nodyx-frontend/src/lib/components/ExtensionSurface.svelte
+++ b/nodyx-frontend/src/lib/components/ExtensionSurface.svelte
@@ -12,7 +12,7 @@
 	import { onMount, onDestroy } from 'svelte'
 	import { browser } from '$app/environment'
 	import { t } from '$lib/i18n'
-	import { createHostHandler, buildBootPayload, frameUrl, createStorageCaller, type HostSurface } from '$lib/extensions/host'
+	import { createHostHandler, buildBootPayload, frameUrl, createStorageCaller, createFetchCaller, type HostSurface } from '$lib/extensions/host'
 
 	const tFn = $derived($t)
 
@@ -64,7 +64,10 @@
 			// déjà « pas encore » avec un code explicite, ce qui vaut mieux qu'un
 			// silence pour qui développe une extension.
 		},
-		{ storage: createStorageCaller({ extensionId, version, surface }, () => token) },
+		{
+			storage: createStorageCaller({ extensionId, version, surface }, () => token),
+			fetch:   createFetchCaller({ extensionId, version, surface }, () => token),
+		},
 	)
 
 	/** Frappe le jeton de surface et récupère l'identité projetée. */

--- a/nodyx-frontend/src/lib/extensions/host.test.ts
+++ b/nodyx-frontend/src/lib/extensions/host.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
-	createHostHandler, buildBootPayload, frameUrl, createStorageCaller, RuntimeCallError,
+	createHostHandler, buildBootPayload, frameUrl, createStorageCaller, createFetchCaller, RuntimeCallError,
 	isSafeInternalPath, isSafeExternalUrl, RequestLedger, PROTOCOL,
 	type HostSurface,
 } from './host'
@@ -183,8 +183,41 @@ describe('appel de stockage vers le coeur', () => {
 	})
 })
 
+describe('reseau, proxy par l hote', () => {
+	it('transmet l appel au runtime et rend la reponse', async () => {
+		const netFetch = vi.fn().mockResolvedValue({ status: 200, headers: {}, body: '{}' })
+		const handle = createHostHandler(SURFACE, {}, { fetch: netFetch })
+		const r = await handle(req({ type: 'net.fetch', payload: { url: 'https://a.example/x', method: 'GET' } }))
+		expect(netFetch).toHaveBeenCalledWith({ url: 'https://a.example/x', method: 'GET' })
+		expect(r).toMatchObject({ ok: true })
+	})
+
+	it('retransmet le code du coeur, pour distinguer un refus d un service en panne', async () => {
+		const netFetch = vi.fn().mockRejectedValue(new RuntimeCallError('HOST_NOT_ALLOWED', 'non accorde'))
+		const handle = createHostHandler(SURFACE, {}, { fetch: netFetch })
+		const r = await handle(req({ type: 'net.fetch', payload: { url: 'https://evil.example/' } }))
+		expect(r).toMatchObject({ ok: false, error: { code: 'HOST_NOT_ALLOWED' } })
+	})
+
+	it('repond « pas branche » quand l hote n a pas de reseau', async () => {
+		const handle = createHostHandler(SURFACE)
+		expect(await handle(req({ type: 'net.fetch' }))).toMatchObject({ ok: false, error: { code: 'NOT_IMPLEMENTED' } })
+	})
+
+	it('poste la charge telle quelle, sans champ op', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ result: { status: 200 } }) })
+		vi.stubGlobal('fetch', fetchMock)
+		const call = createFetchCaller(SURFACE, () => 'JETON')
+		await call({ url: 'https://a.example/x', method: 'GET' })
+		const [url, init] = fetchMock.mock.calls[0]
+		expect(url).toBe('/api/v1/extensions/library/fetch')
+		expect(JSON.parse(init.body)).toEqual({ url: 'https://a.example/x', method: 'GET' })
+		vi.unstubAllGlobals()
+	})
+})
+
 describe('ce qui appartient au lot suivant', () => {
-	it.each(['net.fetch', 'core.get', 'session.renew'])(
+	it.each(['core.get', 'session.renew'])(
 		'%s repond « pas encore », pas un refus muet', async (type) => {
 			// Une extension doit pouvoir distinguer « pas encore » de « refuse ».
 			const handle = createHostHandler(SURFACE)

--- a/nodyx-frontend/src/lib/extensions/host.ts
+++ b/nodyx-frontend/src/lib/extensions/host.ts
@@ -43,6 +43,7 @@ export interface BootPayload {
  */
 export interface HostRuntime {
 	storage?: (op: 'get' | 'set' | 'delete' | 'list', payload: Record<string, unknown>) => Promise<unknown>
+	fetch?:   (payload: Record<string, unknown>) => Promise<unknown>
 }
 
 export interface HostActions {
@@ -117,7 +118,7 @@ export class RequestLedger {
  * et un développeur doit le lire dans la console au lieu de le deviner.
  */
 const RUNTIME_API_TYPES = new Set([
-	'net.fetch', 'core.get', 'session.renew',
+	'core.get', 'session.renew',
 ])
 
 /** Erreur portant le code rendu par le coeur, pour le retransmettre tel quel. */
@@ -136,18 +137,28 @@ export class RuntimeCallError extends Error {
  * coeur, dont le jeton est lie a une surface precise.
  */
 export function createStorageCaller(surface: HostSurface, getToken: () => string | null) {
-	return async function callStorage(op: string, payload: Record<string, unknown>): Promise<unknown> {
+	return createRuntimeCaller(surface, getToken, 'storage')
+}
+
+/** Appelle le proxy reseau du coeur au nom d'une surface. */
+export function createFetchCaller(surface: HostSurface, getToken: () => string | null) {
+	const call = createRuntimeCaller(surface, getToken, 'fetch')
+	return (payload: Record<string, unknown>) => call('', payload)
+}
+
+function createRuntimeCaller(surface: HostSurface, getToken: () => string | null, route: 'storage' | 'fetch') {
+	return async function callRuntime(op: string, payload: Record<string, unknown>): Promise<unknown> {
 		const token = getToken()
 		if (!token) throw new RuntimeCallError('SESSION_EXPIRED', 'aucun jeton d\'extension')
 
-		const res = await fetch(`/api/v1/extensions/${surface.extensionId}/storage`, {
+		const res = await fetch(`/api/v1/extensions/${surface.extensionId}/${route}`, {
 			method:  'POST',
 			headers: {
 				'content-type':    'application/json',
 				'authorization':   `Bearer ${token}`,
 				'x-nodyx-surface': surface.surface,
 			},
-			body: JSON.stringify({ op, ...payload }),
+			body: JSON.stringify(op ? { op, ...payload } : payload),
 		})
 
 		const body = await res.json().catch(() => ({}))
@@ -216,6 +227,16 @@ export function createHostHandler(surface: HostSurface, actions: HostActions = {
 				if (!isSafeExternalUrl(payload.url)) return err(id, 'INVALID_ARGUMENT', 'URL externe invalide')
 				actions.external?.(payload.url)
 				return null
+			}
+
+			case 'net.fetch': {
+				if (!runtime.fetch) return err(id, 'NOT_IMPLEMENTED', 'le réseau n\'est pas branché sur cet hôte')
+				try {
+					return ok(id, await runtime.fetch(payload))
+				} catch (e) {
+					const code = (e as { code?: string })?.code ?? 'UNKNOWN'
+					return err(id, code, (e as Error)?.message ?? 'appel réseau en échec')
+				}
 			}
 
 			case 'storage.get':


### PR DESCRIPTION
Le morceau le plus sensible du SDK, et le dernier verrou avant que la mediatheque soit possible en extension.

## Epinglage

Entre le moment ou l'on juge une adresse et celui ou l'on s'y connecte, un serveur DNS hostile peut changer d'avis : c'est le rebinding. La parade est de faire les deux dans le meme geste, en fournissant a la pile reseau notre propre fonction de resolution, qui valide et rend l'adresse. La connexion part donc vers l'adresse jugee. Ecrit sur `node:http` plutot que sur `fetch`, parce que seule la bibliotheque standard accepte une fonction `lookup`.

## Chaque redirection est une nouvelle cible

Revalidee integralement : c'est le contournement le plus simple d'une liste blanche. Cinq tests le couvrent, dont celui qui verifie que **le secret n'est pas emporte** vers l'autre hote : il appartient a celui qui l'a declare, pas au voyage.

## Un trou de ma propre regle, trouve par un test

Je refusais tout port non standard, ce qui rendait **indeclarable un service d'intranet**, le cas le plus courant qui soit. Le port se declare desormais au manifeste, donc il reste visible sur l'ecran de permissions, et declarer un hote n'ouvre toujours pas toutes ses portes.

## Ou est la couture de test, et pourquoi

Le **transport** est remplacable, jamais le garde d'adresse : remplacer le garde reviendrait a eprouver un systeme qui n'est pas celui qu'on livre. Trois tests laissent le garde de production refuser pour de vrai et verifient qu'**aucune socket n'a ete ouverte**.

La traversee d'une vraie socket reste non couverte par un test portable, et c'est ecrit dans le fichier : la machine n'a que la boucle locale et une adresse publique, et la boucle locale est refusee en toute circonstance. C'est precisement la garantie voulue, donc aucun banc ne peut la contourner sans trahir le test.

## Simplification imposee par cinq tests rouges

La redirection se lit a **un seul endroit**, dans les en-tetes. Le champ duplique que le transport recopiait etait un oubli silencieux en attente.

## Branchement

De la frame au service tiers. L'intersection manifeste ET accord de l'admin, jamais l'un des deux seul. Les secrets ne quittent jamais le serveur, et un test verifie qu'aucune reponse ne contient leur valeur meme en cas d'echec.

812 tests coeur, 86 frontend, tsc propre, svelte-check 0 erreur.
