### PR TITLE
fix(ui): les zones de saisie touchaient la barre du bas, zéro respiration

### DIFF
--- a/nodyx-frontend/src/lib/components/StageChat.svelte
+++ b/nodyx-frontend/src/lib/components/StageChat.svelte
@@ -35,6 +35,12 @@
         // partir de 787, soit 34px de recouvrement, defaut du 17/08).
         // FAUX dans la Scene, qui est un plein ecran RECOUVRANT la barre :
         // y reserver la place gacherait 56px pour rien.
+        //
+        // `calc(--bottom-nav-h + 0.75rem)` et non `max(...)` : un `max` donnait
+        // EXACTEMENT la hauteur de la barre, donc zero respiration. Mesure du
+        // 17/08 : boite de saisie finissant a 788, barre commencant a 787,
+        // elles se touchaient a un pixel pres. La marge est en plus, pas au
+        // lieu de.
         reserverBarreBasse = false,
     }: {
         channelId: string
@@ -272,7 +278,7 @@
 
     <!-- Composeur -->
     <div class="shrink-0 p-3"
-         style="border-top: 1px solid rgba(255,255,255,0.05); {reserverBarreBasse ? 'padding-bottom: max(0.75rem, var(--bottom-nav-h))' : ''}">
+         style="border-top: 1px solid rgba(255,255,255,0.05); {reserverBarreBasse ? 'padding-bottom: calc(var(--bottom-nav-h) + 0.75rem)' : ''}">
         <div class="flex items-center gap-2 rounded-lg px-3 py-2"
              style="background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.07)">
             <button

--- a/nodyx-frontend/src/routes/chat/+page.svelte
+++ b/nodyx-frontend/src/routes/chat/+page.svelte
@@ -1504,7 +1504,7 @@
 			</div>
 
 			<!-- Input area -->
-			<div class="px-4 shrink-0" style="padding-bottom: max(1rem, var(--bottom-nav-h))">
+			<div class="px-4 shrink-0" style="padding-bottom: calc(var(--bottom-nav-h) + 1rem)">
 				<!-- @mention dropdown -->
 				{#if showMentions && mentionSuggestions.length > 0}
 					<div class="relative">

--- a/nodyx-frontend/src/routes/dm/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/dm/[id]/+page.svelte
@@ -1702,7 +1702,7 @@
 		     `lg` où la barre n'existe plus. Le chat le faisait déjà, cette page
 		     ne l'a jamais fait : on y écrivait sous le menu. -->
 		<div class="shrink-0 px-5 py-4 border-t border-white/[0.06] bg-gray-950/30"
-		     style="padding-bottom: max(1rem, var(--bottom-nav-h))">
+		     style="padding-bottom: calc(var(--bottom-nav-h) + 1rem)">
 			<!-- Banner reply : indique le message qu'on est en train de citer -->
 			{#if replyingTo}
 				<div class="dm-reply-banner">


### PR DESCRIPTION
Signalé : « dommage que le bas de la zone de saisie touche le menu ».

## Mesure

Téléphone 390x844, salon vocal :

```
boîte de saisie   bas  = 788
barre du bas      haut = 787
```

Elles se touchaient à **un pixel** près.

## La cause, et c'est mon erreur d'hier

J'avais écrit `padding-bottom: max(1rem, var(--bottom-nav-h))`.

Or `--bottom-nav-h` vaut la hauteur **exacte** de la barre : le `max` choisit
donc toujours cette hauteur et ne laisse **jamais** un pixel de marge. La
respiration doit s'**ajouter**, pas se substituer.

```diff
- padding-bottom: max(1rem, var(--bottom-nav-h))
+ padding-bottom: calc(var(--bottom-nav-h) + 1rem)
```

## Et une erreur de mesure

Ma première vérification annonçait « recouvrement -10px, dégagé ». Elle portait
sur l'`<input>` lui-même et non sur la **boîte arrondie** qui l'entoure, laquelle
descend plus bas de son rembourrage.

Mesurer le mauvais élément donne une réponse juste à une mauvaise question.

## Les trois endroits, pas seulement celui signalé

| Fichier | Rôle | Marge |
|---|---|---|
| `StageChat.svelte` | chat d'un salon vocal | +0.75rem |
| `dm/[id]/+page.svelte` | messages privés | +1rem |
| `chat/+page.svelte` | chat principal | +1rem |

Les deux derniers avaient exactement le même `max(...)`, **dont celui que j'ai
écrit moi-même la veille** en corrigeant les messages privés. Il ne reste plus
aucun `max(` associé à `--bottom-nav-h` dans le dépôt.

## Vérifications

Les trois `calc` sont présents dans le build, `npm run check` à 0 erreur, 105
tests Vitest verts.

La mesure en production suit le déploiement : la préversion locale n'est pas
authentifiée, et une mesure faite dessus serait invalide.