### PR TITLE
fix(admin): les identifiants longs débordaient encore des cartes

### DIFF
--- a/nodyx-frontend/src/app.css
+++ b/nodyx-frontend/src/app.css
@@ -789,6 +789,20 @@ select option {
 		padding: 0.35rem 1rem;
 		border: 0;
 		text-align: left;
+		min-width: 0;
+		/* Mesure du 17/08 : la cellule faisait bien 340px, c'est son CONTENU qui
+		 * debordait. Deux causes, deux lignes.
+		 *
+		 * `white-space` : des cellules portent un `whitespace-nowrap` utilitaire,
+		 * legitime en tableau, absurde en carte. Notre selecteur est plus
+		 * specifique (0,1,1 contre 0,1,0), il gagne sans `!important`.
+		 *
+		 * `overflow-wrap` : un identifiant insecable comme
+		 * `ghost-1504412991@twitch...` ne se coupe nulle part et poussait la carte
+		 * a 451px pour 340px de zone. `anywhere` autorise la coupure au caractere,
+		 * ce qui est le comportement voulu pour un identifiant technique. */
+		white-space: normal;
+		overflow-wrap: anywhere;
 	}
 	.tableau-cartes td[data-label]::before {
 		content: attr(data-label);


### PR DESCRIPTION
Contrôle des 12 pages converties après #584 : **9 conformes, 2 avec un conteneur qui défilait toujours**.

| page | zone | contenu |
|---|---|---|
| /admin/members, tableau 2 | 340px | 384px |
| /admin/members, tableau 4 | 340px | **451px** |
| /admin/audit-log | 340px | **528px** |

La mesure a montré que les cellules faisaient bien **340px** : c'est leur *contenu* qui débordait. Deux causes distinctes, deux lignes.

**1. `white-space`** — des cellules portent un `whitespace-nowrap` utilitaire, légitime en tableau, absurde en carte. Notre sélecteur est plus spécifique (0,1,1 contre 0,1,0), il gagne sans `!important`.

**2. `overflow-wrap`** — un identifiant insécable comme `ghost-1504412991@twitch...` ne se coupe nulle part et poussait la carte à 451px pour 340px de zone. `anywhere` autorise la coupure au caractère, comportement voulu pour un identifiant technique.

## Ce qui a évité de chercher au mauvais endroit

Avoir mesuré la largeur des cellules **avant** de conclure. Elles étaient à la bonne taille, le motif fonctionnait : seul le contenu ne savait pas se couper. Chercher un défaut de mise en page aurait été une impasse.

## Vérifications

Les deux déclarations présentes dans le CSS construit, build complet en copie isolée. Remesure des 12 pages après déploiement.