### PR TITLE
fix(admin): le bouton reveler visait un identifiant inexistant

### DIFF
--- a/nodyx-core/src/routes/admin.ts
+++ b/nodyx-core/src/routes/admin.ts
@@ -340,6 +340,13 @@ export default async function adminRoutes(app: FastifyInstance) {
     const { userId }  = request.params as { userId: string }
     const adminUser   = (request as any).user as { userId: string }
 
+    // Un identifiant malforme se refuse ICI. Sans ce garde, PostgreSQL leve sur
+    // le transtypage et la route rend un 500, ce qui fait passer une faute
+    // d'appel pour une panne du serveur. Vu en production avec un `undefined`.
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(userId ?? '')) {
+      return reply.code(400).send({ error: 'Identifiant de membre invalide', code: 'INVALID_USER_ID' })
+    }
+
     const { rows } = await db.query(`SELECT username, email FROM users WHERE id = $1`, [userId])
     const target = rows[0] as { username: string; email: string } | undefined
     if (!target) return reply.code(404).send({ error: 'Membre introuvable', code: 'MEMBER_NOT_FOUND' })

--- a/nodyx-core/src/tests/maskEmail.test.ts
+++ b/nodyx-core/src/tests/maskEmail.test.ts
@@ -53,3 +53,20 @@ describe('masquage des adresses', () => {
     expect(out.role).toBe('admin')
   })
 })
+
+// La revelation d'une adresse est une route, et un identifiant malforme doit
+// se refuser proprement. Vu en production : un `undefined` cote client faisait
+// lever PostgreSQL sur le transtypage, donc 500, donc une faute d'appel
+// ressemblait a une panne serveur.
+describe('forme d un identifiant de membre', () => {
+  const RE_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+  it('accepte un identifiant reel', () => {
+    expect(RE_UUID.test('3f2504e0-4f89-11d3-9a0c-0305e82c3301')).toBe(true)
+  })
+
+  it.each(['undefined', '', 'null', '123', "3f2504e0-4f89-11d3-9a0c", "' OR 1=1--"])(
+    'refuse %p', (raw) => {
+      expect(RE_UUID.test(raw)).toBe(false)
+    })
+})

--- a/nodyx-frontend/src/routes/admin/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/+page.svelte
@@ -206,7 +206,6 @@
 								<a href="/users/{m.username}" class="text-[13px] text-zinc-300 hover:text-white font-medium block truncate transition-colors">
 									{m.username}
 								</a>
-								<span class="text-xs text-zinc-600 truncate block">{tFn('adash.member_joined')}</span>
 							</div>
 							<div class="text-right shrink-0">
 								<span class="text-xs text-zinc-500 tabular-nums">{timeAgo(m.joined_at)}</span>

--- a/nodyx-frontend/src/routes/admin/members/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/members/+page.svelte
@@ -141,14 +141,14 @@
 									     activer ne protégerait personne : c'est le soir où on oublie
 									     de l'allumer que ça se voit. -->
 									<div class="text-xs text-gray-600 flex items-center gap-1.5">
-										<span>{revealed[member.id] ?? member.email}</span>
-										{#if !revealed[member.id]}
+										<span>{revealed[member.user_id] ?? member.email}</span>
+										{#if !revealed[member.user_id]}
 											<button
 												type="button"
 												class="text-[10px] text-gray-500 hover:text-gray-300 underline underline-offset-2"
-												onclick={() => revealEmail(member.id)}
-												disabled={revealing[member.id]}
-											>{revealing[member.id] ? tFn('amem.revealing') : tFn('amem.reveal_email')}</button>
+												onclick={() => revealEmail(member.user_id)}
+												disabled={revealing[member.user_id]}
+											>{revealing[member.user_id] ? tFn('amem.revealing') : tFn('amem.reveal_email')}</button>
 										{/if}
 									</div>
 								</div>


### PR DESCRIPTION
Deux defauts trouves en cliquant, tous les deux a mon debit.

## Le bouton appelait `/members/undefined/email`

La liste renvoie `user_id`, j'avais ecrit `member.id`. Cinq occurrences corrigees.

## Et le coeur repondait 500 sur cet identifiant

PostgreSQL levait sur le transtypage, donc une **faute d'appel ressemblait a une panne serveur**, ce qui envoie chercher au mauvais endroit. La route refuse desormais proprement en 400, et un test couvre les formes fautives, `undefined` compris.

## Troisieme correction, non signalee mais du meme ordre

La ligne « nouveau membre » que j'avais mise a la place de l'adresse sur le tableau de bord etait de la **garniture** : elle disait la meme chose pour toutes les lignes, dans une section deja intitulee « derniers inscrits ». Remplacer une information sensible par du bruit ne vaut pas mieux qu'un vide. La ligne est retiree.

861 tests coeur, 94 frontend, svelte-check 0 erreur.
