### PR TITLE
fix(admin): les 14 tableaux restants passent en cartes sous md

### DIFF
--- a/nodyx-frontend/src/routes/admin/announcements/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/announcements/+page.svelte
@@ -137,7 +137,7 @@
 				{tFn('aann.empty')}
 			</div>
 		{:else}
-			<table class="w-full text-sm min-w-[620px]">
+			<table class="tableau-cartes w-full text-sm md:min-w-[620px]">
 				<thead class="bg-gray-900 border-b border-gray-800 text-xs text-gray-500 uppercase tracking-wider">
 					<tr>
 						<th class="px-4 py-3 text-left">{tFn('aann.message')}</th>
@@ -152,7 +152,7 @@
 					{#each data.announcements as ann}
 						<tr class="bg-gray-900/30 hover:bg-gray-900/60 transition-colors">
 							<!-- Message -->
-							<td class="px-4 py-3 max-w-xs">
+							<td class="px-4 py-3 max-w-xs" data-label={tFn('aann.message')}>
 								<div class="flex items-start gap-2">
 									<span class="inline-block w-2.5 h-2.5 rounded-full mt-1 shrink-0
 									             {ann.color === 'indigo' ? 'bg-indigo-500' :
@@ -167,12 +167,12 @@
 							</td>
 
 							<!-- Color label -->
-							<td class="px-4 py-3 text-center">
+							<td class="px-4 py-3 text-center" data-label={tFn('aann.color')}>
 								<span class="text-xs text-gray-500 capitalize">{ann.color}</span>
 							</td>
 
 							<!-- Status toggle -->
-							<td class="px-4 py-3 text-center">
+							<td class="px-4 py-3 text-center" data-label={tFn('aann.status')}>
 								<form method="POST" action="?/toggle" use:enhance>
 									<input type="hidden" name="id" value={ann.id} />
 									<input type="hidden" name="is_active" value={String(!ann.is_active)} />
@@ -187,13 +187,13 @@
 							</td>
 
 							<!-- Created -->
-							<td class="px-4 py-3 text-center text-xs text-gray-500 tabular-nums">
+							<td class="px-4 py-3 text-center text-xs text-gray-500 tabular-nums" data-label={tFn('aann.created_col')}>
 								{timeAgo(ann.created_at)}
 							</td>
 
 							<!-- Expires -->
 							<td class="px-4 py-3 text-center text-xs tabular-nums
-							           {ann.expires_at && new Date(ann.expires_at) < new Date() ? 'text-red-500' : 'text-gray-500'}">
+							           {ann.expires_at && new Date(ann.expires_at) < new Date() ? 'text-red-500' : 'text-gray-500'}" data-label={tFn('aann.expires_col')}>
 								{#if ann.expires_at}
 									{new Date(ann.expires_at).toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' })}
 								{:else}

--- a/nodyx-frontend/src/routes/admin/assets/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/assets/+page.svelte
@@ -36,7 +36,7 @@
 		<p class="text-gray-500 text-sm">{tFn('aast.empty')}</p>
 	{:else}
 		<div class="rounded-xl border border-gray-800 overflow-x-auto">
-			<table class="w-full text-sm min-w-[720px]">
+			<table class="tableau-cartes w-full text-sm md:min-w-[720px]">
 				<thead class="bg-gray-900 text-gray-400 text-xs uppercase tracking-wider">
 					<tr>
 						<th class="px-4 py-3 text-left w-12"></th>
@@ -61,16 +61,16 @@
 									</div>
 								{/if}
 							</td>
-							<td class="px-4 py-3">
+							<td class="px-4 py-3" data-label={tFn('aast.col_name')}>
 								<a href="/library/{asset.id}" target="_blank"
 									class="text-white hover:text-indigo-300 font-medium truncate max-w-xs block">
 									{asset.name}
 								</a>
 							</td>
-							<td class="px-4 py-3 text-gray-400">{TYPE_ICONS[asset.asset_type] ?? ''} {asset.asset_type}</td>
-							<td class="px-4 py-3 text-gray-400">{asset.creator_username ?? '·'}</td>
-							<td class="px-4 py-3 text-gray-500 text-xs">{tFn('aast.kb', { n: Math.round(asset.file_size / 1024) })}</td>
-							<td class="px-4 py-3">
+							<td class="px-4 py-3 text-gray-400" data-label={tFn('aast.col_type')}>{TYPE_ICONS[asset.asset_type] ?? ''} {asset.asset_type}</td>
+							<td class="px-4 py-3 text-gray-400" data-label={tFn('aast.col_creator')}>{asset.creator_username ?? '·'}</td>
+							<td class="px-4 py-3 text-gray-500 text-xs" data-label={tFn('aast.col_size')}>{tFn('aast.kb', { n: Math.round(asset.file_size / 1024) })}</td>
+							<td class="px-4 py-3" data-label={tFn('aast.col_status')}>
 								{#if asset.is_banned}
 									<span class="px-2 py-0.5 rounded-full bg-red-900/40 text-red-400 text-xs font-medium">{tFn('aast.banned')}</span>
 								{:else if !asset.is_public}

--- a/nodyx-frontend/src/routes/admin/audit-log/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/audit-log/+page.svelte
@@ -109,7 +109,7 @@
 				{tFn('alog.empty')}
 			</div>
 		{:else}
-			<table class="w-full text-sm min-w-[620px]">
+			<table class="tableau-cartes w-full text-sm md:min-w-[620px]">
 				<thead class="bg-gray-900 border-b border-gray-800 text-xs text-gray-500 uppercase tracking-wider">
 					<tr>
 						<th class="px-4 py-3 text-left w-40">{tFn('alog.col_date')}</th>
@@ -124,12 +124,12 @@
 						{@const m = meta(entry.action)}
 						<tr class="bg-gray-900/30 hover:bg-gray-900/60 transition-colors">
 							<!-- Date -->
-							<td class="px-4 py-3 text-xs text-gray-500 tabular-nums whitespace-nowrap" title={formatDate(entry.created_at)}>
+							<td class="px-4 py-3 text-xs text-gray-500 tabular-nums whitespace-nowrap" title={formatDate(entry.created_at)} data-label={tFn('alog.col_date')}>
 								{timeAgo(entry.created_at)}
 							</td>
 
 							<!-- Actor -->
-							<td class="px-4 py-3">
+							<td class="px-4 py-3" data-label={tFn('alog.col_admin')}>
 								<a href="/users/{entry.actor_username}"
 									class="text-sm font-medium text-gray-200 hover:text-indigo-300 transition-colors">
 									{entry.actor_username}
@@ -145,7 +145,7 @@
 							</td>
 
 							<!-- Target -->
-							<td class="px-4 py-3 max-w-[200px]">
+							<td class="px-4 py-3 max-w-[200px]" data-label={tFn('alog.col_target')}>
 								{#if entry.target_label}
 									<div class="flex items-center gap-1.5">
 										<span class="text-xs text-gray-500 capitalize">{entry.target_type}</span>
@@ -165,7 +165,7 @@
 							</td>
 
 							<!-- Detail -->
-							<td class="px-4 py-3 text-xs text-gray-500">
+							<td class="px-4 py-3 text-xs text-gray-500" data-label={tFn('alog.col_detail')}>
 								{metaDesc(entry)}
 							</td>
 						</tr>

--- a/nodyx-frontend/src/routes/admin/categories/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/categories/+page.svelte
@@ -68,7 +68,7 @@
 
 	<!-- Tree table -->
 	<div class="rounded-xl border border-gray-800 overflow-x-auto">
-		<table class="w-full text-sm min-w-[480px]">
+		<table class="tableau-cartes w-full text-sm md:min-w-[480px]">
 			<thead class="bg-gray-900 border-b border-gray-800 text-xs text-gray-500 uppercase tracking-wider">
 				<tr>
 					<th class="px-4 py-3 text-left">{tFn('acat.col_category')}</th>
@@ -116,7 +116,7 @@
 								</form>
 							</td>
 						{:else}
-							<td class="px-4 py-3">
+							<td class="px-4 py-3" data-label={tFn('acat.col_category')}>
 								<div style="padding-left: {cat.depth * 1.5}rem" class="flex items-center gap-2">
 									{#if cat.depth > 0}<span class="text-gray-700 text-xs">└</span>{/if}
 									<div>
@@ -127,7 +127,7 @@
 									</div>
 								</div>
 							</td>
-							<td class="px-4 py-3 text-center text-gray-500 tabular-nums">{cat.thread_count}</td>
+							<td class="px-4 py-3 text-center text-gray-500 tabular-nums" data-label={tFn('acat.col_threads')}>{cat.thread_count}</td>
 							<td class="px-4 py-3 text-right">
 								<div class="flex items-center justify-end gap-3">
 									<button onclick={() => editingId = cat.id} class="text-xs text-indigo-400 hover:text-indigo-300">{tFn('acat.edit')}</button>

--- a/nodyx-frontend/src/routes/admin/garden/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/garden/+page.svelte
@@ -39,7 +39,7 @@
 		<p class="text-gray-500 text-sm">{tFn('agard.empty')}</p>
 	{:else}
 		<div class="rounded-xl border border-gray-800 overflow-x-auto">
-			<table class="w-full text-sm min-w-[720px]">
+			<table class="tableau-cartes w-full text-sm md:min-w-[720px]">
 				<thead class="bg-gray-900 text-gray-400 text-xs uppercase tracking-wider">
 					<tr>
 						<th class="px-4 py-3 text-left">{tFn('agard.col_idea')}</th>
@@ -55,22 +55,22 @@
 					{#each data.seeds as seed}
 						{@const stage = growthStage(seed.water_count)}
 						<tr class="bg-gray-900/40 hover:bg-gray-800/40 transition-colors {seed.harvest_date ? 'opacity-60' : ''}">
-							<td class="px-4 py-3 max-w-xs">
+							<td class="px-4 py-3 max-w-xs" data-label={tFn('agard.col_idea')}>
 								<p class="text-white font-medium truncate">{seed.title}</p>
 								{#if seed.description}
 									<p class="text-gray-500 text-xs truncate mt-0.5">{seed.description}</p>
 								{/if}
 							</td>
-							<td class="px-4 py-3 text-gray-400">
+							<td class="px-4 py-3 text-gray-400" data-label={tFn('agard.col_category')}>
 								{CATEGORY_ICONS[seed.category] ?? ''} {seed.category}
 							</td>
-							<td class="px-4 py-3">
+							<td class="px-4 py-3" data-label={tFn('agard.col_stage')}>
 								<span class="text-base">{STAGE_ICONS[stage]}</span>
 								<span class="text-xs text-gray-400 ml-1">{tFn(`agard.stage_${stage}`)}</span>
 							</td>
-							<td class="px-4 py-3 text-white font-medium">{seed.water_count}</td>
-							<td class="px-4 py-3 text-gray-400">{seed.planter_username ?? '·'}</td>
-							<td class="px-4 py-3 text-gray-500 text-xs">{formatDate(seed.planted_at)}</td>
+							<td class="px-4 py-3 text-white font-medium" data-label={tFn('agard.col_votes')}>{seed.water_count}</td>
+							<td class="px-4 py-3 text-gray-400" data-label={tFn('agard.col_planted_by')}>{seed.planter_username ?? '·'}</td>
+							<td class="px-4 py-3 text-gray-500 text-xs" data-label={tFn('agard.col_date')}>{formatDate(seed.planted_at)}</td>
 							<td class="px-4 py-3">
 								<div class="flex items-center justify-end gap-2">
 									{#if !seed.harvest_date}

--- a/nodyx-frontend/src/routes/admin/members/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/members/+page.svelte
@@ -111,7 +111,7 @@
 	</div>
 
 	<div class="rounded-xl border border-gray-800 overflow-x-auto">
-		<table class="w-full text-sm min-w-[720px]">
+		<table class="tableau-cartes w-full text-sm md:min-w-[720px]">
 			<thead class="bg-gray-900 border-b border-gray-800 text-xs text-gray-500 uppercase tracking-wider">
 				<tr>
 					<th class="px-4 py-3 text-left">{tFn('amem.col_member')}</th>
@@ -127,7 +127,7 @@
 				{#each filtered as member}
 					<tr class="bg-gray-900/30 hover:bg-gray-900/60 transition-colors">
 						<!-- Member -->
-						<td class="px-4 py-3">
+						<td class="px-4 py-3" data-label={tFn('amem.col_member')}>
 							<div class="flex items-center gap-2.5">
 								<div class="w-8 h-8 rounded-full bg-indigo-800 flex items-center justify-center text-xs font-bold text-indigo-200 shrink-0">
 									{member.username.charAt(0).toUpperCase()}
@@ -156,7 +156,7 @@
 						</td>
 
 						<!-- Role (editable) -->
-						<td class="px-4 py-3">
+						<td class="px-4 py-3" data-label={tFn('amem.col_role')}>
 							{#if member.role === 'owner'}
 								<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium border {ROLE_COLORS.owner}">
 									owner
@@ -188,7 +188,7 @@
 						</td>
 
 						<!-- Grade -->
-						<td class="px-4 py-3">
+						<td class="px-4 py-3" data-label={tFn('amem.col_grade')}>
 							{#if member.grade_name && member.grade_color}
 								<span
 									class="inline-block rounded px-2 py-0.5 text-xs font-medium"
@@ -202,11 +202,11 @@
 						</td>
 
 						<!-- Counts -->
-						<td class="px-4 py-3 text-center text-gray-400 tabular-nums">{member.thread_count}</td>
-						<td class="px-4 py-3 text-center text-gray-400 tabular-nums">{member.post_count}</td>
+						<td class="px-4 py-3 text-center text-gray-400 tabular-nums" data-label={tFn('amem.col_threads')}>{member.thread_count}</td>
+						<td class="px-4 py-3 text-center text-gray-400 tabular-nums" data-label={tFn('amem.col_messages')}>{member.post_count}</td>
 
 						<!-- Date -->
-						<td class="px-4 py-3 text-xs text-gray-500">
+						<td class="px-4 py-3 text-xs text-gray-500" data-label={tFn('amem.col_joined')}>
 							{new Date(member.joined_at).toLocaleDateString('fr-FR')}
 						</td>
 
@@ -262,7 +262,7 @@
 			<h2 class="text-base font-semibold text-white mb-1">{tFn('amem.banned_members')} <span class="text-gray-600 font-normal text-sm">({bans.length})</span></h2>
 			<p class="text-xs text-gray-600 mb-4">{tFn('amem.banned_hint')}</p>
 			<div class="rounded-xl border border-red-900/40 overflow-x-auto">
-				<table class="w-full text-sm min-w-[620px]">
+				<table class="tableau-cartes w-full text-sm md:min-w-[620px]">
 					<thead class="bg-red-950/30 border-b border-red-900/40 text-xs text-red-400/70 uppercase tracking-wider">
 						<tr>
 							<th class="px-4 py-3 text-left">{tFn('amem.col_member')}</th>
@@ -275,7 +275,7 @@
 					<tbody class="divide-y divide-red-900/20">
 						{#each bans as ban}
 							<tr class="bg-red-950/10 hover:bg-red-950/20 transition-colors">
-								<td class="px-4 py-3">
+								<td class="px-4 py-3" data-label={tFn('amem.col_member')}>
 									<div class="flex items-center gap-2.5">
 										<div class="w-8 h-8 rounded-full bg-red-900/50 flex items-center justify-center text-xs font-bold text-red-400 shrink-0">
 											{ban.username.charAt(0).toUpperCase()}
@@ -286,11 +286,11 @@
 										</div>
 									</div>
 								</td>
-								<td class="px-4 py-3 text-xs text-gray-500 max-w-[200px] truncate" title={ban.reason ?? ''}>
+								<td class="px-4 py-3 text-xs text-gray-500 max-w-[200px] truncate" title={ban.reason ?? ''} data-label={tFn('amem.col_reason')}>
 									{#if ban.reason}{ban.reason}{:else}<span class="text-gray-700 italic">·</span>{/if}
 								</td>
-								<td class="px-4 py-3 text-xs text-gray-500">{ban.banned_by_username ?? '·'}</td>
-								<td class="px-4 py-3 text-xs text-gray-500">{new Date(ban.banned_at).toLocaleDateString('fr-FR')}</td>
+								<td class="px-4 py-3 text-xs text-gray-500" data-label={tFn('amem.col_banned_by')}>{ban.banned_by_username ?? '·'}</td>
+								<td class="px-4 py-3 text-xs text-gray-500" data-label={tFn('amem.col_date')}>{new Date(ban.banned_at).toLocaleDateString('fr-FR')}</td>
 								<td class="px-4 py-3 text-right">
 									<form method="POST" action="?/unban" use:enhance class="inline">
 										<input type="hidden" name="user_id" value={ban.user_id} />
@@ -344,7 +344,7 @@
 			<h2 class="text-base font-semibold text-white mb-1">{tFn('amem.banned_ips')} <span class="text-gray-600 font-normal text-sm">({ipBans.length})</span></h2>
 			<p class="text-xs text-gray-600 mb-4">{tFn('amem.banned_ips_hint')}</p>
 			<div class="rounded-xl border border-orange-900/40 overflow-x-auto">
-				<table class="w-full text-sm min-w-[620px]">
+				<table class="tableau-cartes w-full text-sm md:min-w-[620px]">
 					<thead class="bg-orange-950/20 border-b border-orange-900/40 text-xs text-orange-400/70 uppercase tracking-wider">
 						<tr>
 							<th class="px-4 py-3 text-left">{tFn('amem.col_ip')}</th>
@@ -357,12 +357,12 @@
 					<tbody class="divide-y divide-orange-900/20">
 						{#each ipBans as ban}
 							<tr class="bg-orange-950/10 hover:bg-orange-950/20 transition-colors">
-								<td class="px-4 py-3 font-mono text-sm text-orange-300">{ban.ip}</td>
-								<td class="px-4 py-3 text-xs text-gray-500">
+								<td class="px-4 py-3 font-mono text-sm text-orange-300" data-label={tFn('amem.col_ip')}>{ban.ip}</td>
+								<td class="px-4 py-3 text-xs text-gray-500" data-label={tFn('amem.col_reason')}>
 									{#if ban.reason}{ban.reason}{:else}<span class="text-gray-700 italic">·</span>{/if}
 								</td>
-								<td class="px-4 py-3 text-xs text-gray-500">{ban.banned_by_username ?? '·'}</td>
-								<td class="px-4 py-3 text-xs text-gray-500">{new Date(ban.banned_at).toLocaleDateString('fr-FR')}</td>
+								<td class="px-4 py-3 text-xs text-gray-500" data-label={tFn('amem.col_banned_by')}>{ban.banned_by_username ?? '·'}</td>
+								<td class="px-4 py-3 text-xs text-gray-500" data-label={tFn('amem.col_date')}>{new Date(ban.banned_at).toLocaleDateString('fr-FR')}</td>
 								<td class="px-4 py-3 text-right">
 									<form method="POST" action="?/unbanIp" use:enhance class="inline">
 										<input type="hidden" name="ip" value={ban.ip} />
@@ -418,7 +418,7 @@
 			<h2 class="text-base font-semibold text-white mb-1">{tFn('amem.banned_emails')} <span class="text-gray-600 font-normal text-sm">({emailBans.length})</span></h2>
 			<p class="text-xs text-gray-600 mb-4">{tFn('amem.banned_emails_hint')}</p>
 			<div class="rounded-xl border border-yellow-900/40 overflow-x-auto">
-				<table class="w-full text-sm min-w-[620px]">
+				<table class="tableau-cartes w-full text-sm md:min-w-[620px]">
 					<thead class="bg-yellow-950/20 border-b border-yellow-900/40 text-xs text-yellow-400/70 uppercase tracking-wider">
 						<tr>
 							<th class="px-4 py-3 text-left">{tFn('amem.col_email_domain')}</th>
@@ -431,12 +431,12 @@
 					<tbody class="divide-y divide-yellow-900/20">
 						{#each emailBans as ban}
 							<tr class="bg-yellow-950/10 hover:bg-yellow-950/20 transition-colors">
-								<td class="px-4 py-3 font-mono text-sm text-yellow-300">{ban.email}</td>
-								<td class="px-4 py-3 text-xs text-gray-500">
+								<td class="px-4 py-3 font-mono text-sm text-yellow-300" data-label={tFn('amem.col_email_domain')}>{ban.email}</td>
+								<td class="px-4 py-3 text-xs text-gray-500" data-label={tFn('amem.col_reason')}>
 									{#if ban.reason}{ban.reason}{:else}<span class="text-gray-700 italic">·</span>{/if}
 								</td>
-								<td class="px-4 py-3 text-xs text-gray-500">{ban.banned_by_username ?? '·'}</td>
-								<td class="px-4 py-3 text-xs text-gray-500">{new Date(ban.banned_at).toLocaleDateString('fr-FR')}</td>
+								<td class="px-4 py-3 text-xs text-gray-500" data-label={tFn('amem.col_banned_by')}>{ban.banned_by_username ?? '·'}</td>
+								<td class="px-4 py-3 text-xs text-gray-500" data-label={tFn('amem.col_date')}>{new Date(ban.banned_at).toLocaleDateString('fr-FR')}</td>
 								<td class="px-4 py-3 text-right">
 									<form method="POST" action="?/unbanEmail" use:enhance class="inline">
 										<input type="hidden" name="email" value={ban.email} />

--- a/nodyx-frontend/src/routes/admin/moderation/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/moderation/+page.svelte
@@ -49,7 +49,7 @@
 	</div>
 
 	<div class="rounded-xl border border-gray-800 overflow-x-auto">
-		<table class="w-full text-sm min-w-[620px]">
+		<table class="tableau-cartes w-full text-sm md:min-w-[620px]">
 			<thead class="bg-gray-900 border-b border-gray-800 text-xs text-gray-500 uppercase tracking-wider">
 				<tr>
 					<th class="px-4 py-3 text-left">{tFn('amod.col_thread')}</th>
@@ -64,7 +64,7 @@
 				{#each data.threads as thread}
 					<tr class="bg-gray-900/30 hover:bg-gray-900/60 transition-colors">
 						<!-- Title -->
-						<td class="px-4 py-3 max-w-[280px]">
+						<td class="px-4 py-3 max-w-[280px]" data-label={tFn('amod.col_thread')}>
 							<a href="/forum/{thread.category_slug ?? thread.category_id}/{thread.slug ?? thread.id}"
 								class="font-medium text-white hover:text-indigo-300 transition-colors line-clamp-1 text-sm">
 								{thread.title}
@@ -75,14 +75,14 @@
 						</td>
 
 						<!-- Category -->
-						<td class="px-4 py-3 text-xs text-gray-400">{thread.category_name}</td>
+						<td class="px-4 py-3 text-xs text-gray-400" data-label={tFn('amod.col_category')}>{thread.category_name}</td>
 
 						<!-- Counts -->
-						<td class="px-4 py-3 text-center text-gray-400 tabular-nums">{thread.post_count}</td>
-						<td class="px-4 py-3 text-center text-gray-400 tabular-nums">{thread.views}</td>
+						<td class="px-4 py-3 text-center text-gray-400 tabular-nums" data-label={tFn('amod.col_msgs')}>{thread.post_count}</td>
+						<td class="px-4 py-3 text-center text-gray-400 tabular-nums" data-label={tFn('amod.col_views')}>{thread.views}</td>
 
 						<!-- Status badges -->
-						<td class="px-4 py-3">
+						<td class="px-4 py-3" data-label={tFn('amod.col_status')}>
 							<div class="flex items-center justify-center gap-1.5">
 								{#if thread.is_pinned}
 									<span class="px-1.5 py-0.5 rounded text-xs bg-yellow-900/50 text-yellow-400 border border-yellow-800/50">📌</span>

--- a/nodyx-frontend/src/routes/admin/octoguard/logs/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/octoguard/logs/+page.svelte
@@ -20,7 +20,7 @@
 {#if data.logs.length === 0}
 	<div class="og-empty">{tFn('octoguard.logs_empty')}</div>
 {:else}
-	<table class="og-table min-w-[620px]">
+	<table class="tableau-cartes og-table md:min-w-[620px]">
 		<thead>
 			<tr>
 				<th>{tFn('octoguard.col_date')}</th><th>{tFn('octoguard.col_actor')}</th><th>{tFn('octoguard.col_action')}</th><th>{tFn('octoguard.col_target')}</th><th>{tFn('octoguard.col_details')}</th><th></th>
@@ -29,11 +29,11 @@
 		<tbody>
 			{#each data.logs as l (l.id)}
 				<tr>
-					<td class="og-date">{new Date(l.created_at).toLocaleString()}</td>
-					<td>{l.actor_username}</td>
+					<td class="og-date" data-label={tFn('octoguard.col_date')}>{new Date(l.created_at).toLocaleString()}</td>
+					<td data-label={tFn('octoguard.col_actor')}>{l.actor_username}</td>
 					<td class="og-action">{l.action.replace('octoguard.', '')}</td>
-					<td>{l.target_type ?? '·'}{l.target_id ? ` ${l.target_id.slice(0,8)}` : ''}</td>
-					<td class="og-label">{l.target_label ?? '·'}</td>
+					<td data-label={tFn('octoguard.col_target')}>{l.target_type ?? '·'}{l.target_id ? ` ${l.target_id.slice(0,8)}` : ''}</td>
+					<td class="og-label" data-label={tFn('octoguard.col_details')}>{l.target_label ?? '·'}</td>
 					<td>
 						{#if l.metadata?.undoable}
 							<form method="POST" action="?/undo" use:enhance>

--- a/nodyx-frontend/src/routes/admin/octoguard/mutes/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/octoguard/mutes/+page.svelte
@@ -39,17 +39,17 @@
 {#if data.mutes.length === 0}
 	<div class="og-empty">{tFn('octoguard.mutes_empty')}</div>
 {:else}
-	<table class="og-table min-w-[620px]">
+	<table class="tableau-cartes og-table md:min-w-[620px]">
 		<thead>
 			<tr><th>{tFn('octoguard.col_user')}</th><th>{tFn('octoguard.col_channel')}</th><th>{tFn('octoguard.col_reason')}</th><th>{tFn('octoguard.col_expires')}</th><th></th></tr>
 		</thead>
 		<tbody>
 			{#each data.mutes as m (m.id)}
 				<tr>
-					<td>{m.user_username ?? m.user_id?.slice(0,8)}</td>
-					<td>{m.channel_id ? m.channel_id.slice(0,8) : tFn('octoguard.global_dash')}</td>
-					<td>{m.reason ?? '·'}</td>
-					<td>{m.expires_at ? new Date(m.expires_at).toLocaleString() : tFn('octoguard.permanent_dash')}</td>
+					<td data-label={tFn('octoguard.col_user')}>{m.user_username ?? m.user_id?.slice(0,8)}</td>
+					<td data-label={tFn('octoguard.col_channel')}>{m.channel_id ? m.channel_id.slice(0,8) : tFn('octoguard.global_dash')}</td>
+					<td data-label={tFn('octoguard.col_reason')}>{m.reason ?? '·'}</td>
+					<td data-label={tFn('octoguard.col_expires')}>{m.expires_at ? new Date(m.expires_at).toLocaleString() : tFn('octoguard.permanent_dash')}</td>
 					<td>
 						<form method="POST" action="?/unmute" use:enhance>
 							<input type="hidden" name="id" value={m.id} />

--- a/nodyx-frontend/src/routes/admin/sfu-lab/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/sfu-lab/+page.svelte
@@ -229,7 +229,7 @@
       <p class="text-sm text-zinc-600">{tFn('asfu.no_transport')}</p>
     {:else}
       <div class="overflow-x-auto">
-        <table class="w-full text-xs font-mono min-w-[720px]">
+        <table class="tableau-cartes w-full text-xs font-mono md:min-w-[720px]">
           <thead class="text-zinc-500">
             <tr class="text-left">
               <th class="py-1 pr-3 font-semibold">{tFn('asfu.col_participant')}</th>
@@ -246,15 +246,15 @@
           <tbody>
             {#each $sfuAuditStore as r (r.participant + r.direction)}
               <tr class="border-t border-zinc-800/60">
-                <td class="py-1 pr-3 text-zinc-300">{r.participant.slice(0, 8)}</td>
-                <td class="py-1 pr-3 text-zinc-500">{r.direction}</td>
-                <td class="py-1 pr-3 {iceClass(r.iceState)}">{r.iceState}</td>
-                <td class="py-1 pr-3 text-zinc-400">{r.local}</td>
-                <td class="py-1 pr-3 text-indigo-300">{r.remote}</td>
-                <td class="py-1 pr-3 text-zinc-500">{r.proto}</td>
-                <td class="py-1 pr-3 text-right text-zinc-300">{r.recvKbps}</td>
-                <td class="py-1 pr-3 text-right text-zinc-300">{r.sendKbps}</td>
-                <td class="py-1 pr-3 text-right {lossClass(Math.max(r.lossRecv, r.lossSent))}">{(Math.max(r.lossRecv, r.lossSent) * 100).toFixed(1)}%</td>
+                <td class="py-1 pr-3 text-zinc-300" data-label={tFn('asfu.col_participant')}>{r.participant.slice(0, 8)}</td>
+                <td class="py-1 pr-3 text-zinc-500" data-label="Dir">{r.direction}</td>
+                <td class="py-1 pr-3 {iceClass(r.iceState)}" data-label="ICE">{r.iceState}</td>
+                <td class="py-1 pr-3 text-zinc-400" data-label="Local">{r.local}</td>
+                <td class="py-1 pr-3 text-indigo-300" data-label={tFn('asfu.col_remote')}>{r.remote}</td>
+                <td class="py-1 pr-3 text-zinc-500" data-label="Proto">{r.proto}</td>
+                <td class="py-1 pr-3 text-right text-zinc-300" data-label="↓ kbps">{r.recvKbps}</td>
+                <td class="py-1 pr-3 text-right text-zinc-300" data-label="↑ kbps">{r.sendKbps}</td>
+                <td class="py-1 pr-3 text-right {lossClass(Math.max(r.lossRecv, r.lossSent))}" data-label={tFn('asfu.col_loss')}>{(Math.max(r.lossRecv, r.lossSent) * 100).toFixed(1)}%</td>
               </tr>
             {/each}
           </tbody>

--- a/nodyx-frontend/src/routes/admin/tags/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/tags/+page.svelte
@@ -57,7 +57,7 @@
 		<p class="text-sm text-gray-500">{tFn('atags.empty')}</p>
 	{:else}
 		<div class="rounded-xl border border-gray-800 overflow-x-auto">
-			<table class="w-full text-sm min-w-[480px]">
+			<table class="tableau-cartes w-full text-sm md:min-w-[480px]">
 				<thead class="bg-gray-900 border-b border-gray-800 text-xs text-gray-500 uppercase tracking-wider">
 					<tr>
 						<th class="px-4 py-3 text-left">{tFn('atags.col_tag')}</th>
@@ -68,13 +68,13 @@
 				<tbody class="divide-y divide-gray-800/60">
 					{#each tags as tag}
 						<tr class="bg-gray-900/30 hover:bg-gray-900/60 transition-colors">
-							<td class="px-4 py-3">
+							<td class="px-4 py-3" data-label={tFn('atags.col_tag')}>
 								<span class="inline-block rounded-full px-3 py-1 text-xs font-semibold"
 									style="background:{tag.color}; color:{luminance(tag.color) > 0.5 ? '#111' : '#fff'}">
 									{tag.name}
 								</span>
 							</td>
-							<td class="px-4 py-3 text-gray-400 font-mono text-xs">{tag.slug}</td>
+							<td class="px-4 py-3 text-gray-400 font-mono text-xs" data-label={tFn('atags.col_slug')}>{tag.slug}</td>
 							<td class="px-4 py-3 text-right">
 								<form method="POST" action="?/delete" use:enhance class="inline">
 									<input type="hidden" name="tag_id" value={tag.id} />


### PR DESCRIPTION
Suite de #583, qui posait le motif `.tableau-cartes` et le validait sur la page des grades. Les 14 autres tableaux du panneau le reprennent : membres (4), sfu-lab, jardin, annonces, ressources, modération, journal d'audit, octoguard/logs, octoguard/mutes, catégories, tags.

**64 libellés** posés, tous issus de la **clé i18n** de l'en-tête correspondant : aucune chaîne en dur, rien à retraduire, les 4 portes i18n restent vertes.

## La cause du décalage de #583 est corrigée à la source

Mon premier report suivait un compteur **global** de colonnes. Une ligne d'état vide en `colspan` n'ayant qu'une cellule, tout ce qui suivait était décalé d'un cran. Le compteur est désormais **remis à zéro à chaque ligne**, et les lignes en `colspan` sont ignorées.

## Vérifié par relecture automatique, pas à l'œil

Pour chaque tableau, chaque ligne et chaque cellule, le `data-label` obtenu est comparé au `<th>` de la même position.

```
0 désalignement sur les 64
```

Plus : 0 erreur de typage, 113 tests verts, 4 portes i18n vertes, build complet en copie isolée. Mesure de contrôle page par page après déploiement.