### PR TITLE
fix(voice): la croix était recouverte par l'en-tête, pas coupée

### DIFF
--- a/nodyx-frontend/src/lib/components/VoicePanel.svelte
+++ b/nodyx-frontend/src/lib/components/VoicePanel.svelte
@@ -551,7 +551,25 @@
 
     {#if mode === 'float'}
     <!-- Barre vocale flottante -->
-    <div class='fixed left-0 lg:left-[220px] right-0 z-40 pointer-events-none {extraClass}' style='bottom: var(--bottom-nav-h)'>
+    <!-- Le `z` MONTE quand les reglages sont ouverts, et ce n'est pas cosmetique.
+         Mesure dans le navigateur de l'utilisateur (500x996, 17/08) : le panneau
+         des reglages est `fixed inset-0 z-[200]`, mais il est DESCENDANT de cette
+         barre. Un `z-index` sur un element `fixed` cree un contexte d'empilement :
+         le 200 du panneau ne vaut QUE dans ce contexte. A l'etage du dessus, la
+         comparaison est 40 contre le `z-50` de l'entete de l'application, et
+         l'entete gagne. Ses 48px recouvraient les 31 premiers pixels de la croix
+         de fermeture, sur les 44 qu'elle mesure :
+
+             croix top:17 (44x44)
+             y=4  -> NAV.sticky top-0 z-50 h-12   <- l'entete, pas le panneau
+             y=40 -> DIV.flex items-center ...    <- toujours l'entete
+             y=52 -> LA CROIX                     <- enfin, sous les 48px
+
+         Le panneau n'etait ni coupe ni rogne : il etait RECOUVERT. C'est pourquoi
+         ni le collage en haut (#573) ni le bornage a l'ecran (#575) n'y pouvaient
+         rien. On ne monte le `z` que pendant l'ouverture, la barre reste sous
+         l'entete le reste du temps. -->
+    <div class='fixed left-0 lg:left-[220px] right-0 {showVoiceSettings ? "z-[60]" : "z-40"} pointer-events-none {extraClass}' style='bottom: var(--bottom-nav-h)'>
         <div class='mx-auto max-w-4xl px-4 pb-2 pointer-events-auto'>
             <div class='relative group'>
                 <!-- Effet de glow externe -->

--- a/nodyx-frontend/src/lib/voiceSettingsSortie.test.ts
+++ b/nodyx-frontend/src/lib/voiceSettingsSortie.test.ts
@@ -87,6 +87,32 @@ describe('sortie des paramètres audio', () => {
 		}
 	})
 
+	it("fait passer la barre flottante au-dessus de l'en-tête pendant l'ouverture", () => {
+		// LA vraie cause, mesurée dans le navigateur de l'utilisateur (500x996).
+		//
+		// Le panneau des réglages est `fixed inset-0 z-[200]`, mais il descend de la
+		// barre vocale flottante, qui portait un `z-40` fixe. Un `z-index` sur un
+		// élément `fixed` crée un contexte d'empilement : le 200 du panneau ne vaut
+		// QUE dans ce contexte. À l'étage du dessus la comparaison est 40 contre le
+		// `z-50` de l'en-tête de l'application, et l'en-tête gagne. Ses 48px
+		// recouvraient les 31 premiers pixels de la croix, sur 44 :
+		//
+		//     y=4  -> NAV.sticky top-0 z-50 h-12   (l'en-tête, pas le panneau)
+		//     y=52 -> LA CROIX                     (enfin, sous les 48px)
+		//
+		// Le panneau n'était ni coupé ni rogné : il était RECOUVERT. C'est pourquoi
+		// ni le collage en haut ni le bornage à l'écran n'y pouvaient rien.
+		const barre = PANNEAU.match(/<div class='fixed left-0[^']*'/)
+		expect(barre, 'barre vocale flottante introuvable').not.toBeNull()
+		expect(barre![0], "le `z` de la barre doit dépendre de l'ouverture des réglages").toMatch(
+			/showVoiceSettings \?/,
+		)
+		// Doit dépasser le `z-50` de l'en-tête, sinon le correctif ne corrige rien.
+		const ouvert = barre![0].match(/showVoiceSettings \? "z-\[(\d+)\]"/)
+		expect(ouvert, 'valeur du `z` en position ouverte illisible').not.toBeNull()
+		expect(Number(ouvert![1])).toBeGreaterThan(50)
+	})
+
 	it('donne à la croix une cible atteignable au pouce', () => {
 		// 44px est le plancher recommandé sur mobile. On tolère plus petit à
 		// partir de `sm`, où le pointeur est précis.


### PR DESCRIPTION
Cause réelle, **mesurée dans le navigateur de Jonathan** (500x996), après deux
correctifs qui visaient à côté.

## Ce que dit la mesure

```
croix top:17 (44x44)
y=4  -> NAV.sticky top-0 z-50 h-12   <- l'en-tête, pas le panneau
y=40 -> DIV.flex items-center ...    <- toujours l'en-tête
y=52 -> LA CROIX                     <- enfin, sous les 48px
```

Le panneau des réglages est `fixed inset-0 z-[200]`, mais il **descend de la barre
vocale flottante**, qui portait un `z-40` fixe.

Un `z-index` sur un élément `fixed` crée un **contexte d'empilement** : le 200 du
panneau ne vaut *que dans ce contexte*. À l'étage du dessus, la comparaison est
**40 contre le `z-50` de l'en-tête**, et l'en-tête gagne. Ses 48px recouvraient
les 31 premiers pixels de la croix, sur les 44 qu'elle mesure.

Le panneau n'était donc ni coupé ni rogné : il était **recouvert**. Ni le collage
en haut (#573) ni le bornage à l'écran (#575) ne pouvaient y changer quoi que ce
soit — les deux restent justes, ils traitaient d'autres défauts réels.

## Le correctif

La barre ne monte au-dessus de l'en-tête que **pendant l'ouverture** des réglages,
et redescend ensuite.

## Ce qui a débloqué l'enquête

L'observation de Jonathan que le rendu dépendait du **chemin** : arriver en format
mobile depuis le format PC, ou partir directement du mobile.

Deux instances de `VoicePanel` coexistent sous `lg`, la latérale et la flottante,
avec chacune **son propre site de rendu des réglages**. Je mesurais la première,
il voyait la seconde. Toutes mes mesures « OK » étaient valides et portaient sur
le mauvais composant.

## Prouvé

- le nouvel invariant **tombe** sur le `z-40` fixe, **et** sur une valeur qui ne
  dépasse pas 50 (un correctif à `z-[45]` serait accepté par un test naïf)
- 111 tests verts
- `z-[60]` vérifiée générée dans le CSS construit