### PR TITLE
fix(admin): le nowrap était sur le lien, pas sur la cellule

### DIFF
--- a/nodyx-frontend/src/app.css
+++ b/nodyx-frontend/src/app.css
@@ -804,6 +804,17 @@ select option {
 		white-space: normal;
 		overflow-wrap: anywhere;
 	}
+	/* ET SES DESCENDANTS. Mesure du 17/08 sur /admin/audit-log : la regle
+	 * ci-dessus visait la cellule, mais le `whitespace-nowrap` etait porte par le
+	 * LIEN qu'elle contient, un titre de discussion. Resultat, 508px de contenu
+	 * pour 340px de zone alors que la cellule elle-meme etait a la bonne taille.
+	 * Le selecteur (0,0,1,1) l'emporte sur l'utilitaire (0,0,1,0), toujours sans
+	 * `!important`. Le `min-width` laisse les enfants d'une cellule en flex
+	 * retrecir au lieu de pousser la carte. */
+	.tableau-cartes td * {
+		white-space: normal;
+		min-width: 0;
+	}
 	.tableau-cartes td[data-label]::before {
 		content: attr(data-label);
 		flex: 0 0 auto;


### PR DESCRIPTION
Après #585, **11 pages sur 12** conformes. Restait `/admin/audit-log` : 508px de contenu pour 340px de zone.

Ma règle précédente visait la **cellule**, mais le `whitespace-nowrap` était porté par le **lien** qu'elle contient — un titre de discussion. La cellule était à la bonne taille, son descendant refusait de se couper :

```
DIV.flex items-center gap-1.5   droite 509  largeur 429
A.text-sm text-gray-300 ...     droite 509  largeur 384  ws:NOWRAP
```

La règle couvre désormais les descendants. Le sélecteur (0,0,1,1) l'emporte sur l'utilitaire (0,0,1,0), toujours sans `!important`. Le `min-width` laisse les enfants d'une cellule en flex rétrécir au lieu de pousser la carte.

## Vérifications

Règle présente dans le CSS construit, build complet en copie isolée. Remesure des 12 pages après déploiement.