### PR TITLE
refactor(frontend): migrer $app/stores vers $app/state, API dépréciée

### DIFF
--- a/nodyx-frontend/src/lib/appStateMigration.test.ts
+++ b/nodyx-frontend/src/lib/appStateMigration.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * `$app/stores` est formellement déprécié, on ne le réintroduit pas.
+ *
+ * Pourquoi (2026-08-17)
+ * ────────────────────
+ * SvelteKit marque `page`, `navigating` et `updated` de `$app/stores` en
+ * `@deprecated` au profit de `$app/state`, qui exige Svelte 5 — ce que ce projet
+ * utilise. L'API partira en SvelteKit 3.
+ *
+ * La migration a touché 45 fichiers et 140 occurrences. Sans ce contrôle, un
+ * seul copier-coller depuis un vieux fichier ou une réponse d'assistant suffit à
+ * réintroduire l'ancienne API, et on repart pour une deuxième migration.
+ *
+ * Ce que ce contrôle NE prétend PAS régler : l'alerte « Cannot find module
+ * '$app/stores' » d'un éditeur. Elle vient du serveur TypeScript qui ne charge
+ * pas le tsconfig du projet, pas du code. Vérifié : `.svelte-kit/ambient.d.ts`
+ * porte déjà le `/// <reference types="@sveltejs/kit" />` nécessaire, et `tsc`
+ * résout `$app/*` dès qu'on lui donne ce fichier.
+ */
+
+const SRC = new URL('..', import.meta.url).pathname
+
+function fichiers(dir: string, acc: string[] = []): string[] {
+	for (const e of readdirSync(dir)) {
+		if (e === 'node_modules' || e === '.svelte-kit') continue
+		const p = join(dir, e)
+		if (statSync(p).isDirectory()) fichiers(p, acc)
+		else if (/\.(svelte|ts|js)$/.test(e)) acc.push(p)
+	}
+	return acc
+}
+
+// Ce fichier CITE l'ancienne API dans ses commentaires : sans cette exclusion,
+// le controle se denonce lui-meme.
+const MOI = 'appStateMigration.test.ts'
+const TOUS = fichiers(SRC)
+	.filter((p) => !p.endsWith(MOI))
+	.map((p) => [p, readFileSync(p, 'utf-8')] as const)
+
+describe('migration vers $app/state', () => {
+	it('ne réintroduit aucun import de $app/stores', () => {
+		const coupables = TOUS.filter(([, s]) => s.includes('$app/stores')).map(([p]) =>
+			p.slice(p.indexOf('/src/') + 1),
+		)
+		expect(coupables, 'ces fichiers utilisent une API dépréciée').toEqual([])
+	})
+
+	it("n'utilise plus la syntaxe de store $page", () => {
+		// `$app/state` expose un objet réactif, pas un store : `$page` ne compile
+		// simplement plus. Le contrôle attrape surtout les copier-coller.
+		const coupables = TOUS.filter(([, s]) => /\$page\b/.test(s)).map(([p]) =>
+			p.slice(p.indexOf('/src/') + 1),
+		)
+		expect(coupables, 'ces fichiers utilisent encore $page').toEqual([])
+	})
+})

--- a/nodyx-frontend/src/lib/components/NodyxCanvas.svelte
+++ b/nodyx-frontend/src/lib/components/NodyxCanvas.svelte
@@ -6,7 +6,7 @@
 	import CanvasTopBar             from './CanvasTopBar.svelte'
 	import CanvasBottomBar          from './CanvasBottomBar.svelte'
 	import CanvasRightPanel         from './CanvasRightPanel.svelte'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import {
 		CanvasState, DEFAULT_TRANSFORM, screenToWorld, worldToScreen, zoomAt,
 		type CanvasTool, type CanvasElement, type ViewTransform,
@@ -1632,7 +1632,7 @@
 	async function placeImage(file: File, wx: number, wy: number) {
 		imageUploading = true
 		try {
-			const token = $page.data?.token ?? null
+			const token = page.data?.token ?? null
 			const form  = new FormData()
 			form.append('name', file.name.replace(/\.[^.]+$/, '') || 'canvas-image')
 			form.append('asset_type', 'image')

--- a/nodyx-frontend/src/lib/components/PollCard.svelte
+++ b/nodyx-frontend/src/lib/components/PollCard.svelte
@@ -3,7 +3,7 @@
 
 	const tFn = $derived($t)
   import { onMount, onDestroy, untrack } from 'svelte'
-  import { page } from '$app/stores'
+  import { page } from '$app/state'
   import { fly, fade } from 'svelte/transition'
   import { flip } from 'svelte/animate'
 
@@ -282,7 +282,7 @@
     return `${m}m`
   }
 
-  const currentUserId = $derived(($page.data as any).user?.id as string | undefined)
+  const currentUserId = $derived((page.data as any).user?.id as string | undefined)
   const isCreator     = $derived(poll ? String(poll.created_by ?? '') === String(currentUserId) : false)
   const hasVoted      = $derived((poll?.user_votes ?? []).length > 0)
   const canVote       = $derived(poll?.is_open && !voting)

--- a/nodyx-frontend/src/lib/components/StageChat.svelte
+++ b/nodyx-frontend/src/lib/components/StageChat.svelte
@@ -17,7 +17,7 @@
     // l'éditeur riche s'ouvre en plein écran sur mobile, en carte sur desktop.
 
     import { socket } from '$lib/socket'
-    import { page } from '$app/stores'
+    import { page } from '$app/state'
     import { linkifyHtml } from '$lib/linkify'
     import { renderCustomEmojis, customEmojisStore } from '$lib/customEmojis'
     import NodyxEditor from '$lib/components/editor/NodyxEditor.svelte'
@@ -74,7 +74,7 @@
     let editorKey   = $state(0)                     // remonte l'éditeur à chaque ouverture
 
     // ── Qui suis-je (pour la modération) ──────────────────────────────────────
-    const me      = $derived(($page.data as { user?: { id?: string; role?: string } })?.user)
+    const me      = $derived((page.data as { user?: { id?: string; role?: string } })?.user)
     const userId  = $derived(me?.id ?? '')
     const isAdmin = $derived(me?.role === 'owner' || me?.role === 'admin')
     const canActOn = (m: StageMessage) => m.author_id === userId || isAdmin

--- a/nodyx-frontend/src/lib/components/Table.svelte
+++ b/nodyx-frontend/src/lib/components/Table.svelte
@@ -4,7 +4,7 @@
 	import VoiceEqualizer from '$lib/components/VoiceEqualizer.svelte'
 	import { goto } from '$app/navigation'
 	import { PUBLIC_API_URL } from '$env/static/public'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import type { Socket } from 'socket.io-client'
 	import { t } from '$lib/i18n'
 
@@ -133,7 +133,7 @@
 	}
 	function closeMenu() { menuPlayer = null }
 
-	const userRole = $derived(($page.data as any)?.user?.role as string | undefined)
+	const userRole = $derived((page.data as any)?.user?.role as string | undefined)
 	const canModerate = $derived(
 		userRole === 'owner' || userRole === 'admin' || userRole === 'moderator'
 	)

--- a/nodyx-frontend/src/lib/components/VoicePanel.svelte
+++ b/nodyx-frontend/src/lib/components/VoicePanel.svelte
@@ -16,9 +16,9 @@
     import { onMount } from 'svelte'
     import { t } from '$lib/i18n'
     import { voicePanelTarget } from '$lib/voicePanel'
-    import { page } from '$app/stores'
+    import { page } from '$app/state'
 
-    const userRole = $derived(($page.data as any)?.user?.role as string | undefined)
+    const userRole = $derived((page.data as any)?.user?.role as string | undefined)
     const canModerate = $derived(
         userRole === 'owner' || userRole === 'admin' || userRole === 'moderator'
     )

--- a/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
+++ b/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount, onDestroy, untrack } from 'svelte'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { apiFetch } from '$lib/api'
 	import { anchoredPopover } from '$lib/actions/anchoredPopover'
 	import { t } from '$lib/i18n'
