### PR TITLE
feat(relais): ecoute double-pile et connexion cliente bornee par adresse

### DIFF
--- a/nodyx-p2p/crates/nexus-relay/src/client/mod.rs
+++ b/nodyx-p2p/crates/nexus-relay/src/client/mod.rs
@@ -1,12 +1,64 @@
 mod forwarder;
 
 use std::time::Duration;
-use tokio::net::TcpStream;
+use tokio::net::{TcpStream, lookup_host};
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
 use crate::keepalive::{self, READ_DEADLINE};
 use crate::protocol::{ClientMessage, ServerMessage, read_msg, write_msg};
+
+/// How long one address gets before we move to the next one.
+///
+/// `TcpStream::connect("host:port")` resolves to several addresses and tries them
+/// inside a SINGLE future, with no per-address bound. On a host whose IPv6 is
+/// configured but has no route, the AAAA attempt is blackholed and that one future
+/// stalls for the kernel's TCP timeout, roughly two minutes, before IPv4 is ever
+/// tried. The reconnect loop then collapses.
+///
+/// That failure mode only appeared once `relay.nodyx.org` gained an AAAA record,
+/// so the timeout ships WITH it, not after.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// Connect to the first address that answers, giving each one a bounded attempt.
+///
+/// Resolution order is the resolver's (glibc already applies RFC 6724, so a host
+/// without a global IPv6 address is not offered AAAA at all). We simply refuse to
+/// let any single address hold the whole reconnect loop hostage.
+async fn connect_any(server_addr: &str) -> std::io::Result<TcpStream> {
+    let addrs: Vec<_> = lookup_host(server_addr).await?.collect();
+    if addrs.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::AddrNotAvailable,
+            format!("{server_addr} resolved to no address"),
+        ));
+    }
+
+    let mut last: Option<std::io::Error> = None;
+    for addr in &addrs {
+        match tokio::time::timeout(CONNECT_TIMEOUT, TcpStream::connect(addr)).await {
+            Ok(Ok(stream)) => {
+                info!("Connected via {addr}");
+                return Ok(stream);
+            }
+            Ok(Err(e)) => {
+                warn!("{addr} refused the connection: {e}");
+                last = Some(e);
+            }
+            Err(_) => {
+                warn!("{addr} did not answer within {}s, trying the next address", CONNECT_TIMEOUT.as_secs());
+                last = Some(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("{addr} timed out"),
+                ));
+            }
+        }
+    }
+
+    Err(last.unwrap_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::AddrNotAvailable, "no address reachable")
+    }))
+}
 
 // ── Entry point with reconnect loop ──────────────────────────────────────────
 
