### PR TITLE
feat(ops): collecteur CrowdSec vers PostgreSQL, pour Olympus

### DIFF
--- a/scripts/ops/security/collector.mjs
+++ b/scripts/ops/security/collector.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// ─── Collecteur CrowdSec → PostgreSQL ────────────────────────────────────────
+//
+// POURQUOI CE PROGRAMME EXISTE. Olympus doit voir ce que CrowdSec observe et
+// décide, sans jamais être couplé à lui. Trois portes étaient possibles :
+//
+//   1. Olympus lit la base SQLite de CrowdSec  -> couplage a son schema interne,
+//      qui change entre versions. Et le fichier est `root:root 640` alors que le
+//      hub tourne en `nodyx`.
+//   2. Olympus appelle `cscli`                  -> une commande systeme depuis
+//      l'application web. Exclu par le CDC, et pour de bonnes raisons.
+//   3. Un collecteur s'interpose                -> retenu.
+//
+// Le collecteur parle a CrowdSec par son interface SUPPORTEE (`cscli -o json`),
+// normalise, et ecrit dans PostgreSQL. Olympus n'interroge que PostgreSQL. Si
+// CrowdSec change de schema interne, seul ce fichier bouge.
+//
+// IDEMPOTENT. Il tourne en boucle et rejoue les memes alertes : chaque insertion
+// est conditionnee a l'absence prealable (`WHERE NOT EXISTS`). Le relancer deux
+// fois de suite ne cree pas de doublon.
+//
+// CE QU'IL N'EST PAS. Il ne decide rien, ne bloque rien, n'appelle pas nftables.
+// Il lit et recopie.
+
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+
+// `pg` vit dans les dependances du coeur. La resolution ESM part du FICHIER, pas
+// du repertoire courant : ni `NODE_PATH` ni un `cd` n'y changent quoi que ce
+// soit. On resout donc explicitement depuis nodyx-core, ce qui evite aussi de
+// dupliquer la dependance pour un script d'exploitation.
+const require = createRequire('/var/www/nexus/nodyx-core/package.json')
+const pg = require('pg')
+
+const run = promisify(execFile)
+
+/** Les identifiants viennent du .env du cœur : une seule source de vérité. */
+function configBase() {
+  const brut = readFileSync('/var/www/nexus/nodyx-core/.env', 'utf-8')
+  const v = (clef) => brut.match(new RegExp(`^${clef}=(.*)$`, 'm'))?.[1]?.trim()
+  return {
+    host: v('DB_HOST') || 'localhost',
+    port: Number(v('DB_PORT') || 5432),
+    database: v('DB_NAME') || 'nexus',
+    user: v('DB_USER') || 'nexus',
+    password: v('DB_PASSWORD'),
+  }
+}
+
+async function cscli(...args) {
+  try {
+    const { stdout } = await run('/usr/bin/cscli', [...args, '-o', 'json'], {
+      maxBuffer: 32 * 1024 * 1024,
+    })
+    const t = stdout.trim()
+    return t ? JSON.parse(t) : []
+  } catch (e) {
+    // Une panne de cscli ne doit pas tuer le collecteur : il reessaiera au tour
+    // suivant. On la signale, on ne l'avale pas silencieusement — c'est
+    // exactement le motif qui a rendu le pot de miel aveugle pendant cinq mois.
+    console.error(`[collecteur] cscli ${args.join(' ')} en echec :`, e.message)
+    return null
+  }
+}
+
+/** Le scénario CrowdSec, traduit dans notre vocabulaire d'événement. */
+function typeDepuisScenario(scenario = '') {
+  const s = scenario.toLowerCase()
+  if (s.includes('bf') || s.includes('bruteforce')) return 'bruteforce'
+  if (s.includes('scan') || s.includes('crawl')) return 'scan'
+  if (s.includes('http')) return 'anomaly'
+  if (s.includes('ssh')) return 'auth_failure'
+  return 'anomaly'
+}
+
+function severiteDepuisEvenements(n) {
+  if (n >= 50) return 'critical'
+  if (n >= 20) return 'high'
+  if (n >= 5) return 'medium'
+  return 'low'
+}
+
+async function ingererAlertes(client) {
+  const alertes = await cscli('alerts', 'list')
+  if (!alertes) return 0
+  let n = 0
+  for (const a of alertes) {
+    const ip = a.source?.ip ?? a.source?.value
+    if (!ip) continue
+    const ref = `crowdsec:alert:${a.id}`
+    const r = await client.query(
+      `INSERT INTO security_events
+         (ts, source, event_type, severity, src_ip, country, org, action, raw_ref, metadata)
+       SELECT $1, 'crowdsec', $2, $3, $4::inet, $5, $6, 'observed', $7, $8
+       WHERE NOT EXISTS (SELECT 1 FROM security_events WHERE raw_ref = $7)`,
+      [
+        a.created_at ?? new Date().toISOString(),
+        typeDepuisScenario(a.scenario),
+        severiteDepuisEvenements(a.events_count ?? 0),
+        ip,
+        a.source?.cn ?? null,
+        a.source?.as_name ?? null,
+        ref,
+        JSON.stringify({ scenario: a.scenario, events: a.events_count }),
+      ],
+    )
+    n += r.rowCount ?? 0
+  }
+  return n
+}
+
+async function ingererDecisions(client) {
+  const decisions = await cscli('decisions', 'list')
+  if (!decisions) return 0
+  let n = 0
+  for (const bloc of decisions) {
+    for (const d of bloc.decisions ?? []) {
+      if (!d.value) continue
+      const ref = `crowdsec:decision:${d.id}`
+      // `enforcement_plane` : sans bouncer, RIEN n'est applique. On l'ecrit donc
+      // `none`, et `enforced_at` reste NULL. C'est ce qui empechera Olympus
+      // d'afficher « BLOQUE » pour une adresse qui passe tranquillement.
+      const r = await client.query(
+        `INSERT INTO security_decisions
+           (created_at, src_ip, source, decision, reason, duration_seconds,
+            expires_at, status, enforcement_plane, correlation_id, metadata)
+         SELECT $1, $2::inet, 'crowdsec', $3, $4, $5, $6, 'active', 'none', $7, $8
+         WHERE NOT EXISTS (SELECT 1 FROM security_decisions WHERE correlation_id = $7)`,
+        [
+          bloc.created_at ?? new Date().toISOString(),
+          d.value,
+          (d.type ?? 'ban').toLowerCase() === 'ban' ? 'ban' : 'watch',
+          d.scenario ?? 'crowdsec',
+          null,
+          null,
+          ref,
+          JSON.stringify({ scenario: d.scenario, origin: d.origin, duration: d.duration }),
+        ],
+      )
+      n += r.rowCount ?? 0
+    }
+  }
+  return n
+}
+
+const client = new pg.Client(configBase())
+await client.connect()
+try {
+  const a = await ingererAlertes(client)
+  const d = await ingererDecisions(client)
+  console.log(`[collecteur] ${a} alerte(s) et ${d} decision(s) nouvelles`)
+} finally {
+  await client.end()
+}

