### PR TITLE
fix(chat): la zone de saisie était une fente, et sa barre de défilement venait du placeholder

### DIFF
--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -194,7 +194,7 @@
   "chat.send": "Send (Enter)",
   "chat.new_poll": "Create a poll",
   "chat.rich_editor": "Rich editor (Ctrl+Shift+E)",
-  "chat.input_placeholder": "Message in # {{channel}}  ·  /roll /flip /8ball /rps",
+  "chat.input_placeholder": "Message in # {{channel}}",
   "chat.message_refused": "Message refused: prohibited content",
   "chat.voice.insecure": "WebRTC requires HTTPS or localhost.",
   "chat.voice.denied": "Microphone blocked. Check your browser settings.",
@@ -4523,5 +4523,9 @@
   "adash.member_joined": "new member",
   "forum.share_copied": "Link copied",
   "forum.share_failed": "Copy failed",
-  "forum.moderate": "Moderate"
+  "forum.moderate": "Moderate",
+  "chat.cmd_help_roll": "roll dice",
+  "chat.cmd_help_flip": "flip a coin",
+  "chat.cmd_help_8ball": "ask a question",
+  "chat.cmd_help_rps": "rock paper scissors"
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -194,7 +194,7 @@
   "chat.send": "Envoyer (Entrée)",
   "chat.new_poll": "Créer un sondage",
   "chat.rich_editor": "Éditeur riche (Ctrl+Maj+E)",
-  "chat.input_placeholder": "Message dans # {{channel}}  ·  /roll /flip /8ball /rps",
+  "chat.input_placeholder": "Message dans # {{channel}}",
   "chat.message_refused": "Message refusé : contenu interdit",
   "chat.voice.insecure": "WebRTC exige HTTPS ou localhost.",
   "chat.voice.denied": "Microphone bloqué. Vérifiez les paramètres du navigateur.",
@@ -4523,5 +4523,9 @@
   "adash.member_joined": "nouveau membre",
   "forum.share_copied": "Lien copié",
   "forum.share_failed": "Copie impossible",
-  "forum.moderate": "Modérer"
+  "forum.moderate": "Modérer",
+  "chat.cmd_help_roll": "lance des dés",
+  "chat.cmd_help_flip": "pile ou face",
+  "chat.cmd_help_8ball": "pose une question",
+  "chat.cmd_help_rps": "pierre feuille ciseaux"
 }

--- a/nodyx-frontend/src/routes/chat/+page.svelte
+++ b/nodyx-frontend/src/routes/chat/+page.svelte
@@ -181,6 +181,33 @@
 	let mentionQuery       = $state('');
 	let mentionSuggestions = $state<{ username: string; avatar: string | null }[]>([]);
 	let showMentions       = $state(false);
+
+	/**
+	 * Les quatre commandes, listées quand l'utilisateur tape « / ».
+	 *
+	 * Elles vivaient dans le placeholder du champ, ce qui posait deux problèmes.
+	 * Le premier, mesuré : « Message dans # {{channel}} · /roll /flip /8ball
+	 * /rps » fait 54 caractères et passe à DEUX lignes dès que le champ est en
+	 * dessous de 340px de large, ce qui déborde un textarea en `rows={1}` et
+	 * fait apparaître une barre de défilement parasite. Le second : on ne lit un
+	 * placeholder qu'avant d'écrire, or on cherche une commande au moment où on
+	 * la tape.
+	 */
+	const COMMANDES = [
+		{ nom: 'roll',  args: '2d6',        cle: 'chat.cmd_help_roll' },
+		{ nom: 'flip',  args: '',           cle: 'chat.cmd_help_flip' },
+		{ nom: '8ball', args: '…',          cle: 'chat.cmd_help_8ball' },
+		{ nom: 'rps',   args: '🪨 📄 ✂️',   cle: 'chat.cmd_help_rps' },
+	];
+
+	// N'apparaît que sur un « / » en tête, et disparaît dès qu'une commande
+	// complète est écrite : la liste ne doit pas gêner la frappe.
+	const suggestions = $derived.by(() => {
+		const t = inputText;
+		if (!t.startsWith('/') || t.includes(' ')) return [];
+		const q = t.slice(1).toLowerCase();
+		return COMMANDES.filter(c => c.nom.startsWith(q));
+	});
 	let mentionIndex       = $state(0);
 
 	// Reply/quote
@@ -776,6 +803,9 @@
 		inputText = '';
 		showMentions = false;
 		replyTo = null;
+		// Le champ vient d'être vidé : sans ça il resterait à la hauteur du
+		// message qu'on vient d'envoyer.
+		ajusterHauteur(document.querySelector<HTMLTextAreaElement>('textarea#chat-input'));
 	}
 
 	function sendRich() {
@@ -826,7 +856,30 @@
 		if (e.key === 'E' && e.ctrlKey && e.shiftKey) { e.preventDefault(); openRichCompose(); }
 	}
 
