### PR TITLE
fix(types): résoudre $app/* et $env/* pour l'éditeur, pas seulement pour la CI

### DIFF
--- a/nodyx-frontend/src/app.d.ts
+++ b/nodyx-frontend/src/app.d.ts
@@ -1,3 +1,31 @@
+/// <reference types="@sveltejs/kit" />
+/// <reference path="../.svelte-kit/ambient.d.ts" />
+
+// LES DEUX REFERENCES CI-DESSUS SONT LA POUR L'EDITEUR, pas pour la CI.
+//
+// Le probleme (17/08) : chaque fichier important `$app/state`, `$app/environment`,
+// `$app/forms`, `$app/navigation` ou `$env/static/public` affichait
+// « Cannot find module ». Soit 130 fichiers pour `$app/*` et 38 pour `$env/*`.
+//
+// La CI, `npm run check` et le build ne voyaient RIEN, parce qu'ils passent par
+// `tsconfig.json`, qui etend `.svelte-kit/tsconfig.json`, dont l'`include`
+// contient `ambient.d.ts`, lequel porte deja la reference aux types de SvelteKit.
+// Un serveur TypeScript d'editeur qui ouvre un fichier sans charger ce tsconfig
+// n'a lui aucune de ces declarations, d'ou l'alerte permanente.
+//
+// Mesure, sur un programme volontairement prive de `ambient.d.ts` pour imiter
+// l'editeur :
+//
+//     avant : $app/state, $app/environment, $app/forms, $app/navigation
+//             et $env/static/public  -> tous non resolus
+//     apres : tous resolus
+//
+// La seconde reference pointe vers un fichier GENERE et ignore par git. C'est
+// assume : les types de `$env/*` listent les vraies variables du projet, ils ne
+// peuvent pas etre ecrits a la main. La degradation est propre, verifie en
+// supprimant le fichier : TypeScript ignore la reference au lieu d'echouer, et on
+// retombe simplement sur l'alerte d'origine.
+
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
 declare global {


### PR DESCRIPTION
Chaque fichier important `$app/state`, `$app/environment`, `$app/forms`,
`$app/navigation` ou `$env/static/public` affichait « Cannot find module » dans
l'éditeur : **130 fichiers** pour `$app/*`, **38** pour `$env/*`. Intenable à la
veille d'une refonte du panneau d'administration.

## Pourquoi la CI ne voyait rien

`npm run check`, les tests et le build passent par `tsconfig.json`, qui étend
`.svelte-kit/tsconfig.json`, dont l'`include` contient `ambient.d.ts`, lequel porte
déjà la référence aux types de SvelteKit.

Un serveur TypeScript d'éditeur qui ouvre un fichier **sans charger ce tsconfig**
n'a aucune de ces déclarations. Le dépôt était correct, l'éditeur non — d'où une
alerte permanente que rien côté CI ne pouvait révéler.

## Mesure

Sur un programme volontairement privé de `ambient.d.ts`, pour imiter l'éditeur :

| | `$app/state` | `$app/environment` | `$app/forms` | `$app/navigation` | `$env/static/public` |
|---|---|---|---|---|---|
| avant | ✗ | ✗ | ✗ | ✗ | ✗ |
| après | ✓ | ✓ | ✓ | ✓ | ✓ |

## Le correctif

Deux lignes dans `src/app.d.ts`, qui est toujours chargé :

```ts
/// <reference types="@sveltejs/kit" />
/// <reference path="../.svelte-kit/ambient.d.ts" />
```

La seconde pointe vers un fichier **généré et ignoré par git**. C'est assumé : les
types de `$env/*` listent les vraies variables du projet, ils ne peuvent pas être
écrits à la main. La dégradation est propre, **vérifiée en supprimant le
fichier** : TypeScript ignore la référence au lieu d'échouer, et on retombe
simplement sur l'alerte d'origine.

## Ce que je n'ai pas fait

Ajouter `"types": ["@sveltejs/kit"]` au tsconfig. Ce champ **désactive**
l'inclusion automatique de tous les `@types/*`, donc `@types/node` et les globales
de Vitest avec. Le remède aurait été pire que le mal.

## Vérifications

- 0 erreur de typage, 113 tests verts, build complet en copie isolée
- les 5 modules résolus par `tsc` **sans** tsconfig