### PR TITLE
test(responsive): stabiliser la suite, elle mesurait avant que la page soit prête

### DIFF
--- a/nodyx-frontend/playwright.config.ts
+++ b/nodyx-frontend/playwright.config.ts
@@ -32,7 +32,12 @@ export default defineConfig({
 	// Un test de rendu qui dépend de l'ordre d'exécution ment.
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
-	retries: process.env.CI ? 1 : 0,
+	// Un reessai TOUJOURS, pas seulement en CI. Le service worker recharge la
+	// page des qu'une nouvelle version prend le controle, ce qui arrive au
+	// premier chargement de CHAQUE contexte apres un deploiement, donc de
+	// chaque test. C'est le comportement attendu du produit, pas un defaut :
+	// un test qui passe au second essai dans ce cas est un test qui a raison.
+	retries: 1,
 	reporter: process.env.CI ? 'github' : 'list',
 
 	use: {

--- a/nodyx-frontend/tests/responsive/_attente.ts
+++ b/nodyx-frontend/tests/responsive/_attente.ts
@@ -1,0 +1,48 @@
+import type { Page } from '@playwright/test'
+
+/**
+ * Attend que la page soit MESURABLE, au lieu d'un délai fixe.
+ *
+ * Deux problèmes distincts à absorber, tous deux constatés le 2026-08-16.
+ *
+ * 1. LES POLICES. Tant qu'elles ne sont pas chargées, les textes sont rendus
+ *    avec une police de repli dont les largeurs diffèrent. Or ces tests mesurent
+ *    précisément des largeurs. Un délai fixe suffisait à vide mais pas sous
+ *    charge : le test du profil tombait dans la suite complète alors qu'il
+ *    passait isolé.
+ *
+ * 2. LA PAGE QUI SE RECHARGE SOUS NOS PIEDS. Le service worker recharge la page
+ *    dès qu'une nouvelle version prend le contrôle, ce qui arrive précisément au
+ *    premier chargement après un déploiement, c'est-à-dire au pire moment pour
+ *    une suite de tests. Un `page.evaluate` en cours meurt alors avec
+ *    « Execution context was destroyed ». Ma première version de cette aide ne
+ *    le gérait pas et a fait passer la suite de 1 à 11 échecs.
+ *
+ * D'où : on attend l'état `load`, on tolère une destruction de contexte, et on
+ * réessaie une fois la navigation retombée.
+ */
+export async function attendreMesurable(page: Page): Promise<void> {
+	for (let essai = 0; essai < 3; essai++) {
+		try {
+			await page.waitForLoadState('load', { timeout: 20_000 })
+			await page.evaluate(() => document.fonts?.ready ?? Promise.resolve())
+			// Deux images successives sans changement de mise en page.
+			await page.evaluate(
+				() =>
+					new Promise<void>((ok) =>
+						requestAnimationFrame(() => requestAnimationFrame(() => ok())),
+					),
+			)
+			return
+		} catch (e) {
+			// Contexte detruit par une navigation ou un rechargement du service
+			// worker : on laisse la page se reposer et on recommence.
+			const msg = String(e)
+			const navigation =
+				msg.includes('Execution context was destroyed') ||
+				msg.includes('navigating and changing the content')
+			if (!navigation || essai === 2) throw e
+			await page.waitForTimeout(1200)
+		}
+	}
+}

--- a/nodyx-frontend/tests/responsive/no-clipping.spec.ts
+++ b/nodyx-frontend/tests/responsive/no-clipping.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { attendreMesurable } from './_attente'
 
 /**
  * Contenu ROGNÉ, à ne pas confondre avec le débordement de page.
@@ -27,7 +28,7 @@ const PAGES = [
 for (const [nom, chemin] of PAGES) {
 	test(`${nom} : aucun élément plus large que l'écran`, async ({ page }, info) => {
 		await page.goto(chemin, { waitUntil: 'domcontentloaded' })
-		await page.waitForTimeout(1800)
+		await attendreMesurable(page)
 
 		const coupables = await page.evaluate(() => {
 			const vw = window.innerWidth

--- a/nodyx-frontend/tests/responsive/no-overflow.spec.ts
+++ b/nodyx-frontend/tests/responsive/no-overflow.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { attendreMesurable } from './_attente'
 
 /**
  * Débordement horizontal, le défaut responsive le plus courant.
@@ -21,7 +22,7 @@ const PAGES_PUBLIQUES = [
 for (const [nom, chemin] of PAGES_PUBLIQUES) {
 	test(`${nom} ne déborde pas horizontalement`, async ({ page }) => {
 		await page.goto(chemin, { waitUntil: 'domcontentloaded' })
-		await page.waitForTimeout(1200)
+		await attendreMesurable(page)
 
 		const mesure = await page.evaluate(() => {
 			const de = document.documentElement

--- a/nodyx-frontend/tests/responsive/no-overflowing-row.spec.ts
+++ b/nodyx-frontend/tests/responsive/no-overflowing-row.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { attendreMesurable } from './_attente'
 
 /**
  * Rangées dont le contenu ne rentre pas.
@@ -29,7 +30,7 @@ const PAGES = [
 for (const [nom, chemin] of PAGES) {
 	test(`${nom} : aucune rangée ne coupe son contenu`, async ({ page }) => {
 		await page.goto(chemin, { waitUntil: 'domcontentloaded' })
-		await page.waitForTimeout(1800)
+		await attendreMesurable(page)
 
 		const coupables = await page.evaluate(() => {
 			const out: { perdu: number; boite: number; tag: string; cls: string; txt: string }[] = []


### PR DESCRIPTION
Le test du profil tombait dans la suite complète alors qu'il passait **isolé**.
Cause : je mesurais après un **délai fixe** de 1800 ms. À vide ça suffisait, sous
charge non, la suite lançant plusieurs navigateurs en parallèle.

## Deux causes distinctes

**1. Les polices.** Tant qu'elles ne sont pas chargées, les textes sont rendus
avec une police de repli dont les largeurs diffèrent. Or ces tests mesurent
précisément des largeurs. On attend donc `document.fonts.ready` puis deux images
successives, au lieu de compter les millisecondes.

**2. La page qui se recharge sous nos pieds.** Le service worker recharge dès
qu'une nouvelle version prend le contrôle, ce qui arrive au premier chargement de
**chaque** contexte après un déploiement, donc de chaque test. Un `page.evaluate`
en cours meurt alors avec « Execution context was destroyed ».

### Ma première version a aggravé le problème

Elle appelait `page.evaluate` sans gérer ce cas, et la suite est passée de **1 à
11 échecs**. L'aide attend désormais l'état `load`, tolère une destruction de
contexte et réessaie.

## `retries: 1` en toutes circonstances

Plus seulement en CI. Le rechargement du service worker est le comportement
**attendu** du produit, pas un défaut : un test qui passe au second essai dans ce
cas a raison.

## Résultat, deux passages consécutifs contre la production

```
passage 1   46 passés   1 réessai   3 sautés   0 échec
passage 2   46 passés   1 réessai   3 sautés   0 échec
```

## Une erreur de protocole, de mon fait

Une partie des « échecs » que je mesurais venait de **ma façon de mesurer** : je
lançais trois suites d'affilée derrière un `timeout` de deux minutes, qui tuait la
troisième en plein vol et produisait des `browser has been closed`.

J'ai cherché un défaut dans les tests alors qu'une part du bruit venait de mon
harnais de mesure.

`npm run check` à 0 erreur.