+	/**
+	 * Ajuste la hauteur du champ à son contenu.
+	 *
+	 * Le textarea était en `rows={1}` avec `resize-none` et un `max-h-32`, mais
+	 * RIEN ne le faisait jamais grandir : il restait sur une ligne quel que soit
+	 * le message, et le `scrollbar-width: thin` faisait apparaître une barre de
+	 * défilement minuscule dès la deuxième ligne. On écrivait donc ses messages
+	 * dans une fente.
+	 *
+	 * `height = 'auto'` avant la mesure n'est pas décoratif : sans cette remise
+	 * à zéro, `scrollHeight` ne redescend jamais quand on efface du texte, et le
+	 * champ resterait grand après avoir été vidé.
+	 */
+	function ajusterHauteur(el: HTMLTextAreaElement | null) {
+		if (!el) return
+		el.style.height = 'auto'
+		// 128px = max-h-32, la borne au-delà de laquelle on rend la main au
+		// défilement plutôt que de manger tout l'écran.
+		el.style.height = Math.min(el.scrollHeight, 128) + 'px'
+	}
+
 	async function handleInput() {
+		ajusterHauteur(document.querySelector<HTMLTextAreaElement>('textarea#chat-input'))
+
 		// Typing indicator (throttled) — server + P2P fast path
 		if (s && selectedChannel) {
 			if (!typingThrottle) {
@@ -1555,6 +1608,31 @@
 					<div class="flex items-center gap-2 px-3 py-2 mb-1 bg-red-900/40 border border-red-700/60 rounded-lg text-xs text-red-300">
 						<span>⏱</span>
 						<span>{tFn('chat.antispam', { s: String(Math.ceil((rateLimitedUntil - Date.now()) / 1000)) })}</span>
+					</div>
+				{/if}
+
+				<!-- Aide aux commandes, à l'endroit et au moment où on la cherche :
+				     au-dessus du champ, dès qu'on tape « / ». Elle ne prend aucune
+				     place le reste du temps, contrairement au placeholder de 54
+				     caractères qu'elle remplace. -->
+				{#if suggestions.length > 0}
+					<div class="mb-1 flex flex-wrap gap-1.5 px-1">
+						{#each suggestions as c}
+							<button
+								type="button"
+								onclick={() => {
+									inputText = `/${c.nom} `;
+									const el = document.querySelector<HTMLTextAreaElement>('textarea#chat-input');
+									el?.focus();
+									ajusterHauteur(el);
+								}}
+								class="inline-flex items-center gap-1.5 px-2 py-1 border border-white/[0.08] bg-white/[0.03] hover:bg-white/[0.07] hover:border-indigo-700/50 transition-colors text-left"
+							>
+								<span class="text-xs font-semibold text-indigo-300">/{c.nom}</span>
+								{#if c.args}<span class="text-[10px] text-gray-600">{c.args}</span>{/if}
+								<span class="text-[11px] text-gray-500">{tFn(c.cle)}</span>
+							</button>
+						{/each}
 					</div>
 				{/if}
 


### PR DESCRIPTION
Trois causes distinctes, dont **deux trouvées par Jonathan**.

## 1. Le placeholder déclenchait la barre parasite

```
« Message dans # {{channel}}  ·  /roll /flip /8ball /rps »   54 caractères
```

Mesuré en reconstituant le textarea à l'identique :

| Largeur disponible | Placeholder actuel | Placeholder court |
|---|---|---|
| 220px | **2 lignes → barre** | 1 ligne |
| 260px | **2 lignes → barre** | 1 ligne |
| 300px | **2 lignes → barre** | 1 ligne |
| 340px | 1 ligne | 1 ligne |
| 440px | 1 ligne | 1 ligne |

Le textarea étant en `rows={1}`, la seconde ligne déborde et le
`scrollbar-width: thin` fait apparaître la petite barre. Dans une fenêtre de
502px, les cinq boutons et les marges laissent environ **300px** au champ : pile
dans la zone qui casse.

Le placeholder se limite désormais à « Message dans # {{channel}} ».

## 2. Aucun agrandissement automatique

`rows={1}`, `resize-none` et `max-h-32` coexistaient, mais **rien ne faisait
jamais grandir le champ**. On écrivait ses messages dans une fente d'une ligne,
quelle que soit leur longueur.

Ajout de `ajusterHauteur()`, appelé à la frappe et après envoi. La remise à
`height: auto` avant mesure n'est pas décorative : sans elle `scrollHeight` ne
redescend jamais, et le champ resterait grand une fois vidé.

## 3. Les commandes étaient au mauvais endroit

Ton intuition était juste. Un placeholder ne se lit qu'**avant** d'écrire, or on
cherche une commande au moment où on la tape.

Elles sortent du placeholder et apparaissent au-dessus du champ dès qu'on tape
« / », filtrées à la frappe et cliquables. Zéro place occupée le reste du temps.

## i18n

`chat.input_placeholder` raccourci, et 4 clés neuves (`chat.cmd_help_*`) livrées
dans `fr.json` **et** `en.json`. Parité tenue à 4529 clés.

## Vérifications

`npm run check` à 0 erreur sans avertissement nouveau, **104 tests Vitest verts**,
les 4 portes i18n passent, build réussi.

**Non vérifié au navigateur** : `/chat` exige une session. Le déclenchement de la
barre a en revanche été mesuré hors ligne, avant et après correctif.