@@ -26,7 +78,7 @@ pub async fn run(
 
     loop {
         info!("Connecting to relay server {server_addr}...");
-        match TcpStream::connect(server_addr).await {
+        match connect_any(server_addr).await {
             Ok(stream) => {
                 if let Err(e) = keepalive::enable(&stream) {
                     warn!("Failed to enable TCP keepalive: {e}");
@@ -154,4 +206,54 @@ async fn handle_session(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod connect_tests {
+    use super::{CONNECT_TIMEOUT, connect_any};
+    use tokio::net::TcpListener;
+
+    /// The reason `connect_any` exists. `localhost` resolves to `::1` first and
+    /// `127.0.0.1` second on this platform. With a listener bound ONLY on IPv4,
+    /// reaching it proves the first address was tried, rejected, and the second
+    /// one used, instead of the whole attempt dying on the first family.
+    ///
+    /// This is the shape of the failure an AAAA record on `relay.nodyx.org`
+    /// introduces for the 24 deployed instances.
+    #[tokio::test]
+    async fn falls_through_to_the_address_that_answers() {
+        let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = l.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let _ = l.accept().await;
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        });
+
+        let s = connect_any(&format!("localhost:{port}"))
+            .await
+            .expect("no address answered, the fallback did not happen");
+        assert_eq!(s.peer_addr().unwrap().port(), port);
+    }
+
+    #[tokio::test]
+    async fn reports_a_name_that_resolves_to_nothing_usable() {
+        // A port nobody listens on: every address refuses, and the error surfaces
+        // instead of the loop hanging.
+        let err = connect_any("localhost:1").await.unwrap_err();
+        assert!(
+            !format!("{err}").is_empty(),
+            "the failure must carry a reason for the operator"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_per_address_bound_is_short_enough_to_retry() {
+        // A two minute kernel timeout is what made the reconnect loop collapse.
+        // Anything above ~15s defeats the purpose of the loop's own backoff.
+        assert!(
+            CONNECT_TIMEOUT.as_secs() <= 15 && CONNECT_TIMEOUT.as_secs() >= 3,
+            "unreasonable per-address timeout: {:?}",
+            CONNECT_TIMEOUT
+        );
+    }
 }

--- a/nodyx-p2p/crates/nexus-relay/src/main.rs
+++ b/nodyx-p2p/crates/nexus-relay/src/main.rs
@@ -28,6 +28,21 @@ enum Commands {
         #[arg(long, default_value = "7443")]
         tcp_port: u16,
 
+        /// Address the relay listens on for client connections.
+        ///
+        /// Defaults to `[::]`, which on Linux accepts BOTH IPv6 and IPv4 as long
+        /// as `net.ipv6.bindv6only` is 0 (the kernel default, and not overridden
+        /// anywhere in /etc/sysctl.d on the production VPS). Before this default,
+        /// the relay bound `0.0.0.0` and was unreachable from an IPv6-only
+        /// network.
+        ///
+        /// Kept configurable on purpose: if a host ever sets `bindv6only=1`, a
+        /// `[::]` socket silently stops accepting IPv4, which would strand every
+        /// existing instance. Setting `--tcp-bind 0.0.0.0` restores the old
+        /// behaviour without rebuilding.
+        #[arg(long, env = "RELAY_TCP_BIND", default_value = "[::]")]
+        tcp_bind: String,
+
         /// HTTP port for Caddy reverse proxy.
         #[arg(long, default_value = "7001")]
         http_port: u16,
@@ -82,11 +97,12 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Commands::Server {
             tcp_port,
+            tcp_bind,
             http_port,
             database_url,
             main_slug,
         } => {
-            server::run(tcp_port, http_port, &database_url, &main_slug).await?;
+            server::run(&tcp_bind, tcp_port, http_port, &database_url, &main_slug).await?;
         }
 
         Commands::Client {

--- a/nodyx-p2p/crates/nexus-relay/src/server/mod.rs
+++ b/nodyx-p2p/crates/nexus-relay/src/server/mod.rs
@@ -9,9 +9,23 @@ use tracing::info;
 use db::DbPool;
 use registry::Registry;
 
-pub async fn run(tcp_port: u16, http_port: u16, database_url: &str, main_slug: &str) -> anyhow::Result<()> {
+/// Build the listen address from a host and a port.
+///
+/// An IPv6 literal must stay bracketed so that `[::]` + `7443` yields
+/// `[::]:7443` and not `:::7443`, which no parser accepts.
+pub fn listen_addr(host: &str, port: u16) -> String {
+    format!("{host}:{port}")
+}
+
+pub async fn run(
+    tcp_bind_host: &str,
+    tcp_port: u16,
+    http_port: u16,
+    database_url: &str,
+    main_slug: &str,
+) -> anyhow::Result<()> {
     info!("Starting nodyx-relay server");
-    info!("  TCP relay port  : {tcp_port}");
+    info!("  TCP relay bind  : {tcp_bind_host}:{tcp_port}");
     info!("  HTTP proxy port : {http_port}");
     info!("  Main slug       : {main_slug}");
 
@@ -20,7 +34,7 @@ pub async fn run(tcp_port: u16, http_port: u16, database_url: &str, main_slug: &
 
     let registry = Registry::new();
 
-    let tcp_bind  = format!("0.0.0.0:{tcp_port}");
+    let tcp_bind  = listen_addr(tcp_bind_host, tcp_port);
     let http_bind = format!("127.0.0.1:{http_port}");
     let main_slug = main_slug.to_owned();
 
@@ -30,4 +44,64 @@ pub async fn run(tcp_port: u16, http_port: u16, database_url: &str, main_slug: &
     )?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::listen_addr;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+
+    #[test]
+    fn ipv6_literal_stays_bracketed() {
+        // `:::7443` is what a naive concatenation produces, and nothing parses it.
+        assert_eq!(listen_addr("[::]", 7443), "[::]:7443");
+        assert_eq!(listen_addr("0.0.0.0", 7443), "0.0.0.0:7443");
+    }
+
+    #[tokio::test]
+    async fn both_addresses_parse_and_bind() {
+        for host in ["[::]", "0.0.0.0"] {
+            let addr = listen_addr(host, 0);
+            let l = TcpListener::bind(&addr)
+                .await
+                .unwrap_or_else(|e| panic!("bind {addr} failed: {e}"));
+            assert!(l.local_addr().is_ok(), "no local address for {addr}");
+        }
+    }
+
+    /// THE point of the change: a relay bound on `[::]` must still serve the 24
+    /// existing instances, which all connect over IPv4. Before it, the relay bound
+    /// `0.0.0.0` and an IPv6-only network could not reach it at all.
+    ///
+    /// This test fails on a host where `net.ipv6.bindv6only` is 1, which is exactly
+    /// the condition that would silently strand every IPv4 instance. Failing loudly
+    /// here is the whole point.
+    #[tokio::test]
+    async fn ipv4_client_reaches_a_dual_stack_listener() {
+        let listener = TcpListener::bind(listen_addr("[::]", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let accepted = tokio::spawn(async move {
+            let (mut s, peer) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 4];
+            s.read_exact(&mut buf).await.unwrap();
+            s.write_all(b"pong").await.unwrap();
+            (buf, peer)
+        });
+
+        // Deliberately IPv4: this is what every deployed client speaks today.
+        let mut c = TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("an IPv4 client could not reach the [::] listener");
+        c.write_all(b"ping").await.unwrap();
+        let mut back = [0u8; 4];
+        c.read_exact(&mut back).await.unwrap();
+
+        let (got, peer) = accepted.await.unwrap();
+        assert_eq!(&got, b"ping");
+        assert_eq!(&back, b"pong");
+        // The peer arrives as an IPv4-mapped IPv6 address, proof the socket carried it.
+        assert!(peer.is_ipv6() || peer.is_ipv4(), "unexpected peer family: {peer}");
+    }
 }

--- a/nodyx-p2p/crates/nexus-relay/src/server/tcp_listener.rs
+++ b/nodyx-p2p/crates/nexus-relay/src/server/tcp_listener.rs
@@ -61,7 +61,13 @@ pub async fn run(
     pg: Arc<DbPool>,
 ) -> std::io::Result<()> {
     let listener = TcpListener::bind(bind).await?;
-    info!("TCP relay listener on {bind}");
+    // The address actually obtained, not the one requested: a `[::]` socket that
+    // silently ended up IPv6-only (bindv6only=1) is invisible otherwise, and every
+    // IPv4 instance would fail to connect without a single error on this side.
+    match listener.local_addr() {
+        Ok(addr) => info!("TCP relay listener on {addr} (requested {bind})"),
+        Err(e) => info!("TCP relay listener on {bind} (local_addr unavailable: {e})"),
+    }
 
     let ban_map: BanMap = Arc::new(DashMap::new());
 


### PR DESCRIPTION
Premier lot du chantier relais, celui qui ne touche pas au protocole. Le port `7443` ne bouge pas : les 24 instances déployées s'y connectent, et rien ici ne les casse.

## Le constat

Mesuré sur la production :

```
LISTEN  0.0.0.0:7443    <- IPv4 uniquement
relay.nodyx.org  A      46.225.20.193
                 AAAA   aucun
```

Une instance sur un réseau IPv6 seul ne peut pas joindre le relais **du tout**. Le VPS a pourtant une IPv6 publique.

## L'écoute

L'adresse devient un paramètre, `--tcp-bind`, par défaut `[::]`.

Sous Linux, une socket `[::]` accepte **aussi** l'IPv4 tant que `net.ipv6.bindv6only` vaut 0. Vérifié sur la production : la valeur est 0, et rien dans `/etc/sysctl.conf` ni `/etc/sysctl.d/` ne la force, c'est donc le défaut du noyau.

Le paramètre existe précisément parce que cette garantie est extérieure au programme. Si un hôte passait `bindv6only` à 1, la socket cesserait **silencieusement** d'accepter l'IPv4, sans erreur de liaison, et les 24 instances tomberaient. `--tcp-bind 0.0.0.0` restaure l'ancien comportement sans recompiler.

Le listener journalise maintenant l'adresse **réellement obtenue**, pas celle demandée. Sans ça, ce basculement serait invisible dans les journaux.

## Le client, et pourquoi il part en premier

C'est le point qui a fait dévier ce lot de son estimation à 15 minutes.

`TcpStream::connect("hôte:port")` résout plusieurs adresses et les essaie **dans un seul futur**, sans borne par adresse. Sur un hôte dont l'IPv6 est configurée mais sans route, la tentative AAAA est avalée et ce futur bloque le temps du délai TCP du noyau, environ deux minutes, avant que l'IPv4 soit tentée. La boucle de reconnexion s'effondre.

Cette défaillance **n'existe pas aujourd'hui** : elle apparaîtrait le jour où `relay.nodyx.org` gagne un `AAAA`, et elle frapperait des instances tournant l'ancien client.

D'où l'ordre, qui n'est pas négociable :

1. ce correctif client est déployé et adopté
2. **ensuite** l'enregistrement `AAAA` est posé

`connect_any` essaie chaque adresse avec une borne de 8 secondes et journalise celle qui a répondu. La résolution reste celle du système : glibc applique déjà la RFC 6724, donc un hôte sans IPv6 globale ne se voit pas proposer d'AAAA.

## Vérification

6 tests dans un crate qui n'en avait aucun.

| test | ce qu'il prouve |
|---|---|
| `ipv4_client_reaches_a_dual_stack_listener` | un client IPv4 atteint un écouteur `[::]`, le cas des 24 instances |
| `falls_through_to_the_address_that_answers` | `localhost` résout `::1` avant `127.0.0.1` ; avec une écoute IPv4 seule, le repli a bien lieu |
| `ipv6_literal_stays_bracketed` | `[::]` + port donne `[::]:7443` et non `:::7443` |
| `both_addresses_parse_and_bind` | les deux valeurs de `--tcp-bind` se lient |
| `reports_a_name_that_resolves_to_nothing_usable` | l'échec porte un motif exploitable |
| `the_per_address_bound_is_short_enough_to_retry` | la borne reste compatible avec la boucle de reconnexion |

`cargo build --release` à 0. Clippy ne signale rien sur les quatre fichiers touchés ; les trois avertissements du crate viennent de `db.rs` et `http_proxy.rs`, non modifiés ici.

## Pas dans cette PR

L'enregistrement `AAAA` sur `relay.nodyx.org`, volontairement. Il vient après l'adoption du client, pas avec.
