### PR TITLE
docs(relais): expliquer le mur du port 7443, et le detecter a l'installation

### DIFF
--- a/docs/en/RELAY.md
+++ b/docs/en/RELAY.md
@@ -1,4 +1,4 @@
-# ⚡ Nodyx Relay, Install without a domain or open ports
+# Nodyx Relay, Install without a domain or open ports
 
 > **The problem:** You want to host Nodyx at home, on a Raspberry Pi, an old PC, your home router setup, but you don't have a domain, and your ISP blocks incoming ports.
 >
@@ -8,18 +8,18 @@
 
 ## Table of Contents
 
-- [How it works](#-how-it-works)
-- [Requirements](#-requirements)
-- [Installation](#-installation)
-- [Comparison with other methods](#-comparison-with-other-methods)
-- [Checking that the tunnel is active](#-checking-that-the-tunnel-is-active)
-- [Troubleshooting](#-troubleshooting)
-- [FAQ](#-faq)
-- [For the curious, Technical architecture](#-for-the-curious--technical-architecture)
+- [How it works](#how-it-works)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Comparison with other methods](#comparison-with-other-methods)
+- [Checking that the tunnel is active](#checking-that-the-tunnel-is-active)
+- [Troubleshooting](#troubleshooting)
+- [FAQ](#faq)
+- [For the curious, Technical architecture](#for-the-curious-technical-architecture)
 
 ---
 
-## 🔌 How it works
+## How it works
 
 ```
                     Your machine (at home)
@@ -47,22 +47,23 @@
 
 ---
 
-## 📋 Requirements
+## Requirements
 
 | Element | Required? | Notes |
 |---|---|---|
-| Personal domain | ❌ No | The relay provides `your-slug.nodyx.org` for free |
-| Open ports 80/443 | ❌ No | The relay only uses **outbound** traffic |
-| Cloudflare account | ❌ No | Complete independence |
-| Internet connection | ✅ Yes | Any connection works (fiber, 4G, satellite) |
-| 64-bit Linux OS | ✅ Yes | Ubuntu 22.04/24.04, Debian 11/12, Raspberry Pi OS 64-bit |
-| Architecture | ✅ `x86_64` or `aarch64` | PC/VPS or Raspberry Pi 3/4/5 |
+| Personal domain | No | The relay provides `your-slug.nodyx.org` for free |
+| Open ports 80/443 | No | The relay only uses **outbound** traffic |
+| Cloudflare account | No | Complete independence |
+| Internet connection | Yes | Fiber, 4G, satellite, all fine |
+| **Outbound** TCP on port `7443` | Yes | The one real requirement. Home connections allow it by default. Company, university and institute networks often do **not**. [How to check in five seconds](#the-tunnel-never-connects-the-port-7443-wall) |
+| 64-bit Linux OS | Yes | Ubuntu 22.04/24.04, Debian 11/12, Raspberry Pi OS 64-bit |
+| Architecture | `x86_64` or `aarch64` | PC/VPS or Raspberry Pi 3/4/5 |
 
-> 💡 **Raspberry Pi 4, 8 GB RAM, Ubuntu Server 24.04 (arm64):** tested and validated in real-world conditions, March 1, 2026.
+> **Raspberry Pi 4, 8 GB RAM, Ubuntu Server 24.04 (arm64):** tested and validated in real-world conditions, March 1, 2026.
 
 ---
 
-## 🚀 Installation
+## Installation
 
 ### Method 1, Interactive installer (recommended)
 
@@ -129,26 +130,26 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now nodyx-relay-client
 ```
 
-> 💡 Your token is available in `/root/nodyx-credentials.txt` if you used `install.sh`, or in the JSON response from the nodyx.org registration API.
+> **Tip.** Your token is available in `/root/nodyx-credentials.txt` if you used `install.sh`, or in the JSON response from the nodyx.org registration API.
 
 ---
 
-## ⚖️ Comparison with other methods
+## Comparison with other methods
 
 | Method | Domain required | Ports to open | Third-party account | Dependency |
 |---|---|---|---|---|
-| **Nodyx Relay** ⭐ | ❌ No | ❌ No | ❌ No | Our infrastructure only |
-| VPS + own domain | ✅ Yes (~€1/year) | ✅ 80, 443 | ❌ No | None |
-| sslip.io auto | ❌ No | ✅ 80, 443 | ❌ No | None |
-| Cloudflare Tunnel | ✅ Yes (CF domain) | ❌ No | ✅ Cloudflare | Cloudflare |
-| Tailscale + Funnel | ❌ No | ❌ No | ✅ Tailscale | Tailscale |
-| Ngrok | ❌ No | ❌ No | ✅ Ngrok | Ngrok |
+| **Nodyx Relay** | No | No | No | Our infrastructure only |
+| VPS + own domain | Yes (~€1/year) | 80, 443 | No | None |
+| sslip.io auto | No | 80, 443 | No | None |
+| Cloudflare Tunnel | Yes (CF domain) | No | Cloudflare | Cloudflare |
+| Tailscale + Funnel | No | No | Tailscale | Tailscale |
+| Ngrok | No | No | Ngrok | Ngrok |
 
 > **Nodyx philosophy:** The relay is open source, self-hosted on our own VPS, and can be replaced by a community relay. Zero dependency on a third-party company.
 
 ---
 
-## 🔍 Checking that the tunnel is active
+## Checking that the tunnel is active
 
 ```bash
 # Service status
@@ -172,7 +173,85 @@ curl -I https://your-slug.nodyx.org/
 
 ---
 
-## 🔧 Troubleshooting
+## Troubleshooting
+
+### The tunnel never connects, the port 7443 wall
+
+**Start here.** This is the most common failure, and the least guessable one, because nothing on your machine is misconfigured.
+
+Your instance opens **one outbound connection** to `relay.nodyx.org` on TCP port `7443`. That is the whole mechanism. Nothing comes in, nothing is forwarded, no rule is ever added to your box.
+
+The catch: many networks only let `80` and `443` out. Home connections almost always allow `7443`. Company, university, school and institute networks frequently do not, and they rarely tell you.
+
+#### Find out in five seconds
+
+```bash
+nc -zv relay.nodyx.org 7443
+```
+
+Three answers are possible, and each one means something different:
+
+| What you see | What it means | What to do |
+|---|---|---|
+| `succeeded!` or `Connected` | The port is open, traffic goes through | The problem is elsewhere, keep reading below |
+| `Connection refused` | Something answered and said no. Your network is fine | The relay itself is down, please [tell us](https://github.com/Pokled/nodyx/discussions) |
+| **Nothing, it just hangs, then times out** | Your network silently drops the packets | **This is the wall. Read on** |
+
+> **Read that table twice.** The difference between *refused* and *times out* is the single most useful signal in this whole page. A refusal is an answer. Silence is a filter.
+
+No `nc` on your machine? This works everywhere Python is installed:
+
+```bash
+python3 -c "import socket;socket.create_connection(('relay.nodyx.org',7443),timeout=8);print('open')"
+```
+
+#### If your network filters the port
+
+You have three ways out, easiest first.
+
+**1. Ask for the port to be opened, outbound only.**
+
+Network administrators say no to vague requests and yes to precise ones. Here is a paragraph you can copy and send as is:
+
+> Hello,
+> I need to allow **outbound** TCP traffic from my machine to `relay.nodyx.org` (`46.225.20.193`) on port `7443`.
+> This is an outgoing connection only. It requires **no incoming rule**, no port forwarding, and no exposed service on my side. The machine stays unreachable from the outside.
+> The connection stays open and carries the traffic of a self-hosted community platform.
+> Thank you.
+
+**2. Use IPv6, if your network provides it.**
+
+Since August 2026 the relay also answers on a dedicated IPv6 name. Some networks that filter IPv4 leave IPv6 alone, and IPv6-only networks can now connect at all, which was impossible before.
+
+```bash
+# Does your machine have working IPv6?
+python3 -c "import socket;socket.create_connection(('relay6.nodyx.org',7443),timeout=8);print('IPv6 works')"
+```
+
+If that prints `IPv6 works`, point your client at it:
+
+```bash
+sudo systemctl edit --full nodyx-relay-client
+# in the ExecStart line, replace:
+# --server relay.nodyx.org:7443
+# with:
+# --server relay6.nodyx.org:7443
+sudo systemctl restart nodyx-relay-client
+```
+
+> `relay6.nodyx.org` publishes an `AAAA` record only. It is the same relay, the same port, the same token. Only the road differs.
+
+**3. Move the machine to another connection.**
+
+A 4G or 5G phone share is enough to confirm the diagnosis in two minutes. If the tunnel comes up instantly there, the wall really was your network, not your setup.
+
+#### What this is not
+
+- **Not** a port to open on your router. There is nothing to open inbound, ever.
+- **Not** a firewall problem on your own machine. Outgoing traffic is allowed by default on Linux.
+- **Not** something you misconfigured. A filtered network gives no error message on your side, which is exactly what makes it so confusing.
+
+---
 
 ### The service won't start
 
@@ -182,7 +261,8 @@ sudo journalctl -u nodyx-relay-client --no-pager -n 50
 
 | Error | Cause | Solution |
 |---|---|---|
-| `Connection refused` | relay.nodyx.org unreachable | Check your Internet connection |
+| `Connection refused` | Something answered and said no, so your network is fine | The relay itself may be down, [tell us](https://github.com/Pokled/nodyx/discussions) |
+| `Connection timed out`, or nothing at all | Your network silently drops port `7443` | [The port 7443 wall](#the-tunnel-never-connects-the-port-7443-wall) |
 | `Registration rejected: Invalid slug or token` | Incorrect token | Check `/root/nodyx-credentials.txt` |
 | `Binary not found` | Binary not installed | Reinstall with `install.sh` or Method 2 |
 | `Address already in use` (port 80) | Another service listening on :80 | `sudo ss -tlnp \| grep :80` |
@@ -206,7 +286,7 @@ sudo systemctl restart nodyx-relay-client
 
 ---
 
-## ❓ FAQ
+## FAQ
 
 **Q: Does my data transit through your server?**
 
@@ -234,7 +314,7 @@ Yes. The `nodyx-relay client` binary can run outside the Docker container, just 
 
 ---
 
-## 🏗️ For the curious, Technical architecture
+## For the curious, Technical architecture
 
 ### The relay server (nodyx.org)
 

--- a/install.sh
+++ b/install.sh
@@ -403,6 +403,20 @@ T_EN[relay_mode_url]='Nodyx Relay mode — URL: %s%s%s'
 T_FR[relay_mode_url]='Mode Nodyx Relay — URL : %s%s%s'
 T_EN[relay_mode_no_port]='No port to open. The tunnel will be established to relay.nodyx.org.'
 T_FR[relay_mode_no_port]='Aucun port à ouvrir. Le tunnel sera établi vers relay.nodyx.org.'
+T_EN[relay_probe]='Checking that your network lets the tunnel out on port 7443...'
+T_FR[relay_probe]='Vérification que votre réseau laisse sortir le tunnel sur le port 7443...'
+T_EN[relay_probe_ok]='Outbound port 7443 is open. The tunnel will work.'
+T_FR[relay_probe_ok]='Le port 7443 sort bien. Le tunnel fonctionnera.'
+T_EN[relay_probe_v6]='Port 7443 is filtered over IPv4, but IPv6 works. Using %s instead.'
+T_FR[relay_probe_v6]='Le port 7443 est filtré en IPv4, mais IPv6 fonctionne. Utilisation de %s à la place.'
+T_EN[relay_probe_blocked]='Your network silently drops outbound port 7443. The tunnel cannot come up.'
+T_FR[relay_probe_blocked]='Votre réseau bloque silencieusement le port 7443 en sortie. Le tunnel ne pourra pas monter.'
+T_EN[relay_probe_hint]='This is a network restriction, not a mistake on your side. Company, university and institute networks often allow only 80 and 443.'
+T_FR[relay_probe_hint]="C'est une restriction du réseau, pas une erreur de votre part. Les réseaux d'entreprise, d'université et d'institut n'autorisent souvent que 80 et 443."
+T_EN[relay_probe_doc]='What to do, including a message to send to your network administrator: %s'
+T_FR[relay_probe_doc]="Que faire, avec un message prêt à envoyer à votre administrateur réseau : %s"
+T_EN[relay_probe_continue]='Continue anyway? The instance will install correctly but stay unreachable until the port is opened. [y/N]'
+T_FR[relay_probe_continue]="Continuer quand même ? L'instance s'installera correctement mais restera injoignable tant que le port ne sera pas ouvert. [o/N]"
 T_EN[auto_domain]='Auto domain: %s%s%s'
 T_FR[auto_domain]='Domaine automatique : %s%s%s'
 T_EN[sslip_resolves]='sslip.io auto-resolves to %s — HTTPS certificate handled by Caddy.'
@@ -1063,7 +1077,7 @@ _nodyx_upgrade() {
 Description=Nodyx Relay Client
 After=network.target
 [Service]
-ExecStart=/usr/local/bin/nodyx-relay client --server relay.nodyx.org:7443 --slug ${_slug} --token ${_dir_token} --local-port 80
+ExecStart=/usr/local/bin/nodyx-relay client --server ${RELAY_SERVER:-relay.nodyx.org:7443} --slug ${_slug} --token ${_dir_token} --local-port 80
 Restart=on-failure
 RestartSec=5s
 StartLimitIntervalSec=60
@@ -1785,6 +1799,49 @@ NET_MODE="${NET_MODE:-2}"
 RELAY_MODE=false
 DOMAIN_IS_AUTO=false
 
+# ── La sonde qui évite une installation « réussie » mais injoignable ──────────
+#
+# Le relais n'a besoin que d'UNE sortie TCP sur 7443. Les connexions grand public
+# l'autorisent, les réseaux d'entreprise, d'université et d'institut souvent pas,
+# et ils ne le disent jamais. Sans ce contrôle, l'installeur se terminait en
+# annonçant un succès, puis l'instance restait muette sans le moindre indice.
+# Cas réel : une inscription en août 2026, tombée exactement là-dessus.
+#
+# Un port filtré ne REFUSE pas, il ne répond rien : on borne donc l'essai.
+RELAY_SERVER="relay.nodyx.org:7443"
+
+_relay_joignable() {
+  timeout 8 bash -c "exec 3<>/dev/tcp/$1/$2" 2>/dev/null
+}
+
+verifier_sortie_relais() {
+  info "$(t relay_probe)"
+
+  if _relay_joignable relay.nodyx.org 7443; then
+    ok "$(t relay_probe_ok)"
+    return 0
+  fi
+
+  # IPv4 filtrée. Certains réseaux laissent passer l'IPv6, et un réseau IPv6 seul
+  # ne pouvait pas se connecter du tout avant que ce nom existe.
+  if _relay_joignable relay6.nodyx.org 7443; then
+    RELAY_SERVER="relay6.nodyx.org:7443"
+    ok "$(printf "$(t relay_probe_v6)" "relay6.nodyx.org")"
+    return 0
+  fi
+
+  warn "$(t relay_probe_blocked)"
+  info "$(t relay_probe_hint)"
+  info "$(printf "$(t relay_probe_doc)" "https://nodyx.dev/relay#the-tunnel-never-connects-the-port-7443-wall")"
+
+  local reponse=""
+  read -r -p "  $(t relay_probe_continue) " reponse || true
+  case "${reponse,,}" in
+    y|yes|o|oui) return 0 ;;
+    *) die "$(t relay_probe_blocked)" ;;
+  esac
+}
+
 case "$NET_MODE" in
   1)
     prompt DOMAIN "$(t prompt_domain)"
@@ -1794,6 +1851,7 @@ case "$NET_MODE" in
     DOMAIN="${COMMUNITY_SLUG}.nodyx.org"
     ok "$(printf "$(t relay_mode_url)" "${BOLD}" "https://${DOMAIN}" "${RESET}")"
     info "$(t relay_mode_no_port)"
+    verifier_sortie_relais
     ;;
   3|*)
     DOMAIN="${PUBLIC_IP//./-}.sslip.io"
@@ -2995,7 +3053,7 @@ After=network.target
 
 [Service]
 ExecStart=/usr/local/bin/nodyx-relay client \
-  --server relay.nodyx.org:7443 \
+  --server ${RELAY_SERVER:-relay.nodyx.org:7443} \
   --slug ${COMMUNITY_SLUG} \
   --token ${NODYX_DIRECTORY_TOKEN} \
   --local-port 80

--- a/scripts/ops/caddy-pages/instance-offline.html
+++ b/scripts/ops/caddy-pages/instance-offline.html
@@ -4,7 +4,7 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="robots" content="noindex, nofollow">
-	<title>Instance hors-ligne — Nodyx</title>
+	<title>Instance hors-ligne · Nodyx</title>
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@500;700;800&display=swap" rel="stylesheet">
@@ -243,7 +243,7 @@
 
 		<h1>Cette instance est temporairement injoignable</h1>
 
-		<div class="subdomain" id="host">—</div>
+		<div class="subdomain" id="host">…</div>
 
 		<p class="lead">
 			Le tunnel Nodyx est enregistré, mais le serveur de la communauté ne répond pas pour le moment.
@@ -261,27 +261,43 @@
     <div class="diag">
       <p class="diag-titre">Vérifier en une commande, sur votre serveur :</p>
       <pre><code>nc -zv relay.nodyx.org 7443     # doit répondre « succeeded »
+nc -zv relay6.nodyx.org 7443    # la même chose, en IPv6
 systemctl status nodyx-relay    # le client doit être « active »
 journalctl -u nodyx-relay -n 20 # les tentatives de reconnexion</code></pre>
       <p class="diag-note">
         Si <code>nc</code> échoue alors que votre serveur accède bien à Internet, c'est votre
         pare-feu sortant. Autorisez le port <code>7443</code> en sortie, ou contactez
-        l'administrateur du réseau. <b>Vous n'avez aucun port à ouvrir en entrée</b> — Nodyx ne
+        l'administrateur du réseau. <b>Vous n'avez aucun port à ouvrir en entrée</b>, Nodyx ne
         le demande jamais.
+      </p>
+      <p class="diag-note">
+        Si la première commande échoue mais que la seconde répond, votre réseau laisse passer
+        l'IPv6 : basculez le client sur <code>relay6.nodyx.org:7443</code>, c'est le même relais
+        par une autre route.
+      </p>
+      <p class="diag-note">
+        <b><a href="https://nodyx.dev/relay#the-tunnel-never-connects-the-port-7443-wall">Guide complet
+        de déblocage</a></b> : comment lire le résultat de chaque commande, et un message prêt à
+        envoyer à votre administrateur réseau.
       </p>
     </div>
 
     <details class="langues">
       <summary>English / Português</summary>
-      <p><b>English —</b> Most often, your network blocks <b>outbound</b> connections to port
+      <p><b>English.</b> Most often, your network blocks <b>outbound</b> connections to port
         <code>7443</code>. Many corporate, university and institute networks only allow 443. Your
         instance is running; its tunnel just cannot reach us. Test with
-        <code>nc -zv relay.nodyx.org 7443</code>. You never need to open any <i>inbound</i> port.</p>
-      <p><b>Português —</b> Na maioria das vezes, a sua rede bloqueia conexões <b>de saída</b> para
+        <code>nc -zv relay.nodyx.org 7443</code>. You never need to open any <i>inbound</i> port.
+        If IPv6 works on your network, <code>relay6.nodyx.org:7443</code> is the same relay by
+        another road. <b><a href="https://nodyx.dev/relay#the-tunnel-never-connects-the-port-7443-wall">Full unblocking guide</a></b>, including a message you can
+        send to your network administrator.</p>
+      <p><b>Português.</b> Na maioria das vezes, a sua rede bloqueia conexões <b>de saída</b> para
         a porta <code>7443</code>. Muitas redes corporativas, universitárias e de institutos só
         permitem a 443. A sua instância está funcionando; apenas o túnel não consegue nos alcançar.
         Teste com <code>nc -zv relay.nodyx.org 7443</code>. Você nunca precisa abrir nenhuma porta
-        de <i>entrada</i>.</p>
+        de <i>entrada</i>. Se a sua rede tiver IPv6, <code>relay6.nodyx.org:7443</code> é o mesmo
+        relay por outro caminho. <b><a href="https://nodyx.dev/relay#the-tunnel-never-connects-the-port-7443-wall">Guia completo de desbloqueio</a></b>, com uma
+        mensagem pronta para enviar ao administrador da sua rede.</p>
     </details>
 
 		<div class="actions">
@@ -295,7 +311,7 @@ journalctl -u nodyx-relay -n 20 # les tentatives de reconnexion</code></pre>
 		</div>
 
 		<div class="footer">
-			Le réseau <a href="https://nodyx.org">Nodyx</a> est décentralisé —
+			Le réseau <a href="https://nodyx.org">Nodyx</a> est décentralisé,
 			chaque communauté héberge sa propre instance.
 		</div>
 	</main>


### PR DESCRIPTION
Une instance derrière un réseau filtrant s'installait **sans la moindre erreur**, puis restait injoignable sans explication. C'est le scénario du 17 août, et la documentation l'aggravait au lieu d'aider.

## L'affirmation fausse

Le tableau des prérequis disait, mot pour mot :

> | Internet connection | Yes | **Any connection works (fiber, 4G, satellite)** |

C'est faux. Il faut une **sortie** autorisée sur le port `7443`. Les connexions grand public l'autorisent, les réseaux d'entreprise, d'université et d'institut souvent pas, et ils ne le disent jamais.

La ligne est corrigée, et le prérequis réel apparaît enfin comme tel.

## La section qui manquait

Placée **en tête** du dépannage, parce que c'est la panne la plus fréquente et la moins devinable.

Elle repose sur une distinction que la page ignorait complètement :

| Ce que vous voyez | Ce que ça veut dire |
|---|---|
| `succeeded` | le port est ouvert |
| `Connection refused` | quelque chose a répondu non, votre réseau va bien |
| **rien, ça reste bloqué** | votre réseau filtre en silence |

Un port refusé **répond**. Un port filtré **se tait**. C'est le signal le plus utile de toute la page, et l'ancien tableau de dépannage disait exactement l'inverse : il attribuait `Connection refused` à un problème de connexion Internet.

La section donne aussi un **message prêt à copier** pour un administrateur réseau. Un administrateur refuse une demande vague et accepte une demande précise, alors autant la fournir.

## L'installeur ne ment plus

Une sonde vérifie la sortie sur `7443` **avant** de configurer le relais.

- port ouvert, on continue
- IPv4 filtrée mais IPv6 fonctionnelle, l'installeur bascule **tout seul** sur `relay6.nodyx.org`
- les deux bloqués, il explique, renvoie vers le guide, et **demande confirmation** au lieu d'annoncer un succès trompeur

`RELAY_SERVER` est lu partout via `${RELAY_SERVER:-relay.nodyx.org:7443}`, pour rester sûr sous `set -u` quel que soit l'ordre d'exécution.

Sonde vérifiée en isolation : port ouvert détecté, port fermé détecté, aucun blocage.

## Le défaut invisible trouvé en chemin

**Les 10 liens internes de `RELAY.md` étaient tous morts**, dont les 8 de la table des matières.

Le moteur de rendu supprime les tirets de tête des ancres (`slugifyHeading`, `docs.server.ts`). Or chaque titre commençait par un emoji, qui laisse justement un tiret une fois retiré. `#-how-it-works` ne pouvait donc jamais correspondre à `how-it-works`.

Les emojis retirés, la table des matières fonctionne pour la première fois. Vérifié par script contre la fonction de slug réelle du moteur : **10 liens, 0 cassé, 38 ancres**.

## Vérifications

- `bash -n install.sh` sans erreur
- structure HTML de la page hors-ligne validée, aucune balise non fermée
- zéro tiret cadratin dans les trois fichiers, et zéro sur l'ensemble de mes lignes ajoutées à `install.sh`
- le schéma ASCII de `RELAY.md` est intact, vérifié caractère par caractère après un premier essai qui l'avait abîmé
