### PR TITLE
fix(forum): l'en-tête d'un sujet devient lisible sur téléphone

### DIFF
--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -4520,5 +4520,8 @@
   "ext_install.allowed_registries": "Registries accepted on this instance: {{list}}.",
   "amem.reveal_email": "reveal",
   "amem.revealing": "…",
-  "adash.member_joined": "new member"
+  "adash.member_joined": "new member",
+  "forum.share_copied": "Link copied",
+  "forum.share_failed": "Copy failed",
+  "forum.moderate": "Moderate"
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -4520,5 +4520,8 @@
   "ext_install.allowed_registries": "Registres acceptés sur cette instance : {{list}}.",
   "amem.reveal_email": "révéler",
   "amem.revealing": "…",
-  "adash.member_joined": "nouveau membre"
+  "adash.member_joined": "nouveau membre",
+  "forum.share_copied": "Lien copié",
+  "forum.share_failed": "Copie impossible",
+  "forum.moderate": "Modérer"
 }

--- a/nodyx-frontend/src/routes/forum/[category]/[thread]/+page.svelte
+++ b/nodyx-frontend/src/routes/forum/[category]/[thread]/+page.svelte
@@ -55,6 +55,51 @@
 		user && !threadPoll && (user.id === thread.author_id || isMod)
 	);
 
+	// ── Partage du sujet ──────────────────────────────────────────────────
+	// Le bouton existait depuis toujours SANS aucun gestionnaire : une pure
+	// décoration. `navigator.share` ouvre la feuille de partage du système,
+	// le seul geste qui ait du sens sur un téléphone ; ailleurs elle n'existe
+	// pas et on retombe sur le presse-papier.
+	let shareState = $state<'idle' | 'copied' | 'failed'>('idle');
+	let shareTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function flashShare(next: 'copied' | 'failed') {
+		shareState = next;
+		if (shareTimer) clearTimeout(shareTimer);
+		shareTimer = setTimeout(() => { shareState = 'idle' }, 2500);
+	}
+
+	async function shareThread() {
+		const url = $page.url.href;
+
+		if (typeof navigator !== 'undefined' && navigator.share) {
+			try {
+				await navigator.share({ title: thread.title, url });
+				return;
+			} catch (err) {
+				// Fermer la feuille de partage n'est pas un échec : on ne
+				// bascule PAS sur le presse-papier dans ce cas, sinon annuler
+				// un partage copierait quand même le lien dans le dos de
+				// l'utilisateur.
+				if ((err as Error)?.name === 'AbortError') return;
+			}
+		}
+
+		try {
+			await navigator.clipboard.writeText(url);
+			flashShare('copied');
+		} catch {
+			// Presse-papier refusé (contexte non sécurisé, permission). On le
+			// dit plutôt que de laisser le bouton muet, ce qui était justement
+			// le défaut d'origine.
+			flashShare('failed');
+		}
+	}
+
+	// Repli des actions de modération sur mobile : quatre boutons de plus sur
+	// une ligne de 375 px reproduiraient l'encombrement qu'on vient d'enlever.
+	let showModActions = $state(false);
+
 	function startEditTitle() {
 		titleInput   = thread.title;
 		editingTitle = true;
@@ -115,27 +160,17 @@
 <!-- ── En-tête du thread avec avatar créateur ─────────────────────────────── -->
 <div class="mb-8">
 	<!-- Fil d'Ariane -->
-	<div class="flex items-center justify-between mb-4">
-		<a href="/forum/{thread.category_slug ?? thread.category_id}" class="text-sm text-gray-500 hover:text-indigo-400 transition-colors flex items-center gap-1">
+	<!-- Les boutons Partager et Suivre vivaient ici. Partager descend dans la
+	     barre d'actions sous la carte, où il est enfin câblé. Suivre est retiré :
+	     la fonctionnalité n'existe pas côté nodyx-core (aucune route, aucune
+	     table), et un bouton qui ne fait rien ment à l'utilisateur. -->
+	<div class="mb-4">
+		<a href="/forum/{thread.category_slug ?? thread.category_id}" class="text-sm text-gray-500 hover:text-indigo-400 transition-colors inline-flex items-center gap-1">
 			<svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
 				<path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
 			</svg>
 			{tFn('forum.back_to_forum')}
 		</a>
