### PR TITLE
fix(ui): la pire cible tactile du produit disparaît des téléphones

### DIFF
--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -2616,12 +2616,21 @@ a.nx-icon-btn[class*="active"],
   pointer-events: none;
 }
 
+/* Poignee de redimensionnement des panneaux.
+   MASQUEE sous lg : redimensionner n'a de sens que pour des COLONNES, or sous ce
+   point de rupture le panneau est un TIROIR. Elle y restait pourtant, invisible,
+   large de 6px et haute de tout l'ecran, a intercepter les touchers au bord.
+   L'audit du 15/08 la remontait comme la pire cible tactile du produit
+   (6 x 752px). Au doigt, elle est de toute facon inattrapable.
+   Elargie a 10px sur grand ecran : 6px se rate a la souris, et comme elle est
+   transparente, l'elargir ne change rien a l'apparence. */
 .panel .edge-handle,
 .members-c .edge-handle {
+  display: none;
   position: absolute;
   top: 0;
   bottom: 0;
-  width: 6px;
+  width: 10px;
   cursor: ew-resize;
   z-index: 10;
   background: transparent;
@@ -2636,6 +2645,15 @@ a.nx-icon-btn[class*="active"],
 
 .members-c .edge-handle {
   left: 0;
+}
+
+/* La poignee ne sert que sur de vraies COLONNES. Cette reprise DOIT venir
+   apres la regle `display: none` ci-dessus : a specificite egale c'est
+   l'ordre qui tranche, et placee avant elle etait purement annulee (piege
+   deja rencontre le 15/08 sur le `top` du tiroir, dans cette meme feuille). */
+@media (min-width: 1024px) {
+  .panel .edge-handle,
+  .members-c .edge-handle { display: block; }
 }
 
 .panel .edge-handle:hover,


### PR DESCRIPTION
L'audit du 15/08 remontait un `<button>` de **6 x 752px** comme la plus mauvaise
cible tactile du produit. C'est `.edge-handle`, la poignée qui redimensionne les
panneaux : 6px de large, toute la hauteur de l'écran, transparente.

## Pourquoi elle n'a rien à faire sur un téléphone

Redimensionner n'a de sens que pour des **colonnes**. Sous `lg` le panneau est un
**tiroir**, et la poignée y restait pourtant, invisible, à intercepter les
touchers au bord de l'écran. Au doigt elle est de toute façon inattrapable.

| Largeur | Avant | Après |
|---|---|---|
| Mobile / tablette | poignée de 6px présente | **masquée** |
| Bureau | 6px | **10px**, plus facile à attraper |

L'élargir ne change **rien à l'apparence** : elle est transparente.

## Le piège de cascade, pour la deuxième fois dans cette même feuille

La reprise `@media (min-width: 1024px)` avait d'abord été posée dans la media
query du **haut** du fichier, très au-dessus des règles de base. À spécificité
égale c'est l'ordre qui tranche : elle était purement annulée, et la poignée
restait masquée **partout, bureau compris**.

Même cause que le `top` du tiroir la veille. Déplacée juste après la règle
qu'elle surcharge, avec un commentaire.

Ce qui rend ce piège coûteux : `npm run check` était vert dans les deux cas, et
la relecture du code ne montre rien. **La règle est bien écrite, elle est
simplement sans effet.** Seule une mesure du rendu l'attrape.

## Vérifié au navigateur, aux trois largeurs

```
mobile    390px   0 poignée visible
tablette  768px   0 poignée visible
bureau   1280px   2 poignées de 10x752
```

`npm run check` à 0 erreur, 105 tests Vitest verts.