### PR TITLE
fix(ui): empiler ne suffit pas, il faut items-stretch (3e fois que ce piège mord)

### DIFF
--- a/nodyx-frontend/src/lib/components/ReputationRings.svelte
+++ b/nodyx-frontend/src/lib/components/ReputationRings.svelte
@@ -63,8 +63,12 @@
 </script>
 
 <!-- Empile sous `sm` : cote a cote, les anneaux laissaient 200px a la
-     legende, qui en demande 256. Ses libelles etaient donc coupes de 56px. -->
-<div class="flex flex-col sm:flex-row items-center gap-4 sm:gap-6 p-5"
+     legende, qui en demande 256. Ses libelles etaient donc coupes de 56px.
+     `items-stretch` est INDISPENSABLE en plus de `flex-col` : en colonne l'axe
+     transversal est HORIZONTAL, et `items-center` demande aux enfants de ne pas
+     s'etirer. Empiler seul ne corrigeait donc rien, la legende restait a 202px
+     dans un conteneur de 374. Meme piege que sur le profil avec `items-start`. -->
+<div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-4 sm:gap-6 p-5"
      style="background: var(--p-card-bg); border: 1px solid var(--p-card-border)">
 
 	<!-- SVG rings -->

--- a/nodyx-frontend/tests/responsive/no-overflowing-row.spec.ts
+++ b/nodyx-frontend/tests/responsive/no-overflowing-row.spec.ts
@@ -42,6 +42,14 @@ for (const [nom, chemin] of PAGES) {
 				if (st.overflowX === 'auto' || st.overflowX === 'scroll') continue
 				// `truncate` coupe VOLONTAIREMENT, avec une ellipse pour le dire.
 				if (st.textOverflow === 'ellipsis') continue
+				// `overflow: hidden` est une DECISION explicite de l'auteur : « ce qui
+				// depasse ici, je le rogne exprès ». Le detecteur n'a pas a la
+				// contredire. Sans cette regle, l'en-tete de categorie remontait 80px
+				// causes par ses deux halos decoratifs en `absolute -right-20`, larges
+				// a dessein et rognes par la carte. Contrepartie assumee : on ne verra
+				// pas un `overflow-hidden` pose a la va-vite pour MASQUER un vrai
+				// debordement. Les deux autres detecteurs restent la pour ca.
+				if (st.overflowX === 'hidden' || st.overflow === 'hidden') continue
 
 				const perdu = el.scrollWidth - el.clientWidth
 				// 4px de tolérance pour les arrondis de mise à l'échelle.


### PR DESCRIPTION
Après déploiement, deux des trois correctifs de #553 n'avaient pas produit
l'effet attendu. Vérification faite, l'un était un **vrai défaut mal corrigé**,
l'autre un **faux positif de mon détecteur**.

## Anneaux de réputation : vrai défaut, mal corrigé

Le passage en `flex-col` avait bien pris. Mesuré sur la page réelle :

```
374px  flex/column  <div class="flex flex-col sm:flex-row items-center ...">
202px  flex/column  <div class="flex flex-col gap-3 flex-1 min-w-0">   ← la légende
```

Le conteneur est bien en colonne et fait 374px. Mais la légende reste à 202px,
parce qu'il porte **`items-center`** : en colonne, l'axe transversal est
horizontal, et `items-center` demande aux enfants de **ne pas s'étirer**.

**Empiler seul ne corrigeait donc rien.**

### C'est la troisième fois que ce piège mord ici

| Endroit | Classe fautive | Conséquence |
|---|---|---|
| Profil | `items-start` sur `flex-col` | `<main>` à 1358px pour 374 |
| Anneaux | `items-center` sur `flex-col` | légende à 202px pour 374 |

La règle : sur un conteneur qui passe en colonne sous un point de rupture, tout
`items-*` autre que `stretch` empêche les enfants de prendre la largeur. Ni
`min-w-0` ni `flex-1` n'y changent quoi que ce soit, `flex-1` ne gouvernant que
l'axe principal.

## En-tête de catégorie : faux positif

Les 80px signalés venaient des deux **halos décoratifs** de la carte, en
`absolute -right-20` et `-left-20`, soit exactement 80px, et la carte est en
`overflow-hidden` pour les rogner à dessein. Aucun contenu n'était perdu.

Le détecteur écarte désormais tout élément dont l'`overflow-x` est `hidden` :
c'est une **décision explicite de l'auteur**, « ce qui dépasse ici je le rogne
exprès », et un test n'a pas à la contredire.

Contrepartie assumée et écrite dans le fichier : on ne verra pas un
`overflow-hidden` posé à la va-vite pour *masquer* un vrai débordement. Les deux
autres détecteurs restent là pour ça.

## Vérifications

Sur construction locale servant le nouveau code : **37 tests Playwright verts**,
2 sautés. `npm run check` à 0 erreur, 104 tests Vitest verts.