### PR TITLE
fix(ui): relever le plancher typographique là où on LIT, pas partout

### DIFF
--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -1703,7 +1703,7 @@
 			<svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 				<path stroke-linecap="round" stroke-linejoin="round" d="M3 12h18M3 6h18M3 18h12"/>
 			</svg>
-			<span class="text-[10px] font-medium">Actu</span>
+			<span class="text-xs font-medium">Actu</span>
 		</a>
 		{/if}
 
@@ -1713,7 +1713,7 @@
 				<path stroke-linecap="round" stroke-linejoin="round" d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
 				<polyline stroke-linecap="round" stroke-linejoin="round" points="9 22 9 12 15 12 15 22"/>
 			</svg>
-			<span class="text-[10px] font-medium">Forum</span>
+			<span class="text-xs font-medium">Forum</span>
 		</a>
 
 		<!-- Chat (si connecté) -->
@@ -1727,7 +1727,7 @@
 					{unreadCount > 9 ? '9+' : unreadCount}
 				</span>
 			{/if}
-			<span class="text-[10px] font-medium">Chat</span>
+			<span class="text-xs font-medium">Chat</span>
 		</a>
 		{/if}
 
@@ -1742,7 +1742,7 @@
 					{dmUnread > 9 ? '9+' : dmUnread}
 				</span>
 			{/if}
-			<span class="text-[10px] font-medium">DMs</span>
+			<span class="text-xs font-medium">DMs</span>
 		</a>
 		{/if}
 
@@ -1752,7 +1752,7 @@
 				<path stroke-linecap="round" stroke-linejoin="round" d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
 				<path stroke-linecap="round" stroke-linejoin="round" d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
 			</svg>
-			<span class="text-[10px] font-medium">Biblio</span>
+			<span class="text-xs font-medium">Biblio</span>
 		</a>
 
 		<!-- Annuaire -->
@@ -1762,7 +1762,7 @@
 				<line x1="2" y1="12" x2="22" y2="12"/>
 				<path stroke-linecap="round" stroke-linejoin="round" d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
 			</svg>
-			<span class="text-[10px] font-medium">Annuaire</span>
+			<span class="text-xs font-medium">Annuaire</span>
 		</a>
 
 		<!-- Profil / Connexion -->
@@ -1776,7 +1776,7 @@
 					{user.username.charAt(0).toUpperCase()}
 				</div>
 			{/if}
-			<span class="text-[10px] font-medium">Profil</span>
+			<span class="text-xs font-medium">Profil</span>
 		</a>
 		{:else}
 		<a href="/auth/login" class="flex-1 flex flex-col items-center justify-center py-2 min-h-14 gap-0.5 text-gray-500">
@@ -1785,7 +1785,7 @@
 				<polyline stroke-linecap="round" stroke-linejoin="round" points="10 17 15 12 10 7"/>
 				<line x1="15" y1="12" x2="3" y2="12"/>
 			</svg>
-			<span class="text-[10px] font-medium">{tFn("common.login")}</span>
+			<span class="text-xs font-medium">{tFn("common.login")}</span>
 		</a>
 		{/if}
 	</nav>

--- a/nodyx-frontend/src/routes/forum/[category]/+page.svelte
+++ b/nodyx-frontend/src/routes/forum/[category]/+page.svelte
@@ -701,7 +701,7 @@
 					<!-- Compteur de réponses -->
 					<div class="flex flex-col items-center px-3 py-1.5 border border-white/[.06] group-hover:border-indigo-700/50 transition-colors min-w-[60px] text-center">
 						<span class="text-lg font-bold text-indigo-400 leading-none">{replyCount(thread.post_count)}</span>
-						<span class="text-[10px] text-gray-500 uppercase tracking-wider">{tFn('forum.replies_label')}</span>
+						<span class="text-[11px] text-gray-500 uppercase tracking-wider">{tFn('forum.replies_label')}</span>
 					</div>
 
 					<!-- Dernier posteur -->


### PR DESCRIPTION
Tu trouves la typographie trop petite sur téléphone, et l'audit te donne raison :
9px, 9.6px, 10px et 10.4px sur toutes les pages.

## Le résultat le plus utile de cette passe : un remplacement en bloc est exclu

Le frontend utilisateur compte **371 occurrences sous 12px**, et elles ne servent
pas toutes à lire :

| Taille | Occurrences | Ce que c'est |
|---|---|---|
| `text-[8px]` | 12 | Presque toutes des **initiales dans des pastilles de 20px** et des badges |
| `text-[9px]` | 55 | |
| `text-[10px]` | 216 | |
| `text-[11px]` | 88 | |

Passer les 8px à 12px ferait **déborder les cercles**. Ces tailles sont porteuses
de mise en page, pas seulement décoratives.

On relève donc uniquement ce qui est du **texte lu**, en commençant par le plus
exposé.

## Ce qui change

| Endroit | Avant | Après |
|---|---|---|
| Barre de navigation du bas, 8 libellés | `text-[10px]` | `text-xs` (rendu 13px) |
| Liste des sujets, libellé « réponses » | `text-[10px]` | `text-[11px]` |

## Mesuré avant de choisir la taille

La barre du bas porte 7 entrées : agrandir les libellés pouvait la faire
déborder. Vérifié au navigateur sur construction locale :

```
360px   débordement=0   aucun libellé coupé
390px   débordement=0   aucun libellé coupé
412px   débordement=0   aucun libellé coupé
```

11px passait aussi. `text-xs` a été retenu parce qu'il passe également et qu'il
est nettement plus lisible.

## C'est une première passe

Pas la fin du sujet. Les autres surfaces (métadonnées du profil, panneaux vocaux,
fil d'actu) demandent le même tri au cas par cas entre badge et texte lu, et ça
ne se fait pas au `sed`.

## Trouvé au passage, hors périmètre

Les libellés de la barre du bas sont **codés en dur en français** (`Actu`,
`Forum`, `Chat`, `DMs`, `Biblio`, `Annuaire`, `Profil`), sans passer par `tFn()`.
Sur ta capture, l'interface était en anglais et la barre en français. Les portes
i18n ne les voient pas. À traiter séparément.

## Vérifications

`npm run check` à 0 erreur sans avertissement nouveau, 104 tests Vitest verts,
portes i18n vertes.