### PR TITLE
fix: DataCloneError, la charge d'amorcage portait de l'etat Svelte

### DIFF
--- a/nodyx-frontend/src/lib/components/ExtensionSurface.svelte
+++ b/nodyx-frontend/src/lib/components/ExtensionSurface.svelte
@@ -110,8 +110,20 @@
 		}
 		channel.port1.start()
 
+		// `postMessage` clone la charge, et le clonage structuré NE SAIT PAS
+		// cloner un proxy `$state` de Svelte 5 : il lève un DataCloneError.
+		// Sur la page d'accueil la configuration vient du serveur, donc c'est un
+		// objet ordinaire et tout passe ; dans le builder, c'est de l'état
+		// réactif, et la frame ne démarrait jamais. Le même piège avait déjà
+		// coûté un correctif sur le jukebox.
 		const boot = buildBootPayload(ref, window.location.origin, entry, {
-			config, messages, locale, theme, instance, user: grantedUser, route: '/',
+			config:   $state.snapshot(config)   as Record<string, unknown>,
+			messages: $state.snapshot(messages) as Record<string, string>,
+			theme:    $state.snapshot(theme)    as Record<string, string>,
+			instance: $state.snapshot(instance) as Record<string, unknown>,
+			user:     grantedUser,
+			locale,
+			route: '/',
 		})
 		// Cible '*' : la frame est en origine opaque, aucune autre valeur ne
 		// correspondrait. Ce n'est pas une faiblesse, le message ne contient rien

--- a/nodyx-frontend/src/lib/extensions/host.test.ts
+++ b/nodyx-frontend/src/lib/extensions/host.test.ts
@@ -262,3 +262,29 @@ describe('outils', () => {
 		expect(isSafeExternalUrl('ftp://a.example')).toBe(false)
 	})
 })
+
+// Regression vue en production, dans le builder d'accueil.
+//
+// `postMessage` clone la charge, et le clonage structure NE SAIT PAS cloner un
+// proxy `$state` de Svelte 5 : il leve un DataCloneError et la frame ne
+// demarre jamais. Sur la page d'accueil la configuration vient du serveur,
+// donc c'est un objet ordinaire et rien ne se voyait.
+describe('la charge d amorcage doit etre clonable', () => {
+	it('une charge normale passe le clonage structure', () => {
+		const boot = buildBootPayload(SURFACE, 'https://instance.example', 'ui/w.js', {
+			config: { titre: 'x', n: 1 }, messages: { a: 'b' }, locale: 'fr',
+			theme: { accent: '#000' }, instance: { name: 'N' }, user: null, route: '/',
+		})
+		expect(() => structuredClone(boot)).not.toThrow()
+	})
+
+	it('une charge portant une valeur non clonable EST rejetee, ce qui prouve le test', () => {
+		// Sans cette moitie, le test precedent ne demontrerait rien : il faut
+		// que le clonage sache echouer.
+		const boot = buildBootPayload(SURFACE, 'https://instance.example', 'ui/w.js', {
+			config: { rappel: () => 'non clonable' } as unknown as Record<string, unknown>,
+			messages: {}, locale: 'fr', theme: {}, instance: {}, user: null, route: '/',
+		})
+		expect(() => structuredClone(boot)).toThrow()
+	})
+})


### PR DESCRIPTION
Trace relevee dans la console du builder :

```
Uncaught DataCloneError: Failed to execute 'postMessage' on 'Window':
#<Object> could not be cloned.
```

## Cause

`postMessage` clone la charge, et le clonage structure **ne sait pas cloner un proxy `$state`** de Svelte 5. Dans le builder, la configuration d'une colonne **est** de l'etat reactif : l'amorcage levait une exception et la frame ne demarrait jamais.

Sur la page d'accueil, la meme configuration vient du serveur, donc c'est un objet ordinaire et rien ne se voyait. C'est pour ca que la surface marchait d'un cote et pas de l'autre.

C'est le meme piege qui avait deja coute un correctif sur le jukebox, avec `structuredClone` au lieu de `postMessage`. La regle maison se confirme : **ne jamais faire traverser une frontiere a du `$state` sans `$state.snapshot`**.

## Deux tests, dont un qui prouve l'autre

Une charge normale passe le clonage, et une charge portant une fonction est bien **rejetee**. Sans cette seconde moitie, le premier test ne demontrerait rien : il resterait vert meme si le clonage acceptait tout.

94 tests frontend, svelte-check 0 erreur.
