### PR TITLE
fix(ui): l'écran flouté sans sidebar, cause trouvée et reproduite

### DIFF
--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -454,8 +454,9 @@
 	$effect(() => {
 		if (!gallerySidebarOpen || typeof document === 'undefined') return
 		const t = setTimeout(() => {
-			const panneau = document.querySelector<HTMLElement>('.nodyx-sb .panel')
-			if (!panneau) { console.warn('[nodyx] drawer ouvert, panneau ABSENT du DOM'); return }
+			const tous = [...document.querySelectorAll<HTMLElement>('.nodyx-sb .panel')]
+			if (tous.length === 0) { console.warn('[nodyx] drawer ouvert, panneau ABSENT du DOM'); return }
+			const panneau = tous[tous.length - 1]
 			const r = panneau.getBoundingClientRect()
 			const st = getComputedStyle(panneau)
 			// Hors de l'écran, invisible ou derrière le voile : on le dit.
@@ -464,6 +465,15 @@
 					x: Math.round(r.x), largeur: Math.round(r.width),
 					transform: st.transform, display: st.display,
 					visibility: st.visibility, zIndex: st.zIndex,
+					// Les trois informations qui manquaient pour trancher :
+					// la classe est-elle encore la ? l'etat Svelte dit-il ouvert ?
+					// et la media query mobile s'applique-t-elle vraiment ?
+					nbPanneaux: tous.length,
+					classe: panneau.className,
+					etatSvelte: gallerySidebarOpen,
+					largeurEcran: window.innerWidth,
+					mobileActif: window.matchMedia('(max-width: 1023px)').matches,
+					styleInline: panneau.getAttribute('style'),
 				})
 			}
 		}, 400)   // après la transition d'ouverture
@@ -830,7 +840,17 @@
 		<button
 			class="lg:hidden shrink-0 p-2.5 -m-1 flex items-center justify-center transition-colors"
 			style="color: {gallerySidebarOpen ? '#fff' : '#6b7280'}"
-			onclick={() => gallerySidebarOpen = !gallerySidebarOpen}
+			onclick={() => {
+				gallerySidebarOpen = !gallerySidebarOpen;
+				// Ouvrir le tiroir doit AUSSI le deplier. `panelCollapsed` est un
+				// etat de BUREAU (replier le panneau sur le rail), mais la regle
+				// `.panel.collapsed` pose son propre `translateX(-100%)`, qui
+				// survit sur mobile. Or la croix du panneau pose
+				// `panelCollapsed = true` en fermant : au clic suivant sur le
+				// burger, le voile revenait SANS le panneau, reste hors ecran.
+				// Bug du 16/08, reproduit puis corrige.
+				if (gallerySidebarOpen) panelCollapsed = false;
+			}}
 			aria-label={tFn('nav.community_menu')} aria-expanded={gallerySidebarOpen} aria-controls="galaxy-sidebar">
 			{#if gallerySidebarOpen}
 				<svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">

--- a/nodyx-frontend/tests/responsive/authentifie.spec.ts
+++ b/nodyx-frontend/tests/responsive/authentifie.spec.ts
@@ -80,6 +80,47 @@ test.describe('pages authentifiées', () => {
 		).toBeGreaterThan(avant)
 	})
 
