### PR TITLE
feat(core): modèle unifié des événements et décisions de sécurité

### DIFF
--- a/nodyx-core/src/migrations/114_security_events.sql
+++ b/nodyx-core/src/migrations/114_security_events.sql
@@ -1,0 +1,120 @@
+-- ─── Modèle unifié des événements de sécurité ────────────────────────────────
+--
+-- Objectif : pouvoir répondre à « montre-moi tout ce qui est arrivé à cette IP »
+-- sans interroger huit tables différentes.
+--
+-- CHOIX DE CONCEPTION, ET IL EST STRUCTURANT. On ne recopie PAS l'existant.
+-- `honeypot_hits` fait déjà 18 460 lignes ; les dupliquer créerait deux vérités
+-- à maintenir et à purger, et le jour où les deux divergent on ne saurait plus
+-- laquelle croire.
+--
+--   `security_events`      table réelle, pour les sources NOUVELLES
+--                          (crowdsec, suricata, nftables, ssh)
+--   `security_events_all`  vue d'union, qui y projette les tables existantes
+--
+-- Une seule surface d'interrogation, zéro duplication, et les tables d'origine
+-- restent maîtresses de leurs données.
+
+CREATE TABLE IF NOT EXISTS security_events (
+  id             BIGSERIAL PRIMARY KEY,
+  ts             TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+  -- D'où vient l'observation. Pas ce qui s'est passé : QUI l'a vu.
+  source         TEXT         NOT NULL
+                 CHECK (source IN ('crowdsec','suricata','nftables','ssh','caddy','application')),
+
+  -- Ce qui s'est passé.
+  event_type     TEXT         NOT NULL
+                 CHECK (event_type IN ('scan','bruteforce','auth_failure','honeypot','waf',
+                                       'ids_alert','firewall_block','signup_abuse',
+                                       'admin_action','anomaly','request')),
+
+  severity       TEXT         NOT NULL DEFAULT 'info'
+                 CHECK (severity IN ('info','low','medium','high','critical')),
+
+  -- L'adresse OBSERVÉE. Peut être un proxy : c'est le rôle de `metadata` de
+  -- porter la nuance, jamais de cette colonne de prétendre à l'identité.
+  src_ip         INET,
+  src_port       INTEGER,
+  dst_port       INTEGER,
+
+  user_id        UUID,
+  user_agent     TEXT,
+  asn            TEXT,
+  org            TEXT,
+  country        TEXT,
+
+  -- Ce qui a été FAIT de l'événement, distinct de la décision (table 115).
+  action         TEXT         NOT NULL DEFAULT 'observed'
+                 CHECK (action IN ('observed','challenged','blocked')),
+
+  -- Relie plusieurs événements d'un même épisode, toutes sources confondues.
+  correlation_id TEXT,
+
+  -- Référence vers la donnée brute (ligne eve.json, id CrowdSec…), jamais la
+  -- donnée elle-même : le brut vit hors PostgreSQL, avec sa propre rétention.
+  raw_ref        TEXT,
+
+  metadata       JSONB        NOT NULL DEFAULT '{}'::jsonb
+);
+
+-- Les deux axes réels d'interrogation : « cette IP » et « cette source ».
+CREATE INDEX IF NOT EXISTS idx_sec_events_ip_ts     ON security_events (src_ip, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_sec_events_source_ts ON security_events (source, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_sec_events_type_ts   ON security_events (event_type, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_sec_events_corr      ON security_events (correlation_id)
+  WHERE correlation_id IS NOT NULL;
+
+COMMENT ON TABLE security_events IS
+  'Événements de sécurité des sources nouvelles. Les tables historiques ne sont pas '
+  'recopiées ici : la vue security_events_all les y projette.';
+
+-- ── La vue d'union : une seule surface d'interrogation ──────────────────────
+--
+-- `honeypot_hits.ip` est de type TEXT (les autres sont INET), d'où le cast et
+-- le garde-fou `pg_input_is_valid` : une valeur mal formée ne doit pas faire
+-- échouer la vue entière.
+CREATE OR REPLACE VIEW security_events_all AS
+  SELECT
+    id::bigint, ts, source, event_type, severity, src_ip, user_id,
+    user_agent, org, country, action, correlation_id, metadata
+  FROM security_events
+
+  UNION ALL
+
+  SELECT
+    h.id::bigint,
+    h.created_at,
+    'application',
+    'honeypot',
+    'medium',
+    CASE WHEN pg_input_is_valid(h.ip, 'inet') THEN h.ip::inet END,
+    NULL::uuid,
+    h.user_agent,
+    NULLIF(h.org, '—'),
+    NULLIF(h.country, '—'),
+    'observed',
+    h.incident_id,
+    jsonb_build_object('path', h.path, 'method', h.method)
+  FROM honeypot_hits h
+
+  UNION ALL
+
+  SELECT
+    b.id::bigint,
+    b.attempted_at,
+    'application',
+    'signup_abuse',
+    'medium',
+    b.ip,
+    NULL::uuid,
+    b.user_agent,
+    NULL, NULL,
+    'blocked',
+    NULL,
+    jsonb_build_object('reason', b.reason, 'username', b.username)
+  FROM bot_signup_attempts b;
+
+COMMENT ON VIEW security_events_all IS
+  'Union des événements nouveaux et des tables historiques, sans duplication. '
+  'C''est la vue qu''Olympus interroge.';

--- a/nodyx-core/src/migrations/115_security_decisions.sql
+++ b/nodyx-core/src/migrations/115_security_decisions.sql
@@ -1,0 +1,87 @@
+-- ─── Ce que le système a DÉCIDÉ, séparé de ce qui s'est passé ────────────────
+--
+-- `security_events` répond à « qu'est-ce qui est arrivé ».
+-- `security_decisions` répond à « qu'est-ce qu'on en a fait ».
+--
+-- Les mélanger empêcherait la question qui compte vraiment :
+--
+--     CrowdSec a dit BANNIR — mais est-ce que le paquet a réellement été bloqué ?
+--
+-- C'est exactement ce que le banc d'essai doit vérifier.
+--
+-- ── LE CHAMP QUI ÉVITE UNE ILLUSION DE SÉCURITÉ ─────────────────────────────
+--
+-- `enforcement_plane` n'est pas décoratif. Mesure du 17/08 : le trafic web
+-- arrive par Cloudflare, donc l'adresse source au niveau paquet est TOUJOURS un
+-- serveur Cloudflare. Bannir un attaquant web dans nftables ne bloque rien : son
+-- adresse ne touche jamais la carte réseau.
+--
+--     nftables   → attaque directe sur l'IP d'origine, SSH, TURN, relais, média
+--     cloudflare → l'attaquant web, bloqué à l'edge
+--     application→ refus applicatif (limitation de débit, bannissement de compte)
+--
+-- Sans cette colonne, Olympus afficherait « BLOQUÉ » pour une IP qui continue de
+-- passer tranquillement. Une fausse assurance est pire qu'une absence de
+-- protection : on cesse de regarder.
+
+CREATE TABLE IF NOT EXISTS security_decisions (
+  id                BIGSERIAL PRIMARY KEY,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  src_ip            INET        NOT NULL,
+
+  -- Qui a décidé.
+  source            TEXT        NOT NULL
+                    CHECK (source IN ('crowdsec','application','manual','federation')),
+
+  decision          TEXT        NOT NULL
+                    CHECK (decision IN ('ban','captcha','throttle','watch','unban')),
+
+  -- Le motif, lisible : « crowdsec:http-scan », « honeypot:wp-admin ».
+  reason            TEXT        NOT NULL,
+
+  duration_seconds  INTEGER,
+  expires_at        TIMESTAMPTZ,
+
+  status            TEXT        NOT NULL DEFAULT 'active'
+                    CHECK (status IN ('active','expired','revoked','failed')),
+
+  -- OÙ la décision est réellement appliquée. Voir l'explication en tête.
+  enforcement_plane TEXT        NOT NULL
+                    CHECK (enforcement_plane IN ('nftables','cloudflare','application','none')),
+
+  -- L'application a-t-elle été CONFIRMÉE, ou seulement demandée ? Une décision
+  -- prise mais non appliquée doit rester visible comme telle.
+  enforced_at       TIMESTAMPTZ,
+
+  correlation_id    TEXT,
+  metadata          JSONB       NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Une adresse privée ou de bouclage ne désigne aucun visiteur : même règle que
+  -- la contrainte posée sur `reported_ips` en #587, pour la même raison.
+  CONSTRAINT security_decisions_ip_publique CHECK (NOT nodyx_ip_non_publique(src_ip))
+);
+
+CREATE INDEX IF NOT EXISTS idx_sec_dec_ip      ON security_decisions (src_ip, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_sec_dec_actives ON security_decisions (status, expires_at)
+  WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS idx_sec_dec_plane   ON security_decisions (enforcement_plane, created_at DESC);
+
+COMMENT ON COLUMN security_decisions.enforcement_plane IS
+  'Où la décision est réellement appliquée. Un ban nftables ne bloque PAS un '
+  'attaquant web derrière Cloudflare : son paquet vient d''un edge.';
+
+COMMENT ON COLUMN security_decisions.enforced_at IS
+  'Rempli seulement quand l''application est CONFIRMÉE. NULL = décidé mais non '
+  'vérifié : c''est ce que le banc d''essai doit détecter.';
+
+-- ── Ce qui est réellement en vigueur, à un instant donné ────────────────────
+CREATE OR REPLACE VIEW security_decisions_actives AS
+  SELECT *
+  FROM security_decisions
+  WHERE status = 'active'
+    AND (expires_at IS NULL OR expires_at > NOW());
+
+COMMENT ON VIEW security_decisions_actives IS
+  'Décisions en vigueur. Une décision expirée reste en base pour l''historique '
+  'et la corrélation de campagne : c''est elle qui dira « déjà banni hier ».';

--- a/nodyx-core/src/tests/security-model.test.ts
+++ b/nodyx-core/src/tests/security-model.test.ts
@@ -1,0 +1,78 @@
+// ─── Les invariants du modèle de sécurité ────────────────────────────────────
+//
+// Ces contrôles lisent les migrations, pas la base : ils protègent des décisions
+// de conception, pas des données. Une migration est jouée une fois en production
+// et devient irréversible ; ce qu'on y écrit mérite un garde-fou de la même
+// nature que le code.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+const EVENTS = readFileSync(
+  new URL('../migrations/114_security_events.sql', import.meta.url).pathname, 'utf-8')
+const DECISIONS = readFileSync(
+  new URL('../migrations/115_security_decisions.sql', import.meta.url).pathname, 'utf-8')
+
+describe('modèle de sécurité — événements', () => {
+  it('ne recopie AUCUNE donnée existante dans la table', () => {
+    // Le choix structurant : `security_events` accueille les sources nouvelles,
+    // une vue d'union y projette l'existant. Recopier les 18 463 lignes du pot de
+    // miel créerait deux vérités à purger séparément, et le jour où elles
+    // divergent on ne saurait plus laquelle croire.
+    expect(EVENTS).not.toMatch(/INSERT\s+INTO\s+security_events/i)
+    expect(EVENTS).toMatch(/CREATE OR REPLACE VIEW security_events_all/i)
+  })
+
+  it('expose les tables historiques par la vue, sans les modifier', () => {
+    expect(EVENTS).toMatch(/FROM honeypot_hits/i)
+    expect(EVENTS).toMatch(/FROM bot_signup_attempts/i)
+    // Aucune écriture sur les tables d'origine : elles restent maîtresses.
+    expect(EVENTS).not.toMatch(/(UPDATE|DELETE FROM|ALTER TABLE)\s+honeypot_hits/i)
+  })
+
+  it('protège la vue contre une adresse mal formée', () => {
+    // `honeypot_hits.ip` est de type TEXT là où les autres sont INET. Un cast nu
+    // ferait échouer la vue ENTIÈRE sur une seule valeur douteuse.
+    expect(EVENTS).toMatch(/pg_input_is_valid/)
+  })
+
+  it('indexe les deux axes réels : par IP et par source', () => {
+    expect(EVENTS).toMatch(/idx_sec_events_ip_ts[\s\S]*?src_ip/)
+    expect(EVENTS).toMatch(/idx_sec_events_source_ts[\s\S]*?source/)
+  })
+})
+
+describe('modèle de sécurité — décisions', () => {
+  it("porte le plan d'application, et il est obligatoire", () => {
+    // LE champ qui évite une illusion de sécurité. Le trafic web arrive par
+    // Cloudflare : l'adresse source au niveau paquet est toujours un edge. Un
+    // ban nftables ne bloque donc PAS un attaquant web. Sans cette colonne,
+    // Olympus afficherait « BLOQUÉ » pour une IP qui continue de passer — et une
+    // fausse assurance est pire qu'une absence de protection, on cesse de
+    // regarder.
+    expect(DECISIONS).toMatch(/enforcement_plane\s+TEXT\s+NOT NULL/i)
+    for (const plan of ['nftables', 'cloudflare', 'application', 'none']) {
+      expect(DECISIONS, `plan « ${plan} » manquant`).toContain(`'${plan}'`)
+    }
+  })
+
+  it("distingue la décision PRISE de l'application CONFIRMÉE", () => {
+    // `enforced_at` NULL = décidé mais non vérifié. C'est exactement ce que le
+    // banc d'essai doit détecter.
+    expect(DECISIONS).toMatch(/enforced_at\s+TIMESTAMPTZ/i)
+    expect(DECISIONS).not.toMatch(/enforced_at\s+TIMESTAMPTZ\s+NOT NULL/i)
+  })
+
+  it('refuse une adresse qui ne désigne aucun visiteur', () => {
+    // Même règle que la contrainte posée sur `reported_ips` en #587 : une IP
+    // privée ou de bouclage n'a aucun sens comme cible de décision.
+    expect(DECISIONS).toMatch(/CHECK\s*\(NOT nodyx_ip_non_publique\(src_ip\)\)/)
+  })
+
+  it('sépare ce qui est en vigueur de ce qui est historique', () => {
+    // Une décision expirée reste en base : c'est elle qui dira « déjà banni
+    // hier », signal central de la continuité de campagne.
+    expect(DECISIONS).toMatch(/CREATE OR REPLACE VIEW security_decisions_actives/i)
+    expect(DECISIONS).toMatch(/expires_at IS NULL OR expires_at > NOW\(\)/i)
+  })
+})


### PR DESCRIPTION
Lot A du CDC Olympus. Objectif : répondre à « montre-moi tout ce qui est arrivé à cette IP » sans interroger huit tables différentes.

## Choix structurant — aucune duplication

`honeypot_hits` fait déjà 18 463 lignes. Les recopier créerait **deux vérités** à maintenir et à purger séparément, et le jour où elles divergent on ne saurait plus laquelle croire.

| | rôle |
|---|---|
| `security_events` | table réelle, pour les sources **nouvelles** (crowdsec, suricata, nftables, ssh) |
| `security_events_all` | vue d'union, qui y projette l'existant |

Une seule surface d'interrogation, zéro duplication, les tables d'origine restent maîtresses de leurs données.

**Essai en transaction annulée sur la prod** : 20 097 événements interrogeables, table `security_events` à 0 ligne.

## Le champ qui évite une illusion de sécurité

`enforcement_plane` est **obligatoire** sur chaque décision. Mesure du 17/08 : le trafic web arrive par Cloudflare, donc l'adresse source au niveau paquet est toujours un edge. **Bannir un attaquant web dans nftables ne bloque rien.**

Sans cette colonne, Olympus afficherait « BLOQUÉ » pour une IP qui continue de passer — et une fausse assurance est pire qu'une absence de protection, parce qu'on cesse de regarder.

`enforced_at` est distinct et **nullable** : décidé mais non confirmé reste visible comme tel. C'est précisément ce que le banc d'essai devra détecter.

## Deux pièges déjà rencontrés, désamorcés ici

- `honeypot_hits.ip` est de type **TEXT** là où les autres sont **INET**. Un cast nu ferait échouer la vue *entière* sur une seule valeur douteuse → garde-fou `pg_input_is_valid`.
- Une IP privée ou de bouclage n'a aucun sens comme cible de décision → même contrainte `CHECK` que celle posée sur `reported_ips` en #587.

## Prouvé

8 tests d'invariants, dont **2 tombent** sur les mauvaises conceptions : plan d'application rendu optionnel, et recopie du pot de miel dans la table. 888 tests verts au total.