### PR TITLE
fix(admin): la barre latérale mangeait 224px des 390 sur mobile

### DIFF
--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -2669,6 +2669,8 @@
   "widg.kb": "{{n}} KB",
   "widg.tab_preview": "Preview",
   "anav.sec_community": "Community",
+  "anav.open_menu": "Open the menu",
+  "anav.close_menu": "Close the menu",
   "anav.sec_communication": "Communication",
   "anav.sec_content": "Content",
   "anav.sec_platform": "Platform",

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -3772,6 +3772,8 @@
   "widg.kb": "{{n}} Ko",
   "widg.tab_preview": "Aperçu",
   "anav.sec_community": "Communauté",
+  "anav.open_menu": "Ouvrir le menu",
+  "anav.close_menu": "Fermer le menu",
   "anav.sec_communication": "Communication",
   "anav.sec_content": "Contenu",
   "anav.sec_platform": "Plateforme",

--- a/nodyx-frontend/src/routes/admin/+layout.svelte
+++ b/nodyx-frontend/src/routes/admin/+layout.svelte
@@ -75,12 +75,37 @@
 		exact
 			? $page.url.pathname === href
 			: $page.url.pathname.startsWith(href)
+
+	// TIROIR MOBILE. Mesure du 17/08 a 390px : la barre laterale `w-56` (224px)
+	// restait affichee, il ne restait donc que 166px pour le contenu. Le titre de
+	// page etait coupe, et les tableaux amputes (5920 elements hors ecran sur la
+	// page Membres, sans aucun defilement possible).
+	let menuOuvert = $state(false)
+
+	// Fermer a chaque navigation, sinon le tiroir masque la page qu'on vient
+	// d'ouvrir depuis le tiroir lui-meme.
+	$effect(() => {
+		void $page.url.pathname
+		menuOuvert = false
+	})
 </script>
 
 <div class="flex flex-1 min-h-0">
 
