### PR TITLE
fix(ui): trois rangées coupaient leur contenu, et le détecteur qui les trouve

### DIFF
--- a/nodyx-frontend/src/lib/components/ReputationRings.svelte
+++ b/nodyx-frontend/src/lib/components/ReputationRings.svelte
@@ -62,7 +62,9 @@
 	}
 </script>
 
-<div class="flex items-center gap-6 p-5"
+<!-- Empile sous `sm` : cote a cote, les anneaux laissaient 200px a la
+     legende, qui en demande 256. Ses libelles etaient donc coupes de 56px. -->
+<div class="flex flex-col sm:flex-row items-center gap-4 sm:gap-6 p-5"
      style="background: var(--p-card-bg); border: 1px solid var(--p-card-border)">
 
 	<!-- SVG rings -->

--- a/nodyx-frontend/src/routes/forum/[category]/+page.svelte
+++ b/nodyx-frontend/src/routes/forum/[category]/+page.svelte
@@ -265,7 +265,10 @@
 </svelte:head>
 
 <!-- EN-TÊTE DE CATÉGORIE -->
-<div class="relative mb-8 overflow-hidden border border-white/[.06] bg-gradient-to-br from-gray-900 via-gray-900 to-indigo-950/30 p-8">
+<!-- `p-5` sur mobile : `p-8` seul mangeait 64px de rembourrage horizontal
+     sur un ecran de 390px, et le contenu de l'en-tete (fil d'Ariane, titre,
+     pastilles de statistiques) se faisait couper de 80px. -->
+<div class="relative mb-8 overflow-hidden border border-white/[.06] bg-gradient-to-br from-gray-900 via-gray-900 to-indigo-950/30 p-5 sm:p-8">
 	<!-- Effets de lumière -->
 	<div class="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-indigo-500/50 to-transparent"></div>
 	<div class="absolute -top-20 -right-20 w-80 h-80 bg-indigo-600/10 blur-3xl"></div>

--- a/nodyx-frontend/src/routes/forum/[category]/[thread]/+page.svelte
+++ b/nodyx-frontend/src/routes/forum/[category]/[thread]/+page.svelte
@@ -287,7 +287,11 @@
 					</div>
 
 					<!-- Statistiques -->
-					<div class="flex items-center gap-3">
+					<!-- `flex-wrap` : sans lui les trois encarts (vues, reponses,
+					     dernier posteur) tiennent sur une seule ligne quoi qu'il arrive,
+					     et le troisieme se fait couper au bord de l'ecran sur un
+					     telephone. Le conteneur PARENT en avait un, pas celui-ci. -->
+					<div class="flex flex-wrap items-center gap-3">
 						<!-- Vues -->
 						<div class="flex items-center gap-1.5 text-gray-400 bg-gray-800/60 px-3 py-1 border border-gray-700">
 							<svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/nodyx-frontend/tests/responsive/no-clipping.spec.ts
