### PR TITLE
fix(ui): contenu rogné sur le forum et le profil, et le détecteur qui manquait

### DIFF
--- a/nodyx-frontend/src/routes/forum/[category]/+page.svelte
+++ b/nodyx-frontend/src/routes/forum/[category]/+page.svelte
@@ -655,7 +655,12 @@
 					</div>
 
 					<!-- Titre -->
-					<p class="text-base font-semibold text-white group-hover:text-indigo-400 transition-colors line-clamp-1">
+					<!-- Deux lignes sur mobile, une seule des `sm`. Le bloc de droite est
+					     en `shrink-0` et prélève environ 150px avant que le titre n'ait sa
+					     part : sur un téléphone, `line-clamp-1` réduisait des titres comme
+					     « Nodyx Soundboard v2.7.0 : tes sons, ta queue... » à un moignon
+					     illisible. -->
+					<p class="text-base font-semibold text-white group-hover:text-indigo-400 transition-colors line-clamp-2 sm:line-clamp-1">
 						{thread.title}
 					</p>
 
@@ -698,7 +703,7 @@
 
 					<!-- Dernier posteur -->
 					{#if lastPoster}
-						<div class="flex items-center gap-2 pl-2 border-l border-gray-800">
+						<div class="hidden sm:flex items-center gap-2 pl-2 border-l border-gray-800">
 							<div class="text-right hidden sm:block">
 								<p class="text-[10px] text-gray-600">{tFn('forum.last_reply')}</p>
 								<p class="text-xs font-medium text-gray-300">{lastPoster.author_username}</p>
@@ -716,7 +721,7 @@
 				</div>
 
 				<!-- Flèche -->
-				<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-gray-700 group-hover:text-indigo-500 transition-colors shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+				<svg xmlns="http://www.w3.org/2000/svg" class="hidden sm:block w-5 h-5 text-gray-700 group-hover:text-indigo-500 transition-colors shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
 					<path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
 				</svg>
 			</a>

--- a/nodyx-frontend/src/routes/users/[username]/+page.svelte
+++ b/nodyx-frontend/src/routes/users/[username]/+page.svelte
@@ -542,7 +542,15 @@
      MAIN — 2-column layout
      ═══════════════════════════════════════════════════════════════ -->
 <div class="max-w-[1600px] mx-auto px-6 pb-16">
-	<div class="flex flex-col sm:flex-row gap-5 items-start">
+	<!-- `items-stretch` sur mobile, `items-start` seulement à partir de `sm`.
+	     Piège corrigé le 2026-08-15 : en `flex-col`, l'axe TRANSVERSAL est
+	     horizontal, et `items-start` demande aux enfants de ne PAS s'étirer. Le
+	     `<main>` prenait donc la largeur de son contenu, 1358px dans un
+	     conteneur de 374px, et tout le profil était rogné. Son `min-w-0` n'y
+	     changeait rien, et `flex-1` ne gouverne que l'axe principal, ici la
+	     hauteur. En `sm:flex-row`, `items-start` retrouve son sens : aligner les
+	     deux colonnes en haut. -->
+	<div class="flex flex-col sm:flex-row gap-5 items-stretch sm:items-start">
 
 		<!-- ─── LEFT SIDEBAR ─────────────────────────────────────────── -->
 		<aside class="w-full sm:w-64 sm:shrink-0 space-y-3">

--- a/nodyx-frontend/tests/responsive/no-clipping.spec.ts
+++ b/nodyx-frontend/tests/responsive/no-clipping.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Contenu ROGNÉ, à ne pas confondre avec le débordement de page.
+ *
+ * Pourquoi ce fichier existe (2026-08-15)
+ * ───────────────────────────────────────
+ * `no-overflow.spec.ts` vérifie que la PAGE ne glisse pas latéralement
+ * (`scrollWidth > innerWidth`). Il était vert pendant que quatre écrans étaient
+ * visiblement cassés, parce qu'un ancêtre en `overflow: hidden` absorbe le
+ * débordement : la page ne glisse pas, elle COUPE. Deux défauts distincts, et
+ * la suite n'en couvrait qu'un.
+ *
+ * Le cas qui a motivé ce test : sur le profil, le `<main>` mesurait 1358px dans
+ * un conteneur de 374px. Cause, un `items-start` sur un conteneur `flex-col` :
+ * l'axe transversal y est HORIZONTAL, et `items-start` demande aux enfants de
+ * ne pas s'étirer, donc de prendre la largeur de leur contenu. Ni `min-w-0` ni
+ * `flex-1` n'y changent quoi que ce soit.
+ */
+
+const PAGES = [
+	['profil',           '/users/Pokled'],
+	['forum catégorie',  '/forum/annonces'],
+	['accueil',          '/'],
+]
+
+for (const [nom, chemin] of PAGES) {
+	test(`${nom} : aucun élément plus large que l'écran`, async ({ page }, info) => {
+		await page.goto(chemin, { waitUntil: 'domcontentloaded' })
+		await page.waitForTimeout(1800)
+
+		const coupables = await page.evaluate(() => {
+			const vw = window.innerWidth
+			const out: { w: number; tag: string; cls: string; txt: string }[] = []
+
+			for (const el of document.querySelectorAll('body *')) {
+				const w = el.getBoundingClientRect().width
+				if (w <= vw + 8) continue
+
+				// On ne veut QUE l'élément fautif, pas sa lignée : si un enfant est
+				// aussi large, c'est lui la cause et le parent ne fait que la subir.
+				const enfantAussiLarge = [...el.children].some(
+					(c) => c.getBoundingClientRect().width > w - 4,
+				)
+				if (enfantAussiLarge) continue
+
+				// Un élément volontairement défilable horizontalement est légitime :
+				// tableau large, bande de code, carrousel.
+				const st = getComputedStyle(el)
+				if (st.overflowX === 'auto' || st.overflowX === 'scroll') continue
+
+				// Une DÉCORATION sortie du flux et sans le moindre texte est large
+				// à dessein : halo, dégradé, bulle lumineuse. Son rognage par le
+				// parent est l'effet recherché, pas un défaut. Sans cette
+				// exception, l'accueil remonte `twitch-shine` (869px) et
+				// `hb-orb--tl` (500px), qui ne sont pas des bugs.
+				const horsFlux = st.position === 'absolute' || st.position === 'fixed'
+				if (horsFlux && !(el.textContent || '').trim()) continue
+
+				out.push({
+					w: Math.round(w),
+					tag: el.tagName.toLowerCase(),
+					cls: (el.className?.toString?.() || '').slice(0, 70),
+					txt: (el.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 40),
+				})
+			}
+			return out.sort((a, b) => b.w - a.w).slice(0, 4)
+		})
+
+		const largeur = info.project.use.viewport?.width ?? 0
+		expect(
+			coupables,
+			`éléments plus larges que l'écran (${largeur}px) :\n` +
+				coupables.map((c) => `  ${c.w}px  <${c.tag}> ${c.cls}\n     « ${c.txt} »`).join('\n'),
+		).toEqual([])
+	})
+}


### PR DESCRIPTION
Deux écrans signalés en capture.

## Forum, titres de sujets illisibles

Le bloc de droite d'une ligne est en `shrink-0` et ne cède **jamais** : compteur
à `min-w-[60px]`, avatar du dernier posteur, chevron, trois gouttières de 16px.
Environ **150px prélevés** avant que le titre n'ait sa part, et le titre était en
`line-clamp-1`. « Nodyx Soundboard v2.7.0 : tes sons, ta queue... » se réduisait
à un moignon.

Correctif : deux lignes sous `sm`, et le dernier posteur et le chevron masqués
sur mobile. Seul le **texte** du dernier posteur l'était : son avatar de 32px et
sa bordure gauche restaient, et volaient de la largeur pour rien.

## Profil, tout était rogné

Le `<main>` mesurait **1358px dans un conteneur de 374px**.

La cause n'est pas un enfant récalcitrant. Le conteneur est en `flex-col` sur
mobile, son axe **transversal** est donc horizontal, et `items-start` demande aux
enfants de **ne pas s'étirer**, donc de prendre la largeur de leur contenu. Ni le
`min-w-0` du `<main>` ni son `flex-1` n'y changent quoi que ce soit : `flex-1` ne
gouverne que l'axe principal, ici la hauteur.

Correctif : `items-stretch sm:items-start`. En `sm:flex-row`, `items-start`
retrouve son sens, aligner les deux colonnes en haut.

Prouvé par injection sur la page réelle **avant** d'écrire la moindre ligne :

```
AVANT   conteneur 374px   main 1358px   align-items: flex-start
APRES   conteneur 374px   main  374px   align-items: stretch
```

## Le détecteur qui manquait

`no-overflow.spec.ts` vérifie que la **page** ne glisse pas latéralement. Il était
vert pendant que quatre écrans étaient visiblement cassés, parce qu'un ancêtre en
`overflow: hidden` absorbe le débordement : la page ne glisse pas, elle **coupe**.
Deux défauts distincts, et la suite n'en couvrait qu'un.

`no-clipping.spec.ts` cherche désormais tout élément plus large que l'écran. Il
écarte deux faux positifs à dessein :

| Écarté | Pourquoi |
|---|---|
| `overflowX: auto/scroll` | Défilement horizontal volontaire : tableau large, bande de code |
| Décoration hors flux sans aucun texte | Sans ça, l'accueil remontait `twitch-shine` (869px) et `hb-orb--tl` (500px), qui sont des effets voulus |

**État attendu du détecteur** : il **tombe** sur la prod actuelle pour le profil,
et passe pour l'accueil et le forum. Il deviendra vert au déploiement. Ces tests
ne sont pas branchés à la CI, ils ne bloquent donc rien en attendant.

## Vérifications

`npm run check` à 0 erreur sans avertissement nouveau, **104 tests Vitest verts**,
les 4 portes i18n passent.

## Restent à traiter

La zone de saisie du chat (`rows={1}` sans agrandissement automatique, plus une
barre de défilement demandée explicitement par `scrollbar-width: thin`), et les
cibles tactiles trop petites dont une poignée de **6px de large**.