### PR TITLE
fix(voice): le chat du salon envahissait l'écran d'un canal vocal sur téléphone

### DIFF
--- a/nodyx-frontend/src/lib/components/VoiceRoom.svelte
+++ b/nodyx-frontend/src/lib/components/VoiceRoom.svelte
@@ -44,10 +44,23 @@
 	// ── Chat du salon vocal ───────────────────────────────────────────────────
 	// Un canal VOCAL n'avait tout simplement pas de chat : la page n'affiche le
 	// fil de discussion que pour les canaux TEXTE (`{:else}` côté +page.svelte).
-	// On l'ajoute ici, à droite, OUVERT par défaut et repliable d'une flèche.
-	let showChatPanel = $state(
-		!browser || localStorage.getItem('nodyx:voice:chat') !== '0',
-	);
+	// On l'ajoute ici, à droite, repliable.
+	//
+	// OUVERT par défaut sur grand écran, FERMÉ sur mobile : sur un téléphone il
+	// mangeait la moitié de la page d'un salon VOCAL, où l'on vient d'abord pour
+	// rejoindre la voix. Un choix explicite de l'utilisateur, lui, est toujours
+	// respecté, quelle que soit la taille d'écran.
+	//
+	// Rendu SSR à `false` puis corrigé au montage : partir fermé évite qu'un
+	// téléphone affiche brièvement un panneau qui va disparaître.
+	let showChatPanel = $state(false);
+	$effect(() => {
+		if (!browser) return;
+		const choix = localStorage.getItem('nodyx:voice:chat');
+		showChatPanel = choix !== null
+			? choix === '1'
+			: window.matchMedia('(min-width: 1024px)').matches;
+	});
 	$effect(() => {
 		if (browser) {
 			localStorage.setItem('nodyx:voice:chat', showChatPanel ? '1' : '0');
@@ -453,13 +466,16 @@
 {:else}
 	<button
 		onclick={() => (showChatPanel = true)}
-		class="flex w-8 shrink-0 items-center justify-center transition-colors hover:bg-white/5"
+		class="flex w-11 shrink-0 items-center justify-center transition-colors hover:bg-white/5 lg:w-8"
 		style="background: rgba(6,6,12,0.75); border-left: 1px solid rgba(255,255,255,0.05); color: rgb(148,163,184)"
 		title={tFn('voice_room.show_chat')}
 		aria-label={tFn('voice_room.show_chat')}
 	>
-		<svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-			<path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/>
+		<!-- Une bulle de discussion, pas un chevron : le chevron ne disait pas ce
+		     qu'il ouvrait. Meme icone que l'entree « Chat » de la barre du bas,
+		     pour qu'on la reconnaisse. -->
+		<svg class="h-5 w-5 lg:h-4 lg:w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+			<path stroke-linecap="round" stroke-linejoin="round" d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
 		</svg>
 	</button>
 {/if}

--- a/nodyx-frontend/tests/responsive/authentifie.spec.ts
+++ b/nodyx-frontend/tests/responsive/authentifie.spec.ts
@@ -121,6 +121,41 @@ test.describe('pages authentifiées', () => {
 		).toBe(0)
 	})
 
+	/**
+	 * Defaut du 16/08 : sur un salon VOCAL, le chat du salon s'ouvrait par defaut,
+	 * y compris sur telephone ou il mangeait la moitie de l'ecran. On vient
+	 * pourtant d'abord pour rejoindre la voix.
+	 *
+	 * Le test NETTOIE le choix stocke avant de mesurer : la session Playwright
+	 * embarque le localStorage, et un choix explicite de l'utilisateur doit etre
+	 * respecte. Sans ce nettoyage, on mesurerait une preference, pas le defaut.
+	 */
+	test('le chat d un salon vocal reste ferme par defaut sur telephone', async ({ page }, info) => {
+		test.skip(info.project.name.startsWith('tablette'), 'ce defaut ne concerne que le mobile')
+
+		await page.goto('/chat', { waitUntil: 'domcontentloaded' })
+		await page.evaluate(() => localStorage.removeItem('nodyx:voice:chat'))
+		await page.goto('/chat?channel=a3010bd6-cc2e-4ab5-9b6a-8a9046ffbbe5', {
+			waitUntil: 'domcontentloaded',
+		})
+		await page.waitForTimeout(2500)
+
+		const panneau = await page.evaluate(() => {
+			const entete = [...document.querySelectorAll('*')].find((e) =>
+				/chat du salon|room chat/i.test(e.textContent ?? '') && e.children.length < 4,
+			)
+			return entete ? Math.round(entete.getBoundingClientRect().width) : 0
+		})
+		expect(panneau, 'le chat du salon est ouvert par defaut sur telephone').toBe(0)
+
+		// Et le bouton qui l'ouvre doit etre attrapable au pouce.
+		const bouton = page.locator('button[aria-label*="chat" i]').first()
+		if (await bouton.count()) {
+			const b = await bouton.boundingBox()
+			expect(Math.round(b!.width), 'bouton d ouverture du chat trop etroit').toBeGreaterThanOrEqual(40)
+		}
+	})
+
 	/** Le burger doit rester attrapable au pouce : 44px est la recommandation. */
 	test('le burger est assez grand pour un pouce', async ({ page }, info) => {
 		test.skip(info.project.name.startsWith('tablette'), 'le burger est masqué dès lg')


### PR DESCRIPTION
Signalé en capture : sur un salon **vocal**, le chat s'ouvrait par défaut et
occupait la moitié de l'écran, alors qu'on vient d'abord pour rejoindre la voix.

## Ce qui change

| | Avant | Après |
|---|---|---|
| Grand écran | ouvert par défaut | inchangé |
| Téléphone | ouvert par défaut | **fermé** |
| Choix explicite de l'utilisateur | respecté | respecté, quelle que soit la largeur |

Rendu SSR à `false` puis corrigé au montage : partir fermé évite qu'un téléphone
affiche brièvement un panneau qui va disparaître.

## Le bouton ne disait pas ce qu'il ouvrait

C'était un chevron « ‹ » de 16px dans une colonne de 32px. Tu avais raison : on
ne devine pas ce qu'il y a derrière.

Remplacé par une **bulle de discussion**, la même icône que l'entrée « Chat » de
la barre du bas pour qu'on la reconnaisse, et agrandie sur mobile :

```
mobile     bouton 44px   icône 20px
grand écran bouton 32px  icône 16px   (la souris vise juste)
```

## Test de régression

Ajouté à la suite authentifiée. Il **nettoie le choix stocké avant de mesurer** :
la session Playwright embarque le `localStorage`, et sans ce nettoyage on
mesurerait une préférence et non le défaut.

Il tombe bien sur la production actuelle :

```
Error: le chat du salon est ouvert par defaut sur telephone
```

## Vérifications

Les 4 classes responsives sont **générées** dans le CSS construit (`w-11`,
`lg:w-8`, `h-5`, `lg:h-4`), `npm run check` à 0 erreur, 105 tests Vitest verts.