-		
-		<!-- Partage / Actions rapides -->
-		<div class="flex items-center gap-2">
-			<button class="p-2bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-indigo-400 transition-colors" title={tFn('forum.action_share')}>
-				<svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-					<path stroke-linecap="round" stroke-linejoin="round" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
-				</svg>
-			</button>
-			<button class="p-2bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-yellow-400 transition-colors" title={tFn('forum.action_follow')}>
-				<svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-					<path stroke-linecap="round" stroke-linejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-				</svg>
-			</button>
-		</div>
 	</div>
 
 	<!-- Carte d'identité du thread avec avatar du créateur -->
@@ -205,14 +240,14 @@
 							bind:value={titleInput}
 							maxlength="300"
 							required
-							class="flex-1bg-gray-800 border border-indigo-600 px-3 py-2 text-white text-xl font-bold focus:outline-none focus:border-indigo-400"
+							class="flex-1 bg-gray-800 border border-indigo-600 px-3 py-2 text-white text-xl font-bold focus:outline-none focus:border-indigo-400"
 						/>
 						<button type="submit"
-							class="px-4 py-2bg-indigo-600 hover:bg-indigo-500 text-sm font-semibold text-white transition-colors">
+							class="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-sm font-semibold text-white transition-colors">
 							{tFn('common.save')}
 						</button>
 						<button type="button" onclick={() => editingTitle = false}
-							class="px-4 py-2bg-gray-700 hover:bg-gray-600 text-sm text-gray-300 transition-colors">
+							class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-sm text-gray-300 transition-colors">
 							{tFn('common.cancel')}
 						</button>
 					</form>
@@ -223,7 +258,7 @@
 							<button
 								type="button"
 								onclick={startEditTitle}
-								class="opacity-0 group-hover/title:opacity-100 transition-opacity mt-1 p-1.5text-gray-600 hover:text-gray-300 hover:bg-gray-800"
+								class="opacity-0 group-hover/title:opacity-100 transition-opacity mt-1 p-1.5 text-gray-600 hover:text-gray-300 hover:bg-gray-800"
 								title={tFn('forum.edit_title')}
 							>
 								<svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -290,17 +325,66 @@
 					</div>
 				</div>
 			</div>
+		</div>
+	</div>
 
