### PR TITLE
SDK d'extensions : installation depuis un registre, et la page qui manquait

### DIFF
--- a/nodyx-core/src/extensions/registry.ts
+++ b/nodyx-core/src/extensions/registry.ts
@@ -1,0 +1,134 @@
+// Client de registre : telecharger une extension depuis un index distant.
+//
+// C'est le seul endroit du coeur qui va chercher du CODE ailleurs. Trois
+// controles y sont non negociables, et chacun ferme une porte differente.
+//
+// 1. Le registre doit etre dans la liste configuree de l'instance. Sans ca, un
+//    lien fabrique avec `src=<registre_de_l_attaquant>` envoye a un owner
+//    installerait du code arbitraire en un clic.
+// 2. L'index porte l'empreinte, et on la verifie sur les octets recus. Le
+//    telechargement devient verifiable, l'URL de paquet n'a plus a etre crue.
+// 3. Le paquet passe ensuite par la MEME chaine qu'un televersement : lecteur,
+//    validateur, assainissement. Venir d'un registre n'accorde aucune faveur.
+//
+// cf SPECS/NODYX_SDK_CDC.md §9.2 et §9.5
+
+import { createHash } from 'crypto'
+import { PACKAGE } from './limits'
+
+/** Registres de confiance. Le defaut est remplacable par l'instance. */
+export function configuredRegistries(): string[] {
+  const raw = process.env.NODYX_EXTENSION_REGISTRIES
+  if (raw) return raw.split(',').map((s) => s.trim().toLowerCase()).filter(Boolean)
+  return ['extensions.nodyx.org']
+}
+
+export type RegistryError =
+  | 'REGISTRY_NOT_ALLOWED' | 'REGISTRY_UNREACHABLE' | 'REGISTRY_MALFORMED'
+  | 'EXTENSION_NOT_IN_REGISTRY' | 'VERSION_NOT_IN_REGISTRY'
+  | 'DOWNLOAD_FAILED' | 'CHECKSUM_MISMATCH' | 'ARCHIVE_TOO_LARGE'
+
+export type RegistryResult<T> =
+  | { ok: true;  value: T }
+  | { ok: false; code: RegistryError; message: string }
+
+const fail = (code: RegistryError, message: string): RegistryResult<never> => ({ ok: false, code, message })
+
+export interface RegistryVersion {
+  version: string
+  sha256:  string
+  url:     string
+  permissions?: string[]
+}
+
+export interface RegistryEntry {
+  id:       string
+  label?:   string
+  versions: RegistryVersion[]
+}
+
+/** Le registre demande est il un de ceux que l'instance accepte ? */
+export function registryAllowed(host: unknown): host is string {
+  if (typeof host !== 'string') return false
+  const clean = host.trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\/.*$/, '')
+  return configuredRegistries().includes(clean)
+}
+
+export interface FetchLike {
+  (url: string, init?: { signal?: AbortSignal }): Promise<{
+    ok: boolean
+    status: number
+    json(): Promise<unknown>
+    arrayBuffer(): Promise<ArrayBuffer>
+  }>
+}
+
+/** Trouve une version dans un index deja telecharge. */
+export function findVersion(index: unknown, id: string, version: string): RegistryResult<RegistryVersion> {
+  const extensions = (index as { extensions?: unknown })?.extensions
+  if (!Array.isArray(extensions)) return fail('REGISTRY_MALFORMED', 'index illisible')
+
+  const entry = (extensions as RegistryEntry[]).find((e) => e?.id === id)
+  if (!entry) return fail('EXTENSION_NOT_IN_REGISTRY', `${id} n'est pas dans ce registre`)
+
+  const found = (entry.versions ?? []).find((v) => v?.version === version)
+  if (!found) return fail('VERSION_NOT_IN_REGISTRY', `la version ${version} de ${id} n'est pas publiée dans ce registre`)
+
+  if (!/^[a-f0-9]{64}$/.test(found.sha256 ?? '')) return fail('REGISTRY_MALFORMED', 'empreinte absente ou mal formée')
+  if (!/^https:\/\//.test(found.url ?? ''))       return fail('REGISTRY_MALFORMED', 'URL de paquet non sécurisée')
+
+  return { ok: true, value: found }
+}
+
+export interface DownloadedPackage {
+  archive: Buffer
+  version: RegistryVersion
+}
+
+/**
+ * Telecharge un paquet depuis un registre autorise, et VERIFIE son empreinte.
+ *
+ * L'empreinte vient de l'index, pas du paquet : c'est ce qui rend le
+ * telechargement verifiable. Un paquet dont les octets ne correspondent pas est
+ * refuse, quelle qu'en soit la raison.
+ */
+export async function downloadFromRegistry(
+  registry: unknown, id: string, version: string, doFetch: FetchLike,
+): Promise<RegistryResult<DownloadedPackage>> {
+  if (!registryAllowed(registry)) {
+    return fail('REGISTRY_NOT_ALLOWED', 'ce registre ne fait pas partie de ceux configurés sur cette instance')
+  }
+  const host = String(registry).trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\/.*$/, '')
+
+  let index: unknown
+  try {
+    const res = await doFetch(`https://${host}/index.json`)
+    if (!res.ok) return fail('REGISTRY_UNREACHABLE', `le registre a répondu ${res.status}`)
+    index = await res.json()
+  } catch {
+    return fail('REGISTRY_UNREACHABLE', 'le registre est injoignable')
+  }
+
+  const found = findVersion(index, id, version)
+  if (!found.ok) return found
+
+  let archive: Buffer
+  try {
+    const res = await doFetch(found.value.url)
+    if (!res.ok) return fail('DOWNLOAD_FAILED', `le paquet a répondu ${res.status}`)
+    archive = Buffer.from(await res.arrayBuffer())
+  } catch {
+    return fail('DOWNLOAD_FAILED', 'le paquet est introuvable')
+  }
+
+  if (archive.length > PACKAGE.maxArchiveBytes) {
+    return fail('ARCHIVE_TOO_LARGE', `archive au dessus du plafond de ${PACKAGE.maxArchiveBytes / 1024 / 1024} Mo`)
+  }
+
+  const digest = createHash('sha256').update(archive).digest('hex')
+  if (digest !== found.value.sha256) {
+    return fail('CHECKSUM_MISMATCH', 'les octets reçus ne correspondent pas à l\'empreinte publiée : téléchargement refusé')
+  }
+
+  return { ok: true, value: { archive, version: found.value } }
+}

