### PR TITLE
fix: une extension ne pouvait pas appliquer sa feuille de style

### DIFF
--- a/nodyx-core/confinement/evil-extension/ui/widget.js
+++ b/nodyx-core/confinement/evil-extension/ui/widget.js
@@ -101,6 +101,29 @@ export async function mount({ root, nodyx }) {
     return 'statut ' + r.status + ', ' + (await r.text()).slice(0, 40)
   })
 
+  // ── Styles : autorises DANS la frame, mais rien de plus ───────────────────
+  await attempt('feuille de style injectee', 'autorisee, une extension doit dessiner', () => {
+    const st = document.createElement('style')
+    st.textContent = '.sonde-evil { color: rgb(1, 2, 3) }'
+    document.head.appendChild(st)
+    const el = document.createElement('div')
+    el.className = 'sonde-evil'
+    document.body.appendChild(el)
+    const applique = getComputedStyle(el).color === 'rgb(1, 2, 3)'
+    el.remove(); st.remove()
+    // Ici l'attendu est l'INVERSE des autres : si la feuille ne s'applique pas,
+    // aucune extension ne peut dessiner, et la surface s'affiche en texte brut.
+    if (!applique) throw new Error('feuille rejetee')
+    return 'appliquee'
+  })
+
+  await attempt('police chargee depuis un tiers', 'bloquee par la politique', () => new Promise((resolve, reject) => {
+    const st = document.createElement('style')
+    st.textContent = '@font-face { font-family: evil; src: url(https://evil.example/f.woff2) }'
+    document.head.appendChild(st)
+    setTimeout(() => { st.remove(); reject(new Error('aucune requete partie')) }, 800)
+  }))
+
   // ── Le pont ───────────────────────────────────────────────────────────────
   await attempt('capacite non declaree', 'refusee', async () => {
     const v = await nodyx.storage.get('quoi-que-ce-soit')

--- a/nodyx-core/confinement/run.mjs
+++ b/nodyx-core/confinement/run.mjs
@@ -167,22 +167,28 @@ console.log('\nBanc de confinement, extension hostile\n')
 console.log(pad('tentative', 38), pad('attendu', 26), 'resultat')
 console.log('-'.repeat(96))
 
+// Une tentative dont l'attendu commence par « autorisee » doit REUSSIR : c'est
+// le cas des styles, qu'une extension doit pouvoir injecter pour dessiner.
+// Sans cette distinction, le banc serait vert en interdisant tout, y compris
+// ce qui est necessaire.
 let leaks = 0
 for (const r of results) {
+  const doitPasser = r.expectation.startsWith('autorisee')
+  const conforme = doitPasser ? !r.blocked : r.blocked
   const verdict = r.blocked ? 'BLOQUEE (' + r.reason + ')' : 'PASSEE >>> ' + r.leaked
-  if (!r.blocked) leaks++
-  console.log(pad(r.name, 38), pad(r.expectation, 26), verdict)
+  if (!conforme) leaks++
+  console.log(pad(r.name, 38), pad(r.expectation, 26), (conforme ? '' : 'NON CONFORME : ') + verdict)
 }
 
-console.log('\n' + results.length + ' tentatives, ' + (results.length - leaks) + ' bloquees, ' + leaks + ' passees')
+console.log('\n' + results.length + ' tentatives, ' + (results.length - leaks) + ' conformes, ' + leaks + ' non conformes')
 if (cspViolations.length) {
   console.log('\nRefus de la politique de securite (extraits) :')
   for (const v of [...new Set(cspViolations)].slice(0, 6)) console.log('  ' + v)
 }
 
 if (leaks > 0) {
-  console.error('\nECHEC : ' + leaks + ' tentative(s) hostile(s) ont abouti.')
+  console.error('\nECHEC : ' + leaks + ' tentative(s) non conforme(s).')
   if (CHECK) process.exit(1)
 } else {
-  console.log('\nOK : aucune tentative hostile n\'a abouti.')
+  console.log('\nOK : le confinement tient, et une extension peut dessiner.')
 }

--- a/nodyx-core/src/routes/extensionFrame.ts
+++ b/nodyx-core/src/routes/extensionFrame.ts
@@ -38,16 +38,26 @@ const RE_VERSION = /^\d+\.\d+\.\d+$/
  * correspond à rien. `frame-src 'none'` interdit toute iframe imbriquée, donc
  * tout embarquement de tiers, qui passera par une primitive de l'hôte.
  *
- * `style-src-attr 'unsafe-inline'` est délibéré et borné aux attributs
- * `style=""`, qui sont réels dans du code d'interface. Il n'y a PAS de
- * `'unsafe-inline'` dans `style-src` ni dans `script-src` : un nonce le
- * neutraliserait de toute façon, l'écrire ne ferait que masquer l'intention.
+ * **Les styles sont libres DANS la frame, les scripts ne le sont pas.**
+ *
+ * Corrigé le 2026-08-14 après constat en production : une extension injecte sa
+ * feuille de style avec un `<style>` qu'elle crée elle même, et elle ne peut
+ * pas connaître le nonce. Avec un `style-src` à nonce, cette feuille était
+ * rejetée en silence, et la surface s'affichait en texte brut empilé. Le widget
+ * marchait, il était juste illisible.
+ *
+ * Autoriser `'unsafe-inline'` pour les styles n'affaiblit rien ici : nous
+ * sommes dans une frame à origine opaque qui exécute DÉJÀ le code de
+ * l'extension. Lui interdire son CSS n'empêche aucune attaque, ça l'empêche
+ * seulement de dessiner. Ce qui protège l'instance reste entier : origine
+ * opaque, `connect-src` fermé, `frame-src 'none'`, et surtout `script-src` qui
+ * garde son nonce, donc aucun script étranger ne s'exécute.
  */
 export function frameCsp(origin: string, nonce: string): string {
   return [
     `default-src 'none'`,
     `script-src 'nonce-${nonce}' ${origin}`,
-    `style-src 'nonce-${nonce}' ${origin}`,
+    `style-src 'unsafe-inline' ${origin}`,
     `style-src-attr 'unsafe-inline'`,
     `img-src ${origin} data: blob:`,
     `media-src ${origin} blob:`,

--- a/nodyx-core/src/tests/extensionFrame.test.ts
+++ b/nodyx-core/src/tests/extensionFrame.test.ts
@@ -68,11 +68,24 @@ describe('document de frame', () => {
     expect(csp).toContain(ORIGIN)
   })
 
-  it('n autorise pas unsafe-inline pour les scripts ni les styles', async () => {
+  it('garde le nonce sur les SCRIPTS, donc aucun script étranger ne s exécute', () => {
+    // C'est la ligne qui compte : les styles sont libres dans la frame, les
+    // scripts ne le sont pas.
+    return frame().then((r) => {
+      const csp = r.headers['content-security-policy'] as string
+      expect(/script-src[^;]*unsafe-inline/.test(csp)).toBe(false)
+      expect(csp).toMatch(/script-src 'nonce-[^']+'/)
+    })
+  })
+
+  it('autorise en revanche les STYLES, sinon une extension ne peut pas dessiner', async () => {
+    // Constaté en production : une extension injecte sa feuille avec un <style>
+    // qu'elle cree elle meme, et elle ne peut pas connaitre le nonce. Avec un
+    // style-src a nonce, sa feuille etait rejetee en silence et la surface
+    // s'affichait en texte brut empile.
     const csp = (await frame()).headers['content-security-policy'] as string
-    expect(/script-src[^;]*unsafe-inline/.test(csp)).toBe(false)
-    expect(/style-src '[^;]*unsafe-inline/.test(csp)).toBe(false)
-    expect(csp).toContain("style-src-attr 'unsafe-inline'")   // borné aux attributs, délibéré
+    expect(csp).toContain("style-src 'unsafe-inline'")
+    expect(csp).toContain("style-src-attr 'unsafe-inline'")
   })
 
   it('utilise un nonce neuf à chaque requête', async () => {


### PR DESCRIPTION
Constate en production, en regardant la page : le compte a rebours s'affichait en texte brut empile sous la barre laterale. Le widget marchait, il etait illisible.

## Cause

Une extension injecte sa feuille avec un `<style>` qu'elle cree elle meme, et elle ne peut pas connaitre le nonce. Avec un `style-src` a nonce, sa feuille etait rejetee **en silence**.

J'avais vu ce refus dix minutes plus tot et je l'avais qualifie de « sans consequence visible ». Il avait toutes les consequences.

## Les styles sont libres DANS la frame, les scripts ne le sont pas

Autoriser `'unsafe-inline'` pour les styles n'affaiblit rien ici : nous sommes dans une frame a origine opaque qui execute **deja** le code de l'extension. Lui interdire son CSS n'empeche aucune attaque, ca l'empeche seulement de dessiner.

Ce qui protege l'instance reste entier : origine opaque, `connect-src` ferme, `frame-src 'none'`, et `script-src` qui garde son nonce. Un test le verifie separement, pour que l'ouverture des styles ne glisse jamais vers les scripts.

## Le banc de confinement avait un angle mort

C'est la vraie lecon de ce lot. Il ne testait que des tentatives qui doivent **echouer**, donc il serait reste vert en interdisant tout, y compris le necessaire.

Il connait maintenant des tentatives qui doivent **reussir** : la feuille de style injectee doit s'appliquer, et une police tierce doit rester bloquee. **16 tentatives, 16 conformes.**

846 tests coeur, tsc propre.