--- a/scripts/ops/security/crowdsec-nodyx-whitelist.yaml
+++ b/scripts/ops/security/crowdsec-nodyx-whitelist.yaml
@@ -1,0 +1,46 @@
+name: nodyx/whitelists
+description: >
+  Adresses qu'il ne faut JAMAIS bannir sur une instance Nodyx.
+
+  1. LES SERVEURS CLOUDFLARE — le risque le plus grave. Tout le trafic web
+     arrive d'un edge Cloudflare : au niveau paquet, l'adresse source est
+     TOUJOURS l'une de ces plages. En bannir une couperait le site pour TOUT LE
+     MONDE, pas seulement pour l'attaquant. Ce n'est pas un verrouillage
+     d'administrateur, c'est une panne totale.
+
+  2. L'ADRESSE DE L'EXPLOITANT — reprise de la liste blanche fail2ban qui
+     existait deja (`ignoreip = 127.0.0.1/8 ::1 87.88.104.61`). Se bannir
+     soi-meme d'un VPS distant, c'est perdre l'acces SSH.
+
+  Le loopback et les plages privees sont deja couverts par
+  crowdsecurity/whitelists, on ne les redouble pas.
+whitelist:
+  reason: "Cloudflare edges et exploitant Nodyx — un ban ici coupe le service"
+  ip:
+    - "87.88.104.61"
+  cidr:
+    # Plages publiees par Cloudflare (https://www.cloudflare.com/ips/).
+    # Memes valeurs que nodyx-core/src/config/trustedProxies.ts : les deux
+    # listes doivent rester alignees.
+    - "173.245.48.0/20"
+    - "103.21.244.0/22"
+    - "103.22.200.0/22"
+    - "103.31.4.0/22"
+    - "141.101.64.0/18"
+    - "108.162.192.0/18"
+    - "190.93.240.0/20"
+    - "188.114.96.0/20"
+    - "197.234.240.0/22"
+    - "198.41.128.0/17"
+    - "162.158.0.0/15"
+    - "104.16.0.0/13"
+    - "104.24.0.0/14"
+    - "172.64.0.0/13"
+    - "131.0.72.0/22"
+    - "2400:cb00::/32"
+    - "2606:4700::/32"
+    - "2803:f800::/32"
+    - "2405:b500::/32"
+    - "2405:8100::/32"
+    - "2a06:98c0::/29"
+    - "2c0f:f248::/32"