+	/**
+	 * Defaut du 16/08 : ouvrir le tiroir, le fermer par la CROIX du panneau, puis
+	 * le rouvrir au burger donnait un ecran floute SANS sidebar.
+	 *
+	 * La croix pose `panelCollapsed = true` en fermant, et la regle
+	 * `.panel.collapsed` porte son propre `translateX(-100%)`. Rouvrir remettait
+	 * donc `gallerySidebarOpen` a vrai (le voile revenait) pendant que le panneau
+	 * restait hors ecran. Le symptome semblait aleatoire : il dependait en fait
+	 * de la FACON dont on avait ferme la fois precedente.
+	 */
+	test('rouvrir apres une fermeture par la croix montre bien le panneau', async ({ page }, info) => {
+		test.skip(info.project.name.startsWith('tablette'), 'le tiroir n existe pas des lg')
+
+		await page.goto('/forum', { waitUntil: 'domcontentloaded' })
+		await page.waitForTimeout(1800)
+
+		const burger = page.locator('[aria-controls="galaxy-sidebar"]')
+		const posX = () =>
+			page.evaluate(() => {
+				const t = [...document.querySelectorAll('.nodyx-sb .panel')]
+				const el = t[t.length - 1]
+				return el ? Math.round(el.getBoundingClientRect().x) : NaN
+			})
+
+		await burger.click()
+		await page.waitForTimeout(700)
+		expect(await posX(), 'le panneau ne s ouvre pas la premiere fois').toBe(0)
+
+		const croix = page.locator('.nodyx-sb .panel .close').last()
+		test.skip((await croix.count()) === 0, 'croix de fermeture introuvable')
+		await croix.click()
+		await page.waitForTimeout(700)
+
+		await burger.click()
+		await page.waitForTimeout(900)
+		expect(
+			await posX(),
+			'panneau hors ecran apres une fermeture par la croix : `panelCollapsed` n a pas ete remis a zero',
+		).toBe(0)
+	})
+
 	/** Le burger doit rester attrapable au pouce : 44px est la recommandation. */
 	test('le burger est assez grand pour un pouce', async ({ page }, info) => {
 		test.skip(info.project.name.startsWith('tablette'), 'le burger est masqué dès lg')


### PR DESCRIPTION
Le diagnostic posé la veille a livré la réponse :

```
transform: matrix(1, 0, 0, 1, -272, 0)   display: flex   visibility: visible
```

Le panneau n'était **pas caché**, il était **décalé hors écran**.

## La cause

La classe du panneau porte **deux** états :

```svelte
class="panel {panelCollapsed ? 'collapsed' : ''} {gallerySidebarOpen ? '' : ...}"
```

```css
.nodyx-sb .panel.collapsed { transform: translateX(-100%); }
```

Or la **croix dans le panneau** ferme en faisant `gallerySidebarOpen = false`
**et** `panelCollapsed = true`.

Au clic suivant sur le burger, `gallerySidebarOpen` repassait à vrai (le voile
revenait) mais `panelCollapsed` restait vrai, et `.collapsed` gardait le panneau
hors écran.

**Le symptôme n'avait rien d'aléatoire** : il dépendait de la façon dont on avait
fermé la fois précédente. Par la croix il revenait, par le voile ou Échap non.

## Reproduit avant de corriger, sur la production

```
2. ouvert au burger      x=0      collapsed=false
3. fermé par la CROIX    x=-440   collapsed=TRUE
4. rouvert au burger     x=-220   collapsed=TRUE   →  hors écran
```

Après correctif, mêmes étapes 1 à 3, seule la quatrième change :

```
4. rouvert au burger     x=0      collapsed=false  →  VISIBLE
```

## Le correctif

Ouvrir le tiroir le **déplie** aussi. `panelCollapsed` est un état de **bureau**
(replier le panneau sur le rail) qui n'a pas à survivre à une ouverture sur
mobile.

## Test de régression

Ajouté à la suite authentifiée, il rejoue la séquence complète et **tombe sur la
production actuelle** avec le message exact :

```
Error: panneau hors ecran apres une fermeture par la croix :
       `panelCollapsed` n a pas ete remis a zero
```

## Un piège évité en route

Mon premier commentaire d'explication avait été inséré **entre deux attributs**
d'un élément, ce qui est invalide. `npm run check` est passé de 0 à 2 erreurs et
me l'a dit tout de suite. Déplacé dans la fonction.

## Vérifications

`npm run check` à 0 erreur, 105 tests Vitest verts.