-			<!-- Boutons de modération (à droite) -->
-			{#if isMod}
-				<div class="flex flex-col gap-2 flex-shrink-0">
+	<!-- ── Barre d'actions du sujet ──────────────────────────────────────────── -->
+	<!-- Ces boutons formaient une TROISIÈME colonne dans la ligne du titre, en
+	     `flex-shrink-0` et sans `flex-wrap` : sur un écran de 375 px, l'avatar
+	     et cette colonne ne laissaient qu'environ 215 px au titre. Descendus ici,
+	     ils ont leur propre ligne et le titre reprend toute la largeur.
+	     Les deux zones restent séparées à dessein : coller « Supprimer » contre
+	     « Ajouter un sondage » fabrique le mauvais clic sur l'action la moins
+	     réversible de la page. -->
+	<div class="mt-3 flex flex-wrap items-center justify-between gap-2">
+
+		<!-- Ce que le lecteur et l'auteur peuvent faire -->
+		<div class="flex flex-wrap items-center gap-2">
+			<button type="button" onclick={shareThread}
+				class="inline-flex items-center gap-2 px-3 py-1.5 border border-gray-700 text-xs font-medium text-gray-400 hover:text-indigo-400 hover:border-indigo-700 transition-colors">
+				<svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
+				</svg>
+				{tFn('forum.action_share')}
+			</button>
+
+			{#if shareState !== 'idle'}
+				<span role="status" class="text-xs {shareState === 'copied' ? 'text-indigo-400' : 'text-amber-400'}">
+					{shareState === 'copied' ? tFn('forum.share_copied') : tFn('forum.share_failed')}
+				</span>
+			{/if}
+
+			{#if canAddPoll}
+				<button type="button" onclick={() => showPollCreator = true}
+					class="inline-flex items-center gap-2 px-3 py-1.5 border border-dashed border-gray-700 text-xs font-medium text-gray-500 hover:text-indigo-400 hover:border-indigo-700 transition-colors">
+					<span>📊</span>
+					{tFn('forum.add_poll_thread')}
+				</button>
+			{/if}
+		</div>
+
+		<!-- Ce que seule la modération peut faire -->
+		{#if isMod}
+			<div class="w-full sm:w-auto">
+				<!-- Sur mobile les quatre actions sont repliées : les remettre en
+				     ligne sur 375 px reproduirait l'encombrement qu'on vient d'ôter. -->
+				<button type="button" onclick={() => showModActions = !showModActions}
+					aria-expanded={showModActions}
+					class="sm:hidden inline-flex items-center gap-2 px-3 py-1.5 border border-gray-700 text-xs font-medium text-gray-400 hover:text-gray-200 transition-colors">
+					<svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M12 3l7 4v5c0 4.418-2.867 7.75-7 9-4.133-1.25-7-4.582-7-9V7l7-4z" />
+					</svg>
+					{tFn('forum.moderate')}
+				</button>
+
+				<div class="{showModActions ? 'flex' : 'hidden'} sm:flex flex-wrap items-center gap-2 mt-2 sm:mt-0">
 					<!-- Épingler/Désépingler -->
 					<form method="POST" action="?/pinThread" use:enhance={() => {
 						return async ({ update }) => { await update({ reset: false }) }
 					}}>
 						<input type="hidden" name="is_pinned" value={!thread.is_pinned} />
 						<button type="submit"
-							class="w-full px-3 py-1.5border text-xs font-medium transition-colors
+							class="px-3 py-1.5 border text-xs font-medium transition-colors
 							{thread.is_pinned
 								? 'border-indigo-700 text-indigo-400 bg-indigo-900/20 hover:bg-indigo-900/40'
 								: 'border-gray-700 text-gray-400 hover:text-indigo-400 hover:border-indigo-700'}">
@@ -314,7 +398,7 @@
 					}}>
 						<input type="hidden" name="is_locked" value={!thread.is_locked} />
 						<button type="submit"
-							class="w-full px-3 py-1.5border text-xs font-medium transition-colors
+							class="px-3 py-1.5 border text-xs font-medium transition-colors
 							{thread.is_locked
 								? 'border-amber-700 text-amber-400 bg-amber-900/20 hover:bg-amber-900/40'
 								: 'border-gray-700 text-gray-400 hover:text-amber-400 hover:border-amber-700'}">
@@ -328,7 +412,7 @@
 					}}>
 						<input type="hidden" name="is_featured" value={!thread.is_featured} />
 						<button type="submit"
-							class="w-full px-3 py-1.5border text-xs font-medium transition-colors
+							class="px-3 py-1.5 border text-xs font-medium transition-colors
 							{thread.is_featured
 								? 'border-yellow-700 text-yellow-400 bg-yellow-900/20 hover:bg-yellow-900/40'
 								: 'border-gray-700 text-gray-400 hover:text-yellow-400 hover:border-yellow-700'}">
