### PR TITLE
fix(admin): les adresses des membres ne s'affichent plus par accident

### DIFF
--- a/nodyx-core/src/routes/admin.ts
+++ b/nodyx-core/src/routes/admin.ts
@@ -7,6 +7,7 @@
 import { FastifyInstance } from 'fastify'
 import { z } from 'zod'
 import { db, redis } from '../config/database'
+import { maskEmail } from '../utils/maskEmail'
 import { adminOnly } from '../middleware/adminOnly'
 import { validate } from '../middleware/validate'
 import { rateLimit } from '../middleware/rateLimit'
@@ -216,7 +217,10 @@ export default async function adminRoutes(app: FastifyInstance) {
 
     // Recent registrations (last 5)
     const recentMembersRes = await db.query(
-      `SELECT u.username, u.avatar, u.email, cm.joined_at, cm.role
+      // L'adresse ne sort PAS du tableau de bord : on veut y voir qui vient
+      // d'arriver, pas son courriel. Ouvrir cette page en direct diffusait
+      // les adresses des membres.
+      `SELECT u.username, u.avatar, cm.joined_at, cm.role
        FROM community_members cm
        JOIN users u ON u.id = cm.user_id
        WHERE cm.community_id = $1
@@ -282,7 +286,17 @@ export default async function adminRoutes(app: FastifyInstance) {
       [communityId]
     )
 
-    return reply.send({ members: rows })
+    // L'adresse part MASQUEE. Le masquage se fait ici, au serveur, et pas a
+    // l'affichage : une adresse qui ne quitte pas la base ne peut pas fuir par
+    // une capture d'ecran, un journal de navigateur ou un partage de session.
+    // Un admin qui a besoin de l'adresse complete la demande par la route
+    // dediee, et cette demande est tracee.
+    const members = (rows as Array<Record<string, unknown>>).map((m) => ({
+      ...m,
+      email: maskEmail(m.email as string | null),
+    }))
+
+    return reply.send({ members })
   })
 
   app.patch('/members/:userId', {
@@ -311,6 +325,28 @@ export default async function adminRoutes(app: FastifyInstance) {
     }
 
     return reply.send({ ok: true })
+  })
+
+  // ── GET /api/v1/admin/members/:userId/email ─────────────────────────────
+  //
+  // Reveler une adresse est une ACTION, et elle est tracee.
+  //
+  // Un admin garde le pouvoir de voir une adresse quand il en a besoin, pour
+  // un support ou un bannissement. Mais ce n'est plus quelque chose qui
+  // s'affiche par accident sur une capture d'ecran : c'est un geste
+  // deliberе, et le journal d'audit garde qui l'a fait et pour qui. Ca protege
+  // le membre, et ca protege aussi l'admin.
+  app.get('/members/:userId/email', { preHandler: [rateLimit, adminOnly] }, async (request, reply) => {
+    const { userId }  = request.params as { userId: string }
+    const adminUser   = (request as any).user as { userId: string }
+
+    const { rows } = await db.query(`SELECT username, email FROM users WHERE id = $1`, [userId])
+    const target = rows[0] as { username: string; email: string } | undefined
+    if (!target) return reply.code(404).send({ error: 'Membre introuvable', code: 'MEMBER_NOT_FOUND' })
+
+    await logAction(adminUser.userId, 'reveal_email', 'user', userId, target.username)
+
+    return reply.send({ email: target.email })
   })
 
   // POST /api/v1/admin/members/:userId/reset-link

