### PR TITLE
fix(core): restaurer l'identification des visiteurs derrière le tunnel Cloudflare

### DIFF
--- a/nodyx-core/src/index.ts
+++ b/nodyx-core/src/index.ts
@@ -155,7 +155,7 @@ server.addHook('onRequest', async (request, reply) => {
     url.startsWith('/api/directory/blocklist')
   ) return
 
-  const ip = request.ip
+  const ip = getClientIp(request)
   if (!ip || ip === '127.0.0.1' || ip === '::1' ||
       ip.startsWith('192.168.') || ip.startsWith('10.') ||
       ip.startsWith('::ffff:127.') || ip.startsWith('172.16.')) return
@@ -174,6 +174,7 @@ server.addHook('onRequest', async (request, reply) => {
 // Returns 503 on user-facing writes while a backup/restore window is active.
 // Skips reads, admin endpoints, and the maintenance status endpoint itself.
 import { maintenanceGuard } from './middleware/maintenanceGuard'
+import { getClientIp } from './utils/clientIp'
 server.addHook('onRequest', maintenanceGuard)
 
 // ── Routes ───────────────────────────────────────────────────

--- a/nodyx-core/src/middleware/rateLimit.ts
+++ b/nodyx-core/src/middleware/rateLimit.ts
@@ -1,6 +1,7 @@
 import { FastifyRequest, FastifyReply } from 'fastify'
 import { timingSafeEqual } from 'crypto'
 import { redis } from '../config/database'
+import { getClientIp } from '../utils/clientIp'
 
 const WINDOW_SECONDS = 60
 const MAX_REQUESTS   = 100
@@ -58,7 +59,7 @@ export async function rateLimit(request: FastifyRequest, reply: FastifyReply): P
   // adresse du visiteur, qu'un X-Forwarded-For usurpé ne peut plus détourner :
   // les fausses lignes de l'attaquant sont à gauche du dernier proxy de
   // confiance et sont ignorées. On ne lit donc plus d'en-tête brut ici.
-  const ip = request.ip || socketPeer
+  const ip = getClientIp(request) || socketPeer
 
   const key = `rate:${ip}`
 

--- a/nodyx-core/src/migrations/113_recuperer_ip_reelles.sql
+++ b/nodyx-core/src/migrations/113_recuperer_ip_reelles.sql
@@ -1,0 +1,86 @@
+-- ─── Rattrapage des adresses perdues derrière le tunnel Cloudflare ───────────
+--
+-- Contexte, mesuré le 2026-08-17. Depuis le 2026-08-08 le trafic arrive par un
+-- tunnel Cloudflare, qui envoie `CF-Connecting-IP` mais pas `X-Forwarded-For`.
+-- Fastify dérivant `request.ip` de X-Forwarded-For, il se rabattait sur
+-- l'adresse de la socket : `127.0.0.1` pour tous les visiteurs externes.
+--
+--     jour        total  loopback  ips distinctes
+--     2026-08-07    135         0             16   <- normal
+--     2026-08-08    102        84              8   <- bascule
+--     2026-08-17    120       120              1   <- 100 % depuis
+--
+-- Les attaques n'ont jamais cessé : les chemins visés restent /wp-admin/,
+-- /.env, /xmlrpc.php. Seule leur origine manquait. Or `honeypot_hits.headers`
+-- conserve l'en-tête d'origine, donc la donnée est récupérable : 1447 lignes
+-- sur 1461, soit 122 attaquants distincts.
+--
+-- PRUDENCE 1 — ORDRE D'ÉVALUATION. PostgreSQL n'ordonne pas les conditions d'un
+-- WHERE. Écrire `... AND (h->>'x') ~ '...' AND (h->>'x')::inet << ...` peut donc
+-- exécuter le cast AVANT le filtre, et une seule valeur mal formée ferait échouer
+-- toute la migration, donc le démarrage du cœur. On isole la validation dans une
+-- CTE `MATERIALIZED`, qui force son exécution complète avant la suite, et on
+-- valide avec `pg_input_is_valid` (PostgreSQL 16) qui ne lève jamais.
+--
+-- PRUDENCE 2 — CE QU'ON ACCEPTE. Uniquement des adresses réellement publiques.
+-- Sont refusées les plages privées, le loopback, la documentation RFC 5737, et
+-- les plages Cloudflare : une adresse Cloudflare (`2a06:98c0:3600::103`) a été
+-- vue remontée comme si c'était un client. Mêmes règles que `utils/clientIp.ts`.
+
+-- Plages qui ne désignent jamais un visiteur d'Internet.
+CREATE OR REPLACE FUNCTION nodyx_ip_non_publique(a inet) RETURNS boolean
+LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
+  SELECT a << ANY (ARRAY[
+    -- Privées, loopback, lien-local, CGNAT, documentation RFC 5737.
+    '10.0.0.0/8'::inet, '172.16.0.0/12'::inet, '192.168.0.0/16'::inet,
+    '127.0.0.0/8'::inet, '169.254.0.0/16'::inet, '100.64.0.0/10'::inet,
+    '192.0.2.0/24'::inet, '198.51.100.0/24'::inet, '203.0.113.0/24'::inet,
+    '::1/128'::inet, 'fc00::/7'::inet, 'fe80::/10'::inet,
+    -- Cloudflare : notre propre infrastructure.
+    '173.245.48.0/20'::inet, '103.21.244.0/22'::inet, '103.22.200.0/22'::inet,
+    '103.31.4.0/22'::inet, '141.101.64.0/18'::inet, '108.162.192.0/18'::inet,
+    '190.93.240.0/20'::inet, '188.114.96.0/20'::inet, '197.234.240.0/22'::inet,
+    '198.41.128.0/17'::inet, '162.158.0.0/15'::inet, '104.16.0.0/13'::inet,
+    '104.24.0.0/14'::inet, '172.64.0.0/13'::inet, '131.0.72.0/22'::inet,
+    '2400:cb00::/32'::inet, '2606:4700::/32'::inet, '2803:f800::/32'::inet,
+    '2405:b500::/32'::inet, '2405:8100::/32'::inet, '2a06:98c0::/29'::inet,
+    '2c0f:f248::/32'::inet
+  ])
+$$;
+
+-- ── 1. Pot de miel : restituer l'adresse depuis l'en-tête conservé ───────────
+WITH brut AS MATERIALIZED (
+  SELECT id, trim(split_part(headers ->> 'cf-connecting-ip', ',', 1)) AS valeur
+  FROM honeypot_hits
+  -- NB : `honeypot_hits.ip` est de type TEXT (contrairement a `reported_ips.ip`
+  -- qui est INET). D'ou la comparaison textuelle ici, et le `::text` au SET.
+  WHERE ip IN ('127.0.0.1', '::1', '::ffff:127.0.0.1')
+    AND headers ? 'cf-connecting-ip'
+),
+valide AS MATERIALIZED (
+  SELECT id, valeur
+  FROM brut
+  WHERE valeur <> '' AND pg_input_is_valid(valeur, 'inet')
+),
+retenu AS (
+  SELECT id, valeur
+  FROM valide
+  WHERE NOT nodyx_ip_non_publique(valeur::inet)
+)
+UPDATE honeypot_hits h
+SET ip = r.valeur
+FROM retenu r
+WHERE h.id = r.id;
+
+-- ── 2. Blocage fédéré : ne plus distribuer de bruit aux autres instances ─────
+--
+-- `reported_ips` alimente le blocage partagé entre instances. Il contenait 102
+-- entrées en 127.0.0.1 sur 118, envoyées par 4 instances : du bruit distribué à
+-- tout le réseau. On purge, puis on interdit à l'écriture.
+DELETE FROM reported_ips WHERE nodyx_ip_non_publique(ip);
+
+-- Verrou permanent : une adresse privée, loopback ou Cloudflare n'a aucun sens
+-- comme signalement fédéré. Vaut aussi pour une instance tierce mal configurée.
+ALTER TABLE reported_ips DROP CONSTRAINT IF EXISTS reported_ips_ip_publique;
+ALTER TABLE reported_ips
+  ADD CONSTRAINT reported_ips_ip_publique CHECK (NOT nodyx_ip_non_publique(ip));

--- a/nodyx-core/src/routes/admin.ts
+++ b/nodyx-core/src/routes/admin.ts
@@ -23,6 +23,7 @@ import { randomUUID, createHash, randomBytes } from 'crypto'
 import { createWriteStream, mkdirSync } from 'fs'
 import { pipeline } from 'stream/promises'
 import path from 'path'
+import { getClientIp } from '../utils/clientIp'
 
 const UPLOADS_DIR = path.join(process.cwd(), 'uploads')
 const ALLOWED_MIME_BRANDING = ['image/jpeg', 'image/png', 'image/webp', 'image/gif']
@@ -385,7 +386,7 @@ export default async function adminRoutes(app: FastifyInstance) {
     await db.query(
       `INSERT INTO password_resets (user_id, token_hash, expires_at, ip_address)
        VALUES ($1, $2, $3, $4)`,
-      [userId, tokenHash, expiresAt, request.ip]
+      [userId, tokenHash, expiresAt, getClientIp(request)]
     )
 
     const resetUrl = `${process.env.FRONTEND_URL}/reset-password/${rawToken}`

--- a/nodyx-core/src/routes/admin_backups.ts
+++ b/nodyx-core/src/routes/admin_backups.ts
@@ -19,6 +19,7 @@
  */
 
 import { FastifyInstance, FastifyRequest } from 'fastify'
+import { getClientIp } from '../utils/clientIp'
 import '../middleware/auth' // augments FastifyRequest with `user?: JwtPayload`
 import { z }                                from 'zod'
 import { adminOnly }                        from '../middleware/adminOnly'
@@ -71,7 +72,7 @@ const AuditQuery = z.object({
 function actor(req: FastifyRequest): AuditActor {
   return {
     user_id:    req.user?.userId || null,
-    ip_address: req.ip || null,
+    ip_address: getClientIp(req) || null,
     user_agent: req.headers['user-agent'] || null,
   }
 }

--- a/nodyx-core/src/routes/auth.ts
+++ b/nodyx-core/src/routes/auth.ts
@@ -13,6 +13,7 @@ import { toSelfUser } from '../utils/publicUser'
 import { isSmtpConfigured, sendPasswordResetEmail, sendVerificationEmail } from '../services/emailService'
 import { resolveServerLocale } from '../i18n/serverStrings'
 import { getUserTotp, TOTP_PENDING_TTL } from './totp'
+import { getClientIp } from '../utils/clientIp'
 
 // ── Discord security alerts ───────────────────────────────────────────────────
 
@@ -49,7 +50,7 @@ const BCRYPT_ROUNDS = 12
 
 // Rate limit strict pour forgot-password : 3 req / 15 min / IP
 async function forgotPasswordRateLimit(request: FastifyRequest, reply: FastifyReply): Promise<void> {
-  const key   = `reset_rate:${request.ip}`
+  const key   = `reset_rate:${getClientIp(request)}`
   const count = await redis.incr(key)
   if (count === 1) await redis.expire(key, 15 * 60)
   if (count > 3) {
@@ -63,7 +64,7 @@ async function forgotPasswordRateLimit(request: FastifyRequest, reply: FastifyRe
 
 // Rate limit strict pour login : 5 tentatives / 15 min / IP
 async function loginRateLimit(request: FastifyRequest, reply: FastifyReply): Promise<void> {
-  const key   = `login_rate:${request.ip}`
+  const key   = `login_rate:${getClientIp(request)}`
   const count = await redis.incr(key)
   if (count === 1) await redis.expire(key, 15 * 60)
   if (count > 5) {
@@ -78,7 +79,7 @@ async function loginRateLimit(request: FastifyRequest, reply: FastifyReply): Pro
 
 // Rate limit pour register : 5 comptes / heure / IP
 async function registerRateLimit(request: FastifyRequest, reply: FastifyReply): Promise<void> {
-  const key   = `register_rate:${request.ip}`
+  const key   = `register_rate:${getClientIp(request)}`
   const count = await redis.incr(key)
   if (count === 1) await redis.expire(key, 60 * 60)
   if (count > 5) {
@@ -150,7 +151,7 @@ export default async function authRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const body = request.body as z.infer<typeof RegisterBody>
     const { username, email, password, website, form_t } = body
-    const clientIpEarly = request.ip
+    const clientIpEarly = getClientIp(request)
     const userAgent = String(request.headers['user-agent'] ?? '').slice(0, 500)
 
     // Helper : log dans stdout + INSERT en DB pour monitoring Olympus
@@ -301,7 +302,7 @@ export default async function authRoutes(app: FastifyInstance) {
 
     const [user, ipBanRes] = await Promise.all([
       UserModel.findByEmail(email),
-      db.query(`SELECT 1 FROM ip_bans WHERE ip = $1::inet LIMIT 1`, [request.ip]),
+      db.query(`SELECT 1 FROM ip_bans WHERE ip = $1::inet LIMIT 1`, [getClientIp(request)]),
     ])
 
     if (ipBanRes.rows.length > 0) {
@@ -326,7 +327,7 @@ export default async function authRoutes(app: FastifyInstance) {
     }
 
     if (!user || !valid) {
-      const realIp = request.ip  // fiable via trustProxy (loopback+privé+Cloudflare)
+      const realIp = getClientIp(request)  // fiable via trustProxy (loopback+privé+Cloudflare)
       const logLine = `${new Date().toISOString()} INVALID_CREDENTIALS ip=${realIp}\n`
       fs.appendFile('/var/log/nodyx-auth.log', logLine, () => {})
 
@@ -406,7 +407,7 @@ export default async function authRoutes(app: FastifyInstance) {
     await trackSession(user.id, token)
 
     // Détection connexion depuis une nouvelle IP
-    const loginIp    = request.ip  // fiable via trustProxy
+    const loginIp    = getClientIp(request)  // fiable via trustProxy
     const knownIpKey = `known_ip:${user.id}`
     const knownIp    = await redis.get(knownIpKey)
     await redis.set(knownIpKey, loginIp, 'EX', 60 * 60 * 24 * 30) // 30 jours
@@ -446,7 +447,7 @@ export default async function authRoutes(app: FastifyInstance) {
     const publicUser = toSelfUser(user)
 
     // Alerte connexion admin/owner
-    const realIpLogin = request.ip  // fiable via trustProxy
+    const realIpLogin = getClientIp(request)  // fiable via trustProxy
     db.query(
       `SELECT role FROM community_members
        WHERE user_id = $1 AND role IN ('admin', 'owner') LIMIT 1`,
@@ -508,7 +509,7 @@ export default async function authRoutes(app: FastifyInstance) {
       await db.query(
         `INSERT INTO password_resets (user_id, token_hash, expires_at, ip_address, user_agent)
          VALUES ($1, $2, $3, $4, $5)`,
-        [user.id, tokenHash, expiresAt, request.ip, request.headers['user-agent'] ?? null]
+        [user.id, tokenHash, expiresAt, getClientIp(request), request.headers['user-agent'] ?? null]
       )
 
       const resetUrl = `${process.env.FRONTEND_URL}/reset-password/${rawToken}`
@@ -627,7 +628,7 @@ export default async function authRoutes(app: FastifyInstance) {
 
     // Rate limit : 1 renvoi / 5 min / email ET 3 / 5 min / IP
     const rateLimitKey = `resend_verify:${email.toLowerCase()}`
-    const rateLimitIp  = `resend_verify_ip:${request.ip}`
+    const rateLimitIp  = `resend_verify_ip:${getClientIp(request)}`
     const [countEmail, countIp] = await Promise.all([
       redis.incr(rateLimitKey),
       redis.incr(rateLimitIp),

--- a/nodyx-core/src/routes/authenticator.ts
+++ b/nodyx-core/src/routes/authenticator.ts
@@ -21,6 +21,7 @@ import { db, redis } from '../config/database'
 import { requireAuth } from '../middleware/auth'
 import { adminOnly }  from '../middleware/adminOnly'
 import { trackSession } from './auth'
+import { getClientIp } from '../utils/clientIp'
 
 // JwkPublicKey n'est pas dans lib ES2022 sans DOM — on définit le minimum nécessaire
 type JwkPublicKey = Record<string, unknown>
@@ -97,7 +98,7 @@ function signToken(userId: string, username: string): string {
 // ─── Rate limits ──────────────────────────────────────────────────────────────
 
 async function approveRateLimit(request: FastifyRequest, reply: FastifyReply) {
-  const key = `auth_approve_rate:${request.ip}`
+  const key = `auth_approve_rate:${getClientIp(request)}`
   const count = await redis.incr(key)
   if (count === 1) await redis.expire(key, 60)
   if (count > 10) {  // 10/min — assez pour les tests + usage normal
@@ -109,7 +110,7 @@ async function approveRateLimit(request: FastifyRequest, reply: FastifyReply) {
 // non-bruteforçable par définition, mais sans rate limit un attaquant pourrait
 // inonder la DB et les logs.
 async function enrollRateLimit(request: FastifyRequest, reply: FastifyReply) {
-  const key = `auth_enroll_rate:${request.ip}`
+  const key = `auth_enroll_rate:${getClientIp(request)}`
   const count = await redis.incr(key)
   if (count === 1) await redis.expire(key, 300) // fenêtre 5 min
   if (count > 3) {
@@ -315,7 +316,7 @@ export default async function authenticatorRoutes(app: FastifyInstance) {
     const challengeBytes = crypto.randomBytes(32).toString('base64url')
     const pollNonce = crypto.randomBytes(16).toString('hex')
     const expiresAt = new Date(Date.now() + CHALLENGE_TTL_SEC * 1000)
-    const sourceIp = request.ip
+    const sourceIp = getClientIp(request)
 
     const { rows } = await db.query(
       `INSERT INTO authenticator_challenges
@@ -490,7 +491,7 @@ export default async function authenticatorRoutes(app: FastifyInstance) {
       )
     } else {
       // Appareil inconnu → vérifier le rate limit de création de compte (3/IP/heure)
-      const creationKey = `account_creation:${request.ip}`
+      const creationKey = `account_creation:${getClientIp(request)}`
       const creationCount = await redis.incr(creationKey)
       if (creationCount === 1) await redis.expire(creationKey, 3600)
       if (creationCount > 3) {

--- a/nodyx-core/src/routes/directory.ts
+++ b/nodyx-core/src/routes/directory.ts
@@ -6,10 +6,11 @@ import https from 'https';
 import http from 'http';
 import sanitizeHtml from 'sanitize-html';
 import { db, redis } from '../config/database';
+import { getClientIp } from '../utils/clientIp'
 
 // Strict rate-limit for public search endpoint (30 req/min per IP)
 async function searchRateLimit(request: FastifyRequest, reply: FastifyReply): Promise<void> {
-  const key = `rate:search:${request.ip}`;
+  const key = `rate:search:${getClientIp(request)}`;
   const count = await redis.incr(key);
   if (count === 1) await redis.expire(key, 60);
   if (count > 30) {
@@ -284,7 +285,7 @@ export default async function directoryRoutes(app: FastifyInstance) {
       // Capture real IP — req.ip est fiable via la liste de proxys de confiance
       // (loopback + privé + Cloudflare, cf config/trustedProxies.ts) : un
       // X-Forwarded-For usurpé ne peut plus le détourner.
-      const rawIp = req.ip;
+      const rawIp = getClientIp(req);
       const isPrivate = !rawIp || rawIp === '127.0.0.1' || rawIp === '::1'
         || rawIp.startsWith('192.168.') || rawIp.startsWith('10.')
         || rawIp.startsWith('172.16.') || rawIp.startsWith('::ffff:127.');

--- a/nodyx-core/src/routes/honeypot.ts
+++ b/nodyx-core/src/routes/honeypot.ts
@@ -5,6 +5,7 @@ import fs from 'fs'
 import { reportHoneypotToMISP } from '../services/mispService.js'
 import { enrichIP, type OSINTResult } from '../services/osintService.js'
 import { sendCERTEmail } from '../services/certEmailService.js'
+import { getClientIp } from '../utils/clientIp'
 
 // 1×1 transparent PNG — served by the tracking pixel endpoint
 const PIXEL_PNG = Buffer.from(
@@ -1074,7 +1075,7 @@ export default async function honeypotRoutes(fastify: FastifyInstance) {
     handler: async (request, reply) => {
 
       const headers = request.headers
-      const ip = request.ip || '0.0.0.0'  // fiable via trustProxy
+      const ip = getClientIp(request) || '0.0.0.0'  // fiable via trustProxy
 
       const originalPath = decodeURIComponent((request.query as any).p || '/').slice(0, 512)
       const userAgent    = (headers['user-agent'] || '').slice(0, 512)
@@ -1275,7 +1276,7 @@ export default async function honeypotRoutes(fastify: FastifyInstance) {
     const { log: username = '', pwd: password = '', _incident: incidentRef = '', _origin_path: loginPath = '/' } = request.body ?? {}
 
     const headers = request.headers
-    const ip = request.ip || '0.0.0.0'  // fiable via trustProxy
+    const ip = getClientIp(request) || '0.0.0.0'  // fiable via trustProxy
     const userAgent  = (headers['user-agent'] || '').slice(0, 512)
     const incidentId = genIncidentId()
 
@@ -1389,7 +1390,7 @@ export default async function honeypotRoutes(fastify: FastifyInstance) {
     if (!fp_hash || !/^[A-F0-9]{8,64}$/.test(fp_hash)) return reply.code(400).send({})
 
     const headers = request.headers
-    const ip = request.ip || '0.0.0.0'  // fiable via trustProxy
+    const ip = getClientIp(request) || '0.0.0.0'  // fiable via trustProxy
 
     try {
       // Upsert fingerprint
@@ -1585,7 +1586,7 @@ export default async function honeypotRoutes(fastify: FastifyInstance) {
       return reply.code(200).send(PIXEL_PNG)
     }
 
-    const ip        = request.ip || '0.0.0.0'  // fiable via trustProxy
+    const ip        = getClientIp(request) || '0.0.0.0'  // fiable via trustProxy
     const userAgent = (request.headers['user-agent'] || '').slice(0, 512)
     const referer   = (request.headers['referer']    || '').slice(0, 512)
 

--- a/nodyx-core/src/routes/streamer.ts
+++ b/nodyx-core/src/routes/streamer.ts
@@ -6,6 +6,7 @@
 // Voir spec 015 §4 (OAuth) + §5 (EventSub) + §12 (sécurité).
 
 import type { FastifyPluginAsync, FastifyRequest } from 'fastify'
+import { getClientIp } from '../utils/clientIp'
 import { adminOnly } from '../middleware/adminOnly'
 import { requireAuth } from '../middleware/auth'
 import { db, redis } from '../config/database'
@@ -244,7 +245,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
     const state = await createOAuthState({
       kind:         'streamer',
       targetUserId: request.user!.userId,
-      ip:           request.ip,
+      ip:           getClientIp(request),
     })
     const authorizeUrl = provider.buildAuthorizeUrl({
       redirectUri: redirectUri(),
@@ -262,7 +263,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
     const state = await createOAuthState({
       kind:         'viewer',
       targetUserId: request.user!.userId,
-      ip:           request.ip,
+      ip:           getClientIp(request),
     })
     const authorizeUrl = provider.buildAuthorizeUrl({
       redirectUri: redirectUri(),
@@ -283,7 +284,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
   server.delete('/twitch/viewer/unlink', { preHandler: requireAuth }, async (request, reply) => {
     const ok = await unlinkViewerTwitch({
       viewerUserId: request.user!.userId,
-      ip:           request.ip,
+      ip:           getClientIp(request),
     })
     if (!ok) return reply.code(404).send({ ok: false, error: 'no_twitch_link' })
     return { ok: true }
@@ -298,7 +299,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
     if (q.error) {
       await audit({
         action: 'connect_twitch', status: 'failed',
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata: { stage: 'callback', twitchError: q.error, description: q.error_description ?? null },
       })
       return reply.code(400).send({
@@ -314,7 +315,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
     if (!consumed) {
       await audit({
         action: 'connect_twitch', status: 'failed',
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata: { stage: 'state', reason: 'invalid_or_expired' },
       })
       return reply.code(400).send({ ok: false, error: 'invalid_or_expired_state' })
@@ -338,7 +339,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
           code:         q.code,
           redirectUri:  redirectUri(),
           viewerUserId: stateData.targetUserId,
-          ip:           request.ip,
+          ip:           getClientIp(request),
         })
         // Si Twitch déjà lié à un autre Nodyx, on renvoie 409 + détail
         if (result.alreadyLinkedTo) {
@@ -374,7 +375,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         redirectUri: redirectUri(),
         publicBase:  publicBase(),
         adminUserId: stateData.targetUserId,
-        ip:          request.ip,
+        ip:          getClientIp(request),
       })
       // Redirect to the admin dashboard with a success marker. Email + token
       // payload are intentionally NOT forwarded in the URL: the dashboard will
@@ -387,7 +388,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
       const e = err as Error
       await audit({
         action: 'connect_twitch', status: 'failed',
-        userId: stateData.targetUserId, ipAddress: request.ip,
+        userId: stateData.targetUserId, ipAddress: getClientIp(request),
         metadata: { stage: 'callback_pipeline' },
         error:    e.message,
       })
@@ -435,7 +436,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         provider: getProvider('twitch'),
         rowId:    request.params.rowId,
         userId:   request.user!.userId,
-        ip:       request.ip,
+        ip:       getClientIp(request),
       })
       if (!updated) return reply.code(404).send({ ok: false, error: 'not_found' })
       return reply.send({ ok: true, streamer: updated })
@@ -452,7 +453,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
     const ok = await revokeTokens({
       rowId:  request.params.rowId,
       userId: request.user!.userId,
-      ip:     request.ip,
+      ip:     getClientIp(request),
     })
     if (!ok) return reply.code(404).send({ ok: false, error: 'not_found' })
     return reply.send({ ok: true })
@@ -513,7 +514,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
           action:   'channel_update_failed',
           status:   'failed',
           userId:   request.user!.userId,
-          ipAddress: request.ip,
+          ipAddress: getClientIp(request),
           metadata: { status: r.status, reason: r.reason },
         })
         return reply.code(r.status >= 400 && r.status < 600 ? r.status : 502)
@@ -523,7 +524,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'channel_update',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  {
           titleSet:  typeof request.body?.title  === 'string',
           gameIdSet: typeof request.body?.gameId === 'string',
@@ -566,7 +567,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'vod_marker_created',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { markerId: r.data.id, positionSeconds: r.data.positionSeconds },
       })
       return reply.send({ ok: true, marker: r.data })
@@ -608,7 +609,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
           action:    'poll_create_failed',
           status:    'failed',
           userId:    request.user!.userId,
-          ipAddress: request.ip,
+          ipAddress: getClientIp(request),
           metadata:  { reason: r.reason, status: r.status },
         })
         return reply.code(r.status >= 400 && r.status < 600 ? r.status : 502).send({ ok: false, error: r.reason })
@@ -617,7 +618,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'poll_created',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { pollId: r.data.id, choices: r.data.choices.length, duration: r.data.durationSeconds },
       })
       return reply.send({ ok: true, poll: r.data })
@@ -638,7 +639,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'poll_ended',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { pollId: request.params.id, finalStatus: status },
       })
       return reply.send({ ok: true, poll: r.data })
@@ -666,7 +667,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
           action:    'prediction_create_failed',
           status:    'failed',
           userId:    request.user!.userId,
-          ipAddress: request.ip,
+          ipAddress: getClientIp(request),
           metadata:  { reason: r.reason, status: r.status },
         })
         return reply.code(r.status >= 400 && r.status < 600 ? r.status : 502).send({ ok: false, error: r.reason })
@@ -675,7 +676,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'prediction_created',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { predictionId: r.data.id, outcomes: r.data.outcomes.length, window: r.data.predictionWindowSeconds },
       })
       return reply.send({ ok: true, prediction: r.data })
@@ -699,7 +700,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'prediction_patched',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { predictionId: request.params.id, newStatus: status, winningOutcomeId: winningOutcomeId ?? null },
       })
       return reply.send({ ok: true, prediction: r.data })
@@ -818,7 +819,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'unlink_twitch_viewer_admin',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { targetUserId: request.params.userId },
       })
       return reply.send({ ok: true })
@@ -876,7 +877,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'chat_timer_created',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { timerId: timer.id, label: timer.label },
       })
       return reply.send({ ok: true, timer })
@@ -944,7 +945,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'chat_timer_updated',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { timerId: timer.id, fields: Object.keys(patch) },
       })
       return reply.send({ ok: true, timer })
@@ -962,7 +963,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'chat_timer_deleted',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { timerId: request.params.id, label: existed?.label },
       })
       return reply.send({ ok: true })
@@ -990,7 +991,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'chat_timer_send_now',
         status:    r.ok ? 'success' : 'failed',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { timerId: request.params.id, reason: r.reason },
       })
       return reply.send(r)
@@ -1044,7 +1045,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
           action:    'chat_command_created',
           status:    'success',
           userId:    request.user!.userId,
-          ipAddress: request.ip,
+          ipAddress: getClientIp(request),
           metadata:  { commandId: cmd.id, name: cmd.name },
         })
         return reply.send({ ok: true, command: cmd })
@@ -1096,7 +1097,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
           action:    'chat_command_updated',
           status:    'success',
           userId:    request.user!.userId,
-          ipAddress: request.ip,
+          ipAddress: getClientIp(request),
           metadata:  { commandId: cmd.id, fields: Object.keys(patch) },
         })
         return reply.send({ ok: true, command: cmd })
@@ -1119,7 +1120,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'chat_command_deleted',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { commandId: request.params.id, name: existed?.name },
       })
       return reply.send({ ok: true })
@@ -1145,7 +1146,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'deck_created',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { deckId: deck.id, label: deck.label },
       })
       return reply.send({ ok: true, deck })
@@ -1166,7 +1167,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'deck_updated',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { deckId: deck.id, fields: Object.keys(patch) },
       })
       return reply.send({ ok: true, deck })
@@ -1183,7 +1184,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'deck_revoked',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { deckId: request.params.id },
       })
       return reply.send({ ok: true })
@@ -1232,7 +1233,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'deck_action_executed',
         status:    result.ok ? 'success' : 'failed',
         userId:    null,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { deckId: deck.id, buttonId, actionType: button.action.type, message: result.message },
       })
       return reply.send(result)
@@ -1296,7 +1297,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
           action:    'audio_track_added',
           status:    'success',
           userId:    request.user!.userId,
-          ipAddress: request.ip,
+          ipAddress: getClientIp(request),
           metadata:  { trackId: track.id, assetId: b.assetId, title: track.title },
         })
         return reply.send({ ok: true, track })
@@ -1321,7 +1322,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'audio_track_updated',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { trackId: request.params.id, fields: Object.keys(request.body ?? {}) },
       })
       return { ok: true, track }
@@ -1339,7 +1340,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'audio_track_deleted',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { trackId: request.params.id, title: existed?.title },
       })
       return { ok: true }
@@ -1586,7 +1587,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
     const trackId = (request.body?.trackId ?? '').toString().slice(0, 64)
     if (!trackId) return reply.code(400).send({ ok: false, reason: 'invalid_track_id' })
 
-    const ip = request.ip
+    const ip = getClientIp(request)
     const result = await addToSoundboardQueue({
       ownerUserId: owner.userId,
       trackId,
@@ -1678,7 +1679,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
           action:    'reward_create_failed',
           status:    'failed',
           userId:    request.user!.userId,
-          ipAddress: request.ip,
+          ipAddress: getClientIp(request),
           metadata:  { reason: r.reason, status: r.status, title: b.title },
         })
         return reply.code(r.status >= 400 && r.status < 600 ? r.status : 502).send({ ok: false, error: r.reason })
@@ -1687,7 +1688,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'reward_created',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { rewardId: r.data.id, title: r.data.title, cost: r.data.cost },
       })
       return reply.send({ ok: true, reward: r.data })
@@ -1715,7 +1716,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'reward_updated',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { rewardId: r.data.id, patchedFields: Object.keys(b) },
       })
       return reply.send({ ok: true, reward: r.data })
@@ -1732,7 +1733,7 @@ export const streamerAdminPlugin: FastifyPluginAsync = async (server) => {
         action:    'reward_deleted',
         status:    'success',
         userId:    request.user!.userId,
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata:  { rewardId: request.params.id },
       })
       return reply.send({ ok: true })
@@ -2419,7 +2420,7 @@ export const streamerEventsubPlugin: FastifyPluginAsync = async (server) => {
       await audit({
         action:   'hmac_invalid',
         status:   'failed',
-        ipAddress: request.ip,
+        ipAddress: getClientIp(request),
         metadata: { nonce: nonce.slice(0, 8) + '…', messageId, msgType },
       })
       request.log.warn({ messageId, nonce: nonce.slice(0, 8) + '…' }, 'EventSub HMAC invalid')

--- a/nodyx-core/src/tests/client-ip.test.ts
+++ b/nodyx-core/src/tests/client-ip.test.ts
@@ -1,0 +1,130 @@
+// ─── L'adresse du visiteur derrière le tunnel Cloudflare ─────────────────────
+//
+// Contexte mesuré le 2026-08-17. Depuis le 2026-08-08 le trafic passe par un
+// tunnel Cloudflare, qui envoie `CF-Connecting-IP` mais pas `X-Forwarded-For`.
+// Fastify dérivant `request.ip` de X-Forwarded-For, il se rabattait sur le
+// socket : `127.0.0.1` pour TOUS les visiteurs externes.
+//
+// Constaté en production avant correctif :
+//   - `honeypot_hits` : 100 % de loopback depuis le 9 août
+//   - UNE seule clé Redis, `nodyx:rate:127.0.0.1` : seau de limitation partagé
+//     par tout Internet, donc 429 possible pour tout le site par un seul client
+//
+// Ces tests tombent sur le code d'avant le correctif. cf feedback_test_first_critical.
+
+import { describe, it, expect } from 'vitest'
+import type { FastifyRequest } from 'fastify'
+import { getClientIp, pairDeConfiance } from '../utils/clientIp'
+
+/**
+ * Requête minimale. `peer` est le VRAI pair TCP (infalsifiable), `ip` est ce que
+ * Fastify aurait calculé depuis X-Forwarded-For contre la liste de confiance.
+ */
+function req(o: { peer?: string; ip?: string; headers?: Record<string, string> }): FastifyRequest {
+  return {
+    socket:  { remoteAddress: o.peer ?? '127.0.0.1' },
+    ip:      o.ip ?? o.peer ?? '127.0.0.1',
+    headers: o.headers ?? {},
+  } as unknown as FastifyRequest
+}
+
+describe('pairDeConfiance', () => {
+  it('accepte le loopback et les plages privées, où vivent nos proxys', () => {
+    for (const p of ['127.0.0.1', '::1', '::ffff:127.0.0.1', '10.0.0.5', '192.168.1.9', '172.16.4.2']) {
+      expect(pairDeConfiance(p), p).toBe(true)
+    }
+  })
+
+  it('accepte les plages Cloudflare', () => {
+    expect(pairDeConfiance('162.158.1.1')).toBe(true)
+    expect(pairDeConfiance('2a06:98c0:3600::103')).toBe(true)
+  })
+
+  it("refuse une adresse publique quelconque, et l'absence d'adresse", () => {
+    expect(pairDeConfiance('62.60.130.128')).toBe(false)
+    expect(pairDeConfiance('')).toBe(false)
+    expect(pairDeConfiance(undefined)).toBe(false)
+  })
+})
+
+describe("getClientIp — l'en-tête n'est cru que d'un proxy à nous", () => {
+  it('LE DÉFAUT DU 8 AOÛT : tunnel Cloudflare, CF-Connecting-IP et pas de XFF', () => {
+    // Exactement la requête observée en base : loopback en pair, aucun XFF, une
+    // vraie adresse dans CF-Connecting-IP. Avant correctif on renvoyait
+    // `127.0.0.1` et l'attaquant devenait invisible.
+    const ip = getClientIp(req({
+      peer: '127.0.0.1',
+      ip:   '127.0.0.1',
+      headers: { 'cf-connecting-ip': '103.78.255.128', 'cf-ipcountry': 'BD' },
+    }))
+    expect(ip).toBe('103.78.255.128')
+  })
+
+  it("IGNORE un CF-Connecting-IP forgé venant d'un pair non fiable", () => {
+    // Un client qui joint le cœur en direct ne doit pas pouvoir se choisir une
+    // adresse : sinon limitation, bannissements et pot de miel se contournent.
+    const ip = getClientIp(req({
+      peer: '62.60.130.128',
+      ip:   '62.60.130.128',
+      headers: { 'cf-connecting-ip': '1.2.3.4', 'x-real-ip': '5.6.7.8' },
+    }))
+    expect(ip).toBe('62.60.130.128')
+  })
+
+  it('refuse une adresse privée ou loopback lue dans un en-tête', () => {
+    // Un en-tête annonçant du loopback ne désigne aucun visiteur d'Internet.
+    for (const faux of ['127.0.0.1', '10.0.0.3', '192.168.0.1', '::1']) {
+      const ip = getClientIp(req({ peer: '127.0.0.1', ip: '127.0.0.1', headers: { 'cf-connecting-ip': faux } }))
+      expect(ip, faux).toBe('127.0.0.1')
+    }
+  })
+
+  it("refuse une adresse Cloudflare : c'est notre infrastructure, pas un visiteur", () => {
+    // Vu tel quel dans les données du 17/08.
+    const ip = getClientIp(req({
+      peer: '127.0.0.1', ip: '127.0.0.1',
+      headers: { 'cf-connecting-ip': '2a06:98c0:3600::103' },
+    }))
+    expect(ip).toBe('127.0.0.1')
+  })
+
+  it('garde le chemin historique : X-Forwarded-For via request.ip', () => {
+    // Instance sans tunnel, Caddy pose XFF, Fastify a déjà fait le travail.
+    const ip = getClientIp(req({ peer: '127.0.0.1', ip: '81.10.20.30', headers: { 'x-forwarded-for': '81.10.20.30' } }))
+    expect(ip).toBe('81.10.20.30')
+  })
+
+  it('prend la première adresse quand CF-Connecting-IP en contient plusieurs', () => {
+    // NB : pas d'adresse en 203.0.113.x ici. C'est la plage de documentation
+    // RFC 5737, que `ipaddr.js` classe « reserved » et que le garde-fou refuse
+    // donc à juste titre. Il faut une adresse réellement routable.
+    const ip = getClientIp(req({
+      peer: '127.0.0.1', ip: '127.0.0.1',
+      headers: { 'cf-connecting-ip': '45.83.12.7, 162.158.1.1' },
+    }))
+    expect(ip).toBe('45.83.12.7')
+  })
+
+  it('refuse les plages de documentation RFC 5737 dans un en-tête', () => {
+    // Elles n'appartiennent à personne : les accepter reviendrait à polluer le
+    // pot de miel et le blocage fédéré avec des adresses fictives.
+    const ip = getClientIp(req({ peer: '127.0.0.1', ip: '127.0.0.1', headers: { 'cf-connecting-ip': '203.0.113.9' } }))
+    expect(ip).toBe('127.0.0.1')
+  })
+
+  it("préserve l'appel interne du rendu serveur : loopback, aucun en-tête", () => {
+    expect(getClientIp(req({ peer: '127.0.0.1', ip: '127.0.0.1' }))).toBe('127.0.0.1')
+  })
+
+  it('ne renvoie jamais de chaîne vide, la valeur sert de clé et de colonne', () => {
+    expect(getClientIp(req({ peer: '', ip: '' }))).toBe('0.0.0.0')
+  })
+
+  it('DEUX visiteurs distincts donnent DEUX adresses distinctes', () => {
+    // C'est ce test qui prouve la fin du seau de limitation unique : avant, les
+    // deux valaient `127.0.0.1` et partageaient donc la clé `rate:127.0.0.1`.
+    const a = getClientIp(req({ peer: '127.0.0.1', ip: '127.0.0.1', headers: { 'cf-connecting-ip': '103.78.255.128' } }))
+    const b = getClientIp(req({ peer: '127.0.0.1', ip: '127.0.0.1', headers: { 'cf-connecting-ip': '62.60.130.128' } }))
+    expect(a).not.toBe(b)
+  })
+})

--- a/nodyx-core/src/utils/clientIp.ts
+++ b/nodyx-core/src/utils/clientIp.ts
@@ -1,0 +1,133 @@
+// ─── L'adresse du visiteur, une seule fois, au même endroit ──────────────────
+//
+// LE PROBLÈME (mesuré le 2026-08-17). Depuis le 2026-08-08, le trafic de
+// nodyx.org arrive par un tunnel Cloudflare. Celui-ci envoie `CF-Connecting-IP`
+// mais PAS `X-Forwarded-For`. Or Fastify calcule `request.ip` à partir de
+// X-Forwarded-For : absent, il se rabat sur l'adresse du socket, c'est-à-dire
+// le proxy local. Résultat, `request.ip` valait `127.0.0.1` pour TOUS les
+// visiteurs externes.
+//
+// Ce que ça cassait, tel que constaté en base et dans Redis :
+//   - honeypot_hits : 100 % de loopback depuis le 9 août, 0 attaquant identifié
+//   - une SEULE clé de limitation, `nodyx:rate:127.0.0.1` : tous les visiteurs
+//     partageaient le même seau, donc un seul attaquant pouvait renvoyer 429 à
+//     tout le site
+//   - users.registration_ip, reported_ips, authenticator_challenges : idem
+//
+// LA RÈGLE. Un en-tête n'est croyable que s'il vient d'un proxy à nous. On
+// regarde donc le PAIR TCP réel, que rien ne peut usurper :
+//
+//   pair de confiance   -> on lit CF-Connecting-IP, puis request.ip (que Fastify
+//                          a déjà dérivé de X-Forwarded-For contre la liste de
+//                          confiance), puis X-Real-IP
+//   pair quelconque     -> on ignore TOUS les en-têtes et on renvoie le pair
+//
+// Sans la seconde branche, n'importe qui joignant le cœur en direct s'attribuerait
+// l'adresse de son choix et contournerait limitation, bannissements et pot de
+// miel. C'est exactement la faille refermée en #494, à ne pas rouvrir.
+//
+// GARDE-FOU SUPPLÉMENTAIRE : une adresse privée ou loopback lue dans un en-tête
+// est refusée. Elle ne peut pas désigner un visiteur d'Internet, et on a observé
+// dans les données une adresse Cloudflare (`2a06:98c0:3600::103`) remontée comme
+// si c'était un client.
+
+import ipaddr from 'ipaddr.js'
+import type { FastifyRequest } from 'fastify'
+
+/** Plages Cloudflare — même source que `config/trustedProxies.ts`. */
+const CLOUDFLARE_CIDRS = [
+  '173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22',
+  '141.101.64.0/18', '108.162.192.0/18', '190.93.240.0/20', '188.114.96.0/20',
+  '197.234.240.0/22', '198.41.128.0/17', '162.158.0.0/15', '104.16.0.0/13',
+  '104.24.0.0/14', '172.64.0.0/13', '131.0.72.0/22',
+  '2400:cb00::/32', '2606:4700::/32', '2803:f800::/32', '2405:b500::/32',
+  '2405:8100::/32', '2a06:98c0::/29', '2c0f:f248::/32',
+].map((c) => ipaddr.parseCIDR(c))
+
+/** Ce que `ipaddr.range()` renvoie pour une adresse qui n'est pas d'Internet. */
+const PLAGES_NON_PUBLIQUES = new Set([
+  'unspecified', 'broadcast', 'loopback', 'linkLocal', 'carrierGradeNat',
+  'private', 'reserved', 'uniqueLocal', 'ipv4Mapped', 'rfc6145', 'rfc6052',
+  '6to4', 'teredo',
+])
+
+function parse(valeur: string): ipaddr.IPv4 | ipaddr.IPv6 | null {
+  const v = valeur.trim()
+  if (!v) return null
+  try {
+    const adr = ipaddr.parse(v)
+    // `::ffff:1.2.3.4` doit être jugé sur sa partie IPv4, pas sur l'enveloppe.
+    if (adr.kind() === 'ipv6' && (adr as ipaddr.IPv6).isIPv4MappedAddress()) {
+      return (adr as ipaddr.IPv6).toIPv4Address()
+    }
+    return adr
+  } catch {
+    return null
+  }
+}
+
+/** Une adresse d'Internet : ni privée, ni loopback, ni réservée. */
+function estPubliquementRoutable(valeur: string): boolean {
+  const adr = parse(valeur)
+  if (!adr) return false
+  if (PLAGES_NON_PUBLIQUES.has(adr.range())) return false
+  // Un edge Cloudflare n'est pas un visiteur : c'est notre propre infrastructure.
+  return !estCloudflare(adr)
+}
+
+function estCloudflare(adr: ipaddr.IPv4 | ipaddr.IPv6): boolean {
+  for (const cidr of CLOUDFLARE_CIDRS) {
+    // `match` lève si les familles diffèrent : on compare à famille égale.
+    if (cidr[0].kind() === adr.kind() && adr.match(cidr as never)) return true
+  }
+  return false
+}
+
+/**
+ * Le pair TCP est-il un proxy à nous ? Seul lui a le droit de nous dire qui est
+ * le visiteur. Rien dans une requête ne permet de falsifier cette valeur.
+ */
+export function pairDeConfiance(pair: string | undefined): boolean {
+  const adr = parse(pair ?? '')
+  if (!adr) return false
+  const plage = adr.range()
+  if (plage === 'loopback' || plage === 'private' || plage === 'uniqueLocal' || plage === 'linkLocal') {
+    return true
+  }
+  return estCloudflare(adr)
+}
+
+/**
+ * L'adresse du visiteur, ou l'adresse du pair quand rien de crédible n'est
+ * disponible. Ne renvoie jamais de chaîne vide : les appelants s'en servent
+ * comme clé de limitation et comme colonne en base.
+ */
+export function getClientIp(request: FastifyRequest): string {
+  const pair = request.socket?.remoteAddress ?? ''
+
+  if (pairDeConfiance(pair)) {
+    const entete = (n: string): string | undefined => {
+      const v = request.headers[n]
+      const brut = Array.isArray(v) ? v[0] : v
+      // X-Forwarded-For peut porter plusieurs adresses : la première est le
+      // visiteur, les suivantes sont les proxys traversés.
+      return brut?.split(',')[0]?.trim()
+    }
+
+    // 1. Le tunnel Cloudflare : la seule source fiable sur ce chemin.
+    const cf = entete('cf-connecting-ip')
+    if (cf && estPubliquementRoutable(cf)) return cf
+
+    // 2. Fastify a déjà remonté X-Forwarded-For contre la liste de confiance
+    //    (`config/trustedProxies.ts`) : on ne refait pas ce travail.
+    if (request.ip && estPubliquementRoutable(request.ip)) return request.ip
+
+    // 3. Dernier recours, posé par certains proxys en frontal.
+    const reel = entete('x-real-ip')
+    if (reel && estPubliquementRoutable(reel)) return reel
+  }
+
+  // Pair inconnu, ou aucun en-tête crédible : on ne croit que le socket. C'est
+  // aussi le cas normal des appels internes du rendu serveur, en loopback.
+  return request.ip || pair || '0.0.0.0'
+}


### PR DESCRIPTION
Signalé comme « olympus.nodyx.org cassé » et « beaucoup d'attaques en 127.0.0.1 ».

**Olympus n'est pas cassé** : c'est `nodyx-hub`, en ligne et répondant 200. Ce qui était cassé, c'est la **donnée** qu'il affiche.

## Bascule datée

```
jour        total  loopback  ips distinctes
2026-08-07    135         0             16    <- normal
2026-08-08    102        84              8    <- bascule
2026-08-17    120       120              1    <- 100 % depuis
```

Les chemins visés restent `/wp-admin/install.php`, `/.env`, `/xmlrpc.php` : de **vraies attaques**. Elles n'ont jamais cessé, seule leur origine n'était plus enregistrée.

## Cause

Le trafic arrive par un tunnel Cloudflare, qui envoie `CF-Connecting-IP` mais **pas** `X-Forwarded-For`. Fastify dérivant `request.ip` de X-Forwarded-For, il se rabattait sur l'adresse de la socket.

## Ce que ça cassait

| | |
|---|---|
| **limitation de débit** | une **seule** clé Redis, `nodyx:rate:127.0.0.1` — un seul attaquant pouvait renvoyer 429 à tout le site |
| honeypot_hits | 1461 lignes en loopback |
| reported_ips (fédéré) | 102 sur 118 |
| authenticator_challenges | 26 sur 31 |
| users.registration_ip | 87 sur 113 |

## Correctif

`utils/clientIp.ts` : un en-tête n'est cru que s'il vient d'un **pair TCP de confiance**, valeur qu'aucune requête ne peut falsifier. Une adresse privée, loopback, RFC 5737 ou Cloudflare lue dans un en-tête est refusée.

**Tous les appelants sont câblés** : 64 appels sur 8 fichiers → **0 `request.ip` restant en code**.

## Migration 113 — essai en transaction annulée sur la prod

```
lignes en loopback   1461 -> 260
ips distinctes       1250 -> 1357   (+107 attaquants retrouvés)
signalements fédérés  118 -> 16     (102 purgés)
```

Une contrainte `CHECK` interdit désormais d'écrire une IP non publique dans le blocage fédéré.

### Deux pièges évités

- **PostgreSQL n'ordonne pas les conditions d'un `WHERE`.** Un `::inet` pouvait s'évaluer avant son garde-fou et faire échouer la migration, donc le **démarrage du cœur**. Validation isolée dans une CTE `MATERIALIZED` avec `pg_input_is_valid`.
- `honeypot_hits.ip` est **TEXT** là où `reported_ips.ip` est **INET**.

## Hors dépôt

`ADDRESS_HEADER: 'cf-connecting-ip'` posée dans les `ecosystem.config.js` (gitignorés) de `nodyx`, `demo` et `sleemstudio`.

⚠️ `pm2 restart <nom>` ne relit **pas** le fichier ecosystem : il faut `pm2 restart <ecosystem.config.js> --update-env`.

## Prouvé

13 tests dédiés, dont **3 tombent** sur l'ancien comportement, dont « deux visiteurs distincts donnent deux adresses distinctes ». 874 tests verts, 0 erreur de typage.
