### PR TITLE
fix: la poignee de main d'amorcage devait survivre au desordre

### DIFF
--- a/nodyx-core/confinement/run.mjs
+++ b/nodyx-core/confinement/run.mjs
@@ -68,7 +68,12 @@ const HOST_PAGE = `<!doctype html><meta charset="utf-8"><title>hote</title>
   f.src = '/frame';
   f.width = 400; f.height = 200;
   window.__results = null;
-  window.addEventListener('message', (e) => {
+
+  // L'hote ecoute EN RETARD, expres. C'est ce qui arrive dans le builder,
+  // dont l'apercu se redessine : sans rappels de la poignee de main, la frame
+  // reste bloquee et le banc doit le voir.
+  const RETARD_MS = 1200;
+  const brancher = () => window.addEventListener('message', (e) => {
     if (e.data?.type === 'nodyx:hello' && e.source === f.contentWindow) {
       const ch = new MessageChannel();
       // L'hote repond, sinon une promesse du pont reste suspendue et le
@@ -91,6 +96,7 @@ const HOST_PAGE = `<!doctype html><meta charset="utf-8"><title>hote</title>
     if (e.data?.type === 'evil:results') window.__results = e.data.results;
   });
   document.body.append(f);
+  setTimeout(brancher, RETARD_MS);
 </script>
 </body>`
 

--- a/nodyx-core/sdk/nodyx-sdk.js
+++ b/nodyx-core/sdk/nodyx-sdk.js
@@ -196,6 +196,7 @@ window.addEventListener('message', async (e) => {
   const port = e.ports?.[0]
   if (!port) return
   booted = true
+  stopHello()
 
   const bridge = createBridge(port, boot.ext, boot.surface)
   const nodyx  = buildNodyx(boot, bridge)
@@ -219,6 +220,29 @@ window.addEventListener('message', async (e) => {
   }
 })
 
-// L'hôte attend ce signal pour savoir que le SDK est en place et transférer
-// le port. Sans lui, il pourrait poster avant que l'écouteur existe.
-window.parent?.postMessage({ p: PROTOCOL, type: 'nodyx:hello' }, '*')
+// ── La poignee de main, qui doit survivre au desordre ───────────────────────
+//
+// L'hote attend ce signal pour transferer le port. Un seul envoi ne suffit
+// PAS, et ca s'est vu en production : dans le builder d'accueil, l'apercu se
+// redessine a chaque interaction, donc l'hote peut ne pas encore ecouter quand
+// la frame demarre, ou la frame peut etre recreee apres le premier essai. Le
+// message part alors dans le vide et la surface reste bloquee sur son erreur.
+//
+// On repete donc l'appel jusqu'a ce que l'amorcage arrive. C'est sans risque :
+// l'hote ignore un `hello` en trop, et le garde `booted` empeche tout double
+// montage.
+const HELLO_EVERY_MS = 250
+const HELLO_FOR_MS   = 8000
+
+let helloTimer = null
+function sayHello() {
+  if (booted) return stopHello()
+  try { window.parent?.postMessage({ p: PROTOCOL, type: 'nodyx:hello' }, '*') } catch { /* rien a faire */ }
+}
+function stopHello() {
+  if (helloTimer) { clearInterval(helloTimer); helloTimer = null }
+}
+
+sayHello()
+helloTimer = setInterval(sayHello, HELLO_EVERY_MS)
+setTimeout(stopHello, HELLO_FOR_MS)

--- a/nodyx-frontend/src/lib/components/ExtensionSurface.svelte
+++ b/nodyx-frontend/src/lib/components/ExtensionSurface.svelte
@@ -94,6 +94,13 @@
 		if (!frame || e.source !== frame.contentWindow) return
 		if (e.data?.type !== 'nodyx:hello') return
 
+		// Un `hello` qui arrive alors qu'on avait abandonné veut dire que la
+		// frame a redémarré : on repart proprement plutôt que de rester bloqué
+		// sur une erreur. Vu dans le builder, dont l'aperçu se redessine à
+		// chaque interaction.
+		if (status === 'error') status = 'loading'
+		channel?.port1.close()
+
 		channel = new MessageChannel()
 		channel.port1.onmessage = async (ev) => {
 			if (ev.data?.event === 'ready') { status = 'ready'; clearBootTimer(); return }
@@ -119,7 +126,10 @@
 	onMount(() => {
 		if (!browser) return
 		window.addEventListener('message', onWindowMessage)
-		bootTimer = setTimeout(() => { if (status === 'loading') status = 'error' }, 5000)
+		// Le délai laisse la place aux rappels de la poignée de main : abandonner
+		// plus tôt que la frame n'a le droit d'insister produirait une erreur
+		// alors que tout allait bien.
+		bootTimer = setTimeout(() => { if (status === 'loading') status = 'error' }, 10000)
 		// Sans jeton la surface s'affiche quand même : elle n'aura simplement
 		// aucune capacité, ce que le pont lui dira avec un code explicite.
 		void openSession()


### PR DESCRIPTION
Constate en production : la surface se montait sur la page d'accueil mais echouait dans le builder, avec « n'a pas pu se charger ».

## Cause

Le SDK envoyait son `hello` **une seule fois**, au chargement. Dans le builder, l'apercu se redessine a chaque interaction : l'hote peut ne pas encore ecouter quand la frame demarre, ou la frame peut etre recreee apres le premier essai. Le message partait dans le vide et la surface restait bloquee. Sur la page d'accueil, la frame se monte une fois et le hasard du timing nous sauvait.

## Correctif

Le SDK repete son appel toutes les 250 ms pendant 8 secondes. Sans risque : un `hello` en trop est ignore, et le garde `booted` empeche tout double montage.

Cote hote, un `hello` qui arrive **apres un abandon** veut dire que la frame a redemarre : on repart proprement au lieu de rester fige sur l'erreur. Le delai passe a 10 s, pour laisser la place aux rappels plutot que d'abandonner avant que la frame ait le droit d'insister.

## Le banc reproduit le desordre, et il DETECTE le bug

Son hote branche desormais son ecouteur **1,2 seconde en retard**, expres.

Et j'ai verifie ce qui compte : avec l'ancien comportement remis en place, le banc echoue avec « le montage a echoue » ; avec le correctif, il passe. **Un test de regression qui ne tombe pas sur l'ancien code ne prouve rien**, et celui la tombe.

846 tests coeur, svelte-check 0 erreur.