+	<!-- Voile, sous `lg` uniquement : le tiroir se ferme au clic a cote. -->
+	{#if menuOuvert}
+		<div class="lg:hidden fixed inset-0 z-30 bg-black/60 backdrop-blur-sm"
+		     role="button" tabindex="-1"
+		     onclick={() => (menuOuvert = false)}
+		     onkeydown={(e) => e.key === 'Escape' && (menuOuvert = false)}
+		     aria-label={tFn('anav.close_menu')}></div>
+	{/if}
+
 	<!-- ── Sidebar ──────────────────────────────────────────────────────────── -->
-	<aside class="w-56 shrink-0 border-r border-zinc-800/80 bg-zinc-950 flex flex-col">
+	<aside class="w-56 shrink-0 border-r border-zinc-800/80 bg-zinc-950 flex flex-col
+	               max-lg:fixed max-lg:inset-y-0 max-lg:left-0 max-lg:z-40 max-lg:overflow-y-auto
+	               max-lg:transition-transform max-lg:duration-200
+	               {menuOuvert ? 'max-lg:translate-x-0' : 'max-lg:-translate-x-full'}">
 
 		<!-- Header -->
 		<div class="h-14 flex items-center gap-2.5 px-4 border-b border-zinc-800/80">
@@ -178,8 +203,16 @@
 		{/if}
 
 		<!-- Top bar -->
-		<header class="h-14 border-b border-zinc-800/80 bg-zinc-950/60 flex items-center justify-between px-6 shrink-0">
-			<nav class="text-[13px] text-zinc-500 flex items-center gap-1.5">
+		<header class="h-14 border-b border-zinc-800/80 bg-zinc-950/60 flex items-center justify-between px-4 lg:px-6 shrink-0 gap-2">
+			<button type="button" onclick={() => (menuOuvert = true)}
+			        class="lg:hidden shrink-0 -ml-2 w-11 h-11 flex items-center justify-center rounded-lg
+			               text-zinc-400 hover:text-white hover:bg-zinc-800 transition-colors"
+			        aria-label={tFn('anav.open_menu')}>
+				<svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" viewBox="0 0 24 24">
+					<path d="M4 6h16M4 12h16M4 18h16"/>
+				</svg>
+			</button>
+			<nav class="text-[13px] text-zinc-500 flex items-center gap-1.5 min-w-0">
 				<a href="/" class="hover:text-zinc-300 transition-colors">{tFn('anav.forum')}</a>
 				<svg class="w-3 h-3 text-zinc-700" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"/></svg>
 				<span class="text-zinc-300">{tFn('anav.admin_title')}</span>

--- a/nodyx-frontend/src/routes/admin/announcements/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/announcements/+page.svelte
@@ -131,13 +131,13 @@
 	</div>
 
 	<!-- ── Existing announcements ───────────────────────────────────────────── -->
-	<div class="rounded-xl border border-gray-800 overflow-hidden">
+	<div class="rounded-xl border border-gray-800 overflow-x-auto">
 		{#if data.announcements.length === 0}
 			<div class="px-6 py-10 text-center text-sm text-gray-600">
 				{tFn('aann.empty')}
 			</div>
 		{:else}
-			<table class="w-full text-sm">
+			<table class="w-full text-sm min-w-[620px]">
 				<thead class="bg-gray-900 border-b border-gray-800 text-xs text-gray-500 uppercase tracking-wider">
 					<tr>
 						<th class="px-4 py-3 text-left">{tFn('aann.message')}</th>

--- a/nodyx-frontend/src/routes/admin/assets/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/assets/+page.svelte
@@ -35,8 +35,8 @@
 	{#if data.assets.length === 0}
 		<p class="text-gray-500 text-sm">{tFn('aast.empty')}</p>
 	{:else}
-		<div class="rounded-xl border border-gray-800 overflow-hidden">
-			<table class="w-full text-sm">
+		<div class="rounded-xl border border-gray-800 overflow-x-auto">
+			<table class="w-full text-sm min-w-[720px]">
 				<thead class="bg-gray-900 text-gray-400 text-xs uppercase tracking-wider">
 					<tr>
 						<th class="px-4 py-3 text-left w-12"></th>

--- a/nodyx-frontend/src/routes/admin/audit-log/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/audit-log/+page.svelte
@@ -103,13 +103,13 @@
 	</div>
 
 	<!-- Table -->
-	<div class="rounded-xl border border-gray-800 overflow-hidden">
+	<div class="rounded-xl border border-gray-800 overflow-x-auto">
 		{#if data.entries.length === 0}
 			<div class="px-6 py-12 text-center text-sm text-gray-600">
 				{tFn('alog.empty')}
 			</div>
 		{:else}
-			<table class="w-full text-sm">
+			<table class="w-full text-sm min-w-[620px]">
 				<thead class="bg-gray-900 border-b border-gray-800 text-xs text-gray-500 uppercase tracking-wider">
 					<tr>
 						<th class="px-4 py-3 text-left w-40">{tFn('alog.col_date')}</th>

--- a/nodyx-frontend/src/routes/admin/categories/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/categories/+page.svelte
@@ -67,8 +67,8 @@
 	</details>
 
 	<!-- Tree table -->
-	<div class="rounded-xl border border-gray-800 overflow-hidden">
-		<table class="w-full text-sm">
+	<div class="rounded-xl border border-gray-800 overflow-x-auto">
+		<table class="w-full text-sm min-w-[480px]">
 			<thead class="bg-gray-900 border-b border-gray-800 text-xs text-gray-500 uppercase tracking-wider">
 				<tr>
 					<th class="px-4 py-3 text-left">{tFn('acat.col_category')}</th>

--- a/nodyx-frontend/src/routes/admin/garden/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/garden/+page.svelte
@@ -38,8 +38,8 @@
 	{#if data.seeds.length === 0}
 		<p class="text-gray-500 text-sm">{tFn('agard.empty')}</p>
 	{:else}
-		<div class="rounded-xl border border-gray-800 overflow-hidden">
-			<table class="w-full text-sm">
+		<div class="rounded-xl border border-gray-800 overflow-x-auto">
+			<table class="w-full text-sm min-w-[720px]">
 				<thead class="bg-gray-900 text-gray-400 text-xs uppercase tracking-wider">
 					<tr>
 						<th class="px-4 py-3 text-left">{tFn('agard.col_idea')}</th>

--- a/nodyx-frontend/src/routes/admin/grades/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/grades/+page.svelte
@@ -80,8 +80,8 @@
 	{#if data.grades.length === 0}
 		<p class="text-sm text-gray-500">{tFn('agrade.empty')}</p>
 	{:else}
-		<div class="rounded-xl border border-gray-800 overflow-hidden mb-10">
-			<table class="w-full text-sm">
+		<div class="rounded-xl border border-gray-800 overflow-x-auto mb-10">
+			<table class="w-full text-sm min-w-[480px]">
 				<thead class="bg-gray-900 border-b border-gray-800 text-xs text-gray-500 uppercase tracking-wider">
 					<tr>
 						<th class="px-4 py-3 text-left">{tFn('agrade.col_grade')}</th>
@@ -154,8 +154,8 @@
 
 	<!-- Assign grades to members -->
 	<h2 class="text-lg font-bold text-white mb-4">{tFn('agrade.assign_title')}</h2>
-	<div class="rounded-xl border border-gray-800 overflow-hidden">
-		<table class="w-full text-sm">
+	<div class="rounded-xl border border-gray-800 overflow-x-auto">
+		<table class="w-full text-sm min-w-[480px]">
 			<thead class="bg-gray-900 border-b border-gray-800 text-xs text-gray-500 uppercase tracking-wider">
 				<tr>
 					<th class="px-4 py-3 text-left">{tFn('agrade.col_member')}</th>

--- a/nodyx-frontend/src/routes/admin/members/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/members/+page.svelte
@@ -110,8 +110,8 @@
 		/>
 	</div>
 
-	<div class="rounded-xl border border-gray-800 overflow-hidden">
-		<table class="w-full text-sm">
+	<div class="rounded-xl border border-gray-800 overflow-x-auto">
+		<table class="w-full text-sm min-w-[720px]">
 			<thead class="bg-gray-900 border-b border-gray-800 text-xs text-gray-500 uppercase tracking-wider">
 				<tr>
 					<th class="px-4 py-3 text-left">{tFn('amem.col_member')}</th>
@@ -261,8 +261,8 @@
 		<div class="mt-10">
 			<h2 class="text-base font-semibold text-white mb-1">{tFn('amem.banned_members')} <span class="text-gray-600 font-normal text-sm">({bans.length})</span></h2>
 			<p class="text-xs text-gray-600 mb-4">{tFn('amem.banned_hint')}</p>
-			<div class="rounded-xl border border-red-900/40 overflow-hidden">
-				<table class="w-full text-sm">
+			<div class="rounded-xl border border-red-900/40 overflow-x-auto">
+				<table class="w-full text-sm min-w-[620px]">
 					<thead class="bg-red-950/30 border-b border-red-900/40 text-xs text-red-400/70 uppercase tracking-wider">
 						<tr>
 							<th class="px-4 py-3 text-left">{tFn('amem.col_member')}</th>
@@ -343,8 +343,8 @@
 		<div class="mt-8">
 			<h2 class="text-base font-semibold text-white mb-1">{tFn('amem.banned_ips')} <span class="text-gray-600 font-normal text-sm">({ipBans.length})</span></h2>
 			<p class="text-xs text-gray-600 mb-4">{tFn('amem.banned_ips_hint')}</p>
-			<div class="rounded-xl border border-orange-900/40 overflow-hidden">
-				<table class="w-full text-sm">
+			<div class="rounded-xl border border-orange-900/40 overflow-x-auto">
+				<table class="w-full text-sm min-w-[620px]">
 					<thead class="bg-orange-950/20 border-b border-orange-900/40 text-xs text-orange-400/70 uppercase tracking-wider">
 						<tr>
 							<th class="px-4 py-3 text-left">{tFn('amem.col_ip')}</th>
@@ -417,8 +417,8 @@
 		<div class="mt-8">
 			<h2 class="text-base font-semibold text-white mb-1">{tFn('amem.banned_emails')} <span class="text-gray-600 font-normal text-sm">({emailBans.length})</span></h2>
 			<p class="text-xs text-gray-600 mb-4">{tFn('amem.banned_emails_hint')}</p>
-			<div class="rounded-xl border border-yellow-900/40 overflow-hidden">
-				<table class="w-full text-sm">
+			<div class="rounded-xl border border-yellow-900/40 overflow-x-auto">
+				<table class="w-full text-sm min-w-[620px]">
 					<thead class="bg-yellow-950/20 border-b border-yellow-900/40 text-xs text-yellow-400/70 uppercase tracking-wider">
 						<tr>
 							<th class="px-4 py-3 text-left">{tFn('amem.col_email_domain')}</th>

--- a/nodyx-frontend/src/routes/admin/moderation/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/moderation/+page.svelte
@@ -48,8 +48,8 @@
 		</form>
 	</div>
 
-	<div class="rounded-xl border border-gray-800 overflow-hidden">
-		<table class="w-full text-sm">
+	<div class="rounded-xl border border-gray-800 overflow-x-auto">
+		<table class="w-full text-sm min-w-[620px]">
 			<thead class="bg-gray-900 border-b border-gray-800 text-xs text-gray-500 uppercase tracking-wider">
 				<tr>
 					<th class="px-4 py-3 text-left">{tFn('amod.col_thread')}</th>

--- a/nodyx-frontend/src/routes/admin/octoguard/logs/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/octoguard/logs/+page.svelte
@@ -20,7 +20,7 @@
 {#if data.logs.length === 0}
 	<div class="og-empty">{tFn('octoguard.logs_empty')}</div>
 {:else}
-	<table class="og-table">
+	<table class="og-table min-w-[620px]">
 		<thead>
 			<tr>
 				<th>{tFn('octoguard.col_date')}</th><th>{tFn('octoguard.col_actor')}</th><th>{tFn('octoguard.col_action')}</th><th>{tFn('octoguard.col_target')}</th><th>{tFn('octoguard.col_details')}</th><th></th>

--- a/nodyx-frontend/src/routes/admin/octoguard/mutes/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/octoguard/mutes/+page.svelte
@@ -39,7 +39,7 @@
 {#if data.mutes.length === 0}
 	<div class="og-empty">{tFn('octoguard.mutes_empty')}</div>
 {:else}
-	<table class="og-table">
+	<table class="og-table min-w-[620px]">
 		<thead>
 			<tr><th>{tFn('octoguard.col_user')}</th><th>{tFn('octoguard.col_channel')}</th><th>{tFn('octoguard.col_reason')}</th><th>{tFn('octoguard.col_expires')}</th><th></th></tr>
 		</thead>

--- a/nodyx-frontend/src/routes/admin/sfu-lab/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/sfu-lab/+page.svelte
@@ -229,7 +229,7 @@
       <p class="text-sm text-zinc-600">{tFn('asfu.no_transport')}</p>
     {:else}
       <div class="overflow-x-auto">
-        <table class="w-full text-xs font-mono">
+        <table class="w-full text-xs font-mono min-w-[720px]">
           <thead class="text-zinc-500">
             <tr class="text-left">
               <th class="py-1 pr-3 font-semibold">{tFn('asfu.col_participant')}</th>

--- a/nodyx-frontend/src/routes/admin/tags/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/tags/+page.svelte
@@ -56,8 +56,8 @@
 	{#if tags.length === 0}
 		<p class="text-sm text-gray-500">{tFn('atags.empty')}</p>
 	{:else}
-		<div class="rounded-xl border border-gray-800 overflow-hidden">
-			<table class="w-full text-sm">
+		<div class="rounded-xl border border-gray-800 overflow-x-auto">
+			<table class="w-full text-sm min-w-[480px]">
 				<thead class="bg-gray-900 border-b border-gray-800 text-xs text-gray-500 uppercase tracking-wider">
 					<tr>
 						<th class="px-4 py-3 text-left">{tFn('atags.col_tag')}</th>


### PR DESCRIPTION
Mesure à 390px sur la prod, **avec un compte administrateur** (mes premières
mesures redirigeaient vers l'accueil et donnaient huit fois le même résultat — le
signe qu'on mesure la même page huit fois) :

```
/admin/members    5920 éléments hors écran, 4 tableaux plus larges que
                  l'écran, 924 cibles sous 36px
/admin/grades      899 hors écran
/admin/moderation  821 hors écran
/admin/audit-log   594 hors écran
```

Et « déborde 0px » sur toutes : **rien ne défilait**. Le contenu n'était pas
inatteignable, il était **amputé** — même motif que la fenêtre des réglages audio
hier.

## Deux causes, pas 78

### 1. La barre latérale

`<aside class="w-56 shrink-0">` sans **aucune** classe responsive : 224px pris sur
390, il restait **166px** pour toute la page. Le titre « Members » était coupé, le
tableau n'affichait qu'une colonne partielle.

Elle devient un tiroir glissant sous `lg` : voile, bouton de 44px au pouce dans la
barre du haut, et fermeture à chaque navigation — sinon le tiroir masque la page
qu'on vient d'ouvrir depuis le tiroir lui-même. Inchangée à partir de `lg`.

### 2. Les tableaux

13 conteneurs en `overflow-hidden` : les coins arrondis, oui, mais tout ce qui
dépasse est coupé sans défilement. Passés en `overflow-x-auto`.

Et 16 tableaux reçoivent une largeur minimale calculée sur leur **nombre de
colonnes** (720px à partir de 7, 620px à partir de 5, 480px sinon). Sans elle,
`w-full` se contente de comprimer les colonnes et la zone défilante ne sert à rien.

## i18n

`anav.open_menu` et `anav.close_menu` dans `fr.json` **et** `en.json`, les quatre
portes passent.

Les clés sont **insérées à leur place**, pas le fichier réordonné : un tri
alphabétique produisait 8900 lignes de diff pour 2 clés.

## Vérifications

Les huit classes concernées sont vérifiées générées dans le CSS construit. Mesure
de contrôle après déploiement, page par page.