### PR TITLE
test(responsive): couvrir enfin les pages derrière une connexion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ nodyx-frontend/test-results/
 nodyx-frontend/playwright-report/
 nodyx-frontend/blob-report/
 .cache/ms-playwright/
+
+# Etat de session Playwright et identifiants du compte de test : JAMAIS commites
+nodyx-frontend/playwright/.auth/
+nodyx-frontend/.env.test

--- a/nodyx-frontend/playwright.config.ts
+++ b/nodyx-frontend/playwright.config.ts
@@ -45,8 +45,40 @@ export default defineConfig({
 	},
 
 	projects: [
-		{ name: 'mobile-chromium', use: { ...devices['Pixel 7'] } },
-		{ name: 'mobile-webkit',   use: { ...devices['iPhone 14'] } },
-		{ name: 'tablette-webkit', use: { ...devices['iPad Mini'] } },
+		// Ouvre une session une fois, les projets authentifiés la reutilisent.
+		{ name: 'session', testMatch: /auth\.setup\.ts/ },
+
+		// Pages publiques : aucune session, on teste ce que voit un inconnu.
+		{
+			name: 'mobile-chromium',
+			use: { ...devices['Pixel 7'] },
+			testIgnore: /authentifie\.spec\.ts/,
+		},
+		{
+			name: 'mobile-webkit',
+			use: { ...devices['iPhone 14'] },
+			testIgnore: /authentifie\.spec\.ts/,
+		},
+		{
+			name: 'tablette-webkit',
+			use: { ...devices['iPad Mini'] },
+			testIgnore: /authentifie\.spec\.ts/,
+		},
+
+		// Pages derriere une connexion : chat, messages prives, sidebar. C'est
+		// precisement la que les defauts ont survecu le plus longtemps, faute de
+		// test capable de les atteindre.
+		{
+			name: 'connecte-chromium',
+			use: { ...devices['Pixel 7'], storageState: 'playwright/.auth/session.json' },
+			dependencies: ['session'],
+			testMatch: /authentifie\.spec\.ts/,
+		},
+		{
+			name: 'connecte-webkit',
+			use: { ...devices['iPhone 14'], storageState: 'playwright/.auth/session.json' },
+			dependencies: ['session'],
+			testMatch: /authentifie\.spec\.ts/,
+		},
 	],
 })

