### PR TITLE
hotfix(core): imports placés après leur utilisation, le cœur ne démarrait plus

### DIFF
--- a/nodyx-core/src/index.ts
+++ b/nodyx-core/src/index.ts
@@ -1,4 +1,6 @@
 import Fastify, { type FastifyRequest } from 'fastify'
+import { buildLoggerOptions } from './config/logger'
+import { getClientIp } from './utils/clientIp'
 import { Server } from 'socket.io'
 import fastifyStatic from '@fastify/static'
 import fastifyMultipart from '@fastify/multipart'
@@ -178,8 +180,6 @@ server.addHook('onRequest', async (request, reply) => {
 // Returns 503 on user-facing writes while a backup/restore window is active.
 // Skips reads, admin endpoints, and the maintenance status endpoint itself.
 import { maintenanceGuard } from './middleware/maintenanceGuard'
-import { buildLoggerOptions } from './config/logger'
-import { getClientIp } from './utils/clientIp'
 server.addHook('onRequest', maintenanceGuard)
 
 // ── Routes ───────────────────────────────────────────────────


### PR DESCRIPTION
**Incident de production que j'ai causé** en déployant #588. Les quatre cœurs sont tombés, trois instances ont renvoyé 500 pendant une dizaine de minutes.

```
ReferenceError: Cannot access 'logger_1' before initialization
    at dist/index.js:66
```

## Cause

Mon insertion automatique d'import a placé la ligne à la position 181, alors que son utilisation est du **code de haut niveau** exécuté ligne 64 :

```ts
const server = Fastify({ logger: buildLoggerOptions(), ... })
```

TypeScript compile sans broncher, mais le CommonJS émis exécute les `require` dans l'ordre du fichier : au moment de l'appel, le module n'est pas encore chargé.

`getClientIp` était dans le même cas et n'a pas cassé, parce qu'il n'est appelé que **dans des fonctions**, jamais à l'évaluation.

## Ce qui a retardé la détection

Mon contrôle du journal de déploiement comptait les erreurs avec le motif `✗` (U+2717) alors que le script écrit `✘` (U+2718). Il annonçait donc « 0 ligne d'erreur » sur un déploiement qui affichait « 4 problème(s) » et listait quatre applications hors ligne.

**Je lisais un compteur au lieu du verdict.**

## Pourquoi la CI ne pouvait pas l'attraper

Ni `npm run check`, ni les 880 tests, ni les 9 portes ne voient ce défaut : il n'apparaît qu'à l'évaluation du module compilé. Seul un démarrage réel le révèle.