### PR TITLE
feat(core): journal d'accès à ligne unique, exploitable par GoAccess et CrowdSec

### DIFF
--- a/nodyx-core/src/config/logger.ts
+++ b/nodyx-core/src/config/logger.ts
@@ -69,6 +69,10 @@ function entetesRetenus(request: FastifyRequest): Record<string, string> {
 export function buildLoggerOptions(): FastifyServerOptions['logger'] {
   return {
     level: process.env.LOG_LEVEL ?? 'info',
+    // Horodatage ISO plutot que l'epoque en millisecondes de pino : GoAccess
+    // sait lire une date ISO, pas un entier en millisecondes. Et une ligne de
+    // journal lue par un humain gagne a etre datee lisiblement.
+    timestamp: () => `,"time":"${new Date().toISOString()}"`,
     redact: {
       // Ceinture et bretelles : même si un sérialiseur changeait, ces chemins
       // ne sortiraient pas.
@@ -101,4 +105,60 @@ export function buildLoggerOptions(): FastifyServerOptions['logger'] {
       },
     },
   }
+}
+
+/**
+ * Le crochet de fin de requête : UNE ligne par requête, complète.
+ *
+ * POURQUOI. Fastify en journalise deux : « incoming request » porte l'adresse et
+ * l'URL, « request completed » porte le code de statut. Aucune des deux n'est
+ * exploitable seule :
+ *
+ *   - GoAccess a besoin d'adresse + URL + statut sur la MEME ligne ;
+ *   - les scénarios HTTP de CrowdSec s'appuient sur les taux de 404, absents de
+ *     la ligne qui porte l'URL ;
+ *   - et le volume double pour rien (17 Mo de journal en une journée).
+ *
+ * On désactive donc la journalisation automatique (`disableRequestLogging`) et on
+ * émet une ligne unique à la réponse. Volume divisé par deux, et les deux outils
+ * deviennent utilisables.
+ *
+ * MÊMES INTERDITS QUE PLUS HAUT : ni corps, ni cookie, ni autorisation. Un
+ * journal d'accès qui aspire les corps devient la fuite qu'il prétend prévenir.
+ */
+export function journaliserAcces(request: FastifyRequest, reply: FastifyReply, tempsMs: number): void {
+  const h = request.headers
+  const usurpation = ENTETES_USURPATION.filter((n) => h[n] !== undefined)
+  // `ts` : horodatage compact DEDIE a GoAccess, qui refuse les millisecondes et
+  // le `Z` de l'ISO (`%x` ne les analyse pas). On garde donc `time` en ISO
+  // complet pour les humains et la correlation fine — deux evenements dans la
+  // meme seconde restent distinguables — et on ajoute ce champ pour l'outil.
+  const d = new Date()
+  const p2 = (n: number) => String(n).padStart(2, '0')
+  // Deux champs separes : GoAccess veut `%d` pour la date et `%t` pour l'heure.
+  // Son `%x` combine exige que les deux formats correspondent au meme jeton, ce
+  // qui ne fonctionne pas avec un horodatage ISO.
+  const log_date = `${d.getUTCFullYear()}-${p2(d.getUTCMonth() + 1)}-${p2(d.getUTCDate())}`
+  const log_time = `${p2(d.getUTCHours())}:${p2(d.getUTCMinutes())}:${p2(d.getUTCSeconds())}`
+
+  request.log.info(
+    {
+      log_date,
+      log_time,
+      // `ip` est l'adresse RÉELLE du visiteur ; `peer` le proxy local. Deux
+      // champs distincts : les fusionner, c'est perdre la détection d'usurpation.
+      ip: getClientIp(request),
+      peer: request.socket?.remoteAddress,
+      method: request.method,
+      url: request.url,
+      status: reply.statusCode,
+      duree: Math.round(tempsMs * 100) / 100,
+      ua: typeof h['user-agent'] === 'string' ? h['user-agent'].slice(0, 300) : undefined,
+      referer: typeof h.referer === 'string' ? h.referer.slice(0, 300) : undefined,
+      host: typeof h.host === 'string' ? h.host : undefined,
+      // Présence conjointe = empreinte d'outillage (1369 tentatives mesurées).
+      usurpation: usurpation.length ? usurpation.join(',') : undefined,
+    },
+    'access',
+  )
 }

--- a/nodyx-core/src/index.ts
+++ b/nodyx-core/src/index.ts
@@ -1,5 +1,5 @@
 import Fastify, { type FastifyRequest } from 'fastify'
-import { buildLoggerOptions } from './config/logger'
+import { buildLoggerOptions, journaliserAcces } from './config/logger'
 import { getClientIp } from './utils/clientIp'
 import { Server } from 'socket.io'
 import fastifyStatic from '@fastify/static'
@@ -61,7 +61,27 @@ import { startScheduler }  from './scheduler'
 // Fastify écrit `socket.remoteAddress`, donc `127.0.0.1` derrière Cloudflare.
 // Ces journaux sont la source prévue de la détection comportementale ; aveugles,
 // ils n'auraient permis de bannir personne. cf src/config/logger.ts
-const server = Fastify({ logger: buildLoggerOptions(), trustProxy: getTrustProxy() })
+// `disableRequestLogging` : Fastify journalise DEUX lignes par requete, dont
+// aucune n'est exploitable seule (l'une a l'URL sans le statut, l'autre le
+// statut sans l'URL). On emet une ligne unique et complete a la reponse, via le
+// crochet plus bas. GoAccess et les scenarios CrowdSec deviennent utilisables,
+// et le volume est divise par deux. cf src/config/logger.ts
+const server = Fastify({
+  logger: buildLoggerOptions(),
+  trustProxy: getTrustProxy(),
+  disableRequestLogging: true,
+})
+
+// Duree de la requete, mesuree ici plutot que reconstruite : `reply.elapsedTime`
+// n'existe pas dans toutes les versions.
+server.addHook('onRequest', async (request) => {
+  ;(request as unknown as { _debut: bigint })._debut = process.hrtime.bigint()
+})
+server.addHook('onResponse', async (request, reply) => {
+  const debut = (request as unknown as { _debut?: bigint })._debut
+  const ms = debut ? Number(process.hrtime.bigint() - debut) / 1e6 : 0
+  journaliserAcces(request, reply, ms)
+})
 
 // ── CORS (pour les appels fetch client-side : upload, chat, mentions) ────────
 const corsOrigin = process.env.FRONTEND_URL

--- a/nodyx-hub/src/routes/security/trafic/+server.ts
+++ b/nodyx-hub/src/routes/security/trafic/+server.ts
@@ -1,0 +1,59 @@
+// ─── Le rapport GoAccess, servi derriere l'authentification du hub ───────────
+//
+// POURQUOI UNE ROUTE PLUTOT QU'UN FICHIER STATIQUE. Ce rapport contient les
+// ADRESSES DES VISITEURS. Le publier dans `static/` le rendrait accessible a
+// quiconque devine l'URL : une fuite de donnees personnelles, sur un service
+// dont la promesse est justement de ne pas en faire commerce.
+//
+// La route herite de la verification du `+layout.server.ts` du hub par le meme
+// cookie de session — on la revalide ici explicitement, parce qu'un point de
+// terminaison `+server.ts` ne traverse PAS le layout.
+//
+// POURQUOI PAS LE MODE TEMPS REEL DE GOACCESS. Il ouvre un serveur WebSocket sur
+// un port dedie, qu'il faudrait proxifier dans Caddy. Or la configuration Caddy
+// vivante de cette machine vient de `autosave.json` et un rechargement fait
+// tomber le HTTPS de nodyx.org. Le rapport est donc regenere chaque minute par
+// `nodyx-goaccess.timer`, et cette page se rafraichit d'elle-meme.
+
+import { readFileSync, statSync } from 'node:fs'
+import { error } from '@sveltejs/kit'
+import { validateSession } from '$lib/server/auth.js'
+import type { RequestHandler } from './$types'
+
+const RAPPORT = '/var/lib/nodyx-goaccess/rapport.html'
+
+export const GET: RequestHandler = async ({ cookies }) => {
+  // Un `+server.ts` ne passe pas par le layout : la verification doit etre ici,
+  // sinon le rapport serait public.
+  if (!validateSession(cookies.get('hub_session') ?? '')) {
+    error(401, 'Authentification requise')
+  }
+
+  let html: string
+  try {
+    html = readFileSync(RAPPORT, 'utf-8')
+  } catch {
+    // Le minuteur n'a peut-etre pas encore tourne, ou aucune requete n'a encore
+    // ete journalisee. On le dit, plutot que de renvoyer une page vide.
+    error(503, 'Rapport pas encore genere — le minuteur tourne chaque minute')
+  }
+
+  const age = Math.round((Date.now() - statSync(RAPPORT).mtimeMs) / 1000)
+
+  // Rafraichissement automatique : le rapport est regenere chaque minute.
+  const html2 = html.replace(
+    '<head>',
+    `<head><meta http-equiv="refresh" content="60">` +
+      `<!-- rapport genere il y a ${age}s, regeneration chaque minute -->`,
+  )
+
+  return new Response(html2, {
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+      // Jamais en cache : les donnees changent chaque minute, et un cache
+      // intermediaire conserverait des adresses de visiteurs.
+      'cache-control': 'no-store, private',
+      'x-robots-tag': 'noindex, nofollow',
+    },
+  })
+}

