### PR TITLE
fix(voice): la croix de fermeture partait avec le défilement

### DIFF
--- a/nodyx-frontend/src/lib/components/VoiceSettings.svelte
+++ b/nodyx-frontend/src/lib/components/VoiceSettings.svelte
@@ -41,7 +41,13 @@
 <div class="p-4 space-y-5 text-sm select-none">
 
     <!-- ── Header ────────────────────────────────────────────────── -->
-    <div class="flex items-center gap-2">
+    <!-- COLLE EN HAUT : ce panneau defile, et l'en-tete partait avec lui. Des
+         qu'on descendait dans les reglages, la seule sortie disparaissait par le
+         haut (signale le 17/08, capture ou il ne restait que l'arc inferieur du
+         cercle). Les marges negatives compensent le `p-4` de la racine pour que
+         le fond couvre toute la largeur. -->
+    <div class="sticky top-0 z-20 -mx-4 -mt-4 px-4 pt-4 pb-2 flex items-center gap-2
+                bg-gray-950/95 backdrop-blur-sm border-b border-white/[0.06]">
         <span class="text-base">⚙️</span>
         <h3 class="text-xs font-bold text-indigo-300 uppercase tracking-wider">{tFn('voice_settings.header')}</h3>
         {#if onclose}


### PR DESCRIPTION
Signalé « la croix est coupée », avec une capture où il ne restait que **l'arc
inférieur** du cercle en haut du panneau.

Ce n'était ni un problème de taille ni un rognage : le panneau avait été **fait
défiler**, et l'en-tête était parti vers le haut avec le contenu.

## Pourquoi ça compte

Dès qu'on descendait un peu dans les réglages, **la seule sortie disparaissait de
l'écran**. Le défaut d'origine (« on ne peut plus en sortir ») n'était donc
corrigé que tant qu'on ne touchait à rien.

## Le correctif

L'en-tête est collé en haut (`sticky top-0`), avec un fond opaque et une bordure
pour se détacher du contenu qui défile dessous.

Les marges négatives compensent le `p-4` de la racine : sans elles, le contenu se
verrait passer dans les 16px de côté.

## Ce qui m'a évité un quatrième correctif à l'aveugle

Avoir demandé **par où** la croix était coupée au lieu de deviner. En haut, à
droite ou à l'intérieur : trois causes, trois correctifs différents. La capture a
répondu en une fois.

## Vérifications

Les cinq classes du collage (`sticky`, `top-0`, `z-20`, `-mx-4`, `-mt-4`) sont
générées dans le CSS construit, `npm run check` à 0 erreur, 105 tests Vitest
verts.