### PR TITLE
fix(admin): les tableaux deviennent des cartes sous md, fin du rognage

### DIFF
--- a/nodyx-frontend/src/app.css
+++ b/nodyx-frontend/src/app.css
@@ -744,3 +744,63 @@ select option {
   /* fallback pour les images qui mettent du temps à charger : pas de bordure */
   border: none;
 }
+
+/* ── Tableaux d'administration : cartes empilees sous `md` ──────────────────
+ *
+ * Mesure du 17/08 sur /admin/grades a 502px de fenetre, soit 454px utiles :
+ *
+ *     tableau 1 (3 colonnes) : 480px de large -> 26px caches
+ *     tableau 2 (4 colonnes) : 602px de large -> 148px caches
+ *
+ * Rendre le conteneur defilant a bien rendu le contenu ATTEIGNABLE, mais pas
+ * UTILISABLE : la colonne des actions restait hors ecran, avec une barre de
+ * defilement horizontale disgracieuse sur chaque bloc. A cette largeur, le
+ * tableau est simplement le mauvais format.
+ *
+ * Chaque ligne devient donc une carte, chaque cellule une ligne « libelle /
+ * valeur ». Le libelle vient de `data-label` sur le `<td>`, sinon la cellule
+ * s'affiche pleine largeur (utile pour une rangee de boutons, qui se decrit
+ * toute seule). A partir de `md`, le tableau redevient un tableau, inchange.
+ */
+@media (max-width: 767px) {
+	.tableau-cartes thead {
+		display: none;
+	}
+	.tableau-cartes,
+	.tableau-cartes tbody,
+	.tableau-cartes tr,
+	.tableau-cartes td {
+		display: block;
+		width: 100%;
+		min-width: 0;
+	}
+	.tableau-cartes tr {
+		border-bottom: 1px solid var(--p-card-border, rgb(39 39 42));
+		padding: 0.75rem 0;
+	}
+	.tableau-cartes tr:last-child {
+		border-bottom: 0;
+	}
+	.tableau-cartes td {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		padding: 0.35rem 1rem;
+		border: 0;
+		text-align: left;
+	}
+	.tableau-cartes td[data-label]::before {
+		content: attr(data-label);
+		flex: 0 0 auto;
+		font-size: 0.6875rem;
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--p-text-muted, rgb(113 113 122));
+	}
+	/* Une cellule sans libelle prend toute la largeur : rangees de boutons. */
+	.tableau-cartes td:not([data-label]) {
+		justify-content: flex-start;
+	}
+}

--- a/nodyx-frontend/src/routes/admin/grades/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/grades/+page.svelte
@@ -81,7 +81,7 @@
 		<p class="text-sm text-gray-500">{tFn('agrade.empty')}</p>
 	{:else}
 		<div class="rounded-xl border border-gray-800 overflow-x-auto mb-10">
-			<table class="w-full text-sm min-w-[480px]">
+			<table class="tableau-cartes w-full text-sm md:min-w-[480px]">
 				<thead class="bg-gray-900 border-b border-gray-800 text-xs text-gray-500 uppercase tracking-wider">
 					<tr>
 						<th class="px-4 py-3 text-left">{tFn('agrade.col_grade')}</th>
@@ -129,13 +129,13 @@
 									</form>
 								</td>
 							{:else}
-								<td class="px-4 py-3">
+								<td class="px-4 py-3" data-label={tFn('agrade.col_grade')}>
 									<span class="inline-block rounded px-2.5 py-1 text-xs font-semibold"
 										style="background:{grade.color}; color:{luminance(grade.color)>0.5?'#111':'#fff'}">
 										{grade.name}
 									</span>
 								</td>
-								<td class="px-4 py-3 text-xs text-gray-400">{permSummary(grade.permissions ?? {})}</td>
+								<td class="px-4 py-3 text-xs text-gray-400" data-label={tFn('agrade.permissions')}>{permSummary(grade.permissions ?? {})}</td>
 								<td class="px-4 py-3 text-right flex items-center justify-end gap-3">
 									<button onclick={() => editingId = grade.id} class="text-xs text-indigo-400 hover:text-indigo-300">{tFn('agrade.edit')}</button>
 									<form method="POST" action="?/delete" use:enhance class="inline">
