### PR TITLE
fix(p2p): quinn-proto 0.11.16, epuisement memoire distant (GHSA-4w2j-m93h-cj5j)

### DIFF
--- a/nodyx-p2p/Cargo.lock
+++ b/nodyx-p2p/Cargo.lock
@@ -1002,30 +1002,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2196,14 +2184,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2246,12 +2235,6 @@ checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -2263,18 +2246,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2299,16 +2272,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2319,18 +2282,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "redis"


### PR DESCRIPTION
Ferme l'alerte Dependabot #164.

## Le defaut

`GHSA-4w2j-m93h-cj5j`, publie par les mainteneurs de quinn. L'`Assembler` de
`quinn-proto` reassemble les fragments de flux QUIC arrives dans le desordre.
Un pair malveillant envoie des fragments cribles de trous, qui ne peuvent
jamais etre defragmentes, et le buffer de reception enfle sans borne.

CVSS 7.5, vecteur `AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H` : impact sur la seule
disponibilite, aucun sur la confidentialite ni l'integrite.

## Notre exposition reelle etait nulle

`quinn-proto` arrive par `quinn`, dependance **optionnelle** de `reqwest`,
activee uniquement par la feature `http3`. Nos deux declarations ne l'activent
pas :

| Crate | Declaration |
|---|---|
| `nexus-relay` | `default-features = false, features = ["rustls-tls", "stream"]` |
| `nodyx-server` | `default-features = false, features = ["json", "rustls-tls"]` |

Deux verifications plutot qu'un raisonnement :

- `cargo tree --workspace --invert quinn-proto` ne le trouve dans aucun graphe
  resolu, y compris avec `--target all`
- `target/` ne contient **zero** artefact de build portant ce nom

Le code vulnerable etait dans le lockfile, jamais dans un binaire livre.

## Pourquoi corriger quand meme

Sans ce bump l'alerte reste ouverte et bruite le tableau de bord securite.
Surtout, le jour ou quelqu'un active `http3`, il heriterait de la version
trouee sans le voir passer.

## Le changement

Bump de lockfile seul, `cargo update -p quinn-proto` :

    quinn-proto  0.11.14  ->  0.11.16     (seuil corrige : 0.11.15)

Les suppressions de `getrandom`, `r-efi`, `rand` et `rand_chacha` sont la
consequence mecanique du bump : quinn-proto 0.11.16 troque `rand` contre
`rand_pcg`. Aucun `Cargo.toml` touche.

## Verification

`cargo check --workspace --all-targets` : **exit 0**, zero erreur. Les warnings
affichés sont preexistants (imports et fonctions inutilises dans `nexus-turn`
et `nexus-relay`), aucun n'est introduit ici.

La CI passe `cargo build --workspace` et `cargo test --workspace`.