### PR TITLE
test(responsive): tolérance à 32px, le profil était rouge sur le seul WebKit

### DIFF
--- a/nodyx-frontend/tests/responsive/no-overflowing-row.spec.ts
+++ b/nodyx-frontend/tests/responsive/no-overflowing-row.spec.ts
@@ -52,8 +52,16 @@ for (const [nom, chemin] of PAGES) {
 				if (st.overflowX === 'hidden' || st.overflow === 'hidden') continue
 
 				const perdu = el.scrollWidth - el.clientWidth
-				// 4px de tolérance pour les arrondis de mise à l'échelle.
-				if (perdu <= 4) continue
+				// Tolérance de 32px, et non 4. En dessous, c'est presque toujours un
+				// débord VOULU (`-mx-4` pour aller bord à bord donne 16px) ou un écart
+				// de calcul entre moteurs : WebKit compte le débord par marge négative
+				// dans `scrollWidth`, Chromium non, et le profil remontait donc 16px
+				// sur l'un et rien sur l'autre.
+				// Les vraies coupures sont d'un tout autre ordre : la rangée de
+				// statistiques d'un sujet débordait de 182px. Un seuil qui separe
+				// franchement les deux vaut mieux qu'un test rouge sur un seul moteur,
+				// qu'on finirait par ignorer.
+				if (perdu <= 32) continue
 				if (el.clientWidth < 60) continue
 				if (!(el.textContent || '').trim()) continue
 


### PR DESCRIPTION
Après déploiement, deux échecs subsistaient, **uniquement sur WebKit** et
uniquement sur le profil : `-16px` sur le conteneur de l'application. Chromium ne
signalait rien.

## Le détecteur avait tort

16px, c'est **exactement** le `-mx-4` de `profile-scope`, qui va bord à bord à
dessein. WebKit compte ce débord par marge négative dans `scrollWidth`, Chromium
non. Rien n'est coupé, un parent le rogne.

Tolérance portée de 4 à **32px**. En dessous, c'est presque toujours un débord
voulu ou un écart de calcul entre moteurs.

## Prouvé que la tolérance n'aveugle rien

En réintroduisant le défaut d'origine sur la page réelle (retrait du `flex-wrap`
de la rangée de statistiques) :

```
code corrigé         pire débordement =   0px  →  rien à signaler
défaut réintroduit   pire débordement = 182px  →  ATTRAPÉ
```

La marge entre 16px de débord voulu et 182px de vraie coupure est franche.

## État de la suite

Contre la production : **43 verts, 3 sautés, zéro échec**, sur les deux moteurs
et y compris les tests authentifiés.