--- a/nodyx-core/src/routes/extensions.ts
+++ b/nodyx-core/src/routes/extensions.ts
@@ -22,6 +22,7 @@ import { projectUser, columnsFor } from '../extensions/identity'
 import { parseSize } from '../extensions/manifest'
 import { STORAGE } from '../extensions/limits'
 import { proxyFetch } from '../extensions/netFetch'
+import { downloadFromRegistry, configuredRegistries } from '../extensions/registry'
 import { classifyHost } from '../extensions/manifest'
 import type { GrantedNetwork } from '../extensions/net'
 import { PACKAGE, SURFACE }      from '../extensions/limits'
@@ -118,6 +119,73 @@ export async function extensionRoutes(app: FastifyInstance) {
       privateNetworkHosts: read.pkg.privateNetworkHosts,
       sanitized:           read.pkg.sanitized,
     })
+  })
+
+  // ── POST /admin/extensions/from-registry ────────────────────────────────
+  //
+  // Installation depuis un registre. En deux temps, delibere : `dryRun` lit et
+  // rend ce que l'extension demande SANS rien ecrire, l'appel sans `dryRun`
+  // installe ce que l'admin a accepte. Sans ce premier temps, l'ecran de
+  // permissions n'aurait rien a afficher et le consentement serait decoratif.
+  app.post('/admin/extensions/from-registry', { preHandler: [rateLimit, adminOnly] }, async (request, reply) => {
+    const { registry, id, version, dryRun, accept } = (request.body ?? {}) as {
+      registry?: unknown; id?: unknown; version?: unknown; dryRun?: unknown; accept?: unknown
+    }
+
+    if (typeof id !== 'string' || !RE_ID.test(id))                return reply.code(400).send({ error: 'Identifiant invalide', code: 'INVALID_ID' })
+    if (typeof version !== 'string' || !/^\d+\.\d+\.\d+$/.test(version)) return reply.code(400).send({ error: 'Version invalide', code: 'INVALID_VERSION' })
+
+    const downloaded = await downloadFromRegistry(registry, id, version, globalThis.fetch as never)
+    if (!downloaded.ok) {
+      const status = downloaded.code === 'REGISTRY_NOT_ALLOWED' ? 403 : 502
+      return reply.code(status).send({
+        error: downloaded.message,
+        code:  downloaded.code,
+        // On dit lesquels sont acceptes : un admin doit pouvoir comprendre le
+        // refus sans aller lire une variable d'environnement.
+        registries: downloaded.code === 'REGISTRY_NOT_ALLOWED' ? configuredRegistries() : undefined,
+      })
+    }
+
+    const { readExtensionPackage }  = await import('../extensions/package')
+    const { requestedCapabilities } = await import('../extensions/capabilities')
+
+    // Venir d'un registre n'accorde AUCUNE faveur : meme lecteur, meme
+    // validateur, meme assainissement qu'un televersement.
+    const read = readExtensionPackage(downloaded.value.archive)
+    if (!read.ok) return reply.code(400).send({ error: 'Paquet refusé', code: 'PACKAGE_REJECTED', issues: read.issues })
+
+    if (read.pkg.manifest.id !== id) {
+      return reply.code(400).send({ error: 'Le paquet ne porte pas l\'identifiant annoncé par le registre', code: 'ID_MISMATCH' })
+    }
+
+    if (dryRun) {
+      return reply.send({
+        manifest:            read.pkg.manifest,
+        messages:            read.pkg.messages[read.pkg.manifest.default_locale] ?? {},
+        requested:           requestedCapabilities(read.pkg.manifest),
+        sensitive:           sensitiveCapabilities(read.pkg.manifest),
+        privateNetworkHosts: read.pkg.privateNetworkHosts,
+        sanitized:           read.pkg.sanitized,
+        version:             read.pkg.manifest.version,
+      })
+    }
+
+    const grant = Array.isArray(accept) && accept.every((v) => typeof v === 'string')
+      ? { accept: accept as string[] }
+      : undefined
+
+    const result = await installExtension(
+      {
+        archive:     downloaded.value.archive,
+        origin:      `registry:${String(registry).toLowerCase()}`,
+        installedBy: request.user?.userId ?? null,
+        grant,
+      },
+      { query },
+    )
+    if (!result.ok) return reply.code(400).send({ error: 'Paquet refusé', code: 'PACKAGE_REJECTED', issues: result.issues })
+    return reply.code(201).send(result.result)
   })
 
   // ── PATCH /admin/extensions/:id ─────────────────────────────────────────