--- a/scripts/ops/security/systemd/nodyx-security-collector.service
+++ b/scripts/ops/security/systemd/nodyx-security-collector.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Nodyx — collecteur CrowdSec vers PostgreSQL
+Documentation=file:///var/www/nexus/SPECS/OLYMPUS_OBSERVABILITE_CDC.md
+After=crowdsec.service postgresql.service
+Wants=crowdsec.service
+
+[Service]
+Type=oneshot
+# Root : `cscli` exige l'acces aux identifiants locaux de CrowdSec. Le collecteur
+# ne fait que LIRE CrowdSec et ECRIRE dans PostgreSQL. Il ne decide rien, ne
+# bloque rien, n'appelle jamais nftables.
+User=root
+ExecStart=/usr/bin/node /var/www/nexus/scripts/ops/security/collector.mjs
+TimeoutStartSec=120
+
+# Durcissement : il n'a besoin d'ecrire nulle part sur le disque.
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/ops/security/systemd/nodyx-security-collector.timer
+++ b/scripts/ops/security/systemd/nodyx-security-collector.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Nodyx — collecte CrowdSec toutes les 2 minutes
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=2min
+# Deux minutes : assez frais pour qu'Olympus soit utile pendant une attaque,
+# assez espace pour ne rien peser. CrowdSec garde l'historique de son cote, une
+# collecte manquee est rattrapee au tour suivant (le collecteur est idempotent).
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Lot D du CDC. Objectif : voir les données de CrowdSec dans Olympus, **sans coupler Olympus à CrowdSec**.

Trois portes étaient possibles : lire sa base SQLite (couplage à un schéma interne, fichier `root:root 640` alors que le hub tourne en `nodyx`), appeler `cscli` depuis l'application web (exclu par le CDC), ou interposer un collecteur. **Retenu : le collecteur.**

Il parle à CrowdSec par son interface supportée (`cscli -o json`), normalise, écrit dans PostgreSQL. Olympus n'interroge que PostgreSQL.

## Validé de bout en bout

```
[collecteur] 1 alerte(s) et 1 decision(s) nouvelles
[collecteur] 0 alerte(s) et 0 decision(s) nouvelles   <- idempotence
45.83.12.7 | crowdsec | ban | test | none | NON CONFIRMEE
```

Cette dernière ligne montre pourquoi `enforcement_plane` existe : CrowdSec a décidé un bannissement, et Olympus affichera honnêtement qu'il n'est appliqué **nulle part**, faute de bouncer. Pas de fausse assurance.

## Deux pièges rencontrés, documentés dans le fichier

- `NODE_PATH` n'a **aucun effet en ESM** : la résolution part du fichier, pas du répertoire courant.
- Une panne de `cscli` est **signalée, jamais avalée** — c'est exactement le motif muet qui a rendu la jail du pot de miel aveugle depuis le 29 mars.

Minuteur systemd toutes les 2 minutes, unité durcie. La liste blanche CrowdSec est versionnée ici aussi : elle protège les 22 plages Cloudflare, dont un bannissement couperait le site pour tout le monde.