### PR TITLE
fix(i18n): notre guide demandait une Issue que le depot interdisait d'ouvrir

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_language.yml
+++ b/.github/ISSUE_TEMPLATE/new_language.yml
@@ -1,0 +1,74 @@
+name: New Language
+description: Ask for a language to be added to Nodyx, or say you are translating one
+title: "[i18n]: "
+labels: ["i18n", "good first issue"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for wanting to translate Nodyx.
+
+        **You may not need this form at all.** If your language is already listed on
+        [nodyx.org/translate](https://nodyx.org/translate), just open a Pull Request on its file.
+        No issue, no permission needed.
+
+        This form is for a language that is **not in the list yet**. Adding one means wiring it
+        into the language picker, which is a code change we make on our side, so we need to know
+        it is coming.
+
+  - type: input
+    id: language
+    attributes:
+      label: Language
+      description: The name in English, and the name as your language writes it
+      placeholder: "Brazilian Portuguese / Português (Brasil)"
+    validations:
+      required: true
+
+  - type: input
+    id: code
+    attributes:
+      label: Language code
+      description: >
+        The BCP 47 code. Use the regional form only when the language genuinely differs
+        by region, like pt-BR against pt-PT.
+      placeholder: "pt-BR"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: What are you planning to translate?
+      description: Every answer is welcome. Partial work ships, missing strings fall back to English.
+      options:
+        - The interface (one JSON file)
+        - The documentation (docs/)
+        - Both
+        - I am only requesting the language, someone else may translate it
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything we should know
+      description: >
+        Optional. Regional conventions, an existing translation you want to build on,
+        a term you would rather keep in English, or a question.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ### What happens next
+
+        1. We add your language to the picker and create the empty file
+        2. You translate at your own pace and open a Pull Request
+        3. Continuous integration checks that no `{{variable}}` was altered, so you cannot
+           break the app by translating
+        4. Your work ships in the next release, and you get a place in `CONTRIBUTORS.md`
+
+        The full process, including the translation rules, is in
+        [CONTRIBUTING.md](https://github.com/Pokled/nodyx/blob/main/docs/en/CONTRIBUTING.md#translating-nodyx).

--- a/docs/en/CONTRIBUTING.md
+++ b/docs/en/CONTRIBUTING.md
@@ -132,7 +132,7 @@ nodyx-frontend/src/lib/locales/
 
 Continuous integration checks that no variable was altered, so you cannot break the app by translating. We review, we merge, your work ships in the next release.
 
-Your language is not in the list? Copy `en.json`, name it with your language code, and open an Issue so we can wire it into the language picker.
+Your language is not in the list? Open a [New Language issue](https://github.com/Pokled/nodyx/issues/new?template=new_language.yml) and we wire it into the language picker for you. Adding a language is a code change on our side, so a dropped file alone would not show up.
 
 ### The documentation
 1. Go to `docs/`

--- a/docs/es/CONTRIBUTING.md
+++ b/docs/es/CONTRIBUTING.md
@@ -132,7 +132,7 @@ nodyx-frontend/src/lib/locales/
 
 La integración continua comprueba que ninguna variable se haya alterado, así que traducir no puede romper la aplicación. Nosotros revisamos, fusionamos, y tu trabajo sale en la siguiente versión.
 
-¿Tu idioma no está en la lista? Copia `en.json`, nómbralo con el código de tu idioma, y abre una Issue para que lo conectemos al selector de idiomas.
+¿Tu idioma no está en la lista? Abre una [Issue «New Language»](https://github.com/Pokled/nodyx/issues/new?template=new_language.yml) y lo conectamos al selector por ti. Añadir un idioma requiere un cambio de código por nuestra parte: un archivo simplemente depositado no aparecería.
 
 ### La documentación
 1. Ve a `docs/`

--- a/docs/fr/CONTRIBUTING.md
+++ b/docs/fr/CONTRIBUTING.md
@@ -129,7 +129,7 @@ nodyx-frontend/src/lib/locales/
 
 L'intégration continue vérifie qu'aucune variable n'a bougé : tu ne peux pas casser l'application en traduisant. On relit, on fusionne, ton travail part dans la version suivante.
 
-Ta langue n'est pas dans la liste ? Copie `en.json`, nomme-le avec ton code langue, et ouvre une Issue pour qu'on le branche dans le sélecteur de langue.
+Ta langue n'est pas dans la liste ? Ouvre une [Issue « New Language »](https://github.com/Pokled/nodyx/issues/new?template=new_language.yml) et on la branche dans le sélecteur pour toi. Ajouter une langue demande une modification de code chez nous : un fichier simplement déposé n'apparaîtrait pas.
 
 ### La documentation
 1. Va dans `docs/`


### PR DESCRIPTION
## Le problème

Signalé dans la [discussion #595](https://github.com/Pokled/nodyx/discussions/595) par un traducteur qui voulait apporter le portugais brésilien.

Notre guide de contribution dit, mot pour mot :

> Your language is not in the list? Copy `en.json`, name it with your language code, **and open an Issue** so we can wire it into the language picker.

Or `.github/ISSUE_TEMPLATE/config.yml` porte `blank_issues_enabled: false`, et seuls `bug_report.yml` et `feature_request.yml` existaient.

**La seule action que la documentation prescrivait était techniquement impossible.** La personne a fait exactement ce qu'on lui demandait, et s'est retrouvée bloquée. C'est le scénario où un contributeur se croit incompétent alors que l'erreur est chez nous.

## Le correctif

Un gabarit `new_language.yml`, **court à dessein** : quatre champs, dont un facultatif. Un formulaire long décourage précisément le profil de contributeur qu'on cherche ici, quelqu'un qui n'écrit pas de code.

Il dit aussi en tête qu'il n'est **pas** nécessaire dans le cas courant : si la langue figure déjà sur [nodyx.org/translate](https://nodyx.org/translate), une Pull Request suffit, sans permission ni issue.

Les trois guides (`en`, `fr`, `es`) pointent maintenant directement sur le gabarit.

## Une imprécision corrigée au passage

Le guide laissait entendre que copier `en.json` sous un nouveau nom suffisait. C'est faux, et c'est vérifié : le câblage d'une langue est codé en dur à **quatre endroits** dans `nodyx-frontend/src/lib/i18n.ts`.

- le type `Locale`
- le tableau `LOCALES`
- les imports statiques
- la table `messages`

Un fichier simplement déposé n'apparaîtrait donc jamais dans le sélecteur. Le texte le dit désormais, pour que personne ne traduise 4540 chaînes avant de le découvrir.

## Vérification

Les quatre gabarits passent une validation YAML, avec contrôle des contraintes propres au format GitHub : types de blocs autorisés, `id` et `label` obligatoires hors markdown, `dropdown` non vide.

Aucun code applicatif n'est touché, donc aucune incidence sur les quatre portes i18n.