--- a/nodyx-core/src/tests/extensionRegistry.test.ts
+++ b/nodyx-core/src/tests/extensionRegistry.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { createHash } from 'crypto'
+import {
+  registryAllowed, configuredRegistries, findVersion, downloadFromRegistry,
+  type FetchLike,
+} from '../extensions/registry'
+
+const PAQUET = Buffer.from('contenu du paquet')
+const SHA = createHash('sha256').update(PAQUET).digest('hex')
+
+function index(over: Record<string, unknown> = {}) {
+  return {
+    index: 1,
+    extensions: [{
+      id: 'next-event',
+      versions: [{ version: '1.0.0', sha256: SHA, url: 'https://extensions.nodyx.org/p/next-event-1.0.0.nyx' }],
+    }],
+    ...over,
+  }
+}
+
+/** Un reseau simule : l'index, puis le paquet. */
+function net(idx: unknown = index(), archive: Buffer = PAQUET, over: { indexStatus?: number; pkgStatus?: number } = {}): FetchLike {
+  return (async (url: string) => {
+    if (url.endsWith('/index.json')) {
+      return { ok: (over.indexStatus ?? 200) < 400, status: over.indexStatus ?? 200, json: async () => idx, arrayBuffer: async () => new ArrayBuffer(0) }
+    }
+    return {
+      ok: (over.pkgStatus ?? 200) < 400, status: over.pkgStatus ?? 200,
+      json: async () => ({}),
+      arrayBuffer: async () => archive.buffer.slice(archive.byteOffset, archive.byteOffset + archive.byteLength),
+    }
+  }) as FetchLike
+}
+
+afterEach(() => { delete process.env.NODYX_EXTENSION_REGISTRIES })
+
+describe('le registre doit etre configure sur l instance', () => {
+  it('accepte celui par defaut', () => {
+    expect(registryAllowed('extensions.nodyx.org')).toBe(true)
+    expect(configuredRegistries()).toEqual(['extensions.nodyx.org'])
+  })
+
+  it('tolere une forme avec schema ou chemin', () => {
+    expect(registryAllowed('https://extensions.nodyx.org')).toBe(true)
+    expect(registryAllowed('https://extensions.nodyx.org/e/x')).toBe(true)
+  })
+
+  it('REFUSE un registre inconnu', async () => {
+    // Sans ce controle, un lien fabrique avec src=<registre_de_l_attaquant>
+    // envoye a un owner installerait du code arbitraire en un clic.
+    expect(registryAllowed('registre-pirate.example')).toBe(false)
+    const r = await downloadFromRegistry('registre-pirate.example', 'next-event', '1.0.0', net())
+    expect(r).toMatchObject({ ok: false, code: 'REGISTRY_NOT_ALLOWED' })
+  })
+
+  it.each([null, 42, '', 'extensions.nodyx.org.evil.example'])('refuse %p', (raw) => {
+    expect(registryAllowed(raw)).toBe(false)
+  })
+
+  it('l instance peut declarer les siens', () => {
+    process.env.NODYX_EXTENSION_REGISTRIES = 'store.interne.example, extensions.nodyx.org'
+    expect(registryAllowed('store.interne.example')).toBe(true)
+    expect(registryAllowed('autre.example')).toBe(false)
+  })
+})
+
+describe('lecture de l index', () => {
+  it('trouve la version demandee', () => {
+    const r = findVersion(index(), 'next-event', '1.0.0')
+    expect(r).toMatchObject({ ok: true })
+  })
+
+  it('refuse une extension absente', () => {
+    expect(findVersion(index(), 'inconnue', '1.0.0')).toMatchObject({ ok: false, code: 'EXTENSION_NOT_IN_REGISTRY' })
+  })
+
+  it('refuse une version non publiee', () => {
+    expect(findVersion(index(), 'next-event', '9.9.9')).toMatchObject({ ok: false, code: 'VERSION_NOT_IN_REGISTRY' })
+  })
+
+  it('refuse un index illisible', () => {
+    for (const bad of [null, 42, {}, { extensions: 'x' }]) {
+      expect(findVersion(bad, 'next-event', '1.0.0')).toMatchObject({ ok: false, code: 'REGISTRY_MALFORMED' })
+    }
+  })
+
+  it('refuse une empreinte absente ou mal formee', () => {
+    const idx = index({ extensions: [{ id: 'next-event', versions: [{ version: '1.0.0', sha256: 'court', url: 'https://a/x.nyx' }] }] })
+    expect(findVersion(idx, 'next-event', '1.0.0')).toMatchObject({ ok: false, code: 'REGISTRY_MALFORMED' })
+  })
+
+  it('refuse une URL de paquet non securisee', () => {
+    const idx = index({ extensions: [{ id: 'next-event', versions: [{ version: '1.0.0', sha256: SHA, url: 'http://a/x.nyx' }] }] })
+    expect(findVersion(idx, 'next-event', '1.0.0')).toMatchObject({ ok: false, code: 'REGISTRY_MALFORMED' })
+  })
+})
+
+describe('telechargement verifiable', () => {
+  it('rend le paquet quand l empreinte correspond', async () => {
+    const r = await downloadFromRegistry('extensions.nodyx.org', 'next-event', '1.0.0', net())
+    if (!r.ok) throw new Error('refuse a tort : ' + r.code)
+    expect(r.value.archive.toString()).toBe('contenu du paquet')
+  })
+
+  it('REFUSE des octets qui ne correspondent pas a l empreinte publiee', async () => {
+    // L'empreinte vient de l'index, pas du paquet : c'est ce qui rend le
+    // telechargement verifiable et l'URL de paquet inutile a croire.
+    const r = await downloadFromRegistry('extensions.nodyx.org', 'next-event', '1.0.0', net(index(), Buffer.from('AUTRE CHOSE')))
+    expect(r).toMatchObject({ ok: false, code: 'CHECKSUM_MISMATCH' })
+  })
+
+  it('refuse une archive au dessus du plafond', async () => {
+    const gros = Buffer.alloc(21 * 1024 * 1024, 1)
+    const idx = index({ extensions: [{ id: 'next-event', versions: [{ version: '1.0.0', sha256: createHash('sha256').update(gros).digest('hex'), url: 'https://a/x.nyx' }] }] })
+    const r = await downloadFromRegistry('extensions.nodyx.org', 'next-event', '1.0.0', net(idx, gros))
+    expect(r).toMatchObject({ ok: false, code: 'ARCHIVE_TOO_LARGE' })
+  })
+
+  it('traduit un registre injoignable', async () => {
+    const boom: FetchLike = (async () => { throw new Error('reseau') }) as FetchLike
+    expect(await downloadFromRegistry('extensions.nodyx.org', 'next-event', '1.0.0', boom))
+      .toMatchObject({ ok: false, code: 'REGISTRY_UNREACHABLE' })
+  })
+
+  it('traduit un index en erreur', async () => {
+    expect(await downloadFromRegistry('extensions.nodyx.org', 'next-event', '1.0.0', net(index(), PAQUET, { indexStatus: 503 })))
+      .toMatchObject({ ok: false, code: 'REGISTRY_UNREACHABLE' })
+  })
+
+  it('traduit un paquet introuvable', async () => {
+    expect(await downloadFromRegistry('extensions.nodyx.org', 'next-event', '1.0.0', net(index(), PAQUET, { pkgStatus: 404 })))
+      .toMatchObject({ ok: false, code: 'DOWNLOAD_FAILED' })
+  })
+
+  it('ne telecharge RIEN quand le registre n est pas autorise', async () => {
+    const spy = vi.fn(net())
+    await downloadFromRegistry('pirate.example', 'next-event', '1.0.0', spy as unknown as FetchLike)
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -4511,5 +4511,11 @@
   "ext_admin.cap_storage_write": "modify the instance's shared data",
   "ext_admin.cap_core": "read {{scope}}",
   "ext_admin.cap_net": "reach {{host}}",
-  "anav.lbl_extensions": "Extensions"
+  "anav.lbl_extensions": "Extensions",
+  "ext_install.title": "Install an extension",
+  "ext_install.from": "From {{registry}}",
+  "ext_install.reading": "Reading the package from {{registry}}…",
+  "ext_install.bad_link": "This install link is incomplete.",
+  "ext_install.back": "Back to extensions",
+  "ext_install.allowed_registries": "Registries accepted on this instance: {{list}}."
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -4511,5 +4511,11 @@
   "ext_admin.cap_storage_write": "modifier les données partagées de l'instance",
   "ext_admin.cap_core": "lire {{scope}}",
   "ext_admin.cap_net": "joindre {{host}}",
-  "anav.lbl_extensions": "Extensions"
+  "anav.lbl_extensions": "Extensions",
+  "ext_install.title": "Installer une extension",
+  "ext_install.from": "Depuis {{registry}}",
+  "ext_install.reading": "Lecture du paquet depuis {{registry}}…",
+  "ext_install.bad_link": "Ce lien d'installation est incomplet.",
+  "ext_install.back": "Retour aux extensions",
+  "ext_install.allowed_registries": "Registres acceptés sur cette instance : {{list}}."
 }

--- a/nodyx-frontend/src/routes/admin/extensions/install/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/extensions/install/+page.svelte
@@ -1,0 +1,176 @@
+<script lang="ts">
+	// La page d'atterrissage du bouton « Installer » du magasin.
+	//
+	// Le lien ne fait QUE pre-remplir cet ecran : rien n'est telecharge ni
+	// installe avant que l'admin ait vu ce que l'extension demande et dit oui.
+	// Un lien fabrique ne peut donc pas installer quoi que ce soit tout seul.
+	// cf SPECS/NODYX_SDK_CDC.md §9.5
+
+	import { page } from '$app/stores'
+	import { onMount } from 'svelte'
+	import { t } from '$lib/i18n'
+
+	const tFn = $derived($t)
+
+	interface Inspection {
+		manifest:            Record<string, unknown>
+		messages:            Record<string, string>
+		requested:           string[]
+		sensitive:           string[]
+		privateNetworkHosts: string[]
+		sanitized:           Record<string, string[]>
+		version:             string
+	}
+
+	const token    = $derived($page.data.token as string | null)
+	const registry = $derived($page.url.searchParams.get('src') ?? '')
+	const id       = $derived($page.url.searchParams.get('id') ?? '')
+	const version  = $derived($page.url.searchParams.get('v') ?? '')
+
+	let inspection: Inspection | null = $state(null)
+	let issues: Array<{ code: string; path?: string; message: string }> = $state([])
+	let registries: string[] = $state([])
+	let busy = $state(true)
+	let done = $state(false)
+
+	function capabilityLabel(cap: string): string {
+		if (cap === 'identity')               return tFn('ext_admin.cap_identity')
+		if (cap.startsWith('identity:'))      return tFn('ext_admin.cap_identity_field', { field: cap.slice(9) })
+		if (cap === 'storage.user')           return tFn('ext_admin.cap_storage_user')
+		if (cap === 'storage.instance.read')  return tFn('ext_admin.cap_storage_read')
+		if (cap === 'storage.instance.write') return tFn('ext_admin.cap_storage_write')
+		if (cap.startsWith('core:'))          return tFn('ext_admin.cap_core', { scope: cap.slice(5) })
+		if (cap.startsWith('net:'))           return tFn('ext_admin.cap_net', { host: cap.slice(4) })
+		return cap
+	}
+
+	function resolve(value: unknown): string {
+		const raw = String(value ?? '')
+		if (!raw.startsWith('@')) return raw
+		return inspection?.messages?.[raw.slice(1)] ?? raw.slice(1)
+	}
+
+	async function post(body: Record<string, unknown>) {
+		return fetch('/api/v1/admin/extensions/from-registry', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json', Authorization: `Bearer ${token}` },
+			body: JSON.stringify({ registry, id, version, ...body }),
+		})
+	}
+
+	onMount(async () => {
+		if (!id || !version || !registry) { busy = false; return }
+		try {
+			const res = await post({ dryRun: true })
+			const json = await res.json()
+			if (!res.ok) {
+				issues     = json.issues ?? [{ code: json.code ?? 'ERROR', message: json.error ?? '' }]
+				registries = json.registries ?? []
+				return
+			}
+			inspection = json
+		} finally {
+			busy = false
+		}
+	})
+
+	async function confirmInstall() {
+		if (!inspection) return
+		busy = true
+		try {
+			const res = await post({ accept: inspection.requested })
+			const json = await res.json()
+			if (!res.ok) { issues = json.issues ?? [{ code: json.code ?? 'ERROR', message: json.error ?? '' }]; return }
+			done = true
+		} finally {
+			busy = false
+		}
+	}
+</script>
+
+<div class="ei">
+	<h1>{tFn('ext_install.title')}</h1>
+
+	{#if !id || !version || !registry}
+		<p class="ei-muted">{tFn('ext_install.bad_link')}</p>
+		<a class="ei-btn" href="/admin/extensions">{tFn('ext_install.back')}</a>
+
+	{:else if done}
+		<p class="ei-ok">{tFn('ext_admin.installed', { name: id })}</p>
+		<a class="ei-btn" href="/admin/extensions">{tFn('ext_install.back')}</a>
+
+	{:else if busy && !inspection}
+		<p class="ei-muted">{tFn('ext_install.reading', { registry })}</p>
+
+	{:else if inspection}
+		<p class="ei-from">{tFn('ext_install.from', { registry })}</p>
+
+		<div class="ei-id">
+			<strong>{resolve(inspection.manifest.label)}</strong>
+			<span class="ei-version">{inspection.version}</span>
+		</div>
+		<p class="ei-muted">{resolve(inspection.manifest.description)}</p>
+
+		{#if inspection.requested.length === 0}
+			<p class="ei-none">{tFn('ext_admin.no_permission')}</p>
+		{:else}
+			<p class="ei-lead">{tFn('ext_admin.can_touch')}</p>
+			<ul class="ei-caps">
+				{#each inspection.requested as cap (cap)}
+					<li class:sensitive={inspection.sensitive.includes(cap)}>
+						{capabilityLabel(cap)}
+						{#if inspection.sensitive.includes(cap)}<span class="ei-flag">{tFn('ext_admin.sensitive')}</span>{/if}
+					</li>
+				{/each}
+			</ul>
+		{/if}
+
+		{#if inspection.privateNetworkHosts.length}
+			<p class="ei-warn">{tFn('ext_admin.private_network', { hosts: inspection.privateNetworkHosts.join(', ') })}</p>
+		{/if}
+
+		<div class="ei-actions">
+			<button class="ei-btn ei-btn--go" disabled={busy} onclick={confirmInstall}>{tFn('ext_admin.accept_install')}</button>
+			<a class="ei-btn" href="/admin/extensions">{tFn('common.cancel')}</a>
+		</div>
+	{/if}
+
+	{#if issues.length}
+		<ul class="ei-issues">
+			{#each issues as issue (issue.code + (issue.path ?? ''))}
+				<li><code>{issue.code}</code> <span>{issue.message}</span></li>
+			{/each}
+		</ul>
+		{#if registries.length}
+			<p class="ei-muted">{tFn('ext_install.allowed_registries', { list: registries.join(', ') })}</p>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.ei { max-width: 640px; display: flex; flex-direction: column; gap: 10px; }
+	.ei h1 { font-size: 20px; font-weight: 600; margin: 0; }
+	.ei-from { font-size: 12px; color: var(--nx-text-muted, #6b7280); margin: 0; }
+	.ei-id { display: flex; align-items: baseline; gap: 8px; margin-top: 6px; }
+	.ei-version { font-size: 11px; font-family: ui-monospace, monospace; color: var(--nx-text-muted, #6b7280); }
+	.ei-muted { color: var(--nx-text-muted, #6b7280); font-size: 13px; margin: 0; }
+	.ei-lead { font-size: 13px; font-weight: 600; margin: 10px 0 4px; }
+	.ei-none { font-size: 13px; color: var(--nx-text-muted, #6b7280); margin: 10px 0; }
+	.ei-caps { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+	.ei-caps li { font-size: 13px; padding: 6px 10px; border-radius: 6px; background: rgba(255,255,255,.03); }
+	.ei-caps li.sensitive { border-left: 2px solid #f59e0b; }
+	.ei-flag { font-size: 10px; text-transform: uppercase; letter-spacing: .05em; color: #f59e0b; margin-left: 6px; }
+	.ei-warn { font-size: 13px; color: #f59e0b; margin: 6px 0 0; }
+	.ei-actions { display: flex; gap: 8px; margin-top: 14px; }
+	.ei-btn {
+		font-size: 13px; padding: 7px 14px; border-radius: 6px; cursor: pointer; text-decoration: none;
+		border: 1px solid var(--nx-border, rgba(255,255,255,.12)); background: transparent; color: inherit;
+		display: inline-block;
+	}
+	.ei-btn--go { border-color: rgba(167,139,250,.4); }
+	.ei-btn:disabled { opacity: .5; cursor: default; }
+	.ei-ok { font-size: 13px; color: #6ee7b7; margin: 0; }
+	.ei-issues { list-style: none; margin: 10px 0 0; padding: 0; font-size: 12px; }
+	.ei-issues li { padding: 3px 0; color: #fca5a5; }
+	.ei-issues code { font-family: ui-monospace, monospace; }
+</style>


### PR DESCRIPTION
Correction d'un defaut trouve en essayant le bouton du magasin : il pointait vers `/admin/extensions/install`, une page **specifiee au CDC §9.5 et jamais ecrite**. Le magasin livrait donc un bouton qui ne pouvait pas marcher.

## Le lien ne fait que pre-remplir un ecran

Rien n'est telecharge ni installe avant que l'admin ait vu ce que l'extension demande et dit oui. Un lien fabrique ne peut donc rien installer tout seul.

## Trois controles, trois portes fermees

**Le registre doit etre dans la liste configuree de l'instance.** Sans ca, un lien avec `src=<registre_de_l_attaquant>` envoye a un owner installerait du code arbitraire en un clic. Un test verifie qu'un registre inconnu ne declenche **aucun telechargement**.

**L'empreinte vient de l'INDEX**, pas du paquet, et se verifie sur les octets recus : l'URL de telechargement n'a plus a etre crue.

**Le paquet passe par la meme chaine qu'un televersement.** Venir d'un registre n'accorde aucune faveur : meme lecteur, meme validateur, meme assainissement.

## Un controle non prevu, ajoute en ecrivant

Le paquet doit porter l'identifiant annonce par le registre. Sinon un index compromis pourrait faire installer autre chose sous un nom connu.

## Deux temps, delibere

`dryRun` lit et rend ce qui est demande SANS rien ecrire ; l'appel suivant installe ce que l'admin a accepte. Sans ce premier temps, l'ecran de permissions n'aurait rien a afficher.

Quand un registre est refuse, la reponse dit lesquels sont acceptes : un admin doit pouvoir comprendre un refus sans aller lire une variable d'environnement.

## A savoir

Ce lot ne fera pas disparaitre le 404 constate : les quatre instances tournent en 2.12.0 et **rien de ce chantier n'est deploye**. C'est une decision a part.

21 tests sur le client de registre, 839 sur le coeur, 6 cles i18n FR et EN, quatre portes vertes, svelte-check 0 erreur.
