### PR TITLE
fix(ui): la barre de navigation mobile devient opaque, et Playwright la garde

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,9 @@ docs/seo/
 # Briefs de communautés hébergées (cahiers des charges + visuels fournis par
 # leurs auteurs) : contenu privé de l'instance concernée, pas de la plateforme.
 docs/Multigaming/
+
+# Playwright, tests de rendu et responsive (artefacts locaux)
+nodyx-frontend/test-results/
+nodyx-frontend/playwright-report/
+nodyx-frontend/blob-report/
+.cache/ms-playwright/

--- a/nodyx-frontend/package-lock.json
+++ b/nodyx-frontend/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "nodyx-frontend",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodyx-frontend",
-      "version": "2.11.0",
+      "version": "2.12.0",
+      "license": "AGPL-3.0",
       "dependencies": {
         "@iconify/svelte": "^5.2.2",
         "@jitsi/rnnoise-wasm": "0.2.1",
@@ -36,6 +37,7 @@
         "socket.io-client": "4.8.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@sveltejs/adapter-auto": "7.0.1",
         "@sveltejs/adapter-node": "5.5.7",
         "@sveltejs/kit": "^2.68.0",
@@ -583,6 +585,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@polka/url": {
@@ -3726,6 +3744,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/nodyx-frontend/package.json
+++ b/nodyx-frontend/package.json
@@ -20,9 +20,12 @@
     "i18n:placeholders:check": "node scripts/i18n/check-placeholders.mjs --check --quiet",
     "i18n:parity:check": "node scripts/i18n/coverage.mjs --require en",
     "i18n:public:check": "node scripts/i18n/scan.mjs --public --check",
-    "i18n:check": "node scripts/i18n/scan.mjs --check"
+    "i18n:check": "node scripts/i18n/scan.mjs --check",
+    "test:responsive": "playwright test",
+    "test:responsive:ui": "playwright test --ui"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@sveltejs/adapter-auto": "7.0.1",
     "@sveltejs/adapter-node": "5.5.7",
     "@sveltejs/kit": "^2.68.0",

--- a/nodyx-frontend/playwright.config.ts
+++ b/nodyx-frontend/playwright.config.ts
@@ -1,0 +1,52 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Tests de rendu et de responsive.
+ *
+ * Pourquoi ils existent (2026-08-15)
+ * ──────────────────────────────────
+ * Vitest ne voit rien de ce qui se passe à l'écran. Une barre de navigation
+ * devenue transparente, une page qui déborde à 360px ou une cible tactile de
+ * 6px passent tous les contrôles existants : `npm run check`, les quatre portes
+ * i18n et le build sont verts pendant que l'interface est cassée.
+ *
+ * On teste les DEUX moteurs qui divergent vraiment :
+ *   - Chromium, pour Chrome, Edge, Opera, Brave, et le futur client Windows
+ *   - WebKit, pour Safari, pour TOUS les navigateurs sur iPhone (Apple impose
+ *     son moteur), et pour le futur client Linux (Tauri y utilise WebKitGTK)
+ * Firefox est volontairement absent en v1 : Gecko diverge peu sur ces
+ * propriétés, et chaque moteur coûte du temps de CI.
+ *
+ * Cible par défaut : l'instance publique. Surchargeable pour tester une autre
+ * instance ou une préversion locale :
+ *
+ *     BASE_URL=http://127.0.0.1:4173 npm run test:responsive
+ *
+ * NON branché à la CI pour l'instant, à dessein. La règle maison interdit de
+ * fusionner sans CI verte ; un test de bout en bout instable deviendrait une
+ * taxe permanente sur chaque PR. On le branchera quand ces tests auront prouvé
+ * leur stabilité sur plusieurs jours.
+ */
+export default defineConfig({
+	testDir: './tests/responsive',
+	// Un test de rendu qui dépend de l'ordre d'exécution ment.
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 1 : 0,
+	reporter: process.env.CI ? 'github' : 'list',
+
+	use: {
+		baseURL: process.env.BASE_URL ?? 'https://nodyx.org',
+		// Une capture ne sert qu'en cas d'échec, sinon elle encombre.
+		screenshot: 'only-on-failure',
+		trace: 'retain-on-failure',
+		// Le SSR passe par l'API : sur une instance chargée, 15s est court.
+		navigationTimeout: 45_000,
+	},
+
+	projects: [
+		{ name: 'mobile-chromium', use: { ...devices['Pixel 7'] } },
+		{ name: 'mobile-webkit',   use: { ...devices['iPhone 14'] } },
+		{ name: 'tablette-webkit', use: { ...devices['iPad Mini'] } },
+	],
+})

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -1649,8 +1649,15 @@
 
 	<!-- ══ BOTTOM NAV mobile (lg:hidden) — hidden for banned users ═════════ -->
 	{#if !isBanned}
+	<!-- Fond OPAQUE, et surtout pas `--p-card-bg`. Celui-ci est un fond de CARTE :
+	     six thèmes sur sept sont translucides par construction, dont un à 5%
+	     d'opacité. Une carte translucide posée sur un fond de page est voulue,
+	     une barre FIXE avec du contenu qui défile dessous devient du verre. Le
+	     2026-08-15, on lisait « Dernier message » et « Pokled » au travers, par
+	     dessus les icônes. `--p-bg` est opaque sur les sept thèmes.
+	     Gardé par tests/responsive/bottom-nav.spec.ts. -->
 	<nav class="lg:hidden fixed bottom-0 left-0 right-0 z-45 border-t border-gray-800 flex items-stretch"
-	     style="background: var(--p-card-bg); border-color: var(--p-card-border); padding-bottom: env(safe-area-inset-bottom, 0px)">
+	     style="background: var(--p-bg); border-color: var(--p-card-border); padding-bottom: env(safe-area-inset-bottom, 0px)">
 
 		<!-- Fil d'actu (si connecté) -->
 		{#if user}

--- a/nodyx-frontend/tests/responsive/bottom-nav.spec.ts
+++ b/nodyx-frontend/tests/responsive/bottom-nav.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * La barre de navigation du bas, sur mobile.
+ *
+ * Défaut d'origine, constaté le 2026-08-15 : la barre utilisait `--p-card-bg`,
+ * c'est-à-dire un fond de CARTE. Six thèmes sur sept sont translucides par
+ * construction, dont un à 5% d'opacité, et aucun `backdrop-filter` ne venait
+ * rattraper. Résultat mesuré en capture : sur Chromium on LISAIT « Dernier
+ * message » et « Pokled » au travers de la barre, par-dessus les icônes.
+ *
+ * Une carte translucide posée sur un fond de page, c'est voulu. Une barre FIXE
+ * avec du contenu qui défile dessous, c'est du verre.
+ */
+
+/** Récupère la barre fixe du bas, celle qui n'existe qu'en dessous de `lg`. */
+async function barreDuBas(page: Page) {
+	return page.evaluate(() => {
+		const nav = [...document.querySelectorAll('nav')]
+			.find((n) => {
+				const s = getComputedStyle(n)
+				return s.position === 'fixed' && n.getBoundingClientRect().top > window.innerHeight / 2
+			})
+		if (!nav) return null
+		const s = getComputedStyle(nav)
+		const r = nav.getBoundingClientRect()
+		return {
+			fond: s.backgroundColor,
+			backdrop: s.backdropFilter,
+			hauteur: Math.round(r.height),
+			cibles: [...nav.querySelectorAll('a, button')].map((el) => {
+				const cr = el.getBoundingClientRect()
+				return { w: Math.round(cr.width), h: Math.round(cr.height) }
+			}),
+		}
+	})
+}
+
+/** `rgba(r,g,b,a)` ou `rgb(r,g,b)` vers son canal alpha. */
+function alpha(couleur: string): number {
+	const m = couleur.match(/rgba?\(([^)]+)\)/)
+	if (!m) return 1
+	const parts = m[1].split(',').map((v) => parseFloat(v.trim()))
+	return parts.length >= 4 ? parts[3] : 1
+}
+
+test.describe('barre de navigation mobile', () => {
+	test('elle est opaque, sinon le contenu se lit au travers', async ({ page }, info) => {
+		test.skip(info.project.name.startsWith('tablette'), 'la barre est masquée à partir de lg')
+
+		await page.goto('/forum', { waitUntil: 'domcontentloaded' })
+		await page.waitForTimeout(1500)
+
+		const barre = await barreDuBas(page)
+		expect(barre, 'barre du bas introuvable').not.toBeNull()
+
+		// Le cœur du test. Il DOIT tomber sur l'ancien code, qui servait
+		// rgba(17,24,39,0.8) sans aucun flou.
+		const a = alpha(barre!.fond)
+		const flouté = barre!.backdrop !== 'none' && barre!.backdrop !== ''
+		expect(
+			a === 1 || flouté,
+			`fond « ${barre!.fond} » (alpha ${a}) sans backdrop-filter : le contenu qui défile passe au travers`,
+		).toBe(true)
+	})
+
+	test('elle occupe toute la largeur et garde une hauteur tactile', async ({ page }, info) => {
+		test.skip(info.project.name.startsWith('tablette'), 'la barre est masquée à partir de lg')
+
+		await page.goto('/forum', { waitUntil: 'domcontentloaded' })
+		await page.waitForTimeout(1500)
+
+		const barre = await barreDuBas(page)
+		expect(barre).not.toBeNull()
+
+		// 44px est la recommandation courante pour une cible au doigt. On teste
+		// la hauteur de la barre elle-même, pas chaque icône : les libellés
+		// tiennent dans la même zone cliquable.
+		expect(barre!.hauteur, 'barre trop basse pour un pouce').toBeGreaterThanOrEqual(48)
+
+		for (const c of barre!.cibles) {
+			expect(c.h, 'cible de la barre trop courte').toBeGreaterThanOrEqual(40)
+		}
+	})
+})

--- a/nodyx-frontend/tests/responsive/no-overflow.spec.ts
+++ b/nodyx-frontend/tests/responsive/no-overflow.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Débordement horizontal, le défaut responsive le plus courant.
+ *
+ * Au 2026-08-15 l'audit n'en trouvait AUCUN sur ces pages, aux quatre largeurs
+ * testées. Ce fichier n'est donc pas un correctif, c'est un garde-fou : il
+ * fige un acquis pour qu'une future grille, un tableau ou une image large ne le
+ * reprenne pas en silence. Le symptôme côté utilisateur est une page qui
+ * « glisse » latéralement et un texte coupé au bord de l'écran.
+ */
+
+const PAGES_PUBLIQUES = [
+	['accueil',    '/'],
+	['forum',      '/forum'],
+	['découvrir',  '/discover'],
+	['connexion',  '/auth/login'],
+	['inscription', '/auth/register'],
+]
+
+for (const [nom, chemin] of PAGES_PUBLIQUES) {
+	test(`${nom} ne déborde pas horizontalement`, async ({ page }) => {
+		await page.goto(chemin, { waitUntil: 'domcontentloaded' })
+		await page.waitForTimeout(1200)
+
+		const mesure = await page.evaluate(() => {
+			const de = document.documentElement
+			const vw = window.innerWidth
+			const fautifs: { tag: string; cls: string; depassement: number }[] = []
+
+			if (de.scrollWidth > vw + 1) {
+				for (const el of document.querySelectorAll('body *')) {
+					const r = el.getBoundingClientRect()
+					if (r.width === 0 || r.height === 0) continue
+					// Un élément fixe plus étroit que l'écran ne déborde pas vraiment.
+					if (getComputedStyle(el).position === 'fixed' && r.width <= vw + 2) continue
+					if (r.right > vw + 1) {
+						fautifs.push({
+							tag: el.tagName.toLowerCase(),
+							cls: (el.className?.toString?.() || '').slice(0, 80),
+							depassement: Math.round(r.right - vw),
+						})
+					}
+				}
+				fautifs.sort((a, b) => b.depassement - a.depassement)
+			}
+			return { scrollWidth: de.scrollWidth, innerWidth: vw, fautifs: fautifs.slice(0, 3) }
+		})
+
+		// La tolérance d'un pixel absorbe les arrondis de mise à l'échelle.
+		expect(
+			mesure.scrollWidth,
+			`déborde de ${mesure.scrollWidth - mesure.innerWidth}px. Coupables probables : ` +
+				mesure.fautifs.map((f) => `<${f.tag}> ${f.cls} (+${f.depassement}px)`).join(' | '),
+		).toBeLessThanOrEqual(mesure.innerWidth + 1)
+	})
+}


### PR DESCRIPTION
## Le défaut

La barre du bas utilisait `--p-card-bg`, c'est-à-dire un fond de **carte**. Six
thèmes sur sept sont translucides par construction, dont un à **5% d'opacité**,
et aucun `backdrop-filter` ne venait rattraper.

Une carte translucide posée sur un fond de page est voulue. Une barre **fixe**
avec du contenu qui défile dessous devient du verre.

Constaté en capture sur **Chromium et WebKit** : on **lisait** « Dernier
message » et « Pokled » au travers de la barre, par dessus les icônes. Ce
n'était donc pas un problème Safari, ça touchait tout le monde.

## Le correctif

`--p-bg`, opaque sur les sept thèmes. Une variante gardant la translucidité avec
`backdrop-filter: blur(12px)` a été essayée en direct dans le navigateur et
rendait bien aussi ; l'opaque a été retenu, plus net.

## Pourquoi Playwright arrive avec

Parce qu'**aucun contrôle existant ne voyait ce défaut**. `npm run check`, les
quatre portes i18n et le build étaient tous verts pendant que la barre était
transparente. Vitest ne voit rien de ce qui se passe à l'écran.

| Fichier | Ce qu'il couvre |
|---|---|
| `playwright.config.ts` | Chromium et WebKit, trois profils d'appareil |
| `tests/responsive/bottom-nav.spec.ts` | opacité de la barre, hauteur tactile |
| `tests/responsive/no-overflow.spec.ts` | débordement horizontal, 5 pages publiques |

Les deux moteurs retenus sont ceux qui **divergent vraiment** : Chromium pour
Chrome, Edge, Opera, Brave et le futur client Windows ; WebKit pour Safari, pour
**tous** les navigateurs sur iPhone (Apple impose son moteur) et pour le futur
client Linux, où Tauri utilise WebKitGTK. Firefox est écarté en v1, Gecko
diverge peu sur ces propriétés et chaque moteur coûte du temps.

## La preuve

Le test d'opacité **tombe sur l'ancien code**, vérifié avant d'écrire le
correctif :

```
2 failed    « elle est opaque » sur chromium ET webkit
2 skipped   tablette, la barre y est masquée
2 passed    hauteur tactile
```

Après correctif, sur une construction isolée servant le nouveau code (jamais un
build dans le dossier servi par PM2) :

```
19 passed, 2 skipped
```

`no-overflow` ne corrige rien, c'est un garde-fou. L'audit n'a trouvé **aucun**
débordement horizontal sur 6 pages et 4 largeurs, ce test fige cet acquis.

## Pas branché à la CI, à dessein

La règle maison interdit de fusionner sans CI verte. Un test de bout en bout
instable deviendrait une taxe permanente sur chaque PR. On le branchera quand
ces tests auront prouvé leur stabilité sur plusieurs jours.

En attendant, il se lance à la main contre n'importe quelle instance :

```bash
BASE_URL=http://127.0.0.1:4199 npm run test:responsive
```

## Vérifications

`npm run check` à 0 erreur, aucun avertissement nouveau. Les artefacts
Playwright (`test-results/`, `playwright-report/`) sont ajoutés au `.gitignore`.

## Ce que cette PR ne fait pas

Le reste de l'audit responsive attend ses propres PR : les 11 fichiers en
`100vh` à passer en `100dvh` (les 6 des overlays OBS ne doivent **pas** bouger),
les cibles tactiles trop petites dont une poignée de **6px de large**, et les
textes à 9px.