--- a/nodyx-core/src/tests/maskEmail.test.ts
+++ b/nodyx-core/src/tests/maskEmail.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { maskEmail, maskEmailIn } from '../utils/maskEmail'
+
+describe('masquage des adresses', () => {
+  it('garde la premiere lettre de chaque cote et l extension', () => {
+    // Assez pour reconnaitre une adresse qu'on connait deja, pas assez pour la
+    // lire a quelqu'un qui la decouvre.
+    expect(maskEmail('jonathan@gmail.com')).toBe('j••••••@g••••.com')
+  })
+
+  it('ne laisse JAMAIS passer la partie locale complete', () => {
+    for (const e of ['jaronoah@gmail.com', 'contact@nodyx.org', 'a.b.c@sous.domaine.fr']) {
+      const masque = maskEmail(e)
+      const local = e.slice(0, e.indexOf('@'))
+      if (local.length > 1) expect(masque).not.toContain(local)
+    }
+  })
+
+  it('borne la longueur des points, pour ne pas trahir la taille', () => {
+    // Une adresse de quarante caracteres ne doit pas se distinguer d'une de
+    // quinze : la longueur est en soi une information.
+    const court = maskEmail('abcdefg@example.com')
+    const long  = maskEmail('abcdefghijklmnopqrstuvwxyz@example.com')
+    expect(court.split('@')[0]).toBe(long.split('@')[0])
+  })
+
+  it('conserve l extension, utile pour distinguer un domaine jetable', () => {
+    expect(maskEmail('x@yopmail.com')).toContain('.com')
+    expect(maskEmail('x@truc.fr')).toContain('.fr')
+  })
+
+  it('traite les valeurs absentes sans exploser', () => {
+    expect(maskEmail(null)).toBe('')
+    expect(maskEmail(undefined)).toBe('')
+    expect(maskEmail('')).toBe('')
+  })
+
+  it('masque aussi ce qui n est pas une adresse, plutot que de le rendre tel quel', () => {
+    const r = maskEmail('pas-une-adresse')
+    expect(r).not.toBe('pas-une-adresse')
+    expect(r.startsWith('p')).toBe(true)
+  })
+
+  it('gere une adresse a plusieurs arobases en prenant la derniere', () => {
+    expect(maskEmail('a@b@example.com')).toContain('@e')
+  })
+
+  it('masque un champ dans une ligne sans toucher au reste', () => {
+    const row = { id: '1', username: 'ada', email: 'ada@example.com', role: 'admin' }
+    const out = maskEmailIn(row)
+    expect(out.email).toBe('a••@e••••••.com')
+    expect(out.username).toBe('ada')
+    expect(out.role).toBe('admin')
+  })
+})

--- a/nodyx-core/src/utils/maskEmail.ts
+++ b/nodyx-core/src/utils/maskEmail.ts
@@ -1,0 +1,47 @@
+// Masquage des adresses de courriel dans l'administration.
+//
+// Pourquoi ce module existe : le tableau de bord et la liste des membres
+// affichaient les adresses en clair. Ouvrir le panneau d'administration
+// pendant un direct, ou simplement montrer son ecran, diffusait les adresses
+// des membres. Le proprietaire de l'instance a cesse de diffuser son propre
+// projet pour cette raison, ce qui est le signe qu'un defaut de conception
+// coute plus cher qu'il n'en a l'air.
+//
+// Le choix est le MASQUAGE PAR DEFAUT, et pas un « mode discret » a activer :
+// un mode qu'on oublie d'allumer ne protege personne, et c'est precisement le
+// soir ou on l'oublie que ca se voit. L'adresse complete reste accessible, mais
+// par un geste explicite, et ce geste laisse une trace.
+
+/**
+ * `jonathan@gmail.com` -> `j••••••@g••••.com`
+ *
+ * On garde la premiere lettre de chaque cote et l'extension : assez pour
+ * reconnaitre une adresse qu'on connait deja, pas assez pour la lire a
+ * quelqu'un qui la decouvre.
+ */
+export function maskEmail(email: string | null | undefined): string {
+  if (!email || typeof email !== 'string') return ''
+
+  const at = email.lastIndexOf('@')
+  if (at <= 0) {
+    // Pas une adresse : on masque tout sauf la premiere lettre plutot que de
+    // rendre la valeur telle quelle.
+    return email.length > 1 ? email[0] + '•'.repeat(Math.min(email.length - 1, 8)) : '•'
+  }
+
+  const local  = email.slice(0, at)
+  const domain = email.slice(at + 1)
+
+  const dot   = domain.lastIndexOf('.')
+  const host  = dot > 0 ? domain.slice(0, dot) : domain
+  const tld   = dot > 0 ? domain.slice(dot) : ''
+
+  const hide = (s: string) => (s.length <= 1 ? s : s[0] + '•'.repeat(Math.min(s.length - 1, 6)))
+
+  return `${hide(local)}@${hide(host)}${tld}`
+}
+
+/** Applique le masquage sur une ligne qui porte un champ `email`. */
+export function maskEmailIn<T extends { email?: string | null }>(row: T): T & { email: string } {
+  return { ...row, email: maskEmail(row.email) }
+}

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -4517,5 +4517,8 @@
   "ext_install.reading": "Reading the package from {{registry}}…",
   "ext_install.bad_link": "This install link is incomplete.",
   "ext_install.back": "Back to extensions",
-  "ext_install.allowed_registries": "Registries accepted on this instance: {{list}}."
+  "ext_install.allowed_registries": "Registries accepted on this instance: {{list}}.",
+  "amem.reveal_email": "reveal",
+  "amem.revealing": "…",
+  "adash.member_joined": "new member"
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -4517,5 +4517,8 @@
   "ext_install.reading": "Lecture du paquet depuis {{registry}}…",
   "ext_install.bad_link": "Ce lien d'installation est incomplet.",
   "ext_install.back": "Retour aux extensions",
-  "ext_install.allowed_registries": "Registres acceptés sur cette instance : {{list}}."
+  "ext_install.allowed_registries": "Registres acceptés sur cette instance : {{list}}.",
+  "amem.reveal_email": "révéler",
+  "amem.revealing": "…",
+  "adash.member_joined": "nouveau membre"
 }

