### PR TITLE
fix(dm): la page des messages privés n'avait aucun point de rupture responsive

### DIFF
--- a/nodyx-frontend/src/routes/dm/+page.svelte
+++ b/nodyx-frontend/src/routes/dm/+page.svelte
@@ -113,7 +113,12 @@
 <div class="h-full flex">
 
 	<!-- ── Sidebar gauche ─────────────────────────────────────────────────── -->
-	<div class="w-72 shrink-0 flex flex-col border-r border-white/[0.06] bg-gray-950/60">
+	<!-- Pleine largeur sous `md`, largeur fixe au-delà. Avant le 2026-08-15 elle
+	     était figée à `w-72 shrink-0` à TOUTES les largeurs : sur un écran de
+	     502px, les 288px de la liste ne laissaient que 214px au panneau de
+	     droite, dont le contenu est prévu en `max-w-sm` (384px). Il était donc
+	     rogné, et la page n'avait aucun point de rupture responsive. -->
+	<div class="w-full md:w-72 shrink-0 flex flex-col md:border-r border-white/[0.06] bg-gray-950/60">
 
 		<!-- Header -->
 		<div class="px-4 pt-5 pb-3">
@@ -271,7 +276,12 @@
 	</div>
 
 	<!-- ── Zone vide / Sélection ───────────────────────────────────────────── -->
-	<div class="flex-1 flex flex-col items-center justify-center bg-gray-950/20">
+	<!-- Masquée sous `md` : sur mobile la liste occupe tout l'écran, et une
+	     conversation s'ouvre sur sa propre page. Aucun état à gérer pour ça, les
+	     entrées de la liste sont déjà de vrais liens vers `/dm/[id]`. Inviter à
+	     « choisir une conversation » à côté de la liste qu'on est en train de
+	     lire n'apportait rien, et coûtait la moitié de l'écran. -->
+	<div class="hidden md:flex flex-1 flex-col items-center justify-center bg-gray-950/20">
 		<div class="flex flex-col items-center gap-4 text-center px-8 max-w-sm">
 			<!-- Illustration -->
 			<div class="relative">


### PR DESCRIPTION
Signalé en capture : à 502px de large, le panneau de droite est tronqué,
« Choisissez une convers », « Sélectionnez un messag ».

## La cause

La page était en agencement de bureau à **toutes** les largeurs.

```html
<div class="h-full flex">          <!-- toujours en rangée -->
  <div class="w-72 shrink-0 ...">  <!-- liste figée à 288px, ne cède jamais -->
  <div class="flex-1 ...">         <!-- reçoit les miettes -->
```

À 502px, les 288px de la liste ne laissent que **214px** au panneau droit, dont
le contenu est prévu en `max-w-sm`, soit 384px. Il coupe.

## Le correctif

Liste en pleine largeur sous `md`, panneau droit masqué. Sur mobile on voit donc
la liste entière, et une conversation s'ouvre sur sa propre page.

Aucun état à gérer : les entrées sont **déjà** de vrais liens vers `/dm/[id]`,
une route qui existe. Inviter à « choisir une conversation » juste à côté de la
liste qu'on est en train de lire n'apportait rien, et coûtait la moitié de
l'écran.

## Vérifications

`npm run check` à 0 erreur, aucun avertissement nouveau. Et les trois variantes
sont bien **générées** par Tailwind dans le CSS construit, pas supposées :

```css
.md\:w-72{width:calc(var(--spacing) * 72)}
.md\:flex{display:flex}
.md\:border-r{...}
```

## Ce qui n'est pas vérifié

`/dm` exige une session et je n'ai pas d'identifiants de test : **le rendu n'a
pas été contrôlé au navigateur**. C'est aussi pourquoi mes tests Playwright ne
couvrent pas cette page.