@@ -340,12 +424,12 @@
 					{#if !confirmDeleteThread}
 						<button type="button"
 							onclick={() => confirmDeleteThread = true}
-							class="w-full px-3 py-1.5border border-red-800 text-xs font-medium text-red-400 hover:bg-red-900/20 transition-colors">
+							class="px-3 py-1.5 border border-red-800 text-xs font-medium text-red-400 hover:bg-red-900/20 transition-colors">
 							🗑 {tFn('common.delete')}
 						</button>
 					{:else}
-						<div class="flex flex-col gap-1">
-							<span class="text-xs text-red-400 text-center">{tFn('forum.confirm')}</span>
+						<div class="inline-flex items-center gap-2">
+							<span class="text-xs text-red-400">{tFn('forum.confirm')}</span>
 							<form method="POST" action="?/deleteThread"
 								use:enhance={() => async ({ result }) => {
 									// Invalide TOUS les caches de chargement (home, catégorie...)
@@ -353,19 +437,19 @@
 									if (result.type === 'redirect') await goto(result.location, { invalidateAll: true });
 									else { await applyAction(result); await invalidateAll(); }
 								}}>
-								<button type="submit" class="w-full px-2 py-1 bg-red-700 hover:bg-red-600 text-xs text-white font-medium">
+								<button type="submit" class="px-2 py-1 bg-red-700 hover:bg-red-600 text-xs text-white font-medium">
 									{tFn('forum.delete_confirm_yes')}
 								</button>
 							</form>
 							<button type="button" onclick={() => confirmDeleteThread = false}
-								class="w-full px-2 py-1bg-gray-700 text-xs text-gray-300 hover:bg-gray-600">
+								class="px-2 py-1 bg-gray-700 text-xs text-gray-300 hover:bg-gray-600">
 								{tFn('common.cancel')}
 							</button>
 						</div>
 					{/if}
 				</div>
-			{/if}
-		</div>
+			</div>
+		{/if}
 	</div>
 </div>
 
@@ -379,18 +463,9 @@
 			socket={null}
 		/>
 	</div>
-{:else if canAddPoll}
-	<div class="mb-6">
-		<button
-			type="button"
-			onclick={() => showPollCreator = true}
-			class="flex items-center gap-2 px-4 py-2border border-dashed border-gray-700 text-sm text-gray-500 hover:text-indigo-400 hover:border-indigo-700 transition-colors"
-		>
-			<span>📊</span>
-			<span>{tFn('forum.add_poll_thread')}</span>
-		</button>
-	</div>
 {/if}
+<!-- Le bouton « Ajouter un sondage » vivait ici ; il a rejoint la barre
+     d'actions sous l'en-tête, avec les autres gestes de l'auteur. -->
 
 {#if showPollCreator}
 	<PollCreator
@@ -455,7 +530,7 @@
 							{#if canEdit(post) && editingPostId !== post.id}
 								<button type="button"
 									onclick={() => { editingPostId = post.id; deletingPostId = null }}
-									class="px-2 py-1text-xs text-gray-500 hover:text-indigo-400 hover:bg-indigo-900/20 transition-colors"
+									class="px-2 py-1 text-xs text-gray-500 hover:text-indigo-400 hover:bg-indigo-900/20 transition-colors"
 									title={tFn('forum.edit_message_title')}>
 									✏️ {tFn('common.edit')}
 								</button>
@@ -464,7 +539,7 @@
 								{#if deletingPostId !== post.id}
 									<button type="button"
 										onclick={() => { deletingPostId = post.id; editingPostId = null }}
-										class="px-2 py-1text-xs text-gray-500 hover:text-red-400 hover:bg-red-900/20 transition-colors"
+										class="px-2 py-1 text-xs text-gray-500 hover:text-red-400 hover:bg-red-900/20 transition-colors"
 										title={tFn('forum.delete_message_title')}>
 										🗑 {tFn('common.delete')}
 									</button>
@@ -479,11 +554,11 @@
 									}} class="inline-flex items-center gap-1 ml-1">
 										<input type="hidden" name="post_id" value={post.id} />
 										<button type="submit"
-											class="px-2 py-1bg-red-700 hover:bg-red-600 text-xs text-white font-medium">
+											class="px-2 py-1 bg-red-700 hover:bg-red-600 text-xs text-white font-medium">
 											Oui
 										</button>
 										<button type="button" onclick={() => deletingPostId = null}
-											class="px-2 py-1bg-gray-700 text-xs text-gray-300 hover:bg-gray-600">
+											class="px-2 py-1 bg-gray-700 text-xs text-gray-300 hover:bg-gray-600">
 											Non
 										</button>
 									</form>
@@ -512,12 +587,12 @@
 						/>
 						<div class="flex gap-2">
 							<button type="submit"
-								class="px-3 py-1.5bg-indigo-600 hover:bg-indigo-500 text-xs font-semibold text-white transition-colors">
+								class="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-500 text-xs font-semibold text-white transition-colors">
 								{tFn('common.save')}
 							</button>
 							<button type="button"
 								onclick={() => editingPostId = null}
-								class="px-3 py-1.5bg-gray-700 hover:bg-gray-600 text-xs text-gray-300 transition-colors">
+								class="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-xs text-gray-300 transition-colors">
 								{tFn('common.cancel')}
 							</button>
 						</div>

--- a/nodyx-frontend/src/routes/forum/[category]/new/+page.svelte
+++ b/nodyx-frontend/src/routes/forum/[category]/new/+page.svelte
@@ -66,7 +66,7 @@
 	<h1 class="mt-2 text-2xl font-bold text-white mb-6">{tFn('forum.create_topic')}</h1>
 
 	{#if form?.error}
-		<p class="mb-4bg-red-900/50 border border-red-700 px-4 py-2 text-sm text-red-300">
+		<p class="mb-4 bg-red-900/50 border border-red-700 px-4 py-2 text-sm text-red-300">
 			{form.error}
 		</p>
 	{/if}
@@ -168,7 +168,7 @@
 				<button
 					type="button"
 					onclick={() => showPollSection = true}
-					class="flex items-center gap-2 px-3 py-2border border-dashed border-gray-700 text-sm text-gray-500 hover:text-indigo-400 hover:border-indigo-700 transition-colors"
+					class="flex items-center gap-2 px-3 py-2 border border-dashed border-gray-700 text-sm text-gray-500 hover:text-indigo-400 hover:border-indigo-700 transition-colors"
 				>
 					<span>📊</span>
 					<span>{tFn('forum.attach_poll')} <span class="text-gray-600 text-xs">{tFn('common.optional')}</span></span>


### PR DESCRIPTION
## La cause du désastre mobile

La ligne du titre portait **trois** colonnes flex : l'avatar, les infos, et une
colonne de modération en `flex-shrink-0`, le tout **sans `flex-wrap`**. Sur un
écran de 375 px : 48 px d'avatar, 12 px de gouttière, une centaine de pixels de
boutons. Il restait environ **215 px pour le titre**.

## Ce que ça devient

Les actions descendent dans une barre sous la carte, en deux zones separees a
dessein :

| Zone | Contenu |
|---|---|
| Gauche, lecteur et auteur | Partager, Ajouter un sondage |
| Droite, modération | Épingler, Verrouiller, Rétrograder, Supprimer |

Coller « Supprimer » contre « Ajouter un sondage » fabriquerait le mauvais clic
sur l'action la moins réversible de la page : les deux groupes restent séparés.
Sur mobile, les quatre actions de modération sont repliées derrière un bouton
« Modérer », parce que les remettre en ligne sur 375 px reproduirait
l'encombrement qu'on vient d'ôter.

## Les deux boutons du haut

**Partager** était un `<button>` **sans le moindre gestionnaire**, une pure
décoration. Il est câblé : `navigator.share` ouvre la feuille de partage du
système sur mobile, ailleurs on retombe sur le presse-papier avec un retour
visible. Fermer la feuille de partage n'est pas traité comme un échec, sinon
annuler un partage copierait quand même le lien dans le dos de l'utilisateur.

**Suivre est retiré.** Il ne fonctionnait pas parce que **la fonctionnalité
n'existe pas** : les 10 routes forum de nodyx-core ne comportent aucun
abonnement à un sujet, et aucune table ne le porte. Les seules
`subscriptions` du dépôt sont les abonnements Web Push, sans rapport. Un bouton
qui ne fait rien ment à l'utilisateur. Le rebrancher demande une migration, deux
routes et un raccordement aux notifications : c'est un chantier à part.

## Un bug de fond trouvé au passage

**20 classes Tailwind avaient perdu leur espace** dans ces deux fichiers :

```
p-2bg-gray-800      →  p-2 bg-gray-800
py-1.5border        →  py-1.5 border
flex-1bg-gray-800   →  flex-1 bg-gray-800
p-1.5text-gray-600  →  p-1.5 text-gray-600
```

Ce ne sont pas des classes valides : Tailwind ne generait **rien**. Les deux
boutons du haut n'avaient ni fond ni rembourrage, et les quatre boutons de
modération **ni bordure ni rembourrage**. Ça ressemble à une suppression globale
d'un `rounded ` ayant mangé l'espace au passage. Corrigé par une substitution
dont le diff est purement blanc : 20 insertions, 20 suppressions.

## i18n

Trois clés neuves, livrées dans `fr.json` **et** `en.json` dans cette PR :

| Clé | FR | EN |
|---|---|---|
| `forum.share_copied` | Lien copié | Link copied |
| `forum.share_failed` | Copie impossible | Copy failed |
| `forum.moderate` | Modérer | Moderate |

Parité conservée à 4525 clés de chaque côté.

## Vérifications

| Contrôle | Résultat |
|---|---|
| `npm run check` | **0 erreur**, aucun avertissement nouveau |
| `i18n:check` | pass |
| `i18n:keys:check` | pass |
| `i18n:parity:check` | pass |
| `i18n:placeholders:check` | pass |

**Le rendu visuel n'a pas été contrôlé dans un navigateur**, c'est la seule
chose que cette PR ne prouve pas. La CI construit le frontend.