--- a/scripts/ops/security/collector.mjs
+++ b/scripts/ops/security/collector.mjs
@@ -75,11 +75,44 @@ function typeDepuisScenario(scenario = '') {
   return 'anomaly'
 }
 
-function severiteDepuisEvenements(n) {
-  if (n >= 50) return 'critical'
-  if (n >= 20) return 'high'
-  if (n >= 5) return 'medium'
-  return 'low'
+function severite(scenario = '', n = 0) {
+  // La gravite tient d'abord a la NATURE de l'evenement, ensuite a l'insistance.
+  // Une seule tentative d'authentification echouee sur un compte vaut plus qu'un
+  // scan bruyant de 50 requetes sur /wp-admin qui ne mene nulle part. Le volume
+  // ne fait que remonter d'un cran.
+  const s = scenario.toLowerCase()
+  let base
+  if (s.includes('bf') || s.includes('bruteforce') || s.includes('auth')) base = 'high'
+  else if (s.includes('exploit') || s.includes('rce') || s.includes('sqli')) base = 'critical'
+  else if (s.includes('scan') || s.includes('crawl') || s.includes('path')) base = 'medium'
+  else base = 'low'
+
+  if (n < 20) return base
+  const echelle = ['low', 'medium', 'high', 'critical']
+  return echelle[Math.min(echelle.indexOf(base) + 1, echelle.length - 1)]
+}
+
+/** « 4h », « 59m30s », « -1h » -> secondes. CrowdSec renvoie une duree textuelle. */
+function dureeEnSecondes(texte) {
+  if (typeof texte !== 'string') return null
+  let total = 0
+  let vu = false
+  for (const [, n, u] of texte.matchAll(/(-?\d+(?:\.\d+)?)([hms])/g)) {
+    total += Number(n) * (u === 'h' ? 3600 : u === 'm' ? 60 : 1)
+    vu = true
+  }
+  return vu ? Math.round(total) : null
+}
+
+function expiration(texte) {
+  const s = dureeEnSecondes(texte)
+  return s && s > 0 ? new Date(Date.now() + s * 1000).toISOString() : null
+}
+
+/** Memes plages que la contrainte SQL : on ne tente pas ce qui sera refuse. */
+function nonPublique(ip) {
+  return /^(127\.|10\.|192\.168\.|169\.254\.|::1$|fe80:|fc|fd)/i.test(ip) ||
+         /^172\.(1[6-9]|2\d|3[01])\./.test(ip)
 }
 
 async function ingererAlertes(client) {
@@ -98,7 +131,7 @@ async function ingererAlertes(client) {
       [
         a.created_at ?? new Date().toISOString(),
         typeDepuisScenario(a.scenario),
-        severiteDepuisEvenements(a.events_count ?? 0),
+        severite(a.scenario, a.events_count ?? 0),
         ip,
         a.source?.cn ?? null,
         a.source?.as_name ?? null,
@@ -118,6 +151,13 @@ async function ingererDecisions(client) {
   for (const bloc of decisions) {
     for (const d of bloc.decisions ?? []) {
       if (!d.value) continue
+      // Une adresse privee ou de bouclage ne designe aucun visiteur, et la
+      // contrainte CHECK de la table la refuserait — ce qui ferait ECHOUER tout
+      // le tour de collecte. On l'ecarte ici, en le signalant.
+      if (nonPublique(d.value)) {
+        console.error(`[collecteur] decision ignoree, adresse non publique : ${d.value}`)
+        continue
+      }
       const ref = `crowdsec:decision:${d.id}`
       // `enforcement_plane` : sans bouncer, RIEN n'est applique. On l'ecrit donc
       // `none`, et `enforced_at` reste NULL. C'est ce qui empechera Olympus
@@ -133,8 +173,8 @@ async function ingererDecisions(client) {
           d.value,
           (d.type ?? 'ban').toLowerCase() === 'ban' ? 'ban' : 'watch',
           d.scenario ?? 'crowdsec',
-          null,
-          null,
+          dureeEnSecondes(d.duration),
+          expiration(d.duration),
           ref,
           JSON.stringify({ scenario: d.scenario, origin: d.origin, duration: d.duration }),
         ],

--- a/scripts/ops/security/crowdsec-acquis-nodyx-core.yaml
+++ b/scripts/ops/security/crowdsec-acquis-nodyx-core.yaml
@@ -1,0 +1,14 @@
+# ─── Journaux du coeur Nodyx ──────────────────────────────────────────────────
+#
+# Ces lignes portent la VRAIE adresse du visiteur depuis #588. Avant, le
+# serialiseur de Fastify ecrivait `socket.remoteAddress`, soit 127.0.0.1 derriere
+# Cloudflare : brancher CrowdSec dessus n'aurait banni personne.
+#
+# On lit le flux de sortie de PM2 plutot que les fichiers /var/log/nodyx-*.log :
+# ceux-ci sont en root:root alors que le coeur tourne en `nodyx`, et les erreurs
+# d'ecriture y sont avalees. La jail fail2ban du pot de miel est aveugle depuis
+# le 29 mars pour cette raison exacte.
+filenames:
+  - /home/nodyx/.pm2/logs/nodyx-core-out.log
+labels:
+  type: nodyx-core

--- a/scripts/ops/security/crowdsec-parser-nodyx-core.yaml
+++ b/scripts/ops/security/crowdsec-parser-nodyx-core.yaml
@@ -1,0 +1,28 @@
+onsuccess: next_stage
+name: nodyx/core-logs
+description: "Analyse le journal d'acces du coeur Nodyx (une ligne par requete)"
+filter: "evt.Line.Labels.type == 'nodyx-core' && evt.Line.Raw startsWith '{'"
+nodes:
+  # UNE ligne par requete depuis le journal d'acces dedie : adresse, chemin,
+  # statut et duree ensemble. Avant, Fastify en emettait deux — l'une avec
+  # l'URL sans le statut, l'autre l'inverse — et aucune n'etait exploitable.
+  - filter: "JsonExtract(evt.Line.Raw, 'msg') == 'access'"
+    statics:
+      - meta: log_type
+        value: http_access
+      - meta: service
+        value: nodyx-core
+      # `ip` est la VRAIE adresse du visiteur. Surtout pas `peer`, le proxy local.
+      - meta: source_ip
+        expression: JsonExtract(evt.Line.Raw, "ip")
+      - meta: http_path
+        expression: JsonExtract(evt.Line.Raw, "url")
+      - meta: http_verb
+        expression: JsonExtract(evt.Line.Raw, "method")
+      - meta: http_status
+        expression: JsonExtract(evt.Line.Raw, "status")
+      - meta: http_user_agent
+        expression: JsonExtract(evt.Line.Raw, "ua")
+      # Presence conjointe d'en-tetes d'usurpation : empreinte d'outillage.
+      - meta: nodyx_spoof
+        expression: JsonExtract(evt.Line.Raw, "usurpation")

--- a/scripts/ops/security/crowdsec-scenario-sensitive-paths.yaml
+++ b/scripts/ops/security/crowdsec-scenario-sensitive-paths.yaml
@@ -1,0 +1,24 @@
+type: leaky
+name: nodyx/sensitive-paths
+description: "Sondage de chemins sensibles sur une instance Nodyx"
+# TOUTE requete sur /api/v1/_hp est un sondage, par construction : le pot de miel
+# n'est atteint que depuis un chemin-leurre (/wp-login.php, /.env, /xmlrpc.php...).
+# Le vrai chemin voyage dans `?p=`, encode. Filtrer sur l'ENDPOINT plutot que sur
+# le parametre decode est plus simple et ne peut pas rater un encodage exotique.
+#
+# On exclut le loopback : le rendu serveur appelle le coeur en interne, et une
+# de ces lignes portait bien `ip=127.0.0.1`. Sans cette exclusion, l'instance se
+# bannirait elle-meme.
+filter: |
+  evt.Meta.log_type == 'http_access' &&
+  evt.Meta.http_path startsWith '/api/v1/_hp' &&
+  evt.Meta.source_ip != '127.0.0.1' &&
+  evt.Meta.source_ip != '::1'
+groupby: evt.Meta.source_ip
+capacity: 3
+leakspeed: 5m
+blackhole: 5m
+labels:
+  service: nodyx
+  type: scan
+  remediation: true

--- a/scripts/ops/security/goaccess/nodyx-goaccess-rapport.sh
+++ b/scripts/ops/security/goaccess/nodyx-goaccess-rapport.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Regenere le rapport GoAccess a partir du journal d'acces du coeur.
+#
+# Pourquoi pas le mode --real-time-html de GoAccess : il ouvre un serveur
+# WebSocket sur un port dedie, qu'il faudrait proxifier dans Caddy. Or la
+# configuration Caddy vivante de cette machine vient de `autosave.json`, et un
+# rechargement fait tomber le HTTPS de nodyx.org (cf CLAUDE.md). Une
+# regeneration periodique donne 95 % du benefice pour 0 % du risque.
+set -euo pipefail
+
+JOURNAL=/home/nodyx/.pm2/logs/nodyx-core-out.log
+SORTIE=/var/lib/nodyx-goaccess/rapport.html
+TAMPON=$(mktemp /tmp/goaccess-acces.XXXXXX)
+trap 'rm -f "$TAMPON"' EXIT
+
+# On ne garde que les lignes d'acces au format attendu. Les autres lignes du
+# journal (demarrage, erreurs applicatives) ne sont pas des requetes.
+grep '"msg":"access"' "$JOURNAL" 2>/dev/null | grep '"log_date"' > "$TAMPON" || true
+
+if [ ! -s "$TAMPON" ]; then
+  echo "aucune ligne d'acces exploitable, rapport inchange"
+  exit 0
+fi
+
+TMP_HTML="${SORTIE%.html}.tmp.html"
+goaccess "$TAMPON" -p /etc/goaccess/nodyx.conf -o "$TMP_HTML"
+# Remplacement atomique : le hub ne doit jamais lire un fichier a moitie ecrit.
+mv -f "$TMP_HTML" "$SORTIE"
+# Le hub tourne en `nodyx` et doit pouvoir le lire.
+chown root:nodyx "$SORTIE"
+chmod 640 "$SORTIE"
+echo "rapport regenere : $(wc -l < "$TAMPON") requetes, $(wc -c < "$SORTIE") octets"

--- a/scripts/ops/security/goaccess/nodyx-goaccess.service
+++ b/scripts/ops/security/goaccess/nodyx-goaccess.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Nodyx — rapport GoAccess du trafic web
+Documentation=file:///var/www/nexus/SPECS/OLYMPUS_OBSERVABILITE_CDC.md
+After=network.target
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/usr/local/bin/nodyx-goaccess-rapport.sh
+TimeoutStartSec=180
+Nice=10
+# Le rapport contient les adresses des visiteurs : il vit dans un repertoire
+# lisible par le seul groupe `nodyx`, et le hub le servira derriere son
+# authentification. Jamais expose publiquement.
+ReadWritePaths=/var/lib/nodyx-goaccess
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=yes
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/ops/security/goaccess/nodyx-goaccess.timer
+++ b/scripts/ops/security/goaccess/nodyx-goaccess.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Nodyx — regeneration du rapport GoAccess toutes les minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1min
+# Une minute : assez frais pour suivre une attaque en cours, assez espace pour
+# que la generation (qui relit tout le journal) ne pese pas. Le mode temps reel
+# natif de GoAccess exigerait un WebSocket proxifie par Caddy, dont la
+# configuration vivante ne doit pas etre rechargee.
+AccuracySec=10s
+
+[Install]
+WantedBy=timers.target

--- a/scripts/ops/security/goaccess/nodyx.conf
+++ b/scripts/ops/security/goaccess/nodyx.conf
@@ -1,0 +1,18 @@
+# ─── GoAccess pour Nodyx ──────────────────────────────────────────────────────
+#
+# Lit le journal d'acces du coeur, une ligne JSON par requete (cf #588 et le
+# journal d'acces a ligne unique). L'adresse est la VRAIE adresse du visiteur :
+# `ip`, jamais `peer` qui est le proxy local.
+#
+# Le rapport est ecrit dans un fichier que le hub servira derriere son
+# authentification. Il ne doit JAMAIS etre expose publiquement : il contient les
+# adresses des visiteurs.
+
+log-format {"log_date":"%d","log_time":"%t","ip":"%h","method":"%m","url":"%U","status":"%s","ua":"%u"}
+date-format %Y-%m-%d
+time-format %H:%M:%S
+
+# Ne pas resoudre les noms : ca ralentit et ca fuite vers un resolveur.
+no-ip-validation false
+agent-list true
+real-os true


### PR DESCRIPTION
Demande : un tableau de bord temps réel façon GoAccess dans Olympus.

## L'obstacle, le même que pour CrowdSec

Fastify journalisait **deux lignes** par requête : l'une portait l'adresse et l'URL, l'autre le code de statut. Aucune n'était exploitable seule — et le volume doublait pour rien (17 Mo en une journée).

On émet désormais une ligne unique à la réponse. **Mesure après bascule : 100 % des lignes analysées par CrowdSec, contre 50 % avant.**

```
ip 2a01:4f8:1c19:a30c::1 | peer 127.0.0.1 | GET /api/v1/_hp?p=... | 200 | 4124ms
```

`ip` et `peer` restent deux champs : vérité applicative et vérité réseau ne se fusionnent pas.

## Quatre corrections au collecteur, toutes signalées en relecture

1. **La sévérité** tenait au seul volume — un bruteforce à 3 tentatives était « low », un scan bruyant à 50 requêtes « critical ». Elle tient désormais d'abord à la **nature** du scénario. Vérifié : `nodyx/sensitive-paths` passe de « low » à « medium ».
2. **`duration_seconds` et `expires_at`** restaient NULL alors que les colonnes existent. Vérifié : 4h → 14399 s, expiration renseignée.
3. **Une adresse privée violait la contrainte `CHECK`** et aurait fait échouer tout le tour de collecte. Écartée en amont, avec un message — jamais avalée en silence.
4. **`origin`** reste dans `metadata` : documenté comme choix.

## Sur le temps réel

Le mode natif de GoAccess ouvre un serveur WebSocket qu'il faudrait proxifier dans Caddy. La configuration vivante venant de `autosave.json`, un rechargement ferait tomber le HTTPS. On régénère donc le rapport périodiquement : 95 % du bénéfice, 0 % du risque.

## Vérifié

Démarrage réel confirmé après build — l'ordre des `require` dans le compilé a été contrôlé, leçon de #589. 888 tests verts, nodyx.org à 200.