### PR TITLE
fix: le picker du builder affichait l'URL de l'icone a la place du nom

### DIFF
--- a/nodyx-frontend/src/lib/components/homepage/catalog.extensions.test.ts
+++ b/nodyx-frontend/src/lib/components/homepage/catalog.extensions.test.ts
@@ -117,3 +117,24 @@ describe('cohabitation avec les widgets natifs', () => {
 			.toEqual(['ext:library:shelf', 'ext:library:tonight'])
 	})
 })
+
+// Regression vue en production : le picker du builder rend `icon` comme du
+// TEXTE. Une URL d'icone s'y affichait donc en clair, a la place du nom.
+describe('icone du picker', () => {
+	it('ne met jamais une URL dans un champ rendu en texte', () => {
+		const e = extensionWidgetEntries([EXT])[0]
+		expect(e.icon).not.toMatch(/^https?:|^\//)
+		expect(e.icon.length).toBeLessThanOrEqual(4)
+	})
+
+	it('mais conserve l URL a part, pour un rendu en image', () => {
+		expect(extensionWidgetEntries([EXT])[0].iconUrl).toBe(EXT.icon)
+	})
+
+	it('supporte une extension sans icone', () => {
+		const sans = { ...EXT, icon: null }
+		const e = extensionWidgetEntries([sans as PublicExtension])[0]
+		expect(e.icon).toBeTruthy()
+		expect(e.iconUrl).toBeNull()
+	})
+})

--- a/nodyx-frontend/src/lib/components/homepage/catalog.ts
+++ b/nodyx-frontend/src/lib/components/homepage/catalog.ts
@@ -46,7 +46,10 @@ export type CatalogEntry =
 			kind:        'extension'
 			id:          string      // identifiant de mise en page, prefixe `ext:`
 			label:       string
+			/** Caractere affiche a cote du libelle. JAMAIS une URL. */
 			icon:        string
+			/** Icone livree par l'extension, pour un rendu en image. */
+			iconUrl:     string | null
 			family:      WidgetFamily | string
 			desc:        string
 			schema:      FieldSchema[]
@@ -119,7 +122,8 @@ export function buildCatalog(
 		kind:          'extension',
 		id:            e.id,
 		label:         e.label,
-		icon:          e.icon ?? '🧩',
+		icon:          e.icon,
+		iconUrl:       e.iconUrl,
 		family:        e.family,
 		desc:          e.desc,
 		schema:        e.schema,

--- a/nodyx-frontend/src/lib/components/homepage/extensionCatalog.ts
+++ b/nodyx-frontend/src/lib/components/homepage/extensionCatalog.ts
@@ -84,7 +84,10 @@ export interface ExtensionSurfaceEntry {
 	version:     string
 	entry:       string
 	label:       string
-	icon:        string | null
+	/** Caractere affiche a cote du libelle. JAMAIS une URL. */
+	icon:        string
+	/** Icone livree par l'extension, pour un rendu en image. */
+	iconUrl:     string | null
 	family:      string
 	desc:        string
 	schema:      FieldSchema[]
@@ -106,7 +109,11 @@ export function extensionWidgetEntries(extensions: PublicExtension[] = []): Exte
 				version:       ext.version,
 				entry:         s.entry,
 				label:         s.label || ext.label,
-				icon:          ext.icon,
+				// Le builder rend `icon` comme du TEXTE a cote du libelle : y
+				// mettre l'URL l'affichait en clair dans le picker, a la place
+				// du nom. Vu en production.
+				icon:          '🧩',
+				iconUrl:       ext.icon ?? null,
 				family:        ext.family,
 				desc:          ext.description,
 				schema:        (s.schema ?? []).map(canonField).filter((f): f is FieldSchema => f !== null),


### PR DESCRIPTION
Vu en production : la carte de l'extension montrait `/api/v1/extensions/next-event/1.0.0/assets/icon.svg` en gros, la ou le nom devait etre.

## Cause

Le builder rend `icon` comme du **texte** a cote du libelle, parce que les widgets natifs y mettent un emoji. J'y ai mis l'URL de l'icone livree par l'extension, qui s'est donc affichee en clair.

Le caractere sert au rendu, l'URL vit desormais a part dans `iconUrl`, prete pour un rendu en image quand le builder saura le faire.

## Ou la decision est prise

Dans le module **pur**, pas dans `catalog.ts` : ce dernier importe des composants Svelte que le harnais de test du depot ne sait pas transformer. Mes deux premiers tests, ecrits au mauvais endroit, ont echoue pour cette raison exacte, ce qui a confirme l'interet du decoupage fait hier.

Trois tests verrouillent, dont un qui **interdit toute valeur ressemblant a une URL** dans le champ rendu en texte, et un qui couvre l'extension sans icone.

## Ce que ce lot ne corrige pas

Le vrai blocage du montage n'est pas dans le code : la politique servie par le proxy a un `frame-src` **sans `'self'`**, donc une page ne peut pas encadrer une frame de sa propre origine. Aucune extension ne peut demarrer tant que ce n'est pas corrige, et la meme cause casse deja le canvas Scenes de l'admin, qui embarque `/overlay/...` en iframe.

92 tests frontend, svelte-check 0 erreur.
