### PR TITLE
fix(voice): la saisie du chat d'un salon vocal était cachée derrière la barre

### DIFF
--- a/nodyx-frontend/src/lib/bottomNavClearance.test.ts
+++ b/nodyx-frontend/src/lib/bottomNavClearance.test.ts
@@ -22,13 +22,29 @@ import { join } from 'node:path'
  */
 
 const ROUTES = new URL('../routes', import.meta.url).pathname
-const EXCEPTIONS = ['/overlay/', '/admin/']
+const COMPOSANTS = new URL('./components', import.meta.url).pathname
+const EXCEPTIONS = [
+	'/overlay/',
+	'/admin/',
+	// `Table.svelte` a exactement la meme forme que `StageChat` : racine en
+	// `h-full flex flex-col`, saisie, rangees `shrink-0`. Aucune heuristique
+	// ne peut les distinguer, la difference est SEMANTIQUE : Table est une
+	// carte posee dans le flux (jukebox du Canvas), jamais collee au bas de
+	// l'ecran. Exception assumee plutot qu'un motif tordu qui finirait par
+	// laisser passer un vrai cas.
+	'components/Table.svelte',
+]
 
 function pages(dossier: string, acc: string[] = []): string[] {
 	for (const e of readdirSync(dossier)) {
 		const chemin = join(dossier, e)
 		if (statSync(chemin).isDirectory()) pages(chemin, acc)
-		else if (e === '+page.svelte') acc.push(chemin)
+		// Les COMPOSANTS comptent autant que les pages : `StageChat.svelte` porte
+		// la saisie du chat d'un salon vocal, il n'a jamais reserve la barre, et
+		// ce test ne regardait que les `+page.svelte`. Le champ etait donc
+		// entierement cache derriere la barre, sans que rien ne le signale
+		// (defaut du 17/08).
+		else if (e === '+page.svelte' || e.endsWith('.svelte')) acc.push(chemin)
 	}
 	return acc
 }
