### PR TITLE
fix(ui): un écran flouté sans sidebar était structurellement possible

### DIFF
--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -443,6 +443,33 @@
 		gallerySidebarOpen = false
 	})
 
+	// ── Diagnostic : « écran flouté sans sidebar » ───────────────────────────
+	// Symptôme signalé le 2026-08-16, intermittent et jamais reproduit ici : au
+	// clic sur le burger, le voile apparaît mais le panneau non. Le voile est
+	// désormais monté sous la MÊME condition que le panneau, ce qui rend ce cas
+	// impossible par construction. Ce garde-fou reste pour le cas où le panneau
+	// serait présent mais invisible pour une AUTRE raison (transform figé,
+	// z-index, contexte d'empilement) : il rend alors l'état lisible en console
+	// au lieu de laisser l'utilisateur face à un écran flou muet.
+	$effect(() => {
+		if (!gallerySidebarOpen || typeof document === 'undefined') return
+		const t = setTimeout(() => {
+			const panneau = document.querySelector<HTMLElement>('.nodyx-sb .panel')
+			if (!panneau) { console.warn('[nodyx] drawer ouvert, panneau ABSENT du DOM'); return }
+			const r = panneau.getBoundingClientRect()
+			const st = getComputedStyle(panneau)
+			// Hors de l'écran, invisible ou derrière le voile : on le dit.
+			if (r.right <= 0 || r.left >= window.innerWidth || st.visibility === 'hidden' || st.display === 'none') {
+				console.warn('[nodyx] drawer ouvert mais panneau invisible', {
+					x: Math.round(r.x), largeur: Math.round(r.width),
+					transform: st.transform, display: st.display,
+					visibility: st.visibility, zIndex: st.zIndex,
+				})
+			}
+		}, 400)   // après la transition d'ouverture
+		return () => clearTimeout(t)
+	})
+
 	// Bloque le scroll du body quand le drawer est ouvert
 	$effect(() => {
 		if (!browser) return
@@ -1035,7 +1062,13 @@
 	     class:layout-dragging={isDraggingLeft || isDraggingRight}>
 
 		<!-- ── Backdrop Channel Sidebar — mobile ──────────────────────────────── -->
-		{#if !isBanned && gallerySidebarOpen}
+		<!-- Le voile est monte sous la MEME condition que le panneau, `showChannelSidebar`
+		     comprise. Avant, le voile ne dependait que de `gallerySidebarOpen` et le
+		     panneau aussi de `showChannelSidebar` : des que la seconde devenait fausse
+		     (routes /admin, /auth, /banned), on obtenait un ECRAN FLOUTE SANS SIDEBAR,
+		     exactement le symptome signale le 16/08. Les lier rend ce cas impossible,
+		     quelle que soit la sequence qui y menait. -->
+		{#if !isBanned && showChannelSidebar && gallerySidebarOpen}
 		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 		<div class="lg:hidden fixed inset-0 bg-black/60 z-[54] backdrop-blur-xs"
 		     role="button" tabindex="-1" aria-label={tFn('common.close_menu')}


### PR DESCRIPTION
Signalé le 16/08, intermittent : au clic sur le burger, **tout devient flou et
aucune sidebar n'apparaît**.

Symptôme **différent** de celui du service worker corrigé la veille : ici le clic
est bien pris en compte, puisque le voile arrive.

## Non reproduit, donc pas de correctif à l'aveugle

Je n'ai pas réussi à le déclencher. Mais un fait structurel suffit à expliquer
exactement ce symptôme, quelle que soit la séquence qui y menait :

```svelte
voile    {#if !isBanned && gallerySidebarOpen}
panneau  {#if !isBanned && showChannelSidebar}
```

**Deux conditions différentes.** Dès que `showChannelSidebar` devient faux
(routes `/admin`, `/auth`, `/banned`) alors que `gallerySidebarOpen` est vrai, on
obtient un voile flouté **sans panneau**.

Le voile est désormais monté sous la même condition que le panneau. Ce cas
devient **impossible par construction**.

## Diagnostic ajouté

Selon ta règle « instrumenter avant de corriger ». Si le panneau était présent
mais invisible pour une **autre** raison (transform figé, z-index, contexte
d'empilement), un `$effect` le dit en console 400 ms après l'ouverture, avec
`x`, `largeur`, `transform`, `display`, `visibility` et `zIndex`.

Plutôt qu'un écran flou muet, tu auras la cause.

## Vérifié au navigateur

```
fermé    voile=false   panneau x=-220
ouvert   voile=true    panneau x=0
diagnostic : muet, comme attendu quand tout va bien
```

## Tes messages de console

`allowfullscreen`, `TwitchAutoplay`, `Amazon IVS`, `MaxListenersExceeded` :
**tous** issus du lecteur Twitch embarqué, aucun rapport avec ce défaut.

`npm run check` à 0 erreur, 105 tests Vitest verts.