### PR TITLE
fix(deps): fermeture des 4 avis npm ouverts (postcss, kit, nanoid, cookie)

### DIFF
--- a/nodyx-authenticator/package-lock.json
+++ b/nodyx-authenticator/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "nodyx-authenticator",
       "version": "0.0.1",
+      "license": "AGPL-3.0",
       "devDependencies": {
         "@sveltejs/adapter-auto": "^7.0.0",
         "@sveltejs/adapter-static": "^3.0.10",
@@ -908,9 +909,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.63.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.63.0.tgz",
-      "integrity": "sha512-1DrR7vQ9brXLrNE2sLtFXApwr7AUXPfpbIFYc+CQRf2+iURaZbXGU+7TG/RLr+9fdFkoRdyCAVUOHCChw11LFA==",
+      "version": "2.70.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.2.tgz",
+      "integrity": "sha512-RzRoRpuR2KXqc5yMO0akQHDZeT4AslOlznGITURsqHaVbtyYP4Wn3eE3gxj9JcDyNYO0crkxhdwFHc+2vkVm6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1837,9 +1838,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1887,9 +1888,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -1907,7 +1908,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/nodyx-store/package-lock.json
+++ b/nodyx-store/package-lock.json
@@ -1402,9 +1402,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/nodyx-store/package.json
+++ b/nodyx-store/package.json
@@ -24,5 +24,8 @@
     "typescript": "6.0.3",
     "vite": "^7.3.5",
     "vitest": "^4.1.9"
+  },
+  "overrides": {
+    "cookie": "^0.7.2"
   }
 }


### PR DESCRIPTION
Ferme les alertes Dependabot #169, #190, #148 et #216. Avec la #164 (PR #542),
le tableau de bord securite retombe a zero.

Les quatre sont en scope `development` : outils de build, absents du bundle
servi au navigateur. Corrigees quand meme pour vider le tableau et eviter
d'heriter silencieusement d'une version trouee au prochain deploy.

## nodyx-authenticator

`npm audit fix`, lockfile seul, `package.json` inchange (`^2.63.0` autorisait
deja 2.70.2).

| Paquet | Avant | Apres | Avis |
|---|---|---|---|
| `postcss` | 8.5.15 | 8.5.26 | GHSA-r28c-9q8g-f849 (high, #169) et GHSA-fxqj-rqcc-2cmp (medium, #190) |
| `@sveltejs/kit` | 2.63.x | 2.70.2 | GHSA-866w-xmhq-wj7x (medium, #148) |
| `nanoid` | 3.3.17 | 3.3.18 | GHSA-28wg-ghj8-5hjv et GHSA-2v37-7h3g-55p8 |

Deux notes : #190 est le rattrapage du correctif incomplet de #169, donc
8.5.23+ ferme les deux d'un coup. Et `nanoid` n'etait pas remonte par
Dependabot, c'est `npm audit` qui l'a trouve, il part avec le reste.

## nodyx-store

| Paquet | Avant | Apres | Avis |
|---|---|---|---|
| `cookie` | 0.6.0 | 0.7.2 | GHSA-pxg6-pf52-xh8x (low, #216) |

Ici `npm audit fix` ne suffit pas. Le dernier `@sveltejs/kit` publie (2.70.2)
declare toujours `cookie: ^0.6.0`, et un caret sur du `0.x` n'autorise pas
`0.7`. **Aucune version amont ne corrige donc le probleme.**

`npm audit fix --force` proposait de **retrograder** `@sveltejs/kit` vers
`0.0.30` et `@sveltejs/adapter-node` vers `0.0.18`, ce qui aurait detruit le
store. Non retenu, evidemment.

La sortie propre est un `overrides`, motif deja en place dans
`nodyx-authenticator` (`cookie: ^0.7.2`, `esbuild: ^0.28.1`). J'ai aligne le
store dessus.

Le lockfile du store a ete regenere avec `--package-lock-only` : `node_modules`
reste intact et le service PM2 en cours n'a pas ete perturbe. Le remplacement
effectif de `cookie` se fera au prochain deploy.

## Verifications

La CI couvre les deux projets via le job matriciel `check-satellites`
(`npm ci`, `npm run check`, `npm test` si l'app en a, `npm run build`), et les
deux jobs passent sur cette PR.

En local, avant de pousser :

| Projet | Resultat |
|---|---|
| authenticator | `npm run check` 0 erreur, `npm run build` exit 0, `npm audit` 0 vulnerabilite |
| store | copie isolee : `npm ci` + `npm run build` OK, `svelte-check` 338 fichiers 0 erreur 0 warning, `npm audit` 0 vulnerabilite |

Les 10 warnings a11y de l'authenticator sont preexistants et sans rapport
avec ce changement.