@@ -24,7 +24,7 @@
 	const tFn = $derived($t)
 
 	// ── Auth token (used for authenticated uploads) ─────────────────────────
-	const token = $derived(($page.data as any)?.token as string | undefined)
+	const token = $derived((page.data as any)?.token as string | undefined)
 
 	// ── Placeholder (i18n fallback) ─────────────────────────────────────────
 	const resolvedPlaceholder = $derived(placeholder || tFn('editor.default_placeholder'))

--- a/nodyx-frontend/src/lib/socket.ts
+++ b/nodyx-frontend/src/lib/socket.ts
@@ -138,16 +138,16 @@ export async function initSocket(token: string, initialCount: number): Promise<v
   // ── DM ─────────────────────────────────────────────────────────────────────
   // Incrémenter le badge DM quand un message arrive d'un autre utilisateur
   _socket.on('dm:message', (msg: { sender_id: string }) => {
-    import('$app/stores').then(({ page }) => {
-      let currentPath = ''
-      page.subscribe(p => { currentPath = p.url.pathname })()
-      // Ne pas incrémenter si l'user est déjà sur la conversation
-      if (!currentPath.startsWith('/dm/')) {
-        dmUnreadStore.update(n => n + 1)
-      }
-    }).catch(() => {
+    // `$app/state` n'expose plus de `.subscribe()`, et surtout : on n'a besoin
+    // ici que du chemin courant, dans un gestionnaire d'evenement du navigateur.
+    // `window.location.pathname` le donne directement, y compris apres une
+    // navigation cote client (SvelteKit passe par `history.pushState`). C'est
+    // deja ce qu'utilise le gestionnaire `banned` quelques lignes plus haut.
+    // Au passage : plus d'import dynamique, donc plus de repli en `.catch()` qui
+    // incrementait le compteur deux fois si l'import echouait.
+    if (!window.location.pathname.startsWith('/dm/')) {
       dmUnreadStore.update(n => n + 1)
-    })
+    }
   })
 
   socket.set(_socket)

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -4,7 +4,7 @@
 	import { fade, fly } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 	import type { LayoutData } from './$types';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { browser } from '$app/environment';
 	import { goto, beforeNavigate } from '$app/navigation';
 	import { initSocket, unreadCountStore, chatMentionStore, dmUnreadStore, onlineMembersStore, getSocket } from '$lib/socket';
@@ -45,7 +45,7 @@
 		'/users/[username]/card',
 		'/calendar/[id]',
 	]);
-	const ownsOgImage = $derived(PAGES_WITH_OWN_OG.has($page.route.id ?? ''));
+	const ownsOgImage = $derived(PAGES_WITH_OWN_OG.has(page.route.id ?? ''));
 
 	const user            = $derived(data.user);
 	const isBanned        = $derived(data.user?.is_banned === true);
