### PR TITLE
fix(page hors-ligne): le bas de la page etait inatteignable

### DIFF
--- a/scripts/ops/caddy-pages/instance-offline.html
+++ b/scripts/ops/caddy-pages/instance-offline.html
@@ -10,16 +10,30 @@
 	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@500;700;800&display=swap" rel="stylesheet">
 	<style>
 		* { box-sizing: border-box; margin: 0; padding: 0; }
-		html, body { height: 100%; }
+		/* `overflow-x` DOIT etre pose ici, pas sur `body`. La fenetre est gouvernee
+		   par l'element racine ; declare sur `body` seul, le masquage horizontal
+		   restait sans effet et la page se decalait encore de 150 px. Mesure :
+		   `html { overflow-x: hidden }` ramene le decalage a 0. */
+		html { height: 100%; overflow-x: hidden; }
 		body {
 			font-family: 'Inter', system-ui, sans-serif;
 			background: #0a0a0f;
 			color: #e2e8f0;
 			display: flex;
+			/* `center` seul ROGNE par le haut ET par le bas des qu'une carte depasse
+			   la fenetre : le debordement d'un conteneur flex centre est inatteignable.
+			   `safe center` centre tant que ca tient, puis s'aligne au debut. La
+			   premiere declaration reste le repli pour les navigateurs anciens. */
 			align-items: center;
+			align-items: safe center;
 			justify-content: center;
 			padding: 1.5rem;
-			overflow: hidden;
+			/* `height: 100%` + `overflow: hidden` rendait le bas de la page
+			   inaccessible, sans aucune barre de defilement. On garde le masquage
+			   horizontal, qui existe pour les halos en `position: absolute`. */
+			min-height: 100%;
+			overflow-x: hidden;
+			overflow-y: auto;
 			position: relative;
 		}
 
@@ -160,6 +174,9 @@
 			gap: .75rem;
 			justify-content: center;
 			flex-wrap: wrap;
+			/* Sans cette marge, les boutons touchaient le lien « English / Português »
+			   juste au-dessus, au point qu'on ne distinguait plus les deux zones. */
+			margin-top: 1.25rem;
 		}
 
 		.btn {


### PR DESCRIPTION
Signalé sur une instance réelle : le bas de la page hors-ligne était inatteignable, sans aucune barre de défilement, et le lien de traduction touchait les boutons.

## Trois défauts, une seule zone de style

**1. Le contenu était rogné.**

```css
body { height: 100%; overflow: hidden; }
```

Tout ce qui dépassait la fenêtre devenait invisible **et** inaccessible. Devient `min-height: 100%` avec `overflow-y: auto`.

**2. Le centrage coupait des deux côtés.**

`align-items: center` sur un conteneur flex dont le contenu déborde rogne par le **haut** et par le **bas**, et la partie perdue ne peut pas être atteinte, même en défilant. C'est le piège classique du centrage flex.

Passé en `align-items: safe center`, qui centre tant que ça tient puis s'aligne au début. La déclaration simple est conservée juste avant, comme repli pour les navigateurs anciens.

**3. Les boutons touchaient le lien de traduction.**

`.actions` n'avait aucune marge haute. Marge de 1,25 rem, ce qui donne 20 px mesurés entre les deux zones.

## Le débordement horizontal, enfin compris

La page se décalait aussi de **150 px horizontalement**. C'était **préexistant**, noté comme tel depuis le 18 sans cause identifiée.

Trouvé par élimination, en mesurant le décalage réel plutôt que `scrollWidth`, qui ment sur les éléments rognés :

| test | décalage |
|---|---|
| état initial | 150 px |
| sans les halos `.orb` | 150 px |
| sans la carte entière | 150 px |
| **`overflow-x: hidden` sur `html`** | **0 px** |

Aucun élément ne débordait. C'est la **propagation du débordement** : la fenêtre est gouvernée par l'élément racine, et un `overflow-x` déclaré sur `body` seul restait sans effet.

## Vérification

Mesuré à cinq formats, dont celui du signalement (722x494) :

| format | décalage horizontal | bas atteignable | écart lien/boutons |
|---|---|---|---|
| 722x494 | 0 px | oui | 20 px |
| 390x844 | 0 px | oui | 20 px |
| 1280x600 | 0 px | oui | 20 px |
| 1440x900 | 0 px | oui | 20 px |
| 800x380 | 0 px | oui | 20 px |

Capture du bas de page vérifiée à l'oeil après correction : le pied de page apparaît, ce qui n'était jamais arrivé.