@@ -155,7 +155,7 @@
 	<!-- Assign grades to members -->
 	<h2 class="text-lg font-bold text-white mb-4">{tFn('agrade.assign_title')}</h2>
 	<div class="rounded-xl border border-gray-800 overflow-x-auto">
-		<table class="w-full text-sm min-w-[480px]">
+		<table class="tableau-cartes w-full text-sm md:min-w-[480px]">
 			<thead class="bg-gray-900 border-b border-gray-800 text-xs text-gray-500 uppercase tracking-wider">
 				<tr>
 					<th class="px-4 py-3 text-left">{tFn('agrade.col_member')}</th>
@@ -167,9 +167,9 @@
 			<tbody class="divide-y divide-gray-800/60">
 				{#each data.members as member}
 					<tr class="bg-gray-900/30 hover:bg-gray-900/60">
-						<td class="px-4 py-3 font-medium text-white">{member.username}</td>
-						<td class="px-4 py-3 text-xs text-gray-500 capitalize">{member.role}</td>
-						<td class="px-4 py-3">
+						<td class="px-4 py-3 font-medium text-white" data-label={tFn('agrade.col_member')}>{member.username}</td>
+						<td class="px-4 py-3 text-xs text-gray-500 capitalize" data-label={tFn('agrade.col_role')}>{member.role}</td>
+						<td class="px-4 py-3" data-label={tFn('agrade.col_current_grade')}>
 							{#if member.grade_name && member.grade_color}
 								<span class="inline-block rounded px-2 py-0.5 text-xs font-medium"
 									style="background:{member.grade_color}; color:{luminance(member.grade_color)>0.5?'#111':'#fff'}">
@@ -179,7 +179,7 @@
 								<span class="text-gray-600 text-xs">·</span>
 							{/if}
 						</td>
-						<td class="px-4 py-3">
+						<td class="px-4 py-3" data-label={tFn('agrade.col_assign')}>
 							<form method="POST" action="?/assign" use:enhance class="flex items-center gap-2">
 								<input type="hidden" name="user_id" value={member.user_id} />
 								<select name="grade_id" class="rounded-lg bg-gray-800 border border-gray-700 px-2 py-1.5 text-white text-xs focus:outline-none focus:border-indigo-500">


### PR DESCRIPTION
Mon correctif précédent (#580) a rendu les tableaux **défilants**. Le contenu est
devenu atteignable, mais pas utilisable.

Mesure sur `/admin/grades` à 502px de fenêtre, soit 454px utiles :

| | largeur | caché | barre de défilement |
|---|---|---|---|
| tableau 1 (3 colonnes) | 480px | 26px | oui |
| tableau 2 (4 colonnes) | 602px | **148px** | oui |

La colonne des actions restait hors écran, et chaque bloc affichait une barre de
défilement parasite. À cette largeur, **le tableau est simplement le mauvais
format**.

## Le motif

Chaque ligne devient une carte, chaque cellule une ligne « libellé / valeur ». Le
libellé vient d'un `data-label` sur le `<td>`, et reprend la **clé i18n** de
l'en-tête correspondant : aucune chaîne en dur, rien à retraduire.

Une cellule sans libellé prend toute la largeur — ce qui convient aux rangées de
boutons, qui se décrivent toutes seules.

À partir de `md`, le tableau redevient un tableau, inchangé, et le `min-w` ne
s'applique plus que là.

Le motif vit dans `app.css` sous une seule classe `.tableau-cartes`, **réutilisable
pour les 14 autres tableaux** du panneau.

## Ce qui m'a évité un décalage

Avoir posé les 6 libellés **à la main**. Mon premier report automatique suivait
l'ordre des colonnes, mais une ligne d'état vide en `colspan="3"` consommait un
index et décalait tout le reste.

## Vérifications

- 0 erreur de typage, porte `i18n:keys` verte
- build complet en copie isolée
- règle présente dans le CSS construit, sous `@media(max-width:767px)`