@@ -37,16 +53,31 @@ describe('dégagement de la barre de navigation mobile', () => {
 	it('une page avec une zone de saisie en bas réserve --bottom-nav-h', () => {
 		const fautifs: string[] = []
 
-		for (const fichier of pages(ROUTES)) {
+		for (const fichier of [...pages(ROUTES), ...pages(COMPOSANTS)]) {
 			if (EXCEPTIONS.some((e) => fichier.includes(e))) continue
 			const src = readFileSync(fichier, 'utf8')
 
 			// Une zone de saisie : un champ, ET un conteneur bas identifiable.
 			const aUnChamp = /placeholder=|<textarea/.test(src)
-			const aUneZoneBasse = /shrink-0[^"]*border-t|sticky bottom-0|fixed bottom-0/.test(src)
-			if (!aUnChamp || !aUneZoneBasse) continue
+			// `border-top` peut vivre dans la CLASSE (`border-t`) ou dans l'attribut
+			// STYLE. StageChat utilise la seconde forme, et mon premier motif ne
+			// regardait que la premiere : le composant est passe au travers alors
+			// que sa saisie etait entierement cachee derriere la barre.
+			const aUneZoneBasse =
+				/shrink-0[^"]*border-t|sticky bottom-0|fixed bottom-0/.test(src) ||
+				/shrink-0[\s\S]{0,120}border-top\s*:/.test(src)
+			// Et le composant doit reellement etre ANCRE en bas : pleine hauteur en
+			// colonne, ou positionne en bas. Sans cette condition, `Table.svelte`
+			// remontait a tort : il a une saisie et des rangees `shrink-0`, mais
+			// c'est une carte posee dans le flux, jamais collee au bas de l'ecran.
+			const estAncreEnBas =
+				/h-full[\s\S]{0,20}flex-col|flex[\s\S]{0,10}h-full[\s\S]{0,20}flex-col/.test(src) ||
+				/fixed bottom-0|sticky bottom-0/.test(src)
+			if (!aUnChamp || !aUneZoneBasse || !estAncreEnBas) continue
 
-			if (!src.includes('bottom-nav-h')) {
+			// Un composant qui expose une propriete de degagement delegue le choix
+			// a son appelant : c'est une reponse valable, la Scene n'en veut pas.
+			if (!src.includes('bottom-nav-h') && !/reserverBarreBasse/.test(src)) {
 				fautifs.push(fichier.replace(ROUTES, 'routes'))
 			}
 		}

--- a/nodyx-frontend/src/lib/components/StageChat.svelte
+++ b/nodyx-frontend/src/lib/components/StageChat.svelte
@@ -29,7 +29,19 @@
         channelId,
         channelName = '',
         oncollapse,
-    }: { channelId: string; channelName?: string; oncollapse?: () => void } = $props()
+        // Reserver la hauteur de la barre de navigation mobile sous la zone de
+        // saisie. VRAI dans un salon vocal, ou la barre est visible et opaque et
+        // recouvrait entierement le champ (mesure : champ a 801-821, barre a
+        // partir de 787, soit 34px de recouvrement, defaut du 17/08).
+        // FAUX dans la Scene, qui est un plein ecran RECOUVRANT la barre :
+        // y reserver la place gacherait 56px pour rien.
+        reserverBarreBasse = false,
+    }: {
+        channelId: string
+        channelName?: string
+        oncollapse?: () => void
+        reserverBarreBasse?: boolean
+    } = $props()
 
     type StageMessage = {
         id:              string
@@ -259,7 +271,8 @@
     </div>
 
     <!-- Composeur -->
-    <div class="shrink-0 p-3" style="border-top: 1px solid rgba(255,255,255,0.05)">
+    <div class="shrink-0 p-3"
+         style="border-top: 1px solid rgba(255,255,255,0.05); {reserverBarreBasse ? 'padding-bottom: max(0.75rem, var(--bottom-nav-h))' : ''}">
         <div class="flex items-center gap-2 rounded-lg px-3 py-2"
              style="background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.07)">
             <button

--- a/nodyx-frontend/src/lib/components/VoiceRoom.svelte
+++ b/nodyx-frontend/src/lib/components/VoiceRoom.svelte
@@ -458,6 +458,7 @@
 {#if showChatPanel}
 	<div class="w-72 shrink-0 min-h-0 xl:w-80">
 		<StageChat
+			reserverBarreBasse
 			channelId={selectedChannel.id}
 			channelName={selectedChannel.name}
 			oncollapse={() => (showChatPanel = false)}


### PR DESCRIPTION
Signalé en capture : dans un salon vocal, le chat s'affiche mais **la zone de
saisie a disparu**.

## Mesuré avant de conclure

Sur la production, téléphone 390x844 :

```
champ de saisie   haut=801   bas=821
barre du bas      haut=787
recouvrement      34px
```

Le champ **existait** et était « visible » au sens strict (bas 821 < 844), mais
entièrement caché derrière la barre de navigation, qui est opaque.

Même défaut que les messages privés corrigés la veille (#558), dans un **autre
composant** : `StageChat` ne mentionnait pas `--bottom-nav-h`.

## Correctif par propriété, pas inconditionnel

`StageChat` sert à deux endroits :

| Usage | Barre visible ? | Dégagement |
|---|---|---|
| Salon vocal | oui | **activé** |
| Scène plein écran | non, elle recouvre la barre | désactivé |

Réserver 56px dans la Scène gâcherait de la place pour rien.

## Mon garde-fou n'avait pas vu ce cas

Deux raisons cumulées, les deux corrigées :

- il ne regardait que les `+page.svelte`, **pas les composants**
- il cherchait `border-t` dans les **classes**, or `StageChat` pose son
  `border-top` dans l'attribut **style**

S'y ajoutent une condition d'ancrage réel (pleine hauteur en colonne, ou position
basse) et une **exception documentée** pour `Table.svelte`, qui a exactement la
même forme que `StageChat` mais n'est jamais collée au bas de l'écran : la
différence est sémantique, aucune heuristique ne les distingue.

Un composant qui expose une propriété de dégagement est accepté : déléguer le
choix à l'appelant est une réponse valable.

## Vérifié dans les deux sens

Le garde-fou passe sur le code corrigé, et **tombe en nommant `StageChat`** quand
on retire le dégagement.

`npm run check` à 0 erreur, 105 tests Vitest verts, build réussi.