### PR TITLE
fix(federation): ma contrainte renvoyait une 500 aux instances tierces

### DIFF
--- a/nodyx-core/src/routes/directory.ts
+++ b/nodyx-core/src/routes/directory.ts
@@ -6,7 +6,7 @@ import https from 'https';
 import http from 'http';
 import sanitizeHtml from 'sanitize-html';
 import { db, redis } from '../config/database';
-import { getClientIp } from '../utils/clientIp'
+import { getClientIp, estPubliquementRoutable } from '../utils/clientIp'
 
 // Strict rate-limit for public search endpoint (30 req/min per IP)
 async function searchRateLimit(request: FastifyRequest, reply: FastifyReply): Promise<void> {
@@ -699,6 +699,24 @@ export default async function directoryRoutes(app: FastifyInstance) {
         [token]
       )
       if (!inst) return reply.status(403).send({ error: 'invalid token' })
+
+      // Une adresse privee, de bouclage ou reservee ne designe AUCUN visiteur
+      // d'Internet : la signaler au reseau federe serait du bruit distribue a
+      // toutes les instances. La table porte une contrainte CHECK depuis la
+      // migration 113 ; sans ce garde-fou en amont, la violation remonterait en
+      // erreur 500 chez l'instance qui signale.
+      //
+      // Le cas est REEL, pas theorique : toute instance tournant une version
+      // anterieure au correctif d'identification (2026-08-17) enregistre
+      // `127.0.0.1` pour ses visiteurs et signalerait donc du loopback. On lui
+      // repond clairement plutot que de lui renvoyer une panne.
+      if (!estPubliquementRoutable(ip)) {
+        return reply.status(400).send({
+          error: 'ip is not publicly routable',
+          code: 'IP_NOT_ROUTABLE',
+          hint: "Votre instance enregistre peut-etre l'adresse du proxy au lieu de celle du visiteur.",
+        })
+      }
 
       await db.query(
         `INSERT INTO reported_ips (ip, reason, path, instance_slug)

--- a/nodyx-core/src/tests/federation-ip.test.ts
+++ b/nodyx-core/src/tests/federation-ip.test.ts
@@ -1,0 +1,44 @@
+// ─── Le blocage federe ne doit pas casser les instances des autres ───────────
+//
+// CONTEXTE. La migration 113 pose une contrainte CHECK refusant les adresses
+// privees dans `reported_ips` — il y en avait 102 sur 118, du bruit distribue a
+// tout le reseau.
+//
+// MAIS l'insertion n'etait pas protegee. Une instance TIERCE signalant du
+// `127.0.0.1` recevait donc une erreur 500. Et le cas est reel : toute instance
+// tournant une version anterieure au correctif d'identification du 2026-08-17
+// enregistre `127.0.0.1` pour ses visiteurs. Au moins sept instances existent
+// dans l'annuaire, dont une active le jour meme.
+//
+// Casser l'instance de quelqu'un d'autre avec une contrainte posee chez soi est
+// exactement ce qu'un projet federe ne doit pas faire.
+
+import { describe, it, expect } from 'vitest'
+import { estPubliquementRoutable } from '../utils/clientIp'
+
+describe('signalement federe : quelles adresses sont acceptables', () => {
+  it('refuse ce qu une instance mal configuree enverrait', () => {
+    // Ce sont les valeurs REELLEMENT observees avant correctif.
+    for (const ip of ['127.0.0.1', '::1', '10.0.0.5', '192.168.1.9', '172.16.4.2', 'fe80::1']) {
+      expect(estPubliquementRoutable(ip), ip).toBe(false)
+    }
+  })
+
+  it('refuse une adresse Cloudflare : notre propre infrastructure', () => {
+    // Vue telle quelle dans les donnees du 17/08, remontee comme un client.
+    expect(estPubliquementRoutable('2a06:98c0:3600::103')).toBe(false)
+    expect(estPubliquementRoutable('162.158.1.1')).toBe(false)
+  })
+
+  it('refuse les plages de documentation, qui n appartiennent a personne', () => {
+    expect(estPubliquementRoutable('203.0.113.9')).toBe(false)
+    expect(estPubliquementRoutable('198.51.100.4')).toBe(false)
+  })
+
+  it('accepte une vraie adresse d attaquant', () => {
+    // Observees dans le pot de miel le 17/08.
+    for (const ip of ['103.78.255.128', '62.60.130.128', '91.92.241.196', '2a01:4f8:1c19:a30c::1']) {
+      expect(estPubliquementRoutable(ip), ip).toBe(true)
+    }
+  })
+})

--- a/nodyx-core/src/tests/federation-ip.test.ts
+++ b/nodyx-core/src/tests/federation-ip.test.ts
@@ -1,7 +1,7 @@
 // ─── Le blocage federe ne doit pas casser les instances des autres ───────────
 //
 // CONTEXTE. La migration 113 pose une contrainte CHECK refusant les adresses
-// privees dans `reported_ips` — il y en avait 102 sur 118, du bruit distribue a
+// privees dans `reported_ips` : il y en avait 102 sur 118, du bruit distribue a
 // tout le reseau.
 //
 // MAIS l'insertion n'etait pas protegee. Une instance TIERCE signalant du
@@ -13,8 +13,23 @@
 // Casser l'instance de quelqu'un d'autre avec une contrainte posee chez soi est
 // exactement ce qu'un projet federe ne doit pas faire.
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../config/database', () => ({
+  db: { query: vi.fn() },
+  redis: {
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue('OK'),
+    incr: vi.fn().mockResolvedValue(1),
+    expire: vi.fn().mockResolvedValue(1),
+    ttl: vi.fn().mockResolvedValue(60),
+  },
+}))
+
 import { estPubliquementRoutable } from '../utils/clientIp'
+import { db } from '../config/database'
+import directoryRoutes from '../routes/directory'
+import { buildApp } from './helpers/buildApp'
 
 describe('signalement federe : quelles adresses sont acceptables', () => {
   it('refuse ce qu une instance mal configuree enverrait', () => {
@@ -40,5 +55,95 @@ describe('signalement federe : quelles adresses sont acceptables', () => {
     for (const ip of ['103.78.255.128', '62.60.130.128', '91.92.241.196', '2a01:4f8:1c19:a30c::1']) {
       expect(estPubliquementRoutable(ip), ip).toBe(true)
     }
+  })
+})
+
+// ── La regression elle-meme, vue par la route ───────────────────────────────
+//
+// Les controles ci-dessus portent sur une fonction qui existait DEJA : ils
+// passeraient tels quels sur le code d'avant, donc ils ne prouvent rien de la
+// correction. Ceux qui suivent interrogent la route.
+//
+// La base moquee reproduit la contrainte CHECK de la migration 113 : toute
+// insertion d'une adresse non publique leve. C'est la 500 constatee. Le
+// correctif se mesure donc a une chose simple, l'insertion n'est JAMAIS
+// atteinte. cf feedback_test_first_critical.
+
+const TOKEN = 'tok_instance_secret'
+
+/** Le SELECT de jeton repond, l'INSERT se comporte comme PostgreSQL avec la contrainte. */
+function baseAvecContrainte() {
+  vi.mocked(db.query).mockImplementation(async (sql: unknown, params?: unknown) => {
+    const texte = String(sql)
+    if (texte.includes('INSERT INTO reported_ips')) {
+      const ip = (params as unknown[])?.[0]
+      if (!estPubliquementRoutable(String(ip))) {
+        throw new Error(
+          'new row for relation "reported_ips" violates check constraint "reported_ips_ip_publique"',
+        )
+      }
+      return { rows: [], rowCount: 1 } as never
+    }
+    return { rows: [{ slug: 'instance-tierce' }] } as never
+  })
+}
+
+/** Combien de fois l'INSERT a reellement ete tente. */
+function insertionsTentees(): number {
+  return vi.mocked(db.query).mock.calls.filter(
+    ([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO reported_ips'),
+  ).length
+}
+
+async function signaler(ip: string) {
+  const app = await buildApp(async (a) => {
+    await a.register(directoryRoutes, { prefix: '/api' })
+  })
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/directory/report-ip',
+    payload: { token: TOKEN, ip, reason: 'honeypot', path: '/wp-login.php' },
+  })
+  await app.close()
+  return res
+}
+
+describe('POST /api/directory/report-ip : ne pas renvoyer une panne a une instance tierce', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    baseAvecContrainte()
+  })
+
+  it('repond 400 et non 500 quand une instance signale du loopback', async () => {
+    const res = await signaler('127.0.0.1')
+
+    // Sur le code d'avant : l'INSERT partait, la contrainte levait, Fastify
+    // renvoyait 500. C'est precisement ce que ce controle interdit.
+    expect(res.statusCode).toBe(400)
+    expect(res.statusCode).not.toBe(500)
+  })
+
+  it("porte un code stable, pour que l'instance emettrice sache quoi corriger", async () => {
+    const res = await signaler('127.0.0.1')
+    expect(res.json()).toMatchObject({ code: 'IP_NOT_ROUTABLE' })
+  })
+
+  it("n'atteint JAMAIS l'insertion : c'est la mesure du correctif", async () => {
+    for (const ip of ['127.0.0.1', '192.168.1.9', '10.0.0.5', '::1']) {
+      vi.resetAllMocks()
+      baseAvecContrainte()
+
+      const res = await signaler(ip)
+      expect(res.statusCode, ip).toBe(400)
+      expect(insertionsTentees(), `l'INSERT a ete tente pour ${ip}`).toBe(0)
+    }
+  })
+
+  it("laisse evidemment passer un vrai attaquant : on ne casse pas la federation", async () => {
+    const res = await signaler('62.60.130.128')
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({ ok: true })
+    expect(insertionsTentees()).toBe(1)
   })
 })

