### PR TITLE
fix(dm): on écrivait sous le menu, la zone de saisie ne réservait pas la barre

### DIFF
--- a/nodyx-frontend/src/lib/bottomNavClearance.test.ts
+++ b/nodyx-frontend/src/lib/bottomNavClearance.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Toute page avec une zone de saisie en bas doit réserver la barre de navigation.
+ *
+ * Pourquoi (2026-08-15)
+ * ────────────────────
+ * La barre de navigation mobile est `fixed bottom-0`. Une zone de saisie collée
+ * en bas de page passe donc PAR DESSOUS et devient inatteignable : on écrit
+ * sous le menu. La variable `--bottom-nav-h` existe pour ça, elle vaut 56px plus
+ * la zone sûre du téléphone, et 0 à partir de `lg` où la barre disparaît.
+ *
+ * `chat/+page.svelte` l'utilisait depuis toujours. `dm/[id]/+page.svelte` ne l'a
+ * JAMAIS fait, et personne ne l'avait vu : c'est exactement le genre de défaut
+ * qu'un test de rendu ne peut pas attraper, ces deux pages exigeant une session.
+ *
+ * Ce contrôle lit la SOURCE : si un fichier a une zone basse (`border-t` sur un
+ * conteneur `shrink-0`, ou un `sticky/fixed bottom`), il doit mentionner
+ * `--bottom-nav-h` quelque part.
+ */
+
+const ROUTES = new URL('../routes', import.meta.url).pathname
+const EXCEPTIONS = ['/overlay/', '/admin/']
+
+function pages(dossier: string, acc: string[] = []): string[] {
+	for (const e of readdirSync(dossier)) {
+		const chemin = join(dossier, e)
+		if (statSync(chemin).isDirectory()) pages(chemin, acc)
+		else if (e === '+page.svelte') acc.push(chemin)
+	}
+	return acc
+}
+
+describe('dégagement de la barre de navigation mobile', () => {
+	it('une page avec une zone de saisie en bas réserve --bottom-nav-h', () => {
+		const fautifs: string[] = []
+
+		for (const fichier of pages(ROUTES)) {
+			if (EXCEPTIONS.some((e) => fichier.includes(e))) continue
+			const src = readFileSync(fichier, 'utf8')
+
+			// Une zone de saisie : un champ, ET un conteneur bas identifiable.
+			const aUnChamp = /placeholder=|<textarea/.test(src)
+			const aUneZoneBasse = /shrink-0[^"]*border-t|sticky bottom-0|fixed bottom-0/.test(src)
+			if (!aUnChamp || !aUneZoneBasse) continue
+
+			if (!src.includes('bottom-nav-h')) {
+				fautifs.push(fichier.replace(ROUTES, 'routes'))
+			}
+		}
+
+		expect(
+			fautifs,
+			'ces pages ont une zone de saisie en bas sans réserver la barre de navigation ; ' +
+				'sur mobile on y écrit SOUS le menu. Ajouter ' +
+				'`style="padding-bottom: max(1rem, var(--bottom-nav-h))"` sur le conteneur bas.\n' +
+				fautifs.join('\n'),
+		).toEqual([])
+	})
+})

--- a/nodyx-frontend/src/routes/dm/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/dm/[id]/+page.svelte
@@ -1696,7 +1696,13 @@
 		</div>
 
 		<!-- Zone de saisie -->
-		<div class="shrink-0 px-5 py-4 border-t border-white/[0.06] bg-gray-950/30">
+		<!-- `--bottom-nav-h` réserve la hauteur de la barre de navigation mobile,
+		     qui est `fixed bottom-0` et passerait donc PAR DESSUS ce champ. La
+		     variable vaut 56px plus la zone sûre du téléphone, et 0 à partir de
+		     `lg` où la barre n'existe plus. Le chat le faisait déjà, cette page
+		     ne l'a jamais fait : on y écrivait sous le menu. -->
+		<div class="shrink-0 px-5 py-4 border-t border-white/[0.06] bg-gray-950/30"
+		     style="padding-bottom: max(1rem, var(--bottom-nav-h))">
 			<!-- Banner reply : indique le message qu'on est en train de citer -->
 			{#if replyingTo}
 				<div class="dm-reply-banner">


### PR DESCRIPTION
Signalé en capture : sur la page d'une conversation, la zone de saisie passe
**sous** la barre de navigation mobile et devient inatteignable.

## La cause

La barre de navigation est `fixed bottom-0`. Une zone de saisie collée en bas de
page passe donc par dessous.

La variable `--bottom-nav-h` existe **exactement pour ça** : elle vaut 56px plus
la zone sûre du téléphone, et 0 à partir de `lg` où la barre disparaît.

`chat/+page.svelte` l'utilisait depuis toujours. `dm/[id]/+page.svelte` ne l'a
**jamais** fait. Le correctif était à côté, il n'avait simplement jamais été
appliqué ici.

## Tous les appelants vérifiés

Recensement des pages ayant à la fois un champ et un conteneur bas
identifiable : il n'y en a que **deux**, `chat` et `dm/[id]`. Les deux sont
désormais couvertes.

## Le garde-fou

`src/lib/bottomNavClearance.test.ts`, une lecture de **source** dans Vitest, donc
dans la CI existante. Toute page avec une zone de saisie en bas doit mentionner
`--bottom-nav-h`.

C'est le genre de défaut qu'un test de rendu ne peut **pas** attraper : ces deux
pages exigent une session, et Playwright n'y accède pas. Un grep est ici le seul
outil possible.

Il tombe bien sur une régression, vérifié en retirant le correctif :

```
routes/dm/[id]/+page.svelte: expected [ 'routes/dm/[id]/+page.svelte' ] to deeply equal []
Test Files  1 failed
```

puis retour au vert après restauration.

## Le message de console

« Allow attribute will take precedence over `allowfullscreen` » vient d'une
iframe embarquée (lecteur vidéo) et n'a aucun rapport avec ce défaut.

## Vérifications

`npm run check` à 0 erreur sans avertissement nouveau, **105 tests Vitest verts**
sur 10 fichiers.