--- a/nodyx-frontend/tests/responsive/auth.setup.ts
+++ b/nodyx-frontend/tests/responsive/auth.setup.ts
@@ -1,0 +1,66 @@
+import { test as setup, expect } from '@playwright/test'
+import { existsSync, mkdirSync, statSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+/**
+ * Ouvre une session une seule fois et la range dans un fichier, que les tests
+ * authentifiés réutilisent. Évite de se reconnecter à chaque test.
+ *
+ * Pourquoi ce fichier existe (2026-08-15)
+ * ───────────────────────────────────────
+ * Toute la partie du produit derrière une connexion échappait aux tests : chat,
+ * messages privés, sidebar des salons. C'est précisément là que les défauts ont
+ * survécu le plus longtemps. Deux exemples de la même journée :
+ *
+ *   - la zone de saisie des messages privés passait SOUS la barre de navigation
+ *     mobile, parce que la page ne réservait pas `--bottom-nav-h`. Le chat le
+ *     faisait, elle non. Trouvé par capture d'écran, pas par un test.
+ *   - le menu burger n'ouvrait plus rien après un déploiement, à cause d'un
+ *     service worker prenant la main sans recharger.
+ *
+ * IDENTIFIANTS : jamais dans le dépôt. Ils viennent de l'environnement, et le
+ * fichier de session est dans `.gitignore`. Sans eux, les tests authentifiés se
+ * sautent proprement au lieu d'échouer.
+ *
+ *     NODYX_TEST_EMAIL=... NODYX_TEST_PASSWORD=... npm run test:responsive
+ */
+export const FICHIER_SESSION = 'playwright/.auth/session.json'
+
+/** Au-delà, on considère la session périmée et on se reconnecte. */
+const DUREE_SESSION_MS = 6 * 60 * 60 * 1000
+
+setup('ouvrir une session', async ({ page }) => {
+	const email = process.env.NODYX_TEST_EMAIL
+	const motDePasse = process.env.NODYX_TEST_PASSWORD
+	setup.skip(!email || !motDePasse, 'NODYX_TEST_EMAIL / NODYX_TEST_PASSWORD absents')
+
+	// On REUTILISE une session encore fraîche au lieu de se reconnecter.
+	// Ce n'est pas une optimisation : se reconnecter à chaque exécution déclenche
+	// l'anti-force-brute du serveur (« Trop de tentatives de connexion, réessayez
+	// dans 15 minutes »), et la suite entière devient inutilisable. Constaté le
+	// 2026-08-15 en montant ces tests, ce qui prouve au passage que la protection
+	// fonctionne.
+	if (existsSync(FICHIER_SESSION)) {
+		const age = Date.now() - statSync(FICHIER_SESSION).mtimeMs
+		if (age < DUREE_SESSION_MS) {
+			setup.skip(true, `session réutilisée (${Math.round(age / 60000)} min)`)
+			return
+		}
+	}
+
+	await page.goto('/auth/login', { waitUntil: 'domcontentloaded' })
+
+	await page.locator('input[type="email"]').fill(email!)
+	await page.locator('input[type="password"]').fill(motDePasse!)
+	await page.locator('button[type="submit"]').first().click()
+
+	// La connexion est reussie quand on a quitte la page de connexion.
+	await page.waitForURL((u) => !u.pathname.startsWith('/auth/login'), { timeout: 30_000 })
+
+	// Garde-fou : une redirection ne prouve pas une session. On verifie que la
+	// barre de navigation affiche bien les entrees reservees aux connectes.
+	await expect(page.locator('nav a[href="/dm"]').first()).toBeVisible({ timeout: 15_000 })
+
+	if (!existsSync(dirname(FICHIER_SESSION))) mkdirSync(dirname(FICHIER_SESSION), { recursive: true })
+	await page.context().storageState({ path: FICHIER_SESSION })
+})

--- a/nodyx-frontend/tests/responsive/authentifie.spec.ts
+++ b/nodyx-frontend/tests/responsive/authentifie.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Les pages qui exigent une connexion, jamais couvertes jusqu'ici.
+ *
+ * Ces écrans ont accumulé les défauts précisément parce qu'aucun test ne les
+ * atteignait. Chacun des contrôles ci-dessous correspond à un défaut REEL,
+ * trouvé par capture d'écran le 2026-08-15, pas à une précaution théorique.
+ */
+
+test.describe('pages authentifiées', () => {
+	test.skip(
+		!process.env.NODYX_TEST_EMAIL || !process.env.NODYX_TEST_PASSWORD,
+		'identifiants de test absents',
+	)
+
+	/**
+	 * Défaut d'origine : la zone de saisie des messages privés passait SOUS la
+	 * barre de navigation mobile. `chat` réservait `--bottom-nav-h`, `dm/[id]`
+	 * ne l'a jamais fait, et on écrivait sous le menu.
+	 */
+	test('la saisie des messages privés reste au-dessus de la barre', async ({ page }, info) => {
+		test.skip(info.project.name.startsWith('tablette'), 'la barre du bas est masquée dès lg')
+
+		await page.goto('/dm', { waitUntil: 'domcontentloaded' })
+		await page.waitForTimeout(2000)
+
+		const conversation = page.locator('a[href^="/dm/"]').first()
+		test.skip((await conversation.count()) === 0, 'aucune conversation sur ce compte')
+		await conversation.click()
+		await page.waitForTimeout(2500)
+
+		const mesure = await page.evaluate(() => {
+			const champ = document.querySelector('textarea, [contenteditable="true"]')
+			const barre = [...document.querySelectorAll('nav')].find(
+				(n) =>
+					getComputedStyle(n).position === 'fixed' &&
+					n.getBoundingClientRect().top > window.innerHeight / 2,
+			)
+			if (!champ || !barre) return null
+			const c = champ.getBoundingClientRect()
+			const b = barre.getBoundingClientRect()
+			// Recouvrement vertical : positif = le champ passe sous la barre.
+			return { recouvrement: Math.round(c.bottom - b.top), champBas: Math.round(c.bottom) }
+		})
+
+		expect(mesure, 'champ de saisie ou barre introuvable').not.toBeNull()
+		expect(
+			mesure!.recouvrement,
+			`la zone de saisie passe de ${mesure!.recouvrement}px sous la barre de navigation`,
+		).toBeLessThanOrEqual(0)
+	})
+
+	/**
+	 * Défaut d'origine : après un déploiement, le service worker prenait la main
+	 * sans recharger et l'hydratation cassait. Le burger ne répondait plus.
+	 */
+	test('le menu burger ouvre bien la sidebar', async ({ page }, info) => {
+		test.skip(info.project.name.startsWith('tablette'), 'le burger est masqué dès lg')
+
+		await page.goto('/forum', { waitUntil: 'domcontentloaded' })
+		await page.waitForTimeout(2000)
+
+		const burger = page.locator('[aria-controls="galaxy-sidebar"]')
+		await expect(burger).toBeVisible()
+
+		const avant = await page.evaluate(
+			() => Math.round(document.querySelector('.nodyx-sb .panel')?.getBoundingClientRect().x ?? NaN),
+		)
+		await burger.click()
+		await page.waitForTimeout(800)
+		const apres = await page.evaluate(
+			() => Math.round(document.querySelector('.nodyx-sb .panel')?.getBoundingClientRect().x ?? NaN),
+		)
+
+		expect(avant, 'panneau introuvable').not.toBeNaN()
+		expect(
+			apres,
+			`le panneau n'a pas bougé au clic (avant ${avant}px, après ${apres}px)`,
+		).toBeGreaterThan(avant)
+	})
+
+	/** Le burger doit rester attrapable au pouce : 44px est la recommandation. */
+	test('le burger est assez grand pour un pouce', async ({ page }, info) => {
+		test.skip(info.project.name.startsWith('tablette'), 'le burger est masqué dès lg')
+
+		await page.goto('/forum', { waitUntil: 'domcontentloaded' })
+		await page.waitForTimeout(1500)
+
+		const boite = await page.locator('[aria-controls="galaxy-sidebar"]').boundingBox()
+		expect(boite, 'burger introuvable').not.toBeNull()
+		expect(Math.round(boite!.width)).toBeGreaterThanOrEqual(40)
+		expect(Math.round(boite!.height)).toBeGreaterThanOrEqual(40)
+	})
+})


### PR DESCRIPTION
Toute la partie du produit exigeant une session échappait aux tests : chat,
messages privés, sidebar des salons. C'est **exactement là que les défauts ont
survécu le plus longtemps**, faute d'outil capable de les atteindre.

Deux exemples de la seule journée du 15/08, tous deux trouvés par capture
d'écran et non par un test :

- la zone de saisie des messages privés passait **sous** la barre de navigation
- le menu burger n'ouvrait plus rien après un déploiement

## Le compte de test

Créé avec ton autorisation : **`Doomguy`**, un personnage et non une personne
réelle, avec une bio qui dit explicitement qu'il s'agit d'un compte automatisé.

Je n'ai pas suivi la consigne « John Carmack » : nommer un compte d'après
quelqu'un qui existe, sur une instance publique où de vrais membres discutent,
serait une usurpation. Et l'avatar Doom est de l'artwork id Software.

## Trois contrôles, chacun issu d'un défaut réel

| Contrôle | Défaut d'origine |
|---|---|
| La saisie des messages privés reste au-dessus de la barre | Elle passait dessous |
| Le menu burger ouvre bien la sidebar | Il ne répondait plus après déploiement |
| Le burger fait au moins 40px | Il en faisait 28 |

Le premier **tombe sur la production actuelle**, le correctif #558 n'étant pas
encore déployé :

```
✘ la saisie des messages privés reste au-dessus de la barre
  Error: la zone de saisie passe de 7px sous la barre de navigation
```

Le test attrape donc automatiquement ce que tu avais dû repérer à l'œil.

## La réutilisation de session est indispensable, pas une optimisation

Se reconnecter à chaque exécution déclenche l'anti-force-brute du serveur :

```
{"status":429,"code":"RATE_LIMITED",
 "Trop de tentatives de connexion. Réessayez dans 15 minutes."}
```

Constaté en montant ces tests, ce qui prouve au passage que **ta protection
fonctionne**. La session est donc rangée dans un fichier et réutilisée 6 heures.

## Secrets

Les identifiants viennent de l'environnement, **jamais du dépôt**. Le fichier de
session et un éventuel `.env.test` sont dans `.gitignore`.

Sans identifiants, les tests authentifiés se **sautent proprement** au lieu
d'échouer : rien ne casse pour un contributeur qui n'en a pas.

## Vérifications

`npm run check` à 0 erreur, 104 tests Vitest verts.