### PR TITLE
fix(voice): sortir la fenêtre des réglages de son contexte d'empilement

### DIFF
--- a/nodyx-frontend/src/lib/components/VoicePanel.svelte
+++ b/nodyx-frontend/src/lib/components/VoicePanel.svelte
@@ -551,25 +551,7 @@
 
     {#if mode === 'float'}
     <!-- Barre vocale flottante -->
-    <!-- Le `z` MONTE quand les reglages sont ouverts, et ce n'est pas cosmetique.
-         Mesure dans le navigateur de l'utilisateur (500x996, 17/08) : le panneau
-         des reglages est `fixed inset-0 z-[200]`, mais il est DESCENDANT de cette
-         barre. Un `z-index` sur un element `fixed` cree un contexte d'empilement :
-         le 200 du panneau ne vaut QUE dans ce contexte. A l'etage du dessus, la
-         comparaison est 40 contre le `z-50` de l'entete de l'application, et
-         l'entete gagne. Ses 48px recouvraient les 31 premiers pixels de la croix
-         de fermeture, sur les 44 qu'elle mesure :
-
-             croix top:17 (44x44)
-             y=4  -> NAV.sticky top-0 z-50 h-12   <- l'entete, pas le panneau
-             y=40 -> DIV.flex items-center ...    <- toujours l'entete
-             y=52 -> LA CROIX                     <- enfin, sous les 48px
-
-         Le panneau n'etait ni coupe ni rogne : il etait RECOUVERT. C'est pourquoi
-         ni le collage en haut (#573) ni le bornage a l'ecran (#575) n'y pouvaient
-         rien. On ne monte le `z` que pendant l'ouverture, la barre reste sous
-         l'entete le reste du temps. -->
-    <div class='fixed left-0 lg:left-[220px] right-0 {showVoiceSettings ? "z-[60]" : "z-40"} pointer-events-none {extraClass}' style='bottom: var(--bottom-nav-h)'>
+    <div class='fixed left-0 lg:left-[220px] right-0 z-40 pointer-events-none {extraClass}' style='bottom: var(--bottom-nav-h)'>
         <div class='mx-auto max-w-4xl px-4 pb-2 pointer-events-auto'>
             <div class='relative group'>
                 <!-- Effet de glow externe -->
@@ -910,7 +892,35 @@
 
                 <!-- ── VoiceSettings popup ────────────────────────────────────── -->
                 {#if showVoiceSettings}
-                    <div class="fixed inset-0 sm:absolute sm:inset-auto sm:bottom-full sm:mb-2 sm:right-0 sm:w-[340px] z-[200]
+                    <!-- PORTAL OBLIGATOIRE, mesure du 17/08 chez l'utilisateur (500x996).
+                         Cette fenetre est `z-[200]`, et elle etait quand meme RECOUVERTE
+                         par l'entete de l'application (`NAV.sticky top-0 z-50`, 48px), qui
+                         mangeait les 31 premiers pixels de la croix de fermeture sur 44 :
+
+                             y=4  -> NAV.sticky top-0 z-50 h-12   <- l'entete
+                             y=52 -> LA CROIX                     <- enfin
+
+                         La chaine des ancetres dit pourquoi :
+
+                             panneau            z:200
+                             barre vocale       z:40
+                             DIV.fixed top-12   z:10   <- le plafond
+
+                         Chaque `z-index` sur un `fixed` cree un contexte d'empilement. Le
+                         200 ne vaut que dans celui de la barre, qui ne vaut que dans celui
+                         a z:10. Face au z-50 de l'entete, c'est 10 contre 50 : perdu. J'ai
+                         d'abord monte la barre de 40 a 60 (#576) : INERTE, mesure a
+                         l'appui, le plafond etait un cran plus haut.
+
+                         Le portal sort la fenetre a la racine : plus aucun contexte
+                         intermediaire, le 200 compte pour de vrai. C'est deja la parade
+                         employee trois fois dans ce fichier.
+
+                         Consequence : `sm:absolute ... bottom-full right-0` n'a plus de
+                         parent auquel s'accrocher. On passe donc en `fixed` centre au
+                         dessus de la barre, comme la variante laterale. -->
+                    <div use:portal class="fixed inset-0 sm:inset-auto sm:left-1/2 sm:-translate-x-1/2 sm:w-[340px]
+                                sm:bottom-[calc(var(--bottom-nav-h)+5.5rem)] z-[200]
                                 flex flex-col sm:block animate-in fade-in slide-in-from-bottom-4 duration-300"
                          style="pointer-events: auto;">
                         <!-- Sous `sm` le panneau occupe tout l'ecran et defile deja. A

--- a/nodyx-frontend/src/lib/voiceSettingsSortie.test.ts
+++ b/nodyx-frontend/src/lib/voiceSettingsSortie.test.ts
@@ -76,41 +76,48 @@ describe('sortie des paramètres audio', () => {
 		//
 		// Un en-tête `sticky` ne sert à rien sans zone défilante : c'est pourquoi
 		// ce contrôle vit à côté de celui du collage, pas à sa place.
-		const conteneurs = PANNEAU.split('<VoiceSettings').slice(0, -1)
-		expect(conteneurs.length, 'les deux sites de rendu doivent être présents').toBe(2)
-		for (const [i, amont] of conteneurs.entries()) {
-			// On regarde le conteneur immédiat, pas toute la page.
-			const proche = amont.slice(-700)
-			expect(proche, `site de rendu ${i + 1} : aucune borne sur la hauteur`).toMatch(
-				/max-h-\[calc\(100dvh/,
-			)
+		const blocs = PANNEAU.split('{#if showVoiceSettings}').slice(1)
+		const rendus = blocs.filter((b) => b.slice(0, b.indexOf('{/if}')).includes('<VoiceSettings'))
+		expect(rendus.length, 'les deux sites de rendu doivent être présents').toBe(2)
+		for (const [i, bloc] of rendus.entries()) {
+			expect(bloc.slice(0, bloc.indexOf('{/if}')), `site de rendu ${i + 1} : aucune borne`)
+				.toMatch(/max-h-\[calc\(100dvh/)
 		}
 	})
 
-	it("fait passer la barre flottante au-dessus de l'en-tête pendant l'ouverture", () => {
-		// LA vraie cause, mesurée dans le navigateur de l'utilisateur (500x996).
+	it('sort les deux fenêtres de leur arbre avec un portal', () => {
+		// LA vraie cause, mesurée chez l'utilisateur (500x996) après deux
+		// correctifs qui visaient à côté.
 		//
-		// Le panneau des réglages est `fixed inset-0 z-[200]`, mais il descend de la
-		// barre vocale flottante, qui portait un `z-40` fixe. Un `z-index` sur un
-		// élément `fixed` crée un contexte d'empilement : le 200 du panneau ne vaut
-		// QUE dans ce contexte. À l'étage du dessus la comparaison est 40 contre le
-		// `z-50` de l'en-tête de l'application, et l'en-tête gagne. Ses 48px
-		// recouvraient les 31 premiers pixels de la croix, sur 44 :
+		// La fenêtre est `z-[200]` et elle était quand même RECOUVERTE par
+		// l'en-tête de l'application (`NAV.sticky top-0 z-50`, 48px), qui mangeait
+		// les 31 premiers pixels de la croix sur 44 :
 		//
-		//     y=4  -> NAV.sticky top-0 z-50 h-12   (l'en-tête, pas le panneau)
-		//     y=52 -> LA CROIX                     (enfin, sous les 48px)
+		//     y=4  -> NAV.sticky top-0 z-50 h-12   (l'en-tête)
+		//     y=52 -> LA CROIX                     (enfin)
 		//
-		// Le panneau n'était ni coupé ni rogné : il était RECOUVERT. C'est pourquoi
-		// ni le collage en haut ni le bornage à l'écran n'y pouvaient rien.
-		const barre = PANNEAU.match(/<div class='fixed left-0[^']*'/)
-		expect(barre, 'barre vocale flottante introuvable').not.toBeNull()
-		expect(barre![0], "le `z` de la barre doit dépendre de l'ouverture des réglages").toMatch(
-			/showVoiceSettings \?/,
-		)
-		// Doit dépasser le `z-50` de l'en-tête, sinon le correctif ne corrige rien.
-		const ouvert = barre![0].match(/showVoiceSettings \? "z-\[(\d+)\]"/)
-		expect(ouvert, 'valeur du `z` en position ouverte illisible').not.toBeNull()
-		expect(Number(ouvert![1])).toBeGreaterThan(50)
+		// La chaîne des ancêtres dit pourquoi :
+		//
+		//     panneau            z:200
+		//     barre vocale       z:40
+		//     DIV.fixed top-12   z:10   <- le plafond
+		//
+		// Chaque `z-index` sur un `fixed` crée un contexte d'empilement : le 200 ne
+		// vaut que dans celui de la barre, qui ne vaut que dans celui à z:10. Face
+		// au z-50 de l'en-tête, c'est 10 contre 50. Monter la barre de 40 à 60 était
+		// INERTE, mesure à l'appui : le plafond était un cran plus haut.
+		//
+		// Seul le portal règle ça, en sortant la fenêtre à la racine.
+		// On découpe sur le bloc, pas sur une distance en caractères : un simple
+		// commentaire ajouté au-dessus suffisait à faire sortir `use:portal` d'une
+		// fenêtre fixe, et le test tombait sur du code correct.
+		const blocs = PANNEAU.split('{#if showVoiceSettings}').slice(1)
+		const rendus = blocs.filter((b) => b.slice(0, b.indexOf('{/if}')).includes('<VoiceSettings'))
+		expect(rendus.length, 'les deux sites de rendu doivent être présents').toBe(2)
+		for (const [i, bloc] of rendus.entries()) {
+			expect(bloc.slice(0, bloc.indexOf('{/if}')), `site de rendu ${i + 1} : pas de portal`)
+				.toMatch(/use:portal/)
+		}
 	})
 
 	it('donne à la croix une cible atteignable au pouce', () => {


### PR DESCRIPTION
## #576 était inerte

Mesure sur la prod, **après déploiement**, dans la configuration exacte de
Jonathan (500x996) :

```
barre flottante z:60          <- le changement de #576 était bien appliqué
y=4  -> NAV.sticky top-0 z-50 <- et l'en-tête passait toujours devant
y=52 -> LA CROIX

ancêtres créant un contexte : panneau z:200 -> barre z:60 -> DIV.fixed z:10
```

Le plafond n'était pas la barre vocale, mais un ancêtre `fixed` à `z:10` **un cran
plus haut** — que j'avais sous les yeux dans la sortie de console précédente et
que j'ai sauté.

Chaque `z-index` sur un `fixed` crée un contexte d'empilement : le 200 ne vaut que
dans celui de la barre, qui ne vaut que dans celui à `z:10`. Face au `z-50` de
l'en-tête, c'est 10 contre 50.

Monter la barre de 40 à 60 ne pouvait donc rien changer. **Le changement est
retiré**, pas laissé en place : un contournement inerte est un piège pour la
prochaine lecture.

## La vraie parade

`use:portal`, déjà employée trois fois dans ce fichier et documentée juste
au-dessus de l'autre site de rendu. Elle sort la fenêtre à la racine : plus aucun
contexte intermédiaire.

Conséquence assumée : `sm:absolute ... bottom-full right-0` n'a plus de parent
auquel s'accrocher. La fenêtre passe en `fixed` centrée au-dessus de la barre,
comme la variante latérale.

## Deux tests réécrits au passage

Ils cherchaient `max-h` et `use:portal` dans une fenêtre de 700 et 900 caractères
avant `<VoiceSettings`. **Un commentaire ajouté au-dessus suffisait à les faire
tomber sur du code correct** — ce qui est arrivé pendant cette PR. Ils sont
désormais ancrés sur le bloc `{#if showVoiceSettings}`, pas sur une distance.

## Prouvé

- l'invariant **tombe** sans le portal
- 111 tests verts
- `sm:bottom-[calc(var(--bottom-nav-h)+5.5rem)]` et `sm:-translate-x-1/2`
  vérifiées générées dans le CSS construit