### PR TITLE
fix(voice): une seule croix, j'en avais empilé trois

### DIFF
--- a/nodyx-frontend/src/lib/components/VoicePanel.svelte
+++ b/nodyx-frontend/src/lib/components/VoicePanel.svelte
@@ -899,30 +899,9 @@
                                     border border-amber-500/30 sm:rounded-2xl shadow-2xl shadow-amber-500/10
                                     overflow-hidden backdrop-blur-md flex flex-col">
                             <div class="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-amber-500 to-transparent"></div>
-                            <!-- Header fermeture mobile-only -->
-                            <div class="sm:hidden flex items-center justify-between px-4 py-3 border-b border-gray-800 bg-gray-900/95 shrink-0">
-                                <span class="text-sm font-semibold text-white">{tFn('voice.audio_settings_title')}</span>
-                                <button onclick={() => showVoiceSettings = false}
-                                        aria-label={tFn('voice_panel.close_settings')}
-                                        class="min-w-[44px] min-h-[44px] flex items-center justify-center text-gray-400 hover:text-white">
-                                    <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
-                                    </svg>
-                                </button>
-                            </div>
                             <div class="flex-1 overflow-y-auto sm:flex-none sm:overflow-visible">
                                 <VoiceSettings onclose={() => showVoiceSettings = false} />
                             </div>
-                            <button
-                                onclick={() => showVoiceSettings = false}
-                                class="hidden sm:flex absolute top-4 right-4 text-gray-200 hover:text-white
-                                       bg-black/70 w-8 h-8 rounded-full items-center justify-center
-                                       backdrop-blur-sm border border-gray-600 hover:border-amber-500/50
-                                       transition-all duration-200 hover:scale-110"
-                                style="pointer-events: auto; z-index: 201;"
-                            >
-                                <span class="text-sm">✕</span>
-                            </button>
                         </div>
                     </div>
                 {/if}
@@ -1080,25 +1059,6 @@
                                 border border-amber-500/30 rounded-2xl shadow-2xl shadow-amber-500/10
                                 overflow-hidden backdrop-blur-md">
                         <div class="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-amber-500 to-transparent"></div>
-
-                        <!-- EN-TETE AVEC SORTIE, toujours visible. Cette variante n'en
-                             avait AUCUN : sur telephone le panneau s'affichait en pleine
-                             page sans la moindre croix, et on ne pouvait plus en sortir
-                             (signale le 17/08, capture a l'appui). Une croix flottante de
-                             28px existait mais elle etait invisible en pratique. Un
-                             en-tete barre, lui, ne peut pas se confondre avec le contenu. -->
-                        <div class="flex items-center justify-between gap-2 px-4 py-2 border-b border-gray-800 bg-gray-900/95">
-                            <span class="text-sm font-semibold text-white truncate">{tFn('voice.audio_settings_title')}</span>
-                            <button onclick={() => showVoiceSettings = false}
-                                    aria-label={tFn('voice_panel.close_settings')}
-                                    class="shrink-0 w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-full
-                                           text-gray-200 hover:text-white bg-black/50 border border-gray-600
-                                           hover:border-amber-500/50 transition-colors">
-                                <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
-                                </svg>
-                            </button>
-                        </div>
 
                         <VoiceSettings onclose={() => showVoiceSettings = false} />
                     </div>


### PR DESCRIPTION
Signalé : en plein écran, la croix apparaissait **deux fois**.

Conséquence directe de mes correctifs successifs : chaque tentative ajoutait une
sortie sans retirer la précédente, et la dernière (croix **dans**
`VoiceSettings`, qui est la bonne) a rendu toutes les autres redondantes.

## Trois sorties redondantes retirées

| Sortie | Origine |
|---|---|
| En-tête « Paramètres audio » de la variante portail | ajoutée par moi en #570 |
| En-tête mobile (titre + croix) de la variante en ligne | préexistante |
| Croix flottante de bureau, en haut à droite | préexistante |

Toutes faisaient doublon avec l'en-tête **propre** de `VoiceSettings`, qui porte
déjà son titre « SON & MICRO » et désormais sa croix.

## Ce qui reste

Trois chemins de sortie, sans doublon visuel :

- la croix du composant, **44px** au pouce
- le voile cliquable
- la touche Échap

## La leçon

Quand un correctif ne marche pas, **retirer la tentative précédente avant d'en
poser une autre**. J'ai empilé trois sorties sur le même panneau en cherchant
laquelle s'afficherait, et c'est toi qui as dû me signaler le résultat.

## Vérifications

Une seule occurrence de la croix dans le bundle contre deux avant, `npm run
check` à 0 erreur, 105 tests Vitest verts.