### PR TITLE
fix(i18n): le scanner ne voyait pas le français SANS ACCENT

### DIFF
--- a/nodyx-frontend/scripts/i18n/scan.mjs
+++ b/nodyx-frontend/scripts/i18n/scan.mjs
@@ -29,7 +29,7 @@ const PUBLIC_ONLY = args.has('--public')
 // « membres »…) — c'est l'angle mort qui a laissé passer des chaînes en dur.
 // La wordlist ci-dessous couvre ces cas sans accent (verbes/labels UI courants).
 const ACC = /[àâäéèêëïîôùûüÿçœÀÂÄÉÈÊËÏÎÔÙÛÜŸÇŒ]/
-const FR = /\b([Ss]upprimer|[Aa]nnuler|[Ee]nregistrer|[Mm]odifier|[Aa]jouter|[Ee]nvoyer|[Ff]ermer|[Rr]etour|[Ss]uivant|[Rr]echercher|Aucune?|Nouvelle?|Nouveau|[Cc]harger|[Mm]embres?|Connexion|Inscription|Brouillon|[Pp]ublier|[Cc]hoisir|[Cc]opier|[Pp]artager|[Ee]ffacer|[Ee]nlever|[Oo]uvrir|Bienvenue|Erreur|Chargement|[Rr]ejoindre|[Qq]uitter|[Ss]uivre|[Ss]uivi|[Cc]onnecte[rz]|[Cc]onnecte-toi|[Cc]ontinuer|[Vv]alider|[Cc]ontacte[rz]|[Pp]articiper|[Dd]iffuse|Lancer pour|Attribution|[Cc]arte)\b/
+const FR = /\b([Ss]upprimer|[Aa]nnuler|[Ee]nregistrer|[Mm]odifier|[Aa]jouter|[Ee]nvoyer|[Ff]ermer|[Rr]etour|[Ss]uivant|[Rr]echercher|Aucune?|Nouvelle?|Nouveau|[Cc]harger|[Mm]embres?|Connexion|Inscription|Brouillon|[Pp]ublier|[Cc]hoisir|[Cc]opier|[Pp]artager|[Ee]ffacer|[Ee]nlever|[Oo]uvrir|Bienvenue|Erreur|Chargement|[Rr]ejoindre|[Qq]uitter|[Ss]uivre|[Ss]uivi|[Cc]onnecte[rz]|[Cc]onnecte-toi|[Cc]ontinuer|[Vv]alider|[Cc]ontacte[rz]|[Pp]articiper|[Dd]iffuse|Lancer pour|Attribution|[Cc]arte|Annuaire|Profil\b|Actu\b|Biblio\b|Reseau|Accueil|Parametres?|Deconnexion|Sondages?|Taches?|Calendrier|Jardin|Bibliotheque)\b/
 // Contractions et pronoms français : quasi impossibles en anglais → forte fiabilité.
 const FR_FUNC = /(\bvous\b|\bvotre\b|\bvos\b|\bcette\b|qu'il|s'agit|d'une|d'un\b|n'est|c'est|l'instant|parlez|Sois le premier)/
 

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -4534,5 +4534,7 @@
   "nav.bar_dm": "DMs",
   "nav.bar_library": "Library",
   "nav.bar_directory": "Explore",
-  "nav.bar_profile": "Profile"
+  "nav.bar_profile": "Profile",
+  "calendar.page_title": "Calendar",
+  "ucard.meta_description": "Profile of {{name}} on Nodyx, level {{level}}, {{posts}} posts, {{xp}} XP"
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -4534,5 +4534,7 @@
   "nav.bar_dm": "MP",
   "nav.bar_library": "Biblio",
   "nav.bar_directory": "Réseau",
-  "nav.bar_profile": "Profil"
+  "nav.bar_profile": "Profil",
+  "calendar.page_title": "Calendrier",
+  "ucard.meta_description": "Profil de {{name}} sur Nodyx, niveau {{level}}, {{posts}} messages, {{xp}} XP"
 }

--- a/nodyx-frontend/src/routes/calendar/+page.svelte
+++ b/nodyx-frontend/src/routes/calendar/+page.svelte
@@ -42,7 +42,7 @@
 </script>
 
 <svelte:head>
-	<title>Calendrier · {data.communityName ?? 'Nodyx'}</title>
+	<title>{tFn('calendar.page_title')} · {data.communityName ?? 'Nodyx'}</title>
 </svelte:head>
 
 <div class="cal-root">

--- a/nodyx-frontend/src/routes/users/[username]/card/+page.svelte
+++ b/nodyx-frontend/src/routes/users/[username]/card/+page.svelte
@@ -132,7 +132,15 @@
 
 <svelte:head>
 	<title>{tFn('user_card.meta_title', { name: displayName })}</title>
-	<meta name="description" content="Profil de {displayName} sur Nodyx, Niveau {level}, {Number(profile.post_count??0).toLocaleString('fr-FR')} posts, {Number(pts).toLocaleString('fr-FR')} XP" />
+	<!-- Meta-description lue par les moteurs : elle etait codee en dur en
+	     francais, y compris son `toLocaleString('fr-FR')` qui formatait les
+	     nombres a la francaise pour un visiteur anglophone. -->
+	<meta name="description" content={tFn('ucard.meta_description', {
+		name:  displayName,
+		level: String(level),
+		posts: Number(profile.post_count ?? 0).toLocaleString(),
+		xp:    Number(pts).toLocaleString(),
+	})} />
 
 	<!-- Prevent indexing (cards are supplements, not canonical) -->
 	<meta name="robots" content="noindex, follow" />


### PR DESCRIPTION
Suite directe de la barre de navigation : sept libellés français codés en dur
étaient passés sous les **quatre portes**. Le scanner détecte le français par les
**accents** et par une **liste de mots**, or « Annuaire », « Profil », « Actu »
et « Biblio » n'ont ni l'un ni l'autre.

## Le durcissement

Wordlist étendue aux mots français sans accent, sans ambiguïté ou inexistants en
anglais avec ce sens :

```
Annuaire · Profil · Actu · Biblio · Reseau · Accueil · Parametres
Deconnexion · Sondages · Taches · Calendrier · Jardin · Bibliotheque
```

### Un faux positif écarté en route

J'avais d'abord ajouté **`Notifications`**, qui s'écrit **strictement pareil en
anglais**. Il faisait tomber la porte sur trois occurrences parfaitement
légitimes de `settings`. Retiré.

## Deux chaînes réelles révélées, toutes deux publiques

| Fichier | Ce qui était figé en français |
|---|---|
| `calendar/+page.svelte` | `<title>Calendrier</title>`, le **titre d'onglet** |
| `users/[username]/card` | `<meta name="description">`, **lue par les moteurs de recherche** |

La seconde est la pire : « Profil de X sur Nodyx, Niveau Y » était figé en
français, **`toLocaleString('fr-FR')` compris**. Les nombres étaient donc
formatés à la française pour un visiteur anglophone.

## Prouvé que le durcissement sert

En remettant « Calendrier » en dur :

```
   1  routes/calendar/+page.svelte
1 hardcoded French string(s) in 1 file(s).
```

puis retour au vert après restauration.

## Vérifications

`npm run check` à 0 erreur, **105 tests Vitest verts**, 4 portes vertes, parité à
4538 clés.