### PR TITLE
fix(voice): la fenêtre des réglages débordait de l'écran par le haut

### DIFF
--- a/nodyx-frontend/src/lib/components/VoicePanel.svelte
+++ b/nodyx-frontend/src/lib/components/VoicePanel.svelte
@@ -895,11 +895,14 @@
                     <div class="fixed inset-0 sm:absolute sm:inset-auto sm:bottom-full sm:mb-2 sm:right-0 sm:w-[340px] z-[200]
                                 flex flex-col sm:block animate-in fade-in slide-in-from-bottom-4 duration-300"
                          style="pointer-events: auto;">
+                        <!-- Sous `sm` le panneau occupe tout l'ecran et defile deja. A
+                             partir de `sm` il pousse vers le HAUT (`bottom-full`) : sans
+                             borne il deborde d'une fenetre courte, meme defaut qu'en bas. -->
                         <div class="relative flex-1 sm:flex-none bg-gradient-to-b from-gray-900 to-gray-950
                                     border border-amber-500/30 sm:rounded-2xl shadow-2xl shadow-amber-500/10
-                                    overflow-hidden backdrop-blur-md flex flex-col">
+                                    sm:max-h-[calc(100dvh-8rem)] overflow-hidden backdrop-blur-md flex flex-col">
                             <div class="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-amber-500 to-transparent"></div>
-                            <div class="flex-1 overflow-y-auto sm:flex-none sm:overflow-visible">
+                            <div class="flex-1 overflow-y-auto sm:flex-none sm:overflow-y-auto">
                                 <VoiceSettings onclose={() => showVoiceSettings = false} />
                             </div>
                         </div>
@@ -1055,9 +1058,14 @@
                 </div>
                 <div use:portal class="fixed bottom-24 left-1/2 -translate-x-1/2 w-[360px] z-[200]
                             animate-in fade-in slide-in-from-bottom-4 duration-300">
+                    <!-- BORNE A L'ECRAN. Sans `max-h`, ce panneau mesurait 619px de haut
+                         sur un ecran de 600px. Ancre en bas (`bottom-24`), son sommet
+                         tombait a -115px, et `overflow-hidden` interdisait tout
+                         defilement : l'excedent etait purement AMPUTE par le haut, avec
+                         l'en-tete et la croix de fermeture dedans. Mesure du 17/08. -->
                     <div class="relative bg-gradient-to-b from-gray-900 to-gray-950
                                 border border-amber-500/30 rounded-2xl shadow-2xl shadow-amber-500/10
-                                overflow-hidden backdrop-blur-md">
+                                max-h-[calc(100dvh-7rem)] overflow-y-auto backdrop-blur-md">
                         <div class="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-amber-500 to-transparent"></div>
 
                         <VoiceSettings onclose={() => showVoiceSettings = false} />

--- a/nodyx-frontend/src/lib/voiceSettingsSortie.test.ts
+++ b/nodyx-frontend/src/lib/voiceSettingsSortie.test.ts
@@ -32,6 +32,10 @@ const SOURCE = readFileSync(
 	new URL('./components/VoiceSettings.svelte', import.meta.url).pathname,
 	'utf-8',
 )
+const PANNEAU = readFileSync(
+	new URL('./components/VoicePanel.svelte', import.meta.url).pathname,
+	'utf-8',
+)
 
 /** Un bouton dont le libellé d'accessibilité parle de fermeture. */
 const BOUTONS_FERMETURE = SOURCE.match(/<button[^>]*aria-label=\{?[^>]*close[^>]*>/gi) ?? []
@@ -60,6 +64,27 @@ describe('sortie des paramètres audio', () => {
 		expect(enTete![1]).toMatch(/\btop-0\b/)
 		// Fond opaque, sinon les réglages se voient passer sous l'en-tête.
 		expect(enTete![1]).toMatch(/\bbg-/)
+	})
+
+	it("borne la fenêtre à la hauteur de l'écran", () => {
+		// LE vrai défaut du 17/08, celui que le collage seul ne corrigeait pas.
+		//
+		// Mesuré sur la prod : la fenêtre ancrée en bas faisait 619px de haut sur
+		// un écran de 600px. Ancrée par `bottom-24`, son sommet tombait à -115px,
+		// et `overflow-hidden` interdisait tout défilement. L'excédent n'était pas
+		// atteignable, il était AMPUTÉ, avec l'en-tête et la croix dedans.
+		//
+		// Un en-tête `sticky` ne sert à rien sans zone défilante : c'est pourquoi
+		// ce contrôle vit à côté de celui du collage, pas à sa place.
+		const conteneurs = PANNEAU.split('<VoiceSettings').slice(0, -1)
+		expect(conteneurs.length, 'les deux sites de rendu doivent être présents').toBe(2)
+		for (const [i, amont] of conteneurs.entries()) {
+			// On regarde le conteneur immédiat, pas toute la page.
+			const proche = amont.slice(-700)
+			expect(proche, `site de rendu ${i + 1} : aucune borne sur la hauteur`).toMatch(
+				/max-h-\[calc\(100dvh/,
+			)
+		}
 	})
 
 	it('donne à la croix une cible atteignable au pouce', () => {


### PR DESCRIPTION
## Mon diagnostic précédent (#573) était faux

J'avais conclu que le panneau avait été **fait défiler** et que l'en-tête était
parti avec le contenu. J'ai collé l'en-tête en haut : c'est juste, mais ça ne
corrigeait rien, parce qu'**il n'y avait aucune zone défilante** à laquelle se
coller.

## La mesure

Chaîne des ancêtres sur la prod, à 390x600 (hauteur réelle d'un téléphone une
fois la barre du navigateur déduite) :

```
DIV.sticky top-0 ...          top:-114
DIV.p-4 space-y-5 ...         top:-114  h:617
DIV.relative bg-gradient ...  top:-115  h:619  overflow-y:HIDDEN
DIV.fixed bottom-24 ...       top:-115  h:619
écran: 600px
```

La fenêtre fait **619px de haut sur un écran de 600**. Ancrée en bas par
`bottom-24`, son sommet tombe à **-115px**. Et `overflow-hidden` interdit tout
défilement : l'excédent n'était pas inatteignable, il était **amputé**. L'en-tête
et la croix de fermeture étaient dans cet excédent.

C'est pour ça que le défaut n'apparaissait qu'en format mobile, et pas en plein
écran : à 844px de haut, la fenêtre tient.

## Correction

Les deux sites de rendu sont bornés à la hauteur de l'écran et défilent. Le
collage de #573 prend alors son sens : la croix reste visible pendant le
défilement. Les deux moitiés étaient nécessaires.

Le second site avait le même défaut à partir de `sm`, où la fenêtre pousse vers
le **haut** (`bottom-full`) : borné aussi.

## Prouvé

- le nouvel invariant **tombe** sur le code non borné (site de rendu 1)
- 110 tests verts après correction
- `max-h-[calc(100dvh-7rem)]` et `sm:max-h-[calc(100dvh-8rem)]` vérifiées
  **présentes dans le CSS construit**, avec les bons sélecteurs (base et variante
  `sm:`) — le piège des classes collées ne produit rien et ne dit rien

## Ce qui m'a fait perdre une passe

Avoir conclu sur une capture au lieu de mesurer. « Il ne reste que l'arc
inférieur du cercle » se lit aussi bien comme un défilement que comme un
débordement. Une seule mesure de la chaîne des ancêtres a tranché, et elle disait
l'inverse de mon hypothèse.