--- a/nodyx-frontend/src/routes/admin/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/+page.svelte
@@ -206,7 +206,7 @@
 								<a href="/users/{m.username}" class="text-[13px] text-zinc-300 hover:text-white font-medium block truncate transition-colors">
 									{m.username}
 								</a>
-								<span class="text-xs text-zinc-600 truncate block">{m.email}</span>
+								<span class="text-xs text-zinc-600 truncate block">{tFn('adash.member_joined')}</span>
 							</div>
 							<div class="text-right shrink-0">
 								<span class="text-xs text-zinc-500 tabular-nums">{timeAgo(m.joined_at)}</span>

--- a/nodyx-frontend/src/routes/admin/members/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/members/+page.svelte
@@ -51,6 +51,23 @@
 		)
 	)
 
+	// Adresses revelees pendant cette session d'ecran, jamais persistees.
+	let revealed:  Record<string, string>  = $state({})
+	let revealing: Record<string, boolean> = $state({})
+
+	async function revealEmail(userId: string) {
+		if (revealed[userId] || revealing[userId]) return
+		revealing[userId] = true
+		try {
+			const res = await fetch(`/api/v1/admin/members/${userId}/email`, {
+				headers: { Authorization: `Bearer ${$page.data.token}` },
+			})
+			if (res.ok) revealed[userId] = (await res.json()).email
+		} finally {
+			revealing[userId] = false
+		}
+	}
+
 	const bans: Array<{ user_id: string; username: string; email: string; reason: string | null; banned_at: string; banned_by_username: string | null }> = untrack(() => data.bans ?? [])
 	const ipBans: Array<{ ip: string; reason: string | null; banned_at: string; banned_by_username: string | null }> = untrack(() => data.ipBans ?? [])
 	const emailBans: Array<{ email: string; reason: string | null; banned_at: string; banned_by_username: string | null }> = untrack(() => data.emailBans ?? [])
@@ -119,7 +136,21 @@
 									<a href="/users/{member.username}" class="font-medium text-white hover:text-indigo-300 transition-colors">
 										{member.username}
 									</a>
-									<div class="text-xs text-gray-600">{member.email}</div>
+									<!-- Adresse masquée par défaut, révélée par un geste explicite qui
+									     laisse une trace dans le journal d'audit. Un mode discret à
+									     activer ne protégerait personne : c'est le soir où on oublie
+									     de l'allumer que ça se voit. -->
+									<div class="text-xs text-gray-600 flex items-center gap-1.5">
+										<span>{revealed[member.id] ?? member.email}</span>
+										{#if !revealed[member.id]}
+											<button
+												type="button"
+												class="text-[10px] text-gray-500 hover:text-gray-300 underline underline-offset-2"
+												onclick={() => revealEmail(member.id)}
+												disabled={revealing[member.id]}
+											>{revealing[member.id] ? tFn('amem.revealing') : tFn('amem.reveal_email')}</button>
+										{/if}
+									</div>
 								</div>
 							</div>
 						</td>


### PR DESCRIPTION
Le proprietaire de l'instance a cesse de diffuser son propre projet sur Twitch a cause de ca : ouvrir le panneau d'administration affichait les adresses de courriel de ses membres, des la page d'accueil. Un defaut de conception qui coute un canal de communication entier vaut mieux qu'un ticket cosmetique.

## Trois changements, du plus radical au plus nuance

**Le tableau de bord** ne recoit plus l'adresse du tout : la requete ne la selectionne meme pas. Ce qu'on veut y voir, c'est qui vient d'arriver, pas son courriel.

**La liste des membres** la recoit masquee, et le masquage se fait **au serveur**, pas a l'affichage. Une adresse qui ne quitte pas la base ne peut fuir ni par une capture d'ecran, ni par un journal de navigateur, ni par un partage de session. Masquer a l'affichage n'aurait ete qu'un rideau.

**Reveler une adresse devient une action tracee.** Un admin garde le pouvoir de la voir pour un support ou un bannissement, mais c'est un geste delibere, et le journal d'audit existant garde qui l'a fait et pour qui. Ca protege le membre, et ca protege l'admin.

## Pourquoi pas un « mode discret »

Un mode qu'on oublie d'allumer ne protege personne, et c'est precisement le soir ou on l'oublie que ca se voit. Le masquage par defaut laisse ouvrir l'admin en direct sans y penser.

## Un detail qui a sa raison

Le masquage borne le nombre de points : une adresse de quarante caracteres ne doit pas se distinguer d'une de quinze, la longueur etant en soi une information. Un test le verifie.

8 tests sur le masquage, 854 sur le coeur, 94 frontend, quatre portes i18n vertes, svelte-check 0 erreur.
