### PR TITLE
fix(voice): la croix des réglages audio va DANS le composant, pas dans ses conteneurs

### DIFF
--- a/nodyx-frontend/src/lib/components/VoicePanel.svelte
+++ b/nodyx-frontend/src/lib/components/VoicePanel.svelte
@@ -911,7 +911,7 @@
                                 </button>
                             </div>
                             <div class="flex-1 overflow-y-auto sm:flex-none sm:overflow-visible">
-                                <VoiceSettings />
+                                <VoiceSettings onclose={() => showVoiceSettings = false} />
                             </div>
                             <button
                                 onclick={() => showVoiceSettings = false}
@@ -1100,7 +1100,7 @@
                             </button>
                         </div>
 
-                        <VoiceSettings />
+                        <VoiceSettings onclose={() => showVoiceSettings = false} />
                     </div>
                 </div>
             {/if}

--- a/nodyx-frontend/src/lib/components/VoiceSettings.svelte
+++ b/nodyx-frontend/src/lib/components/VoiceSettings.svelte
@@ -26,6 +26,16 @@
     function setNoiseGateThreshold(e: Event) {
         updateLocalAudio({ noiseGateThreshold: +(e.target as HTMLInputElement).value })
     }
+
+    let { onclose }: { onclose?: () => void } = $props()
+
+    // Sortie portee par le COMPOSANT et non par son conteneur.
+    // Le 17/08, deux correctifs successifs ont ajoute une croix aux conteneurs de
+    // VoicePanel sans aucun effet : ce composant se rend par un TROISIEME chemin,
+    // quasiment nu (sa racine est un simple `<div class="p-4">`, sans decor). La
+    // croix voyage donc desormais AVEC le contenu, a cote de son propre titre,
+    // la ou l'utilisateur la cherche. Optionnelle : sans `onclose`, rien ne
+    // s'affiche et les usages existants ne changent pas.
 </script>
 
 <div class="p-4 space-y-5 text-sm select-none">
@@ -34,6 +44,19 @@
     <div class="flex items-center gap-2">
         <span class="text-base">⚙️</span>
         <h3 class="text-xs font-bold text-indigo-300 uppercase tracking-wider">{tFn('voice_settings.header')}</h3>
+        {#if onclose}
+            <button
+                onclick={onclose}
+                aria-label={tFn('voice_panel.close_settings')}
+                class="ml-auto shrink-0 w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-full
+                       text-gray-200 hover:text-white bg-black/50 border border-gray-600
+                       hover:border-amber-500/60 transition-colors"
+            >
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                </svg>
+            </button>
+        {/if}
     </div>
 
     <!-- ── Gain micro ─────────────────────────────────────────────── -->


### PR DESCRIPTION
Troisième tentative sur le même défaut, et les deux précédentes ont échoué pour
la même raison : **j'ajoutais une sortie aux conteneurs** de `VoicePanel`, alors
que ce qui s'affiche à l'écran est `VoiceSettings` rendu quasiment nu.

Sa racine est un simple `<div class="p-4 space-y-5">`, sans bordure, sans décor,
avec sa **propre en-tête** « SON & MICRO ». Aucune de mes croix n'apparaissait.

## Le correctif

La sortie voyage désormais **avec le contenu** : un bouton optionnel dans
l'en-tête de `VoiceSettings` lui-même, à côté du titre, là où l'utilisateur la
cherche. Quel que soit le conteneur qui le rend, elle le suit.

- **44px** au pouce sous `sm`, 36px au-dessus
- `gray-200` sur noir à 50% avec bordure : visible, contrairement au `gray-500`
  sur noir à 40% de la croix flottante d'origine
- propriété **optionnelle** : sans `onclose`, rien ne s'affiche et les usages
  existants ne changent pas

## Les deux appelants câblés, pas un seul

`VoicePanel` rend `VoiceSettings` à **deux endroits** (lignes 914 et 1103).
N'en câbler qu'un aurait laissé le défaut intact dans l'autre moitié des cas.

## La leçon de méthode

J'ai corrigé **deux fois le mauvais élément** parce que je raisonnais sur le code
que je lisais, au lieu de partir du **texte que tu voyais à l'écran**.

Chercher « SON & MICRO » dans les traductions a désigné le bon composant en une
seule commande. J'aurais dû commencer par là.

## Vérifications

La croix est dans le chunk construit, `npm run check` à 0 erreur, 105 tests
Vitest verts.

Le rendu reste **à valider à l'œil** : rejoindre un salon vocal exige un micro
que je n'ai pas.