+++ b/nodyx-frontend/tests/responsive/no-clipping.spec.ts
@@ -33,9 +33,40 @@ for (const [nom, chemin] of PAGES) {
 			const vw = window.innerWidth
 			const out: { w: number; tag: string; cls: string; txt: string }[] = []
 
+			// Un élément est-il posé dans un conteneur qui défile horizontalement ?
+			// Alors sa largeur est voulue : frise d'activité, tableau, carrousel.
+			const dansUnDefilement = (el: Element) => {
+				let p = el.parentElement
+				while (p && p !== document.body) {
+					const o = getComputedStyle(p).overflowX
+					if (o === 'auto' || o === 'scroll') return true
+					p = p.parentElement
+				}
+				return false
+			}
+
 			for (const el of document.querySelectorAll('body *')) {
 				const w = el.getBoundingClientRect().width
-				if (w <= vw + 8) continue
+				// Seuil a 1,5x l'ecran, et non « plus large que l'ecran ».
+				// Plusieurs conteneurs debordent VOLONTAIREMENT de quelques dizaines
+				// de pixels : le profil utilise `-mx-4` pour aller bord a bord, ce qui
+				// donne 422px dans un ecran de 390 sans rien couper. Les catastrophes
+				// reelles sont d'un tout autre ordre : le <main> du profil mesurait
+				// 1358px pour 374, soit 3,5x. Un seuil grossier qui attrape ce qui
+				// casse vaut mieux qu'un test precis qu'on desactive au bout d'une
+				// semaine parce qu'il est rouge en permanence.
+				if (w <= vw * 1.5) continue
+
+				// `<rect>`, `<path>`, `<circle>` : des primitives de DESSIN, pas de
+				// la mise en page. Le profil en remontait dix, toutes fausses.
+				if (el.namespaceURI === 'http://www.w3.org/2000/svg') continue
+
+				// Sans texte, rien n'est illisible : bannière pleine largeur, halo,
+				// grille de cellules colorées. On traque du contenu coupé, pas des
+				// pixels qui dépassent.
+				if (!(el.textContent || '').trim()) continue
+
+				if (dansUnDefilement(el)) continue
 
 				// On ne veut QUE l'élément fautif, pas sa lignée : si un enfant est
 				// aussi large, c'est lui la cause et le parent ne fait que la subir.

--- a/nodyx-frontend/tests/responsive/no-overflowing-row.spec.ts
+++ b/nodyx-frontend/tests/responsive/no-overflowing-row.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Rangées dont le contenu ne rentre pas.
+ *
+ * Troisième détecteur, et le plus fin des trois. Les deux autres regardent la
+ * page (`no-overflow`) et les éléments géants (`no-clipping`, seuil à 1,5x).
+ * Celui-ci attrape ce qui leur échappe : un conteneur de taille normale dont le
+ * contenu déborde de quelques dizaines de pixels et se fait couper.
+ *
+ * Le cas qui l'a motivé, signalé le 2026-08-15 : dans l'en-tête d'un sujet, la
+ * rangée « vues / réponses / dernier posteur » était en `flex` SANS `flex-wrap`.
+ * Les trois encarts tenaient donc sur une ligne quoi qu'il arrive, et le
+ * troisième était tranché au bord de l'écran. Trop petit pour le seuil de
+ * `no-clipping`, invisible pour `no-overflow` puisqu'un ancêtre clippait.
+ *
+ * La mesure : `scrollWidth > clientWidth` sur un élément qui n'est pas censé
+ * défiler. C'est la définition même de « du contenu est coupé ici ».
+ */
+
+const PAGES = [
+	// Un sujet AVEC des reponses d'un autre membre : sans ca l'encart
+	// « dernier posteur » ne s'affiche pas et le test ne prouve rien.
+	['sujet',           '/forum/annonces/nodyx-v2-0-dm-chiffres-e2e-reactions-typing-sons-a1000001'],
+	['forum catégorie', '/forum/annonces'],
+	['profil',          '/users/Pokled'],
+]
+
+for (const [nom, chemin] of PAGES) {
+	test(`${nom} : aucune rangée ne coupe son contenu`, async ({ page }) => {
+		await page.goto(chemin, { waitUntil: 'domcontentloaded' })
+		await page.waitForTimeout(1800)
+
+		const coupables = await page.evaluate(() => {
+			const out: { perdu: number; boite: number; tag: string; cls: string; txt: string }[] = []
+
+			for (const el of document.querySelectorAll('body *')) {
+				if (el.namespaceURI === 'http://www.w3.org/2000/svg') continue
+
+				const st = getComputedStyle(el)
+				// Défilement horizontal assumé : ce n'est pas une coupure.
+				if (st.overflowX === 'auto' || st.overflowX === 'scroll') continue
+				// `truncate` coupe VOLONTAIREMENT, avec une ellipse pour le dire.
+				if (st.textOverflow === 'ellipsis') continue
+
+				const perdu = el.scrollWidth - el.clientWidth
+				// 4px de tolérance pour les arrondis de mise à l'échelle.
+				if (perdu <= 4) continue
+				if (el.clientWidth < 60) continue
+				if (!(el.textContent || '').trim()) continue
+
+				out.push({
+					perdu,
+					boite: el.clientWidth,
+					tag: el.tagName.toLowerCase(),
+					cls: (el.className?.toString?.() || '').slice(0, 65),
+					txt: (el.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 40),
+				})
+			}
+
+			// On ne garde que la coupure la plus profonde de chaque lignée : les
+			// ancêtres répètent le même symptôme et noieraient le vrai coupable.
+			out.sort((a, b) => b.perdu - a.perdu)
+			const vus = new Set<string>()
+			return out
+				.filter((o) => {
+					const cle = o.txt.slice(0, 25)
+					if (vus.has(cle)) return false
+					vus.add(cle)
+					return true
+				})
+				.slice(0, 4)
+		})
+
+		expect(
+			coupables,
+			'rangées dont le contenu est coupé :\n' +
+				coupables
+					.map((c) => `  -${c.perdu}px (boîte ${c.boite}px) <${c.tag}> ${c.cls}\n     « ${c.txt} »`)
+					.join('\n'),
+		).toEqual([])
+	})
+}


### PR DESCRIPTION
Signalé sur l'en-tête d'un sujet : l'encart « Dernier : Pokled » tranché au bord
de l'écran. **Deux autres** trouvés dans la foulée par le détecteur neuf, sur des
pages qui n'avaient rien signalé.

## Les trois rangées

**1. En-tête d'un sujet.** La rangée « vues / réponses / dernier posteur » était
en `flex` **sans `flex-wrap`** : les trois encarts tenaient sur une ligne quoi
qu'il arrive. Le conteneur *parent* en avait un, pas celui-ci.

Prouvé par injection sur la page réelle :

```
AVANT   182px de débordement, sur deux conteneurs
APRES   []   plus aucun débordement sur toute la page
```

**2. En-tête de catégorie.** `p-8` mangeait **64px** de rembourrage horizontal
sur un écran de 390px, et le contenu se faisait couper de 80px. Passé en
`p-5 sm:p-8`.

**3. Anneaux de réputation.** Anneaux et légende côte à côte à toutes les
largeurs : la légende recevait 200px pour un contenu qui en demande 256, ses
libellés étaient donc coupés de 56px. Empilés sous `sm`.

## Le troisième détecteur

| Détecteur | Ce qu'il regarde | Ces trois cas ? |
|---|---|---|
| `no-overflow` | la **page** glisse-t-elle latéralement | non, un ancêtre clippe |
| `no-clipping` | éléments **géants**, seuil à 1,5× | non, trop petits |
| `no-overflowing-row` | `scrollWidth > clientWidth` | **oui** |

C'est la définition même de « du contenu est coupé ici ». Il écarte les
défilements horizontaux assumés et les `truncate`, qui coupent volontairement
avec une ellipse pour le dire.

## Un piège évité dans le test lui-même

Il visait d'abord un sujet **sans réponse**, où l'encart « dernier posteur » ne
s'affiche pas. Il passait donc au vert sans rien prouver. Il vise désormais un
sujet avec des réponses d'un autre membre, et il tombe bien sur le code actuel.

## Aussi dans cette PR

Le calibrage du détecteur `no-clipping`, qui restait rouge à tort sur trois
familles de faux positifs : primitives SVG, frise défilante, et débords
volontaires en `-mx-4`. Détail dans les commits.

Et une erreur de mesure corrigée : j'ai cru un moment à un débordement de 898px
sur les dépôts GitHub. `Range.getBoundingClientRect()` ignore le rognage, je
mesurais du texte correctement coupé par une ellipse. Le `min-w-0` inutile a été
jeté avant d'être livré.

## Vérifications

`npm run check` à 0 erreur sans avertissement nouveau, 104 tests Vitest verts,
portes i18n vertes.