### PR TITLE
fix(ui): passer le frontend utilisateur en 100dvh, avec un garde-fou

### DIFF
--- a/nodyx-frontend/src/lib/viewportUnits.test.ts
+++ b/nodyx-frontend/src/lib/viewportUnits.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Garde-fou : plus de `100vh` dans le frontend utilisateur.
+ *
+ * Pourquoi (2026-08-15)
+ * ────────────────────
+ * Sur mobile, `100vh` vaut la hauteur de l'écran barre d'URL RÉTRACTÉE, donc
+ * toujours plus que la zone réellement visible. Une racine en `min-h-screen`
+ * rend chaque page systématiquement plus haute que l'écran, ce qui produit un
+ * défilement parasite partout. `100dvh` (dynamic viewport height) existe
+ * précisément pour ça et est supporté partout aujourd'hui.
+ *
+ * Ce contrôle est une lecture de SOURCE, pas un test de rendu : Playwright ne
+ * peut pas distinguer un `100vh` d'un `100dvh` une fois la page peinte, et le
+ * symptôme (quelques pixels de défilement en trop) est trop ténu pour être
+ * mesuré de façon fiable. Un grep est ici plus honnête qu'un test instable.
+ *
+ * DEUX EXCEPTIONS LÉGITIMES, à ne jamais « corriger » :
+ *
+ *   - `src/routes/overlay/**` : sources navigateur pour OBS. Fenêtre de taille
+ *     fixe, aucune barre d'URL, `100vh` y est exactement ce qu'il faut.
+ *   - `src/routes/admin/**` : le panneau d'administration n'est pas encore
+ *     passé au responsive (chantier suivant). Retirer cette exception quand ce
+ *     sera fait, ce test le signalera tout seul.
+ */
+
+const RACINE = new URL('../', import.meta.url).pathname
+const EXCEPTIONS = ['/routes/overlay/', '/routes/admin/']
+const INTERDIT = /\bmin-h-screen\b|\bh-screen\b|\b100vh\b/
+
+function fichiersSources(dossier: string, acc: string[] = []): string[] {
+	for (const entree of readdirSync(dossier)) {
+		const chemin = join(dossier, entree)
+		if (statSync(chemin).isDirectory()) {
+			if (entree === 'node_modules' || entree.startsWith('.')) continue
+			fichiersSources(chemin, acc)
+		} else if (/\.(svelte|css)$/.test(entree)) {
+			acc.push(chemin)
+		}
+	}
+	return acc
+}
+
+describe('unités de viewport', () => {
+	it('le frontend utilisateur n utilise plus 100vh, seulement 100dvh', () => {
+		const fautifs: string[] = []
+
+		for (const fichier of fichiersSources(RACINE)) {
+			if (EXCEPTIONS.some((e) => fichier.includes(e))) continue
+			const lignes = readFileSync(fichier, 'utf8').split('\n')
+			lignes.forEach((ligne, i) => {
+				// Un commentaire qui MENTIONNE la classe n'est pas un usage.
+				const nu = ligne.replace(/\/\/.*$/, '').replace(/<!--.*?-->/g, '')
+				if (INTERDIT.test(nu)) {
+					fautifs.push(`${fichier.replace(RACINE, '')}:${i + 1}  ${ligne.trim().slice(0, 80)}`)
+				}
+			})
+		}
+
+		expect(
+			fautifs,
+			'Utiliser 100dvh / min-h-dvh / h-dvh. Sur mobile 100vh dépasse la zone visible ' +
+				'et fabrique un défilement parasite sur toute la page.\n' +
+				fautifs.join('\n'),
+		).toEqual([])
+	})
+
+	it('les overlays OBS gardent 100vh, qui y est correct', () => {
+		// Le pendant du test précédent : il doit rester vrai que les overlays
+		// n'ont PAS été « corrigés » par un remplacement global trop large.
+		const overlays = fichiersSources(join(RACINE, 'routes/overlay'))
+		const avec100vh = overlays.filter((f) => /\b100vh\b/.test(readFileSync(f, 'utf8')))
+		expect(avec100vh.length, 'les overlays OBS ont perdu leur 100vh').toBeGreaterThan(0)
+	})
+})

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -746,7 +746,7 @@
 	{@render children()}
 {:else}
 {#if hasMatrix}<MatrixRain />{/if}
-<div class="min-h-screen flex flex-col" style="{appVars}; background: {hasMatrix ? 'transparent' : 'var(--p-bg)'}; color: var(--p-text)">
+<div class="min-h-dvh flex flex-col" style="{appVars}; background: {hasMatrix ? 'transparent' : 'var(--p-bg)'}; color: var(--p-text)">
 
 	<!-- Listener Streamer Hub : joue les sons de notif pour les admins/owners. -->
 	{#if data.user?.role}
@@ -1309,7 +1309,7 @@
 		     moindre debordement (ex: banniere full-bleed -mx-6 du profil, +24px)
 		     faisait apparaitre une scrollbar horizontale + du contenu glissant
 		     sous les sidebars. On clippe l'horizontal, plus jamais de scrollbar. -->
-		<main class="app-shell-main {langView ? 'h-[calc(100vh-48px)] overflow-hidden' : 'h-full overflow-y-auto overflow-x-hidden'} min-w-0 pb-[var(--bottom-nav-h)]"
+		<main class="app-shell-main {langView ? 'h-[calc(100dvh-48px)] overflow-hidden' : 'h-full overflow-y-auto overflow-x-hidden'} min-w-0 pb-[var(--bottom-nav-h)]"
 		      class:panel-collapsed={isBanned || !showChannelSidebar || panelCollapsed}
 		      class:members-collapsed={membersCollapsed}>
 

--- a/nodyx-frontend/src/routes/banned/+page.svelte
+++ b/nodyx-frontend/src/routes/banned/+page.svelte
@@ -12,7 +12,7 @@
 	<title>{tFn('banned.title')}</title>
 </svelte:head>
 
-<div class="min-h-screen bg-gray-950 flex items-center justify-center px-4">
+<div class="min-h-dvh bg-gray-950 flex items-center justify-center px-4">
 	<div class="max-w-md w-full text-center">
 		<div class="w-20 h-20 rounded-full bg-red-900/30 border border-red-800/60 flex items-center justify-center mx-auto mb-6">
 			<svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">

--- a/nodyx-frontend/src/routes/calendar/+page.svelte
+++ b/nodyx-frontend/src/routes/calendar/+page.svelte
@@ -165,7 +165,7 @@
 
 <style>
 .cal-root {
-	min-height: 100vh;
+	min-height: 100dvh;
 	background: #09090f;
 	display: flex;
 	flex-direction: column;

--- a/nodyx-frontend/src/routes/dm/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/dm/[id]/+page.svelte
@@ -604,7 +604,7 @@
 	})
 
 	// Effet 0 : inhiber le scroll de la fenêtre (body + html) tant que le DM
-	// est monté. Le +layout global a min-h-screen sur sa racine + un <main>
+	// est monté. Le +layout global a min-h-dvh sur sa racine + un <main>
 	// avec h-full overflow-y-auto, ce qui crée une deuxième scrollbar de
 	// fenêtre quand le DM rentre dans le viewport mais que le main pense
 	// avoir une hauteur géante. En bloquant le scroll fenêtre, seul le

--- a/nodyx-frontend/src/routes/feed/+page.svelte
+++ b/nodyx-frontend/src/routes/feed/+page.svelte
@@ -801,7 +801,7 @@
 <style>
 /* ── Root ─────────────────────────────────────────────────────────────────── */
 .feed-root {
-	min-height: 100vh;
+	min-height: 100dvh;
 	background: #09090f;
 }
 

--- a/nodyx-frontend/src/routes/garden/+page.svelte
+++ b/nodyx-frontend/src/routes/garden/+page.svelte
@@ -290,7 +290,7 @@
 <style>
 /* ── Root ──────────────────────────────────────────────────────────────────── */
 .garden-root {
-	min-height: 100vh;
+	min-height: 100dvh;
 	background: #09090f;
 	display: flex;
 	flex-direction: column;

--- a/nodyx-frontend/src/routes/settings/+page.svelte
+++ b/nodyx-frontend/src/routes/settings/+page.svelte
@@ -1352,7 +1352,7 @@
 /* ── Root layout ─────────────────────────────────────────────────────────── */
 .settings-root {
     display: flex;
-    min-height: calc(100vh - 48px);
+    min-height: calc(100dvh - 48px);
     background: #06060a;
     color: #e2e8f0;
 }
@@ -1367,7 +1367,7 @@
     border-right: 1px solid rgba(255,255,255,0.05);
     position: sticky;
     top: 48px;
-    height: calc(100vh - 48px);
+    height: calc(100dvh - 48px);
     overflow-y: auto;
     scrollbar-width: thin;
 }

--- a/nodyx-frontend/src/routes/soundboard/+page.svelte
+++ b/nodyx-frontend/src/routes/soundboard/+page.svelte
@@ -246,7 +246,7 @@
 	<meta name="description" content={tFn('soundboard.meta_desc')}/>
 </svelte:head>
 
-<div class="min-h-screen bg-gradient-to-br from-zinc-950 via-zinc-900 to-zinc-950 text-zinc-100">
+<div class="min-h-dvh bg-gradient-to-br from-zinc-950 via-zinc-900 to-zinc-950 text-zinc-100">
 	<div class="max-w-5xl mx-auto px-4 py-8 space-y-8">
 
 		<!-- Toast feedback ajout queue -->

--- a/nodyx-frontend/src/routes/whisper/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/whisper/[id]/+page.svelte
@@ -174,7 +174,7 @@
 	<title>{tFn('whisper.meta_title')}</title>
 </svelte:head>
 
-<div class="flex flex-col h-[calc(100vh-64px)] max-w-2xl mx-auto px-2 py-4">
+<div class="flex flex-col h-[calc(100dvh-64px)] max-w-2xl mx-auto px-2 py-4">
 
 	<!-- Header -->
 	<div class="flex items-center gap-3 mb-3 px-2">


### PR DESCRIPTION
## Le défaut

Sur mobile, `100vh` vaut la hauteur de l'écran **barre d'URL rétractée**, donc
toujours plus que la zone réellement visible. La racine du layout était en
`min-h-screen` : chaque page était donc systématiquement plus haute que l'écran,
ce qui fabrique un défilement parasite partout.

`100dvh` (dynamic viewport height) existe précisément pour ça et est supporté
partout aujourd'hui.

## Le changement

9 fichiers du frontend utilisateur passent en `min-h-dvh` / `h-dvh` / `100dvh`.

**Non touchés, volontairement :**

| Chemin | Pourquoi |
|---|---|
| `src/routes/overlay/**` | Sources navigateur pour OBS. Fenêtre de taille fixe, aucune barre d'URL : `100vh` y est exactement ce qu'il faut. |
| `src/routes/admin/**` | Le panneau d'administration n'est pas encore passé au responsive, c'est le chantier suivant. 4 occurrences restantes. |

## Le garde-fou

`src/lib/viewportUnits.test.ts`, une lecture de **source** dans Vitest, donc
dans la CI existante.

Pourquoi pas Playwright ici : il ne peut pas distinguer un `100vh` d'un `100dvh`
une fois la page peinte, et le symptôme (quelques pixels de défilement en trop)
est trop ténu pour être mesuré de façon fiable. **Un grep est plus honnête qu'un
test instable.**

Le test porte les deux exceptions et signalera de lui-même le jour où l'admin
passera au responsive.

Il **tombe** bel et bien sur une régression, vérifié en remettant
`min-h-screen` dans `banned/+page.svelte` :

```
routes/banned/+page.svelte:15  <div class="min-h-screen bg-gray-950 ...">
Tests  1 failed | 1 passed
```

puis retour au vert après restauration.

## Un piège évité

Une classe Tailwind inexistante ne génère **rien**, silencieusement. C'est
exactement ce qui avait produit les 20 classes collées du forum. Vérifié dans le
CSS construit plutôt que supposé :

```css
.min-h-dvh{min-height:100dvh}          /* générée */
.h-\[calc\(100dvh - 48px\)\]           /* les valeurs arbitraires suivent */
```

## À ne pas confondre

Ce changement **ne corrigera pas** le décollement de 5px de la barre du bas sur
WebKit. La barre est en `position: fixed`, elle se positionne par rapport au
viewport et non à la hauteur de la page. Je l'avais annoncé trop vite dans un
échange précédent, c'est corrigé ici.

## Vérifications

| Contrôle | Résultat |
|---|---|
| `npm run check` | **0 erreur**, aucun avertissement nouveau |
| Vitest | **104 tests verts**, 9 fichiers |
| 4 portes i18n | pass |
| Build | réussi, CSS vérifié |