### PR TITLE
fix(forum): le message d'ouverture n'est pas une réponse

### DIFF
--- a/nodyx-frontend/src/lib/components/homepage/widgets/RecentThreads.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/RecentThreads.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte'
+	import { replyCount } from '$lib/forumCounts';
 	import { t, locale } from '$lib/i18n'
 
 	const tFn = $derived($t)
@@ -120,7 +121,7 @@
 								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 									<path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
 								</svg>
-								{t.post_count}
+								{replyCount(t.post_count)}
 							</span>
 						{/if}
 					</div>
@@ -159,12 +160,12 @@
 							{#if showDate}
 								<span class="rt-meta-date">{timeAgo(t.last_post_at ?? t.created_at)}</span>
 							{/if}
-							{#if showReplies && t.post_count > 0}
+							{#if showReplies && replyCount(t.post_count) > 0}
 								<span class="rt-meta-replies">
 									<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 										<path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
 									</svg>
-									{t.post_count}
+									{replyCount(t.post_count)}
 								</span>
 							{/if}
 						</div>

--- a/nodyx-frontend/src/lib/forumCounts.test.ts
+++ b/nodyx-frontend/src/lib/forumCounts.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { replyCount, isUnanswered } from './forumCounts'
+
+describe('replyCount', () => {
+	// Le cas exact rapporté : un sujet ouvert, aucune réponse, affichait
+	// « 1 réponse ». Ce test TOMBE sur l'ancien code (qui rendait post_count tel quel).
+	it('un sujet avec le seul message d ouverture a ZERO reponse', () => {
+		expect(replyCount(1)).toBe(0)
+	})
+
+	it('retranche toujours le message d ouverture', () => {
+		expect(replyCount(2)).toBe(1)
+		expect(replyCount(10)).toBe(9)
+		expect(replyCount(45)).toBe(44)
+	})
+
+	// Le premier message n'est pas protégé contre la suppression : un sujet peut
+	// tomber à 0 message. Sans la borne, l'écran afficherait « -1 réponse ».
+	it('ne descend jamais sous zero', () => {
+		expect(replyCount(0)).toBe(0)
+		expect(replyCount(-5)).toBe(0)
+	})
+
+	it('traite l absence de valeur comme zero', () => {
+		expect(replyCount(null)).toBe(0)
+		expect(replyCount(undefined)).toBe(0)
+	})
+})
+
+describe('isUnanswered', () => {
+	// La cause du filtre vide : la condition d origine etait `post_count === 0`,
+	// qu AUCUN sujet ne pouvait satisfaire puisque tous portent leur ouverture.
+	it('est vrai pour un sujet qui n a que son ouverture', () => {
+		expect(isUnanswered(1)).toBe(true)
+	})
+
+	it('est faux des la premiere reponse', () => {
+		expect(isUnanswered(2)).toBe(false)
+		expect(isUnanswered(30)).toBe(false)
+	})
+
+	it('reste vrai pour un sujet vide ou une valeur absente', () => {
+		expect(isUnanswered(0)).toBe(true)
+		expect(isUnanswered(null)).toBe(true)
+	})
+
+	// Garde-fou de non-regression : sur les donnees reelles de nodyx.org au
+	// 2026-08-14, 14 sujets sur 58 n avaient qu un seul message. Le filtre doit
+	// les faire apparaitre, la ou il en montrait zero.
+	it('selectionne bien les sujets a un seul message dans une liste', () => {
+		const sujets = [{ post_count: 1 }, { post_count: 1 }, { post_count: 5 }, { post_count: 2 }]
+		expect(sujets.filter(s => isUnanswered(s.post_count)).length).toBe(2)
+	})
+})

--- a/nodyx-frontend/src/lib/forumCounts.ts
+++ b/nodyx-frontend/src/lib/forumCounts.ts
@@ -1,0 +1,36 @@
+/**
+ * Nombre de RÉPONSES d'un sujet, à partir de son nombre de messages.
+ *
+ * Pourquoi ce helper existe (2026-08-14)
+ * ──────────────────────────────────────
+ * À la création d'un sujet, le corps du message est inséré comme une ligne de
+ * la table `posts` (`forums.ts`, `PostModel.create` juste après `createThread`).
+ * Le `post_count` renvoyé par l'API compte donc le message d'ouverture.
+ *
+ * Conséquence, avant ce helper : un sujet sans la moindre réponse affichait
+ * « 1 réponse », et le filtre « sans réponse » cherchait `post_count === 0`,
+ * une condition qu'AUCUN sujet ne pouvait satisfaire. Sur nodyx.org, 14 sujets
+ * sur 58 étaient réellement sans réponse et le filtre en affichait zéro.
+ *
+ * Le backend connaissait déjà la distinction : la réputation n'accorde pas le
+ * bonus « réponse » au premier message. Seul l'affichage l'ignorait.
+ *
+ * `post_count` reste juste et n'est PAS modifié : c'est bien un nombre de
+ * messages. C'est l'appeler « réponses » qui était faux.
+ *
+ * ATTENTION : ne s'applique QU'AU compteur d'un sujet. Le `post_count` d'un
+ * utilisateur (profil, tableau des membres) ou d'une catégorie compte de vrais
+ * messages et ne doit surtout pas être décrémenté.
+ */
+export function replyCount(postCount: number | null | undefined): number {
+	// `Math.max(0, …)` n'est pas de la superstition : rien n'empêche aujourd'hui
+	// de supprimer le premier message d'un sujet (`DELETE /posts/:id` ne le
+	// protège pas), ce qui laisserait un sujet à 0 message et produirait un
+	// « -1 réponse » à l'écran.
+	return Math.max(0, (postCount ?? 0) - 1)
+}
+
+/** Un sujet est sans réponse quand il ne porte que son message d'ouverture. */
+export function isUnanswered(postCount: number | null | undefined): boolean {
+	return replyCount(postCount) === 0
+}

--- a/nodyx-frontend/src/routes/+page.svelte
+++ b/nodyx-frontend/src/routes/+page.svelte
@@ -2,6 +2,7 @@
 	import type { PageData } from './$types';
 	import { onMount, onDestroy } from 'svelte';
 	import { t } from '$lib/i18n';
+	import { replyCount } from '$lib/forumCounts';
 	import WidgetZone from '$lib/components/homepage/WidgetZone.svelte';
 	import GridRenderer from '$lib/components/homepage/GridRenderer.svelte';
 	import type { PublicExtension } from '$lib/components/homepage/extensionCatalog';
@@ -556,8 +557,8 @@
 						<span class="text-[10px] ml-auto" style="color: #374151">{timeAgo(thread.created_at)}</span>
 					</div>
 				</div>
-				{#if (thread.post_count ?? 0) > 1}
-					<span class="sg shrink-0 text-[10px] font-bold tabular-nums mt-0.5" style="color: #374151">{thread.post_count}</span>
+				{#if replyCount(thread.post_count) > 0}
+					<span class="sg shrink-0 text-[10px] font-bold tabular-nums mt-0.5" style="color: #374151">{replyCount(thread.post_count)}</span>
 				{/if}
 			</a>
 			{:else}
@@ -622,7 +623,7 @@
 					<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
 					</svg>
-					<span class="sg text-[10px] font-bold">{thread.post_count ?? 0}</span>
+					<span class="sg text-[10px] font-bold">{replyCount(thread.post_count)}</span>
 				</div>
 			</div>
 

--- a/nodyx-frontend/src/routes/forum/[category]/+page.svelte
+++ b/nodyx-frontend/src/routes/forum/[category]/+page.svelte
@@ -4,6 +4,7 @@
 	import type { FlyParams, FadeParams } from 'svelte/transition';
 	import { page } from '$app/stores';
 	import { t } from '$lib/i18n';
+	import { replyCount, isUnanswered } from '$lib/forumCounts';
 
 	const tFn = $derived($t)
 
@@ -95,10 +96,10 @@
 				filtered = filtered.filter(t => t.is_pinned);
 				break;
 			case 'unanswered':
-				filtered = filtered.filter(t => (t.post_count || 0) === 0);
+				filtered = filtered.filter(t => isUnanswered(t.post_count));
 				break;
 			case 'popular':
-				filtered = filtered.filter(t => (t.post_count || 0) >= 10);
+				filtered = filtered.filter(t => replyCount(t.post_count) >= 10);
 				break;
 			case 'today':
 				const today = new Date();
@@ -124,6 +125,9 @@
 					new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
 				);
 			case 'popular':
+				// Volontairement sur post_count et non sur replyCount : retrancher le
+				// message d'ouverture des DEUX côtés ne change pas l'ordre. Passer par
+				// le helper ici n'apporterait rien qu'un appel de plus par comparaison.
 				return filtered.sort((a, b) => (b.post_count || 0) - (a.post_count || 0));
 			case 'views':
 				return filtered.sort((a, b) => (b.views || 0) - (a.views || 0));
@@ -225,8 +229,8 @@
 	const categoryStats = $derived({
 		total: threads.length,
 		pinned: threads.filter(t => t.is_pinned).length,
-		unanswered: threads.filter(t => (t.post_count || 0) === 0).length,
-		popular: threads.filter(t => (t.post_count || 0) >= 10).length,
+		unanswered: threads.filter(t => isUnanswered(t.post_count)).length,
+		popular: threads.filter(t => replyCount(t.post_count) >= 10).length,
 		today: threads.filter(t => {
 			const today = new Date();
 			today.setHours(0, 0, 0, 0);
@@ -688,7 +692,7 @@
 				<div class="flex items-center gap-4 shrink-0">
 					<!-- Compteur de réponses -->
 					<div class="flex flex-col items-center px-3 py-1.5 border border-white/[.06] group-hover:border-indigo-700/50 transition-colors min-w-[60px] text-center">
-						<span class="text-lg font-bold text-indigo-400 leading-none">{thread.post_count}</span>
+						<span class="text-lg font-bold text-indigo-400 leading-none">{replyCount(thread.post_count)}</span>
 						<span class="text-[10px] text-gray-500 uppercase tracking-wider">{tFn('forum.replies_label')}</span>
 					</div>
 

--- a/nodyx-frontend/src/routes/forum/[category]/[thread]/+page.svelte
+++ b/nodyx-frontend/src/routes/forum/[category]/[thread]/+page.svelte
@@ -19,6 +19,7 @@
 	import PollCard from '$lib/components/PollCard.svelte';
 	import PollCreator from '$lib/components/PollCreator.svelte';
 	import { t } from '$lib/i18n';
+	import { replyCount } from '$lib/forumCounts';
 
 	const tFn = $derived($t)
 
@@ -35,6 +36,9 @@
 			$page.url.origin,
 		) ?? `${$page.url.origin}/og-image.jpg`,
 	);
+	// post_count compte le message d'ouverture : ce n'est PAS un nombre de
+	// réponses. Voir $lib/forumCounts.
+	const replies = $derived(replyCount(thread.post_count));
 	const user   = $derived(data.user);
 	const isMod  = $derived(user?.role === 'owner' || user?.role === 'admin' || user?.role === 'moderator');
 
@@ -125,7 +129,7 @@
 	<meta name="description" content="Discussion : {thread.title} par {thread.author_username}" />
 	<link rel="canonical" href={$page.url.href} />
 	<meta property="og:title"       content="{thread.title} · {$page.data.communityName ?? 'Nodyx'}" />
-	<meta property="og:description" content="Discussion par {thread.author_username} · {thread.post_count} {tFn('forum.replies_label')} · {thread.views} {tFn('forum.views')}" />
+	<meta property="og:description" content="Discussion par {thread.author_username} · {replies} {tFn('forum.replies_label')} · {thread.views} {tFn('forum.views')}" />
 	<meta property="og:type"        content="article" />
 	<meta property="og:url"         content={$page.url.href} />
 	<!-- Pas de og:image:width/height ici : l'image de tête d'un article a des
@@ -143,7 +147,7 @@
 		"author": { "@type": "Person", "name": thread.author_username },
 		"datePublished": thread.created_at,
 		"dateModified": thread.updated_at ?? thread.created_at,
-		"commentCount": thread.post_count,
+		"commentCount": replies,
 		"interactionStatistic": {
 			"@type": "InteractionCounter",
 			"interactionType": "https://schema.org/ViewAction",
@@ -299,7 +303,7 @@
 							<svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
 							</svg>
-							<span class="font-medium text-gray-300">{thread.post_count}</span>
+							<span class="font-medium text-gray-300">{replies}</span>
 							<span class="text-gray-600 text-xs">{tFn('forum.replies_label')}</span>
 						</div>
 

--- a/nodyx-frontend/src/routes/rss.xml/+server.ts
+++ b/nodyx-frontend/src/routes/rss.xml/+server.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from './$types';
 import { apiFetch } from '$lib/api';
+import { replyCount } from '$lib/forumCounts';
 
 const BASE_URL  = 'https://nodyx.example.com';
 const SITE_NAME = 'Nodyx';
@@ -28,7 +29,7 @@ export const GET: RequestHandler = async ({ fetch }) => {
       <pubDate>${new Date(thread.created_at).toUTCString()}</pubDate>
       <author>${thread.author_username}</author>
       <category><![CDATA[${category.name}]]></category>
-      <description><![CDATA[Sujet posté par ${thread.author_username} dans ${category.name}, ${thread.post_count} réponse(s)]]></description>
+      <description><![CDATA[Sujet posté par ${thread.author_username} dans ${category.name}, ${replyCount(thread.post_count)} réponse(s)]]></description>
     </item>`);
 				}
 			}


### PR DESCRIPTION
## Le défaut

À la création d'un sujet, le corps du message est inséré comme une ligne de la
table `posts` (`forums.ts`, `PostModel.create` juste après `createThread`).
`post_count` compte donc **le message d'ouverture**.

Sur le sujet signalé, l'unique post a été créé **17 millisecondes** après le
sujet lui-même : c'est l'ouverture, pas une réponse.

Deux conséquences visibles :

1. Un sujet sans la moindre réponse affiche « 1 réponse ».
2. Le filtre « sans réponse » cherchait `post_count === 0`, une condition
   qu'**aucun sujet ne pouvait satisfaire**.

Données réelles de nodyx.org au moment du correctif :

| Sujets | Nombre |
|---|---|
| avec 0 message en base | 0 |
| avec exactement 1 message, donc **0 réponse** | **14** |
| avec plus d'un message | 44 |
| total | 58 |

Le filtre devait montrer 14 sujets, il en montrait zéro.

Le backend connaissait déjà la distinction : la réputation n'accorde pas le
bonus « réponse » au premier message, commentaire à l'appui dans `forums.ts`.
Seul l'affichage l'ignorait.

## Le correctif

`post_count` n'est **pas** modifié et **nodyx-core n'est pas touché** : ce
compteur est juste, c'est l'appeler « réponses » qui était faux.

Tout passe par un helper partagé, `$lib/forumCounts`, plutôt que par un `-1`
dispersé dans sept fichiers où le prochain appelant aurait oublié de le mettre.

### Appelants câblés, tous vérifiés au grep

| Endroit | Ce qui est corrigé |
|---|---|
| Page sujet | badge visible, `og:description`, `commentCount` du JSON-LD (schema.org compte les commentaires reçus, pas l'article) |
| Page catégorie | filtres « sans réponse » et « populaire », les deux statistiques d'en-tête, badge de la liste |
| Accueil | deux emplacements. Le garde `> 1` était un contournement qui masquait le badge sans corriger le nombre |
| Widget `RecentThreads` | trois emplacements |
| Flux RSS | « X réponse(s) » |

### Volontairement non touchés

Le **tri par popularité** : retrancher 1 des deux côtés ne change pas l'ordre,
c'est annoté sur place pour qu'on ne le « corrige » pas par erreur plus tard.

Et tous les `post_count` qui comptent de **vrais messages** : profil
utilisateur, tableau des membres, totaux de catégorie, modération, `StatsBar`,
statistiques d'instance. Vérifié fichier par fichier après coup, aucun n'est
modifié.

### Une borne qui n'est pas de la superstition

`replyCount` est borné à zéro par `Math.max`. `DELETE /posts/:id` ne protège
pas le premier message : un sujet peut tomber à 0 message, ce qui afficherait
« -1 réponse ».

## Vérifications

| Contrôle | Résultat |
|---|---|
| Tests unitaires neufs | **8**, dont un qui **tombe sur l'ancien code** (un sujet à un seul message doit valoir 0 réponse) |
| Suite frontend complète | **102 tests verts** |
| `npm run check` | **0 erreur**, aucun avertissement nouveau |
| 4 portes i18n | pass |

Aucune chaîne neuve : les libellés existants (`forum.replies_label`,
`forum.filter_unanswered`) sont réutilisés tels quels.