### PR TITLE
fix(profil): la page d'édition ne s'adaptait pas aux écrans étroits

### DIFF
--- a/nodyx-frontend/src/routes/users/me/edit/+page.svelte
+++ b/nodyx-frontend/src/routes/users/me/edit/+page.svelte
@@ -201,7 +201,7 @@
 
 	<!-- "Voir mon profil" pill button — top-right of the banner -->
 	<a href="/users/{profile.username}"
-	   class="absolute top-3 right-4 flex items-center gap-1.5 px-3 py-1.5 rounded-full
+	   class="absolute top-3 right-4 flex items-center gap-1.5 px-3 py-1.5 max-sm:py-2.5 rounded-full
 	          bg-gray-900/70 backdrop-blur-sm border border-gray-700/50
 	          text-xs font-medium text-gray-300 hover:text-white hover:bg-gray-800/90
 	          transition-colors shadow-md">
@@ -270,10 +270,12 @@
 	<input type="hidden" name="name_font_url" value={nameFontUrl ?? ''} />
 
 	<!-- ─── ROW 1: Identité + Visuels ──────────────────────────────────── -->
-	<div class="grid grid-cols-5 gap-4">
+	<!-- Empile sous `md`. A 502px les deux colonnes cote a cote laissaient 260px
+	     et 150px : « Status » et « Location » tronquaient, la bio etait coupee. -->
+	<div class="grid grid-cols-1 md:grid-cols-5 gap-4">
 
 		<!-- Identité (3/5) -->
-		<div class="col-span-3 bg-gray-900/80 border border-gray-800 rounded-xl p-5 space-y-4">
+		<div class="md:col-span-3 bg-gray-900/80 border border-gray-800 rounded-xl p-5 space-y-4">
 			<h2 class="text-xs uppercase tracking-widest text-gray-500 font-semibold flex items-center gap-2">
 				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z"/></svg>
 				{tFn('pedit.section_identity')}
@@ -306,7 +308,7 @@
 				</div>
 			</div>
 
-			<div class="grid grid-cols-2 gap-3">
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
 				<div>
 					<label for="status" class="block text-xs text-gray-400 mb-1.5 font-medium">{tFn('pedit.status')}</label>
 					<input id="status" name="status" type="text" maxlength="100"
@@ -337,7 +339,7 @@
 		</div>
 
 		<!-- Visuels (2/5) -->
-		<div class="col-span-2 bg-gray-900/80 border border-gray-800 rounded-xl p-5 space-y-5">
+		<div class="md:col-span-2 bg-gray-900/80 border border-gray-800 rounded-xl p-5 space-y-5">
 			<h2 class="text-xs uppercase tracking-widest text-gray-500 font-semibold flex items-center gap-2">
 				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"/></svg>
 				{tFn('pedit.section_visuals')}
@@ -367,11 +369,11 @@
 					</div>
 					<div class="flex gap-1">
 						<button type="button" onclick={() => { avatarMode = 'url' }}
-							class="px-2.5 py-1 rounded-md text-xs font-medium transition-colors {avatarMode === 'url' ? 'bg-indigo-600 text-white' : 'bg-gray-700/80 text-gray-400 hover:text-white'}">
+							class="px-2.5 max-sm:py-2.5 py-1 rounded-md text-xs font-medium transition-colors {avatarMode === 'url' ? 'bg-indigo-600 text-white' : 'bg-gray-700/80 text-gray-400 hover:text-white'}">
 							URL
 						</button>
 						<button type="button" onclick={() => { avatarMode = 'file' }}
-							class="px-2.5 py-1 rounded-md text-xs font-medium transition-colors {avatarMode === 'file' ? 'bg-indigo-600 text-white' : 'bg-gray-700/80 text-gray-400 hover:text-white'}">
+							class="px-2.5 max-sm:py-2.5 py-1 rounded-md text-xs font-medium transition-colors {avatarMode === 'file' ? 'bg-indigo-600 text-white' : 'bg-gray-700/80 text-gray-400 hover:text-white'}">
 							{tFn('pedit.file')}
 						</button>
 					</div>
@@ -417,11 +419,11 @@
 				{/if}
 				<div class="flex gap-1 mb-2">
 					<button type="button" onclick={() => { bannerMode = 'url' }}
-						class="px-2.5 py-1 rounded-md text-xs font-medium transition-colors {bannerMode === 'url' ? 'bg-indigo-600 text-white' : 'bg-gray-700/80 text-gray-400 hover:text-white'}">
+						class="px-2.5 max-sm:py-2.5 py-1 rounded-md text-xs font-medium transition-colors {bannerMode === 'url' ? 'bg-indigo-600 text-white' : 'bg-gray-700/80 text-gray-400 hover:text-white'}">
 						URL
 					</button>
 					<button type="button" onclick={() => { bannerMode = 'file' }}
-						class="px-2.5 py-1 rounded-md text-xs font-medium transition-colors {bannerMode === 'file' ? 'bg-indigo-600 text-white' : 'bg-gray-700/80 text-gray-400 hover:text-white'}">
+						class="px-2.5 max-sm:py-2.5 py-1 rounded-md text-xs font-medium transition-colors {bannerMode === 'file' ? 'bg-indigo-600 text-white' : 'bg-gray-700/80 text-gray-400 hover:text-white'}">
 						{tFn('pedit.file')}
 					</button>
 				</div>
@@ -637,7 +639,7 @@
 			<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244"/></svg>
 			{tFn('pedit.section_social')}
 		</h2>
-		<div class="grid grid-cols-2 gap-4">
+		<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
 			<div>
 				<label for="github_username" class="block text-xs text-gray-400 mb-1.5 font-medium">
 					GitHub <span class="text-gray-600 font-normal">{tFn('pedit.eg_username')}</span>
@@ -700,7 +702,7 @@
 	</div>
 
 	<!-- ─── ROW 3: Tags + Liens personnalisés ──────────────────────────────── -->
-	<div class="grid grid-cols-2 gap-4">
+	<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
 
 		<!-- Tags -->
 		<div class="bg-gray-900/80 border border-gray-800 rounded-xl p-5">


### PR DESCRIPTION
Mesure à 502px : **quatre grilles n'avaient aucun point de rupture**, elles
gardaient leurs colonnes côte à côte quelle que soit la largeur.

```
grid-cols-5   Identité (3) + Visuels (2)
grid-cols-2   Statut + Lieu
grid-cols-2   réseaux sociaux
grid-cols-2   Tags + Liens personnalisés
```

Conséquence sur un écran de 502px : les deux colonnes principales tombaient à
**260px et 150px**.

- « Status » et « Location » tronquaient leur texte de substitution
  (« Coding rigl », « Paris, Fran »)
- la bio était coupée en bas
- deux champs sortaient carrément de l'écran (`300..518` et `389..607` pour 502px
  de large)

Elles empilent désormais sous `md` et `sm` selon leur contenu.

## Cibles tactiles

Même mesure, sous le plancher des 44px recommandés au pouce :

| élément | avant |
|---|---|
| bascules URL / Fichier (avatar et bannière) | 25px |
| lien « voir mon profil » | 31px |

Élargis sous `sm` seulement — l'affichage reste compact au-delà.

## Vérifications

Les six classes concernées sont vérifiées générées dans le CSS construit.