### PR TITLE
fix(i18n): la barre de navigation parlait français quelle que soit la langue

### DIFF
--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -4527,5 +4527,12 @@
   "chat.cmd_help_roll": "roll dice",
   "chat.cmd_help_flip": "flip a coin",
   "chat.cmd_help_8ball": "ask a question",
-  "chat.cmd_help_rps": "rock paper scissors"
+  "chat.cmd_help_rps": "rock paper scissors",
+  "nav.bar_feed": "Feed",
+  "nav.bar_forum": "Forum",
+  "nav.bar_chat": "Chat",
+  "nav.bar_dm": "DMs",
+  "nav.bar_library": "Library",
+  "nav.bar_directory": "Explore",
+  "nav.bar_profile": "Profile"
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -4527,5 +4527,12 @@
   "chat.cmd_help_roll": "lance des dés",
   "chat.cmd_help_flip": "pile ou face",
   "chat.cmd_help_8ball": "pose une question",
-  "chat.cmd_help_rps": "pierre feuille ciseaux"
+  "chat.cmd_help_rps": "pierre feuille ciseaux",
+  "nav.bar_feed": "Actu",
+  "nav.bar_forum": "Forum",
+  "nav.bar_chat": "Chat",
+  "nav.bar_dm": "MP",
+  "nav.bar_library": "Biblio",
+  "nav.bar_directory": "Réseau",
+  "nav.bar_profile": "Profil"
 }

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -1703,7 +1703,7 @@
 			<svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
 				<path stroke-linecap="round" stroke-linejoin="round" d="M3 12h18M3 6h18M3 18h12"/>
 			</svg>
-			<span class="text-xs font-medium">Actu</span>
+			<span class="text-xs font-medium">{tFn('nav.bar_feed')}</span>
 		</a>
 		{/if}
 
@@ -1713,7 +1713,7 @@
 				<path stroke-linecap="round" stroke-linejoin="round" d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
 				<polyline stroke-linecap="round" stroke-linejoin="round" points="9 22 9 12 15 12 15 22"/>
 			</svg>
-			<span class="text-xs font-medium">Forum</span>
+			<span class="text-xs font-medium">{tFn('nav.bar_forum')}</span>
 		</a>
 
 		<!-- Chat (si connecté) -->
@@ -1727,7 +1727,7 @@
 					{unreadCount > 9 ? '9+' : unreadCount}
 				</span>
 			{/if}
-			<span class="text-xs font-medium">Chat</span>
+			<span class="text-xs font-medium">{tFn('nav.bar_chat')}</span>
 		</a>
 		{/if}
 
@@ -1742,7 +1742,7 @@
 					{dmUnread > 9 ? '9+' : dmUnread}
 				</span>
 			{/if}
-			<span class="text-xs font-medium">DMs</span>
+			<span class="text-xs font-medium">{tFn('nav.bar_dm')}</span>
 		</a>
 		{/if}
 
@@ -1752,7 +1752,7 @@
 				<path stroke-linecap="round" stroke-linejoin="round" d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
 				<path stroke-linecap="round" stroke-linejoin="round" d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
 			</svg>
-			<span class="text-xs font-medium">Biblio</span>
+			<span class="text-xs font-medium">{tFn('nav.bar_library')}</span>
 		</a>
 
 		<!-- Annuaire -->
@@ -1762,7 +1762,7 @@
 				<line x1="2" y1="12" x2="22" y2="12"/>
 				<path stroke-linecap="round" stroke-linejoin="round" d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
 			</svg>
-			<span class="text-xs font-medium">Annuaire</span>
+			<span class="text-xs font-medium">{tFn('nav.bar_directory')}</span>
 		</a>
 
 		<!-- Profil / Connexion -->
@@ -1776,7 +1776,7 @@
 					{user.username.charAt(0).toUpperCase()}
 				</div>
 			{/if}
-			<span class="text-xs font-medium">Profil</span>
+			<span class="text-xs font-medium">{tFn('nav.bar_profile')}</span>
 		</a>
 		{:else}
 		<a href="/auth/login" class="flex-1 flex flex-col items-center justify-center py-2 min-h-14 gap-0.5 text-gray-500">


### PR DESCRIPTION
Les 7 libellés de la barre du bas étaient codés **en dur en français** : `Actu`,
`Forum`, `Chat`, `DMs`, `Biblio`, `Annuaire`, `Profil`.

Sur une interface en anglais, la barre restait donc en français. Visible sur ta
capture : « Members » et « Last message » au-dessus d'une barre francophone.

## Pourquoi les 4 portes i18n ne l'ont pas vu

Le scanner détecte le français par les **accents** et par une **liste de mots**.
Aucun de ces sept libellés n'a d'accent, et aucun n'est dans la liste. Ils
passaient au travers.

C'est un trou du garde-fou autant qu'un défaut de la page.

## Un jeu de clés court et dédié

`nav.bar_*` plutôt que réutiliser les `nav.*` existants : ceux-ci valent
« Fil d'actu », « Messages », « Bibliothèque », bien trop longs pour sept entrées
sur un téléphone.

## Une régression de ma propre passe typographique, rattrapée ici

Le passage de 10px à `text-xs` (13px) de la veille avait été mesuré sur la barre
**anonyme**, qui n'a que 4 entrées et des cases de 97px. Connecté, la barre en
porte **sept** et les cases tombent à 51px :

```
« Annuaire »  58px  →  COUPÉ
« Directory » 60px  →  COUPÉ
```

Même angle mort deux jours de suite : mesurer l'état le plus favorable.

D'où **« Réseau »** (47px) et **« Explore »** (49px), sémantiquement justes
puisque la page est « Découvrir le réseau Nodyx ».

## Mesure de la barre à 7 entrées, dans les deux langues

| Langue | Largeurs | Résultat |
|---|---|---|
| FR | 320 / 360 / 390 / 412px | aucun libellé coupé |
| EN | 360 / 390 / 412px | aucun libellé coupé |
| EN | 320px | « Explore » coupé, **assumé** |

À 320px les cases font 46px : sept libellés à 13px ne tiennent plus quel que
soit le mot. C'est une limite structurelle, pas un problème de vocabulaire. Et
320px est sous le plancher moderne, l'iPhone SE actuel faisant 375.

## Vérifications

`npm run check` à 0 erreur, **105 tests Vitest verts**, 4 portes i18n vertes,
parité à 4536 clés.