@@ -95,7 +95,7 @@
 
 	// Reset chat mention badge when user is on /chat
 	$effect(() => {
-		if ($page.url.pathname.startsWith('/chat') && $chatMentionStore > 0) {
+		if (page.url.pathname.startsWith('/chat') && $chatMentionStore > 0) {
 			chatMentionStore.set(0)
 		}
 	})
@@ -104,7 +104,7 @@
 	let _lastMentionCount = 0
 	$effect(() => {
 		const c = $chatMentionStore
-		if (c > _lastMentionCount && !$page.url.pathname.startsWith('/chat')) {
+		if (c > _lastMentionCount && !page.url.pathname.startsWith('/chat')) {
 			playMention()
 		}
 		_lastMentionCount = c
@@ -140,8 +140,8 @@
 
 	const isActive = (href: string) =>
 		href === '/'
-			? $page.url.pathname === '/'
-			: $page.url.pathname.startsWith(href)
+			? page.url.pathname === '/'
+			: page.url.pathname.startsWith(href)
 
 	// App-wide theme — cascade : défaut → thème d'INSTANCE (owner, son univers) → thème du MEMBRE (override perso)
 	const appVars = $derived(themeToVars(resolveTheme((data as any).appTheme, (data as any).instanceTheme)))
@@ -439,7 +439,7 @@
 
 	// Ferme le drawer sur changement de page (navigation SvelteKit)
 	$effect(() => {
-		const _ = $page.url.pathname
+		const _ = page.url.pathname
 		gallerySidebarOpen = false
 	})
 
@@ -500,7 +500,7 @@
 	// mounted over the new page until the user clicks "back".
 	let skipLangReset = false
 	$effect(() => {
-		$page.url.pathname
+		page.url.pathname
 		if (skipLangReset) { skipLangReset = false; return }
 		langView = false
 	})
@@ -580,9 +580,9 @@
 	}
 	const showChannelSidebar = $derived(
 		!isBanned &&
-		!$page.url.pathname.startsWith('/admin') &&
-		!$page.url.pathname.startsWith('/auth') &&
-		$page.url.pathname !== '/banned'
+		!page.url.pathname.startsWith('/admin') &&
+		!page.url.pathname.startsWith('/auth') &&
+		page.url.pathname !== '/banned'
 	)
 
 	// Routes /overlay/* sont des pages OBS browser source : fullscreen
@@ -593,13 +593,13 @@
 	// porte sa propre barre d'application, le chrome de l'app ferait doublon.
 	// On bypass complètement le rendu du layout pour ces routes.
 	const isBareRoute = $derived(
-		$page.url.pathname.startsWith('/overlay/') ||
-		$page.url.pathname.startsWith('/deck/') ||
-		$page.url.pathname === '/translate',
+		page.url.pathname.startsWith('/overlay/') ||
+		page.url.pathname.startsWith('/deck/') ||
+		page.url.pathname === '/translate',
 	)
 
 	// Active channel ID from URL (used on /chat to highlight the current channel)
-	const activeChatChannelId = $derived($page.url.searchParams.get('channel') ?? null)
+	const activeChatChannelId = $derived(page.url.searchParams.get('channel') ?? null)
 
 	// ── Voice state (for member roster in sidebar) ─────────────────────────────
 	const voiceState       = $derived($voiceStore)
@@ -717,8 +717,8 @@
 
 	// ── Contextual breadcrumb ──────────────────────────────────────────────────
 	const breadcrumbs = $derived((() => {
-		const path = $page.url.pathname;
-		const d = $page.data as any;
+		const path = page.url.pathname;
+		const d = page.data as any;
 		if (path === '/') return [];
 		const crumbs: { label: string; href?: string }[] = [];
 		if (path.startsWith('/forum')) {
@@ -730,7 +730,7 @@
 			if (d?.thread?.title) crumbs.push({ label: d.thread.title });
 		} else if (path.startsWith('/chat')) {
 			crumbs.push({ label: tFn('nav.chat') });
-			const chId = $page.url.searchParams.get('channel');
+			const chId = page.url.searchParams.get('channel');
 			if (chId) {
 				const ch = layoutChannels.find(c => c.id === chId);
 				if (ch) crumbs.push({ label: (ch.type === 'voice' ? '🔊 ' : '# ') + ch.name });
@@ -798,10 +798,10 @@
 	     s'affichait jamais dans les partages). Les pages qui définissent
 	     leur propre og:image (threads) ajoutent la leur en plus. -->
 	{#if !ownsOgImage}
-		<meta property="og:image" content="{$page.url.origin}/og-image.jpg" />
+		<meta property="og:image" content="{page.url.origin}/og-image.jpg" />
 		<meta property="og:image:width"  content="1200" />
 		<meta property="og:image:height" content="630" />
-		<meta name="twitter:image" content="{$page.url.origin}/og-image.jpg" />
+		<meta name="twitter:image" content="{page.url.origin}/og-image.jpg" />
 	{/if}
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="theme-color" content="var(--nx-accent)" />
@@ -1432,7 +1432,7 @@
             {/if}
 
 
-            <div class="w-full flex-1 flex flex-col {langView ? 'lang-view-wrap h-full' : ($page.url.pathname === '/' || $page.url.pathname.startsWith('/chat') || $page.url.pathname.startsWith('/admin') || $page.url.pathname.startsWith('/users/') || $page.url.pathname.startsWith('/feed') || $page.url.pathname.startsWith('/settings') || $page.url.pathname.startsWith('/garden') || $page.url.pathname.startsWith('/calendar') || $page.url.pathname.startsWith('/discover') || $page.url.pathname.startsWith('/wiki') || $page.url.pathname.startsWith('/library') || $page.url.pathname.startsWith('/dm') || $page.url.pathname.startsWith('/auth/') ? 'h-full' : ($page.url.pathname.startsWith('/forum') || $page.url.pathname.startsWith('/tasks')) ? 'px-4 sm:px-6 py-8' : 'max-w-5xl mx-auto px-4 py-8')}">
+            <div class="w-full flex-1 flex flex-col {langView ? 'lang-view-wrap h-full' : (page.url.pathname === '/' || page.url.pathname.startsWith('/chat') || page.url.pathname.startsWith('/admin') || page.url.pathname.startsWith('/users/') || page.url.pathname.startsWith('/feed') || page.url.pathname.startsWith('/settings') || page.url.pathname.startsWith('/garden') || page.url.pathname.startsWith('/calendar') || page.url.pathname.startsWith('/discover') || page.url.pathname.startsWith('/wiki') || page.url.pathname.startsWith('/library') || page.url.pathname.startsWith('/dm') || page.url.pathname.startsWith('/auth/') ? 'h-full' : (page.url.pathname.startsWith('/forum') || page.url.pathname.startsWith('/tasks')) ? 'px-4 sm:px-6 py-8' : 'max-w-5xl mx-auto px-4 py-8')}">
                 {#if langView}
                     <!-- svelte-ignore a11y_no_static_element_interactions -->
                     <div class="fixed inset-0 bg-black/40 backdrop-blur-xs z-40" onclick={() => langView = false} transition:fade={{ duration: 200 }}></div>
@@ -1821,7 +1821,7 @@
 		<!-- Profil / Connexion -->
 		{#if user}
 		<a href="/users/{user.username}"
-		   class="flex-1 flex flex-col items-center justify-center py-2 min-h-14 gap-0.5 {$page.url.pathname.startsWith('/users/') ? 'text-indigo-400' : 'text-gray-500'}">
+		   class="flex-1 flex flex-col items-center justify-center py-2 min-h-14 gap-0.5 {page.url.pathname.startsWith('/users/') ? 'text-indigo-400' : 'text-gray-500'}">
 			{#if user.avatar}
 				<img src={user.avatar} class="w-5 h-5 rounded-full object-cover" alt="" />
 			{:else}

--- a/nodyx-frontend/src/routes/admin/+layout.svelte
+++ b/nodyx-frontend/src/routes/admin/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import type { LayoutData } from './$types'
 	import NodyxVersionBadge from '$lib/components/NodyxVersionBadge.svelte'
 	import { t } from '$lib/i18n'
@@ -73,8 +73,8 @@
 
 	const isActive = (href: string, exact = false) =>
 		exact
-			? $page.url.pathname === href
-			: $page.url.pathname.startsWith(href)
+			? page.url.pathname === href
+			: page.url.pathname.startsWith(href)
 
 	// TIROIR MOBILE. Mesure du 17/08 a 390px : la barre laterale `w-56` (224px)
 	// restait affichee, il ne restait donc que 166px pour le contenu. Le titre de
@@ -85,7 +85,7 @@
 	// Fermer a chaque navigation, sinon le tiroir masque la page qu'on vient
 	// d'ouvrir depuis le tiroir lui-meme.
 	$effect(() => {
-		void $page.url.pathname
+		void page.url.pathname
 		menuOuvert = false
 	})
 </script>

--- a/nodyx-frontend/src/routes/admin/backups/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/backups/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
 	import { t as i18n } from '$lib/i18n';
@@ -63,7 +63,7 @@
 		setTimeout(() => { toasts = toasts.filter(t => t.id !== id); }, 3500);
 	}
 
-	function getToken() { return ($page.data as any).token as string ?? ''; }
+	function getToken() { return (page.data as any).token as string ?? ''; }
 
 	// ── Helpers ──────────────────────────────────────────────────────────────
 	function fmtBytes(n: number): string {

--- a/nodyx-frontend/src/routes/admin/extensions/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/extensions/+page.svelte
@@ -7,7 +7,7 @@
 	// extension qui ne demande rien, parce que c'est la meme porte pour tout le
 	// monde.
 
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { invalidateAll } from '$app/navigation'
 	import { t } from '$lib/i18n'
 	import type { PageData } from './$types'
@@ -30,7 +30,7 @@
 	let busy        = $state(false)
 	let notice      = $state('')
 
-	const token = $derived($page.data.token as string | null)
+	const token = $derived(page.data.token as string | null)
 
 	/** Libelle lisible d'une capacite, sans jargon de code. */
 	function capabilityLabel(cap: string): string {

--- a/nodyx-frontend/src/routes/admin/extensions/install/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/extensions/install/+page.svelte
@@ -6,7 +6,7 @@
 	// Un lien fabrique ne peut donc pas installer quoi que ce soit tout seul.
 	// cf SPECS/NODYX_SDK_CDC.md §9.5
 
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { onMount } from 'svelte'
 	import { t } from '$lib/i18n'
 
@@ -22,10 +22,10 @@
 		version:             string
 	}
 
-	const token    = $derived($page.data.token as string | null)
-	const registry = $derived($page.url.searchParams.get('src') ?? '')
-	const id       = $derived($page.url.searchParams.get('id') ?? '')
-	const version  = $derived($page.url.searchParams.get('v') ?? '')
+	const token    = $derived(page.data.token as string | null)
+	const registry = $derived(page.url.searchParams.get('src') ?? '')
+	const id       = $derived(page.url.searchParams.get('id') ?? '')
+	const version  = $derived(page.url.searchParams.get('v') ?? '')
 
 	let inspection: Inspection | null = $state(null)
 	let issues: Array<{ code: string; path?: string; message: string }> = $state([])

--- a/nodyx-frontend/src/routes/admin/homepage/builder/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/homepage/builder/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { PageData } from './$types'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import GridRenderer from '$lib/components/homepage/GridRenderer.svelte'
 	import ImagePositionPicker from '$lib/components/homepage/ImagePositionPicker.svelte'
 	import type { WidgetFamily } from '$lib/components/homepage/plugins'
@@ -66,7 +66,7 @@
 		toasts = [...toasts, { id, text, ok }]
 		setTimeout(() => { toasts = toasts.filter(t => t.id !== id) }, 3000)
 	}
-	function getToken() { return ($page.data as any).token as string ?? '' }
+	function getToken() { return (page.data as any).token as string ?? '' }
 
 	function markUnsaved() { unsaved = true }
 

--- a/nodyx-frontend/src/routes/admin/members/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/members/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { enhance } from '$app/forms'
 	import type { PageData } from './$types'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { PUBLIC_API_URL } from '$env/static/public'
 	import { untrack } from 'svelte'
 	import { t } from '$lib/i18n'
@@ -20,7 +20,7 @@
 		resetLinkError = ''
 		resetLinkResult = null
 		try {
-			const token = ($page.data as any).token as string | null
+			const token = (page.data as any).token as string | null
 			const res = await fetch(`${PUBLIC_API_URL}/api/v1/admin/members/${userId}/reset-link`, {
 				method:  'POST',
 				headers: token ? { Authorization: `Bearer ${token}` } : {},
@@ -60,7 +60,7 @@
 		revealing[userId] = true
 		try {
 			const res = await fetch(`/api/v1/admin/members/${userId}/email`, {
-				headers: { Authorization: `Bearer ${$page.data.token}` },
+				headers: { Authorization: `Bearer ${page.data.token}` },
 			})
 			if (res.ok) revealed[userId] = (await res.json()).email
 		} finally {

--- a/nodyx-frontend/src/routes/admin/moderation/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/moderation/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { enhance } from '$app/forms'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import type { PageData } from './$types'
 	import { t } from '$lib/i18n'
 

--- a/nodyx-frontend/src/routes/admin/modules/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/modules/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types'
 	import { MODULE_DISPLAY, FAMILY_META, FAMILY_ORDER, type ModuleFamily } from '$lib/modules'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { untrack } from 'svelte'
 	import { t } from '$lib/i18n'
 
@@ -55,7 +55,7 @@
 		saving[id]      = true
 
 		try {
-			const token = $page.data.token as string | null
+			const token = page.data.token as string | null
 			const res = await fetch(`/api/v1/admin/modules/${id}`, {
 				method:  'PATCH',
 				headers: {

--- a/nodyx-frontend/src/routes/admin/octoguard/+layout.svelte
+++ b/nodyx-frontend/src/routes/admin/octoguard/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { t as i18n } from '$lib/i18n'
 	let { children } = $props()
 
@@ -17,8 +17,8 @@
 	]
 
 	function isActive(href: string): boolean {
-		if (href === '/admin/octoguard') return $page.url.pathname === href
-		return $page.url.pathname.startsWith(href)
+		if (href === '/admin/octoguard') return page.url.pathname === href
+		return page.url.pathname.startsWith(href)
 	}
 </script>
 

--- a/nodyx-frontend/src/routes/admin/settings/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/settings/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { PageData, ActionData } from './$types'
 	import { enhance } from '$app/forms'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { onMount, untrack } from 'svelte'
 	import { t } from '$lib/i18n'
 	import ImagePositionPicker from '$lib/components/homepage/ImagePositionPicker.svelte'
@@ -81,7 +81,7 @@
 	}
 
 	onMount(async () => {
-		const token = ($page.data as any).token as string | null
+		const token = (page.data as any).token as string | null
 		if (!token) return
 		try {
 			const res = await fetch('/api/v1/admin/smtp/status', {
@@ -110,7 +110,7 @@
 	}
 
 	async function saveConfig() {
-		const token = ($page.data as any).token as string | null
+		const token = (page.data as any).token as string | null
 		if (!token || !cfg) return
 		cfgSaving = true
 		cfgSaved = false
@@ -147,7 +147,7 @@
 	}
 
 	async function testTwitch() {
-		const token = ($page.data as any).token as string | null
+		const token = (page.data as any).token as string | null
 		if (!token) return
 		twitchTesting = true
 		twitchTestResult = null
@@ -165,7 +165,7 @@
 	}
 
 	async function sendSmtpTest() {
-		const token = ($page.data as any).token as string | null
+		const token = (page.data as any).token as string | null
 		if (!token || !smtpTestTo.trim()) return
 		smtpTesting = true
 		smtpTestResult = null
@@ -194,7 +194,7 @@
 	let uploadingSidebarBg = $state(false)
 
 	async function uploadBrandingFile(type: 'logo' | 'banner' | 'sidebar', file: File) {
-		const token = ($page.data as any).token as string | null
+		const token = (page.data as any).token as string | null
 		if (!token) return
 
 		const fd = new FormData()

--- a/nodyx-frontend/src/routes/admin/status/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/status/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { runNetworkDiagnostic } from '$lib/utils/networkTester';
-    import { page } from '$app/stores';
+    import { page } from '$app/state';
     import { fade, fly } from 'svelte/transition';
     import { t } from '$lib/i18n';
 
@@ -46,7 +46,7 @@
         addLog(tFn('astatus.log_init'));
         // Token : le test récupère des credentials TURN FRAIS via l'API
         // (les statiques de build expirent en <24h → RELAY OFFLINE menteur).
-        const token = $page.data.token as string | null;
+        const token = page.data.token as string | null;
         runNetworkDiagnostic((res) => { diag = res; }, token);
 
         // Séquence synchronisée avec ton UI

--- a/nodyx-frontend/src/routes/admin/streamer-hub/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/streamer-hub/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { invalidateAll, replaceState } from '$app/navigation'
 	import { onMount, onDestroy } from 'svelte'
 	import { fly } from 'svelte/transition'
@@ -149,7 +149,7 @@
 	const engagementHasPolls       = $derived<boolean>((data as { engagementHasPolls?: boolean }).engagementHasPolls === true)
 	const engagementHasPredictions = $derived<boolean>((data as { engagementHasPredictions?: boolean }).engagementHasPredictions === true)
 	const rewardsHasScope          = $derived<boolean>((data as { rewardsHasScope?: boolean }).rewardsHasScope === true)
-	const pageToken     = $derived(($page.data as { token?: string }).token ?? '')
+	const pageToken     = $derived((page.data as { token?: string }).token ?? '')
 
 	// ── Onglets ─────────────────────────────────────────────────────────────
 	// 6 zones pour ne pas surcharger la page : overview / studio live /
@@ -334,7 +334,7 @@
 	}
 
 	function authHeaders(): Record<string, string> {
-		const token = $page.data.token as string | null
+		const token = page.data.token as string | null
 		return token ? { 'Authorization': `Bearer ${token}` } : {}
 	}
 

--- a/nodyx-frontend/src/routes/admin/widgets/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/widgets/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { PLUGIN_LIST } from '$lib/components/homepage/plugins';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { onMount } from 'svelte';
 	import { t as i18n } from '$lib/i18n';
 
@@ -81,7 +81,7 @@
 	}
 
 	// ── Fetch installed ──────────────────────────────────────────────────────
-	function getToken() { return ($page.data as any).token as string ?? '' }
+	function getToken() { return (page.data as any).token as string ?? '' }
 
 	async function loadInstalled() {
 		loadingList = true

--- a/nodyx-frontend/src/routes/auth/verify-pending/+page.svelte
+++ b/nodyx-frontend/src/routes/auth/verify-pending/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { t } from '$lib/i18n'
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 
 	const tFn = $derived($t)
 
-	const email = $derived($page.url.searchParams.get('email') ?? '');
+	const email = $derived(page.url.searchParams.get('email') ?? '');
 
 	let resending   = $state(false);
 	let resendDone  = $state(false);

--- a/nodyx-frontend/src/routes/banned/+page.svelte
+++ b/nodyx-frontend/src/routes/banned/+page.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { enhance } from '$app/forms';
 	import { t } from '$lib/i18n';
 
 	const tFn = $derived($t);
 
-	const communityName = $derived($page.data.communityName ?? tFn('banned.this_community'));
+	const communityName = $derived(page.data.communityName ?? tFn('banned.this_community'));
 </script>
 
 <svelte:head>

--- a/nodyx-frontend/src/routes/chat/+page.svelte
+++ b/nodyx-frontend/src/routes/chat/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount, onDestroy, tick, untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { browser } from '$app/environment';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import type { PageData } from './$types';
 	import { socket, getSocket } from '$lib/socket';
@@ -92,7 +92,7 @@
 	// où le timing de goto est plus lent que le state Svelte. Avec untrack le
 	// $effect ne fire QUE quand l'URL change réellement.
 	$effect(() => {
-		const urlChannelId = $page.url.searchParams.get('channel');
+		const urlChannelId = page.url.searchParams.get('channel');
 		untrack(() => {
 			if (localChannels.length === 0) return;
 			if (urlChannelId) {

--- a/nodyx-frontend/src/routes/communities/+page.svelte
+++ b/nodyx-frontend/src/routes/communities/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { PUBLIC_API_URL } from '$env/static/public';
 	import { t } from '$lib/i18n';
 
@@ -28,10 +28,10 @@
 	let { data }: { data: PageData } = $props()
 
 	const instances = $derived<NodyxInstance[]>(data.instances ?? [])
-	const user      = $derived($page.data.user)
+	const user      = $derived(page.data.user)
 
 	// Slugs liés — initialisé depuis le serveur, puis géré localement (optimistic updates)
-	let linkedSlugs = $state<string[]>(($page.data.user as any)?.linked_instances ?? [])
+	let linkedSlugs = $state<string[]>((page.data.user as any)?.linked_instances ?? [])
 
 	let linkLoading = $state<string | null>(null) // slug en cours
 
@@ -46,7 +46,7 @@
 		try {
 			const res = await fetch(`${PUBLIC_API_URL}/api/v1/users/me/linked-instances`, {
 				method: 'PATCH',
-				headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${$page.data.token}` },
+				headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${page.data.token}` },
 				body: JSON.stringify({ action, slug }),
 			})
 			const json = await res.json()

--- a/nodyx-frontend/src/routes/feed/+page.svelte
+++ b/nodyx-frontend/src/routes/feed/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { t } from '$lib/i18n'
 	import type { PageData } from './$types'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { apiFetch } from '$lib/api'
 	import { onMount, untrack } from 'svelte'
 	import NodyxEditor from '$lib/components/editor/NodyxEditor.svelte'
@@ -12,8 +12,8 @@
 
 	let { data }: { data: PageData } = $props()
 
-	const me    = $derived(($page.data as any).user)
-	const token = $derived(($page.data as any).token as string)
+	const me    = $derived((page.data as any).user)
+	const token = $derived((page.data as any).token as string)
 
 	// ── Posts state ───────────────────────────────────────────────────────────
 	let posts     = $state<any[]>(untrack(() => data.posts ?? []))

--- a/nodyx-frontend/src/routes/forum/+page.svelte
+++ b/nodyx-frontend/src/routes/forum/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { t } from '$lib/i18n';
 	const tFn = $derived($t)
 
@@ -32,7 +32,7 @@
 	const allCats  = $derived([...topLevel, ...topLevel.flatMap((c: any) => c.children ?? [])]);
 	const totThreads = $derived(allCats.reduce((n: number, c: any) => n + (c.thread_count ?? 0), 0));
 	const totPosts   = $derived(allCats.reduce((n: number, c: any) => n + (c.post_count ?? 0), 0));
-	const totMembers = $derived(($page.data as any).memberCount ?? 0);
+	const totMembers = $derived((page.data as any).memberCount ?? 0);
 
 	// Le membre le plus récemment actif sur le forum : c'est l'auteur du dernier
 	// message toutes catégories confondues.

--- a/nodyx-frontend/src/routes/forum/[category]/+page.svelte
+++ b/nodyx-frontend/src/routes/forum/[category]/+page.svelte
@@ -2,7 +2,7 @@
 	import type { PageData } from './$types';
 	import { fly, fade } from 'svelte/transition';
 	import type { FlyParams, FadeParams } from 'svelte/transition';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { t } from '$lib/i18n';
 	import { replyCount, isUnanswered } from '$lib/forumCounts';
 
@@ -253,15 +253,15 @@
 </script>
 
 <svelte:head>
-	<title>{categoryName} · {$page.data.communityName ?? 'Nodyx'}</title>
-	<meta name="description" content="Discussions dans {categoryName}, forum {$page.data.communityName ?? 'Nodyx'}" />
-	<link rel="canonical" href={$page.url.href} />
-	<meta property="og:title"       content="{categoryName} · {$page.data.communityName ?? 'Nodyx'}" />
-	<meta property="og:description" content="Discussions dans {categoryName}, forum {$page.data.communityName ?? 'Nodyx'}" />
+	<title>{categoryName} · {page.data.communityName ?? 'Nodyx'}</title>
+	<meta name="description" content="Discussions dans {categoryName}, forum {page.data.communityName ?? 'Nodyx'}" />
+	<link rel="canonical" href={page.url.href} />
+	<meta property="og:title"       content="{categoryName} · {page.data.communityName ?? 'Nodyx'}" />
+	<meta property="og:description" content="Discussions dans {categoryName}, forum {page.data.communityName ?? 'Nodyx'}" />
 	<meta property="og:type"        content="website" />
-	<meta property="og:url"         content={$page.url.href} />
-	<meta property="og:image"       content={$page.data.communityBannerUrl ?? $page.data.communityLogoUrl ?? `${$page.url.origin}/default-og-image.png`} />
-	<meta property="og:site_name"   content={$page.data.communityName ?? 'Nodyx'} />
+	<meta property="og:url"         content={page.url.href} />
+	<meta property="og:image"       content={page.data.communityBannerUrl ?? page.data.communityLogoUrl ?? `${page.url.origin}/default-og-image.png`} />
+	<meta property="og:site_name"   content={page.data.communityName ?? 'Nodyx'} />
 </svelte:head>
 
 <!-- EN-TÊTE DE CATÉGORIE -->

--- a/nodyx-frontend/src/routes/forum/[category]/[thread]/+page.server.ts
+++ b/nodyx-frontend/src/routes/forum/[category]/[thread]/+page.server.ts
@@ -24,7 +24,7 @@ export const load: PageServerLoad = async ({ fetch, params, cookies }) => {
 	// Image de partage (og:image) : la première image du premier post, donc la
 	// bannière de l'article. Lue côté serveur pour que Discord/Twitter/Facebook
 	// (qui n'exécutent pas de JS) la voient dans le HTML SSR. Chemin relatif :
-	// le composant l'absolutise via $page.url.origin.
+	// le composant l'absolutise via page.url.origin.
 	const ogImagePath: string | null =
 		(json.posts?.[0]?.content ?? '').match(/<img\b[^>]*\bsrc=["']([^"']+)["']/i)?.[1] ?? null;
 

--- a/nodyx-frontend/src/routes/forum/[category]/[thread]/+page.svelte
+++ b/nodyx-frontend/src/routes/forum/[category]/[thread]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	// Les scrapers OG (Discord, Twitter, Facebook) exigent des URLs absolues
-	// et lisent le HTML SSR : l'origin vient de $page.url, jamais de window.
+	// et lisent le HTML SSR : l'origin vient de page.url, jamais de window.
 	// Les bannières/logos sont stockés en chemins relatifs (/uploads/...).
 	function absolutize(url: string | null | undefined, origin: string): string | null {
 		if (!url) return null
@@ -11,7 +11,7 @@
 	import { enhance, applyAction } from '$app/forms';
 	import { untrack } from 'svelte';
 	import { invalidateAll, goto } from '$app/navigation';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import type { PageData } from './$types';
 	import ProfileCard from '$lib/components/ProfileCard.svelte';
 	import NodyxEditor from '$lib/components/editor/NodyxEditor.svelte';
@@ -32,9 +32,9 @@
 	// communauté → logo → og-image par défaut. Toujours une seule og:image.
 	const shareImage = $derived(
 		absolutize(
-			data.ogImagePath ?? $page.data.communityBannerUrl ?? $page.data.communityLogoUrl,
-			$page.url.origin,
-		) ?? `${$page.url.origin}/og-image.jpg`,
+			data.ogImagePath ?? page.data.communityBannerUrl ?? page.data.communityLogoUrl,
+			page.url.origin,
+		) ?? `${page.url.origin}/og-image.jpg`,
 	);
 	// post_count compte le message d'ouverture : ce n'est PAS un nombre de
 	// réponses. Voir $lib/forumCounts.
@@ -74,7 +74,7 @@
 	}
 
 	async function shareThread() {
-		const url = $page.url.href;
+		const url = page.url.href;
 
 		if (typeof navigator !== 'undefined' && navigator.share) {
 			try {
@@ -125,25 +125,25 @@
 </script>
 
 <svelte:head>
-	<title>{thread.title} · {$page.data.communityName ?? 'Nodyx'}</title>
+	<title>{thread.title} · {page.data.communityName ?? 'Nodyx'}</title>
 	<meta name="description" content="Discussion : {thread.title} par {thread.author_username}" />
-	<link rel="canonical" href={$page.url.href} />
-	<meta property="og:title"       content="{thread.title} · {$page.data.communityName ?? 'Nodyx'}" />
+	<link rel="canonical" href={page.url.href} />
+	<meta property="og:title"       content="{thread.title} · {page.data.communityName ?? 'Nodyx'}" />
 	<meta property="og:description" content="Discussion par {thread.author_username} · {replies} {tFn('forum.replies_label')} · {thread.views} {tFn('forum.views')}" />
 	<meta property="og:type"        content="article" />
-	<meta property="og:url"         content={$page.url.href} />
+	<meta property="og:url"         content={page.url.href} />
 	<!-- Pas de og:image:width/height ici : l'image de tête d'un article a des
 	     dimensions variables (le pipeline d'upload re-encode/redimensionne).
 	     Déclarer une taille fixe fausserait l'aperçu. Les scrapers lisent la
 	     vraie taille de l'image. -->
 	<meta property="og:image"        content={shareImage} />
 	<meta name="twitter:image"       content={shareImage} />
-	<meta property="og:site_name"   content={$page.data.communityName ?? 'Nodyx'} />
+	<meta property="og:site_name"   content={page.data.communityName ?? 'Nodyx'} />
 	{@html `<script type="application/ld+json">${JSON.stringify({
 		"@context": "https://schema.org",
 		"@type": "DiscussionForumPosting",
 		"headline": thread.title,
-		"url": $page.url.href,
+		"url": page.url.href,
 		"author": { "@type": "Person", "name": thread.author_username },
 		"datePublished": thread.created_at,
 		"dateModified": thread.updated_at ?? thread.created_at,
@@ -155,8 +155,8 @@
 		},
 		"isPartOf": {
 			"@type": "DiscussionForumPosting",
-			"name": $page.data.communityName ?? 'Nodyx',
-			"url": $page.url.origin + '/forum'
+			"name": page.data.communityName ?? 'Nodyx',
+			"url": page.url.origin + '/forum'
 		}
 	})}</script>`}
 </svelte:head>

--- a/nodyx-frontend/src/routes/forum/[category]/new/+page.svelte
+++ b/nodyx-frontend/src/routes/forum/[category]/new/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import type { ActionData, PageData } from './$types';
 	import NodyxEditor from '$lib/components/editor/NodyxEditor.svelte';
 	import PollCreator from '$lib/components/PollCreator.svelte';

--- a/nodyx-frontend/src/routes/garden/+page.svelte
+++ b/nodyx-frontend/src/routes/garden/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { PageData, ActionData } from './$types'
 	import { goto } from '$app/navigation'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { enhance } from '$app/forms'
 	import { PUBLIC_API_URL } from '$env/static/public'
 	import { untrack } from 'svelte'
@@ -55,7 +55,7 @@
 	}
 
 	function applyCategory(cat: string) {
-		const u = new URL($page.url)
+		const u = new URL(page.url)
 		if (cat) u.searchParams.set('category', cat)
 		else u.searchParams.delete('category')
 		u.searchParams.delete('offset')

--- a/nodyx-frontend/src/routes/library/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/library/[id]/+page.svelte
@@ -2,7 +2,7 @@
 	import type { PageData } from './$types'
 	import { PUBLIC_API_URL } from '$env/static/public'
 	import { goto } from '$app/navigation'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { p2pManager, p2pAssetPeers } from '$lib/p2p'
 	import { t } from '$lib/i18n'
 	import { browser } from '$app/environment'
@@ -11,7 +11,7 @@
 
 	let { data }: { data: PageData } = $props()
 	const asset = $derived(data.asset)
-	const me    = $derived(($page.data as any).user)
+	const me    = $derived((page.data as any).user)
 
 	const TYPE_ICONS: Record<string, string> = {
 		frame: '🖼️', banner: '🎨', badge: '🏅', sticker: '⭐',
@@ -48,7 +48,7 @@
 	)
 
 	// Token from layout data (HttpOnly cookie — not accessible via document.cookie)
-	const token = $derived(($page.data as any).token as string | null)
+	const token = $derived((page.data as any).token as string | null)
 
 	let equipping      = $state(false)
 	let equipToast     = $state<'ok' | 'err' | null>(null)

--- a/nodyx-frontend/src/routes/overlay/alert/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/alert/[token]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { browser } from '$app/environment'
 	import { PUBLIC_API_URL } from '$env/static/public'
 	import { fly, fade, scale } from 'svelte/transition'
@@ -16,7 +16,7 @@
 	// par l'admin et substitue les variables `{user_name}`, `{bits}`, etc.
 	// dans les templates par event type.
 
-	const token = $derived(($page.params as { token: string }).token)
+	const token = $derived((page.params as { token: string }).token)
 
 	type AlertTheme = 'cyber' | 'soft' | 'retro' | 'neon' | 'holographic' | 'minimal' | 'custom'
 	type AlertPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left' | 'center'

--- a/nodyx-frontend/src/routes/overlay/board/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/board/[token]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { browser } from '$app/environment'
 	import { PUBLIC_API_URL } from '$env/static/public'
 	import { fade, fly, scale } from 'svelte/transition'
@@ -14,7 +14,7 @@
 	// socket pour config-updated. Mode "récap fin de stream" auto-trigger sur
 	// stream.offline.
 
-	const token = $derived(($page.params as { token: string }).token)
+	const token = $derived((page.params as { token: string }).token)
 
 	type Category = 'subs' | 'bits' | 'raids' | 'chatters'
 	type Period   = 'session' | '7d' | '30d' | 'all'

--- a/nodyx-frontend/src/routes/overlay/clips/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/clips/[token]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { browser } from '$app/environment'
 	import { PUBLIC_API_URL } from '$env/static/public'
 	import { fade } from 'svelte/transition'
@@ -17,7 +17,7 @@
 	// pas les clips, et l'iframe statique se fait bloquer par Chrome autoplay
 	// policy). Bonus : on a un vrai contrôle (play/pause/ended event).
 
-	const token = $derived(($page.params as { token: string }).token)
+	const token = $derived((page.params as { token: string }).token)
 
 	type Clip = {
 		id:           string

--- a/nodyx-frontend/src/routes/overlay/goal/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/goal/[token]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { browser } from '$app/environment'
 	import { PUBLIC_API_URL } from '$env/static/public'
 	import { fade } from 'svelte/transition'
@@ -13,7 +13,7 @@
 	// qui agrège les chiffres. Quand reached === true, animation de
 	// célébration (pulse + sparkle) pour le streamer et ses viewers.
 
-	const token = $derived(($page.params as { token: string }).token)
+	const token = $derived((page.params as { token: string }).token)
 
 	type GoalTheme = 'cyber' | 'soft' | 'retro' | 'neon' | 'minimal' | 'custom'
 	type CustomTheme = {

--- a/nodyx-frontend/src/routes/overlay/ticker/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/ticker/[token]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { browser } from '$app/environment'
 	import { PUBLIC_API_URL } from '$env/static/public'
 	import { fade } from 'svelte/transition'
@@ -15,7 +15,7 @@
 	// Push socket en live, CSS animation pure pour le scroll (0 charge JS
 	// pendant que ça tourne dans OBS), bootstrap REST au premier load.
 
-	const token = $derived(($page.params as { token: string }).token)
+	const token = $derived((page.params as { token: string }).token)
 
 	type TickerEventKey =
 		| 'channel.follow' | 'channel.subscribe' | 'channel.subscription.gift'

--- a/nodyx-frontend/src/routes/overlay/timer/[token]/+page.svelte
+++ b/nodyx-frontend/src/routes/overlay/timer/[token]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { browser } from '$app/environment'
 	import { PUBLIC_API_URL } from '$env/static/public'
 	import { fade } from 'svelte/transition'
@@ -16,7 +16,7 @@
 	//
 	// 6 thèmes (cyber/soft/retro/neon/minimal/custom), 5 positions, 3 formats.
 
-	const token = $derived(($page.params as { token: string }).token)
+	const token = $derived((page.params as { token: string }).token)
 
 	type State = { isLive: boolean; startedAt: string | null }
 	type Theme    = 'cyber' | 'soft' | 'retro' | 'neon' | 'minimal' | 'custom'

--- a/nodyx-frontend/src/routes/polls/+page.svelte
+++ b/nodyx-frontend/src/routes/polls/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { page } from '$app/stores'
+  import { page } from '$app/state'
   import { goto } from '$app/navigation'
   import { fly, fade } from 'svelte/transition'
   import PollCard     from '$lib/components/PollCard.svelte'

--- a/nodyx-frontend/src/routes/settings/+page.svelte
+++ b/nodyx-frontend/src/routes/settings/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import NetworkDoctor from '$lib/components/NetworkDoctor.svelte';
     import E2EKeyBackup from '$lib/components/E2EKeyBackup.svelte';
-    import { page } from '$app/stores';
+    import { page } from '$app/state';
 
     import { PUBLIC_API_URL, PUBLIC_SIGNET_URL } from '$env/static/public';
     import { tick } from 'svelte';
@@ -24,7 +24,7 @@
 
     // Visibilité de la section Notifs Streamer : owners/admins seulement.
     const isStreamerNotifVisible = $derived(() => {
-        const u = $page.data.user as { role?: string } | null | undefined
+        const u = page.data.user as { role?: string } | null | undefined
         return u?.role === 'owner' || u?.role === 'admin'
     })
 
@@ -60,7 +60,7 @@
     let twitchError             = $state<string | null>(null)
 
     async function loadTwitchLink() {
-        const token = ($page.data as any).token as string | null
+        const token = (page.data as any).token as string | null
         if (!token) { twitchLoaded = true; return }
         try {
             const res = await fetch('/api/v1/streamer/twitch/viewer/me', {
@@ -79,7 +79,7 @@
         twitchConnecting = true
         twitchError = null
         try {
-            const token = ($page.data as any).token as string | null
+            const token = (page.data as any).token as string | null
             const res = await fetch('/api/v1/streamer/twitch/viewer/auth-init', {
                 headers: { Authorization: `Bearer ${token}` },
             })
@@ -102,7 +102,7 @@
         twitchUnlinking = true
         twitchError = null
         try {
-            const token = ($page.data as any).token as string | null
+            const token = (page.data as any).token as string | null
             const res = await fetch('/api/v1/streamer/twitch/viewer/unlink', {
                 method:  'DELETE',
                 headers: { Authorization: `Bearer ${token}` },
@@ -123,7 +123,7 @@
 
     // Lis ?just_linked_twitch=login au mount → toast + ouvre la section
     $effect(() => {
-        const justLinked = $page.url.searchParams.get('just_linked_twitch')
+        const justLinked = page.url.searchParams.get('just_linked_twitch')
         if (justLinked) {
             activeSection = 'connected-accounts'
             twitchToast   = get(t)('settings.twitch.linked_toast', { login: justLinked })
@@ -137,7 +137,7 @@
 
     // Deep-link ?section=xxx (ex: bouton « Paramètres » depuis les DM)
     $effect(() => {
-        const s = $page.url.searchParams.get('section')
+        const s = page.url.searchParams.get('section')
         if (s) {
             activeSection = s
             const url = new URL(window.location.href)
@@ -167,7 +167,7 @@
     let signetQrLink      = $state<string | null>(null)
 
     async function loadSignetDevices() {
-        const token = ($page.data as any).token as string | null
+        const token = (page.data as any).token as string | null
         if (!token) return
         try {
             const res = await fetch(`${PUBLIC_API_URL}/api/auth/devices`, {
@@ -182,7 +182,7 @@
     }
 
     async function generateSignetToken() {
-        const token = ($page.data as any).token as string | null
+        const token = (page.data as any).token as string | null
         if (!token) return
         signetGenerating = true
         signetToken = null
@@ -211,7 +211,7 @@
     }
 
     async function revokeSignetDevice(deviceId: string) {
-        const token = ($page.data as any).token as string | null
+        const token = (page.data as any).token as string | null
         if (!token) return
         signetRevoking = deviceId
         try {
@@ -232,7 +232,7 @@
     }
 
     $effect(() => {
-        if ($page.data.user) loadSignetDevices()
+        if (page.data.user) loadSignetDevices()
     })
 
     // ── 2FA TOTP ──────────────────────────────────────────────────────────────
@@ -250,7 +250,7 @@
     let totpSuccess   = $state('')
 
     $effect(() => {
-        const token = ($page.data as any).token as string | null
+        const token = (page.data as any).token as string | null
         if (!token || totpLoaded) return
         fetch('/api/v1/auth/totp/status', { headers: { Authorization: `Bearer ${token}` } })
             .then(r => r.ok ? r.json() : null)
@@ -260,7 +260,7 @@
     })
 
     async function totpStartSetup() {
-        const token = ($page.data as any).token as string | null
+        const token = (page.data as any).token as string | null
         if (!token) return
         totpLoading = true; totpError = ''
         try {
@@ -276,7 +276,7 @@
     }
 
     async function totpConfirm() {
-        const token = ($page.data as any).token as string | null
+        const token = (page.data as any).token as string | null
         if (!token || !totpCode) return
         totpLoading = true; totpError = ''
         try {
@@ -296,7 +296,7 @@
     }
 
     async function totpDisable() {
-        const token = ($page.data as any).token as string | null
+        const token = (page.data as any).token as string | null
         if (!token || !totpCode) return
         totpLoading = true; totpError = ''
         try {
@@ -321,11 +321,11 @@
 
     // ── Instances liées (Galaxy Bar) ──────────────────────────────────────────
 
-    const user = $derived($page.data.user as { linked_instances?: string[] } | null);
+    const user = $derived(page.data.user as { linked_instances?: string[] } | null);
     let linkedSlugs = $state<string[]>([]);
     $effect(() => { linkedSlugs = user?.linked_instances ?? [] });
 
-    const directoryInstances = $derived($page.data.directoryInstances as Array<{
+    const directoryInstances = $derived(page.data.directoryInstances as Array<{
         slug: string; name: string; url: string; logo_url: string | null;
     }> ?? []);
 
@@ -347,7 +347,7 @@
         try {
             const res = await fetch(`${PUBLIC_API_URL}/api/v1/users/me/linked-instances`, {
                 method: 'PATCH',
-                headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${$page.data.token}` },
+                headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${page.data.token}` },
                 body: JSON.stringify({ action: 'add', slug }),
             });
             const json = await res.json();
@@ -362,7 +362,7 @@
     async function removeInstance(slug: string) {
         const res = await fetch(`${PUBLIC_API_URL}/api/v1/users/me/linked-instances`, {
             method: 'PATCH',
-            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${$page.data.token}` },
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${page.data.token}` },
             body: JSON.stringify({ action: 'remove', slug }),
         });
         const json = await res.json();
@@ -403,7 +403,7 @@
     }
 
     async function togglePush() {
-        const token = ($page.data as any).token as string | null
+        const token = (page.data as any).token as string | null
         if (!token || !pushSupported) return
         pushLoading = true
         pushError   = ''
@@ -627,7 +627,7 @@
                 </div>
             </div>
 
-            {#if pushSupported && $page.data.user}
+            {#if pushSupported && page.data.user}
             <div class="s-card">
                 <div class="s-row">
                     <div class="s-row-info">
@@ -765,7 +765,7 @@
         {/if}
 
         <!-- ═══ SÉCURITÉ 2FA ════════════════════════════════════════════════ -->
-        {#if activeSection === 'security' && $page.data.user}
+        {#if activeSection === 'security' && page.data.user}
         <div class="s-pane" style="--accent: #f87171; --accent-bg: rgba(239,68,68,0.07); --accent-border: rgba(239,68,68,0.18)">
             <div class="s-pane-header">
                 <div class="s-pane-icon" style="background: var(--accent-bg); border-color: var(--accent-border); color: var(--accent)">
@@ -909,7 +909,7 @@
         {/if}
 
         <!-- ═══ MESSAGES CHIFFRÉS (sauvegarde de clé E2E) ════════════════════ -->
-        {#if activeSection === 'encryption' && $page.data.user}
+        {#if activeSection === 'encryption' && page.data.user}
         <div class="s-pane" style="--accent: var(--nx-accent-soft); --accent-bg: rgb(var(--nx-accent-rgb) / 0.08); --accent-border: rgb(var(--nx-accent-rgb) / 0.2)">
             <div class="s-pane-header">
                 <div class="s-pane-icon" style="background: var(--accent-bg); border-color: var(--accent-border); color: var(--accent)">
@@ -923,9 +923,9 @@
                 </div>
             </div>
 
-            {#if ($page.data as any).token}
+            {#if (page.data as any).token}
             <div class="s-card">
-                <E2EKeyBackup token={($page.data as any).token} mode="manage" />
+                <E2EKeyBackup token={(page.data as any).token} mode="manage" />
             </div>
             {/if}
         </div>

--- a/nodyx-frontend/src/routes/status/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/status/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { apiFetch } from '$lib/api'
 	import { t } from '$lib/i18n'
 	import NodyxEditor from '$lib/components/editor/NodyxEditor.svelte'
@@ -7,7 +7,7 @@
 
 	let { data }: { data: PageData } = $props()
 	const tFn   = $derived($t)
-	const me    = $derived(($page.data as any).user)
+	const me    = $derived((page.data as any).user)
 	const token = $derived(data.token as string)
 
 	let post    = $state<any>(data.post)

--- a/nodyx-frontend/src/routes/tasks/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/tasks/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { goto } from '$app/navigation'
 	import type { PageData } from './$types'
 	import { untrack } from 'svelte'
@@ -14,7 +14,7 @@
 	let board   = $state(untrack(() => structuredClone(data.board)))
 	let members = $state(untrack(() => data.members))
 
-	const token     = $derived($page.data.token as string)
+	const token     = $derived(page.data.token as string)
 	const API       = '/api/v1/tasks'
 
 	// ── Drag & drop ───────────────────────────────────────────────────────────

--- a/nodyx-frontend/src/routes/users/[username]/+page.svelte
+++ b/nodyx-frontend/src/routes/users/[username]/+page.svelte
@@ -4,7 +4,7 @@
 	import ReputationRings from '$lib/components/ReputationRings.svelte'
 	import GenerativeBanner from '$lib/components/GenerativeBanner.svelte'
 	import ActivityHeatmap from '$lib/components/ActivityHeatmap.svelte'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { goto } from '$app/navigation'
 	import { resolveTheme, themeToStyle } from '$lib/profileThemes'
 	import { socket } from '$lib/socket'
@@ -18,7 +18,7 @@
 	const profile = $derived(data.profile)
 
 	// Logged-in user — from parent layout
-	const me = $derived(($page.data as any).user)
+	const me = $derived((page.data as any).user)
 	const isOwnProfile = $derived(me?.username === profile.username)
 
 	// Initials fallback
@@ -182,7 +182,7 @@
 	)
 
 	// ── Follow system ──────────────────────────────────────────────
-	const token = $derived(($page.data as any).token as string | null)
+	const token = $derived((page.data as any).token as string | null)
 
 	let following      = $state(untrack(() => data.isFollowing ?? false))
 	let followersCount = $state(untrack(() => Number(profile.followers_count ?? 0)))

--- a/nodyx-frontend/src/routes/whisper/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/whisper/[id]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types'
 	import { onMount, onDestroy, tick, untrack } from 'svelte'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { goto } from '$app/navigation'
 	import { getSocket } from '$lib/socket'
 	import { PUBLIC_API_URL } from '$env/static/public'
@@ -12,9 +12,9 @@
 
 	let { data }: { data: PageData } = $props()
 
-	const roomId  = $derived($page.params.id)
-	const me      = $derived(($page.data as any).user)
-	const token   = $derived(($page.data as any).token as string | null)
+	const roomId  = $derived(page.params.id)
+	const me      = $derived((page.data as any).user)
+	const token   = $derived((page.data as any).token as string | null)
 
 	// ── State ────────────────────────────────────────────────────────────────
 	interface WMessage {

--- a/nodyx-frontend/src/routes/wiki/[slug]/+page.svelte
+++ b/nodyx-frontend/src/routes/wiki/[slug]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { PageData } from './$types'
-	import { page } from '$app/stores'
+	import { page } from '$app/state'
 	import { t } from '$lib/i18n'
 
 	const tFn = $derived($t)
@@ -23,7 +23,7 @@
 
 	async function deletePage() {
 		if (!confirm(tFn('wiki_view.confirm_delete', { title: pg.title }))) return
-		const token = $page.data.token as string | null
+		const token = page.data.token as string | null
 		const res = await fetch(`/api/v1/wiki/${pg.slug}`, {
 			method: 'DELETE',
 			headers: token ? { Authorization: `Bearer ${token}` } : {},


### PR DESCRIPTION
Prépare la refonte du panneau d'administration : autant retirer une API vouée à
disparaître **avant** le chantier que pendant.

SvelteKit marque `page`, `navigating` et `updated` de `$app/stores` en
`@deprecated` au profit de `$app/state`, qui exige Svelte 5 — ce projet y est
déjà. L'API partira en SvelteKit 3.

## Périmètre, relevé avant de toucher quoi que ce soit

```
45 fichiers (44 .svelte, 1 .ts)
1 seul symbole importé : `page`. Ni `navigating` ni `updated`
140 occurrences de `$page`
0 collision de nom, 0 bloc <script module>, 0 usage nu de `$page`
```

## Le seul cas non mécanique

`src/lib/socket.ts` importait `$app/stores` en **dynamique** et s'abonnait juste
pour lire le chemin courant. `$app/state` n'expose plus de `.subscribe()`, et de
toute façon on est dans un gestionnaire d'événement du navigateur :
`window.location.pathname` donne l'information directement, y compris après une
navigation côté client. C'est déjà ce qu'utilise le gestionnaire `banned` quelques
lignes plus haut.

Effet de bord corrigé au passage : le `.catch()` de l'import dynamique
incrémentait le compteur de messages non lus même quand la condition ne le voulait
pas.

## Ce que cette PR ne fait pas

Elle ne corrige **pas** l'alerte « Cannot find module '$app/stores' » d'un
éditeur. J'ai d'abord cru le contraire. Vérification faite, la configuration du
dépôt est correcte :

| fichiers donnés à `tsc` | résultat |
|---|---|
| sonde + `app.d.ts` seuls | `TS2307` sur `$app/*` **et** `$env/*` |
| sonde + `app.d.ts` + `ambient.d.ts` | aucune erreur |

`.svelte-kit/ambient.d.ts` porte déjà le `/// <reference types="@sveltejs/kit" />`
et figure dans l'`include` du tsconfig généré. L'alerte vient du serveur
TypeScript de l'éditeur, qui ne charge pas le tsconfig du projet pour ce fichier.
Rien à corriger dans le code — la migration reste justifiée par la dépréciation,
pas par cette alerte.

## Vérifications

- 0 erreur de typage, **113 tests verts**, 4 portes i18n vertes
- build complet en copie isolée
- aucune trace de `$app/stores` dans le paquet construit

## Garde-fou

`src/lib/appStateMigration.test.ts`, deux invariants, chacun **prouvé tombant**
sur la récidive correspondante (import de l'ancienne API, syntaxe `$page`). Sans
lui, un seul copier-coller depuis un vieux fichier relance la migration.