### PR TITLE
test(voice): verrouiller la sortie des paramètres audio

### DIFF
--- a/nodyx-frontend/src/lib/voiceSettingsSortie.test.ts
+++ b/nodyx-frontend/src/lib/voiceSettingsSortie.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+/**
+ * La sortie des paramètres audio doit rester atteignable, même après défilement.
+ *
+ * Pourquoi (2026-08-17)
+ * ────────────────────
+ * Ce défaut a été signalé TROIS fois d'affilée, sous trois formes différentes,
+ * et les deux premiers correctifs étaient incomplets :
+ *
+ *  1. « on ne peut plus sortir des paramètres audio » : il n'y avait aucune
+ *     croix. Ajoutée.
+ *  2. « j'ai la croix 2 fois » : trois affordances de fermeture s'étaient
+ *     empilées au fil des passes. Deux supprimées.
+ *  3. « la croix est coupée » : le panneau avait simplement été FAIT DÉFILER, et
+ *     l'en-tête était parti vers le haut avec le contenu. Il ne restait que
+ *     l'arc inférieur du cercle.
+ *
+ * Le troisième est le plus vicieux : la croix EXISTE, elle est unique, elle est
+ * assez grande, elle passe toute revue de code, et l'utilisateur ne peut quand
+ * même pas sortir dès qu'il touche à un réglage un peu bas dans la liste.
+ *
+ * Ce contrôle lit la SOURCE, parce qu'aucun test de rendu ne verrait ces trois
+ * défauts : le panneau exige une session, un salon vocal et un micro.
+ *
+ * Il tombe sur chacune des trois versions fautives : zéro croix (1), plus d'une
+ * croix (2), croix non collée en haut (3).
+ */
+
+const SOURCE = readFileSync(
+	new URL('./components/VoiceSettings.svelte', import.meta.url).pathname,
+	'utf-8',
+)
+
+/** Un bouton dont le libellé d'accessibilité parle de fermeture. */
+const BOUTONS_FERMETURE = SOURCE.match(/<button[^>]*aria-label=\{?[^>]*close[^>]*>/gi) ?? []
+
+describe('sortie des paramètres audio', () => {
+	it('offre exactement une croix de fermeture', () => {
+		// Zéro : on reste piégé dans le panneau (défaut d'origine).
+		// Deux ou plus : l'utilisateur ne sait plus laquelle est la bonne.
+		expect(BOUTONS_FERMETURE).toHaveLength(1)
+	})
+
+	it('rend cette croix conditionnelle au rappel de fermeture', () => {
+		// Sans `onclose`, le bouton ne ferait rien : mieux vaut ne pas l'afficher
+		// que d'afficher une sortie morte.
+		expect(SOURCE).toMatch(/\{#if onclose\}/)
+		expect(SOURCE).toMatch(/onclick=\{onclose\}/)
+	})
+
+	it("garde l'en-tête collé en haut de la zone qui défile", () => {
+		// LE défaut du 17/08. Le conteneur parent est `overflow-y-auto` : sans
+		// `sticky top-0`, l'en-tête défile avec les réglages et la seule sortie
+		// disparaît par le haut.
+		const enTete = SOURCE.match(/<div class="([^"]*sticky[^"]*)"[\s\S]{0,400}?\{#if onclose\}/)
+		expect(enTete, "l'en-tête portant la croix n'est pas collé en haut").not.toBeNull()
+		expect(enTete![1]).toMatch(/\bsticky\b/)
+		expect(enTete![1]).toMatch(/\btop-0\b/)
+		// Fond opaque, sinon les réglages se voient passer sous l'en-tête.
+		expect(enTete![1]).toMatch(/\bbg-/)
+	})
+
+	it('donne à la croix une cible atteignable au pouce', () => {
+		// 44px est le plancher recommandé sur mobile. On tolère plus petit à
+		// partir de `sm`, où le pointeur est précis.
+		expect(BOUTONS_FERMETURE[0]).toMatch(/w-11 h-11/)
+	})
+})


### PR DESCRIPTION
Ce défaut a été signalé **trois fois d'affilée**, sous trois formes différentes,
et mes deux premiers correctifs étaient incomplets :

| # | Symptôme signalé | Cause réelle |
|---|---|---|
| 1 | « on ne peut plus en sortir » | il n'y avait aucune croix |
| 2 | « j'ai la croix 2 fois » | trois affordances de fermeture s'étaient empilées au fil des passes |
| 3 | « la croix est coupée » | l'en-tête défilait avec le contenu, il ne restait que l'arc inférieur du cercle |

Le troisième est le plus vicieux : la croix **existe**, elle est **unique**, elle
est **assez grande**, elle passe toute revue de code, et l'utilisateur ne peut
quand même pas sortir dès qu'il touche à un réglage un peu bas dans la liste.

## Pourquoi un contrôle sur la source

Aucun test de rendu ne verrait ces trois défauts : le panneau exige une session,
un salon vocal et un micro. Ce contrôle lit donc le fichier `.svelte` et vérifie
quatre invariants : exactement une croix, conditionnée à `onclose`, dans un
en-tête `sticky top-0` à fond opaque, avec une cible de 44px au pouce.

## Prouvé qu'il tombe

Les trois versions fautives ont été rejouées :

```
3. en-tête non collé (croix qui défile)    1 test rouge
2. croix en double                         1 test rouge
1. aucune croix (défaut d'origine)         4 tests rouges
```

Un test de régression qui ne tombe pas sur l'ancien code ne prouve rien.