### PR TITLE
fix(ui): le tiroir mobile part du haut, et le burger devient cliquable au pouce

### DIFF
--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -763,16 +763,16 @@
 		<!-- Mobile hamburger : ne s'affiche que si le panneau qu'il ouvre existe -->
 		{#if !isBanned && showChannelSidebar}
 		<button
-			class="lg:hidden shrink-0 p-1.5 flex items-center justify-center transition-colors"
+			class="lg:hidden shrink-0 p-2.5 -m-1 flex items-center justify-center transition-colors"
 			style="color: {gallerySidebarOpen ? '#fff' : '#6b7280'}"
 			onclick={() => gallerySidebarOpen = !gallerySidebarOpen}
 			aria-label={tFn('nav.community_menu')} aria-expanded={gallerySidebarOpen} aria-controls="galaxy-sidebar">
 			{#if gallerySidebarOpen}
-				<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+				<svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
 				</svg>
 			{:else}
-				<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+				<svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/>
 				</svg>
 			{/if}
@@ -1928,8 +1928,12 @@
 }
 
 /* ── Sketch 001: Discord two-tier sidebar — exact sketch CSS, scoped ────── */
+/* Sur mobile le rail et le panneau forment un TIROIR qui recouvre la page.
+   Les 48px reserves a la barre du haut y sont une bande morte : le tiroir a
+   sa propre croix de fermeture, il n'a pas besoin de laisser voir la barre.
+   Au-dessus de lg ils redeviennent des colonnes, sous la barre. */
 .nodyx-sb .rail {
-  position: fixed; top: 48px; bottom: 0; left: 0; width: 56px;
+  position: fixed; top: 0; bottom: 0; left: 0; width: 56px;
   background: #000; border-right: 1px solid #111;
   display: flex; flex-direction: column; align-items: center; padding: 8px 0; gap: 4px; z-index: 40;
 }
@@ -1955,11 +1959,21 @@
 .nodyx-sb .rail .icon.docs:hover { background: #111; color: #818cf8; border-radius: 8px; }
 
 .nodyx-sb .panel {
-  position: fixed; top: 48px; bottom: 0; left: 56px;
+  position: fixed; top: 0; bottom: 0; left: 56px;
   width: var(--left-panel-width, 220px);
   background: #0a0a0a; border-right: 1px solid #111;
   z-index: 39; display: flex; flex-direction: column;
   transform: translateX(0); transition: transform .25s cubic-bezier(.4,0,.2,1), width .25s cubic-bezier(.4,0,.2,1);
+}
+
+/* Au-dessus de lg le rail et le panneau ne sont plus un tiroir mais deux
+   colonnes permanentes : ils reprennent leur place SOUS la barre du haut,
+   qui doit rester visible et cliquable. Cette regle DOIT venir apres les
+   deux definitions ci-dessus : a specificite egale, c'est l'ordre qui
+   tranche, et placee avant elle etait purement et simplement annulee. */
+@media (min-width: 1024px) {
+  .nodyx-sb .rail,
+  .nodyx-sb .panel { top: 48px; }
 }
 .nodyx-sb .panel.collapsed { transform: translateX(-100%); }
 .nodyx-sb .panel.dragging {


### PR DESCRIPTION
Deux points signalés sur capture.

## Le burger était trop petit

Une icône de 16px dans 6px de rembourrage, soit **28x28** au total. C'est
exactement le `<button> 28x28px` que l'audit responsive avait remonté comme
cible tactile trop petite.

Passé à **44x44**, la recommandation courante, par `p-2.5` et une icône en
`w-6 h-6`. Le `-m-1` évite de décaler ses voisins dans la barre.

## Le tiroir laissait une bande morte en haut

Le rail et le panneau étaient en `top: 48px` à **toutes** les largeurs, pour
laisser voir la barre du haut.

Sur grand écran c'est juste : ce sont deux colonnes permanentes sous la barre.
Sur téléphone ce sont un **tiroir qui recouvre la page**, et ces 48px devenaient
une zone vide, alors que le tiroir a déjà sa propre croix de fermeture.

Ils partent donc de `top: 0` sous `lg`, et retrouvent leurs 48px au-dessus.

## Un piège de cascade évité de justesse

La reprise `@media (min-width: 1024px)` avait d'abord été posée **avant** les
deux définitions de base. À spécificité égale, c'est l'ordre qui tranche : elle
était purement et simplement annulée, et le bureau serait parti en production
avec un tiroir collé au plafond.

Déplacée après, avec un commentaire pour que personne ne la remonte.

## Mesure au navigateur, aux deux largeurs

```
mobile  390px   rail top=0    panel top=0    burger 44x44
bureau 1280px   rail top=48   panel top=48   burger masqué
```

## Vérifications

`npm run check` à 0 erreur sans avertissement nouveau, 104 tests Vitest verts.

## Ce que cette PR ne fait pas

La **typographie**. Tu la trouves trop petite sur téléphone, et l'audit te donne
raison : 9px, 9.6px, 10px et 10.4px sur toutes les pages. Mais toucher aux
tailles de texte touche **tout** le produit : ça mérite sa propre décision et sa
propre PR.