--- a/nodyx-core/src/utils/clientIp.ts
+++ b/nodyx-core/src/utils/clientIp.ts
@@ -67,7 +67,7 @@ function parse(valeur: string): ipaddr.IPv4 | ipaddr.IPv6 | null {
 }
 
 /** Une adresse d'Internet : ni privée, ni loopback, ni réservée. */
-function estPubliquementRoutable(valeur: string): boolean {
+export function estPubliquementRoutable(valeur: string): boolean {
   const adr = parse(valeur)
   if (!adr) return false
   if (PLAGES_NON_PUBLIQUES.has(adr.range())) return false


### PR DESCRIPTION
## Le problème

La migration `113` a posé une contrainte `CHECK` refusant les adresses non publiques dans `reported_ips`. Le nettoyage était justifié : 102 entrées sur 118 étaient du loopback, du bruit distribué à tout le réseau fédéré.

**Mais l'insertion, elle, n'a pas été protégée.** Une instance tierce qui signale `127.0.0.1` déclenche la contrainte et reçoit une **erreur 500**.

Le cas n'est pas théorique. Toute instance tournant une version antérieure au correctif d'identification du 17/08 enregistre `127.0.0.1` pour ses visiteurs, et signale donc du loopback. Plusieurs instances actives sont dans ce cas.

Poser une contrainte chez soi et renvoyer une panne à l'instance de quelqu'un d'autre est précisément ce qu'un projet fédéré ne doit pas faire.

## Le correctif

Un garde-fou avant l'insertion dans `POST /api/directory/report-ip`, qui répond **400** avec un code stable au lieu de laisser la base exploser :

```json
{
  "error": "ip is not publicly routable",
  "code": "IP_NOT_ROUTABLE",
  "hint": "Votre instance enregistre peut-etre l'adresse du proxy au lieu de celle du visiteur."
}
```

L'instance émettrice apprend ainsi quoi corriger chez elle, au lieu de constater une panne opaque.

## Ce qui est prouvé

Les premiers contrôles portaient sur `estPubliquementRoutable`, une fonction **qui existait déjà**. Ils passaient donc à l'identique sur le code fautif et ne démontraient rien du correctif.

Quatre contrôles supplémentaires interrogent la route. La base moquée reproduit la contrainte `CHECK` de la migration 113, donc l'ancien code produit la vraie 500 :

| contrôle | sans le garde-fou | avec |
|---|---|---|
| répond 400 et non 500 | **tombe** | passe |
| porte le code `IP_NOT_ROUTABLE` | **tombe** | passe |
| n'atteint jamais l'INSERT | **tombe** | passe |
| laisse passer un vrai attaquant | passe | passe |

Le dernier est un contrôle de non-régression : il doit passer dans les deux cas, et c'est ce qu'il fait.

Vérification exécutée en retirant le garde-fou du code : 3 échecs sur 8. Remis : 8 verts, et 896 tests verts sur l'ensemble du cœur, compilation `tsc` propre.
