### PR TITLE
feat(docs): servir la documentation traduite, elle existait sans etre visible

### DIFF
--- a/nodyx-docs/src/lib/components/Sidebar.svelte
+++ b/nodyx-docs/src/lib/components/Sidebar.svelte
@@ -2,7 +2,10 @@
   import { nav, type NavSection, type NavItem } from '../nav.js'
   import { page } from '$app/stores'
 
-  const { currentSlug }: { currentSlug: string } = $props()
+  // `lang` prefixe chaque lien. Sans lui, un lecteur arrive sur /fr/relay puis
+  // retombe en anglais au premier clic de la barre laterale.
+  const { currentSlug, lang = 'en' }: { currentSlug: string; lang?: string } = $props()
+  const prefixe = $derived(lang === 'en' ? '' : `/${lang}`)
 
   function isActive(item: NavItem) {
     return item.slug === currentSlug
@@ -20,7 +23,7 @@
           {#each section.items as item}
             <li>
               <a
-                href="/{item.slug}"
+                href="{prefixe}/{item.slug}"
                 class="nav-item"
                 class:active={isActive(item)}
                 aria-current={isActive(item) ? 'page' : undefined}

--- a/nodyx-docs/src/lib/docs.server.ts
+++ b/nodyx-docs/src/lib/docs.server.ts
@@ -4,10 +4,32 @@ import { join, resolve }     from 'path'
 import { marked }            from 'marked'
 import hljs                  from 'highlight.js'
 import { slugToFile }        from './nav.js'
+import { DOC_LANGS, isDocLang } from './langs.js'
+import type { DocLang }      from './langs.js'
+export { DOC_LANGS, isDocLang }
+export type { DocLang }
 
 // Resolve docs directory relative to the repo root
 const REPO_ROOT = resolve(process.cwd(), '..')
-const DOCS_DIR  = join(REPO_ROOT, 'docs', 'en')
+const DOCS_ROOT = join(REPO_ROOT, 'docs')
+const DOCS_DIR  = join(DOCS_ROOT, 'en')
+
+
+/**
+ * Les langues qui ont au moins une page. Un dossier vide (`de`, `it` au
+ * 19/08) ne doit pas apparaître dans le sélecteur : proposer une langue qui
+ * renvoie systématiquement de l'anglais est pire que ne pas la proposer.
+ */
+export async function availableDocLangs(): Promise<{ code: DocLang; label: string; pages: number }[]> {
+  const out: { code: DocLang; label: string; pages: number }[] = []
+  for (const { code, label } of DOC_LANGS) {
+    const dir = join(DOCS_ROOT, code)
+    if (!existsSync(dir)) continue
+    const pages = (await readdir(dir)).filter((f) => f.endsWith('.md')).length
+    if (pages > 0) out.push({ code, label, pages })
+  }
+  return out
+}
 
 // ── Custom renderer ───────────────────────────────────────────────────────────
 
@@ -183,8 +205,12 @@ export async function buildSearchIndex(pages: Array<{ slug: string; title: strin
   const entries: SearchEntry[] = []
   for (const page of pages) {
     try {
-      const raw = await readDocFile(page.slug)
-      if (!raw) continue
+      // L'index de recherche reste anglophone : c'est la seule langue complete,
+      // et melanger les langues dans un index unique renverrait des resultats
+      // que le lecteur ne peut pas lire.
+      const found = await readDocFile(page.slug, 'en')
+      if (!found) continue
+      const raw = found.raw
 
       // Whole-page entry — first 500 chars of plain text, anchored at top of page
       const wholePlain = stripMarkdown(raw.replace(/^#{1,6}\s+/gm, ''))
@@ -278,18 +304,46 @@ export interface DocResult {
   description: string
   readingTime: string
   raw:         string
+  /** La langue réellement servie. Retombe sur `en` si la page n'est pas traduite. */
+  lang:        DocLang
+  /** La langue demandée dans l'URL. Différente de `lang` = repli en cours. */
+  requested:   DocLang
 }
 
-async function readDocFile(slug: string): Promise<string | null> {
+/**
+ * Le fichier de la page, dans la langue demandée, sinon en anglais.
+ *
+ * Le repli est indispensable et non cosmétique : au 19/08, le français couvrait
+ * 14 pages sur 21 et l'espagnol 9. Sans lui, deux tiers des liens d'un lecteur
+ * francophone finiraient en 404.
+ *
+ * On renvoie la langue RÉELLEMENT servie, pour que la page puisse le dire au
+ * lecteur. Servir de l'anglais sous une URL `/fr/` sans le signaler laisserait
+ * croire que la traduction est faite.
+ */
+async function readDocFile(
+  slug: string,
+  lang: DocLang = 'en',
+): Promise<{ raw: string; served: DocLang } | null> {
   const filename = slugToFile(slug)
-  const filepath = join(DOCS_DIR, filename)
-  if (!existsSync(filepath)) return null
-  return readFile(filepath, 'utf-8')
+
+  if (lang !== 'en') {
+    const traduit = join(DOCS_ROOT, lang, filename)
+    if (existsSync(traduit)) {
+      return { raw: await readFile(traduit, 'utf-8'), served: lang }
+    }
+  }
+
+  const anglais = join(DOCS_DIR, filename)
+  if (!existsSync(anglais)) return null
+  return { raw: await readFile(anglais, 'utf-8'), served: 'en' }
 }
 
-export async function renderDoc(slug: string): Promise<DocResult | null> {
-  const raw = await readDocFile(slug)
-  if (raw === null) return null
+export async function renderDoc(slug: string, lang: DocLang = 'en'): Promise<DocResult | null> {
+  const found = await readDocFile(slug, lang)
+  if (found === null) return null
+
+  const { raw, served } = found
 
   const processed  = processCallouts(raw)
   const html       = await marked.parse(processed)
@@ -304,5 +358,8 @@ export async function renderDoc(slug: string): Promise<DocResult | null> {
   const description = extractDescription(raw)
   const rt          = readingTime(raw)
 
-  return { html, headings, title, description, readingTime: rt, raw }
+  // `requested` et `served` diffèrent quand la page n'est pas encore traduite :
+  // c'est ce qui permet à la page de le DIRE au lecteur au lieu de lui servir
+  // de l'anglais sous une URL française sans prévenir.
+  return { html, headings, title, description, readingTime: rt, raw, lang: served, requested: lang }
 }

--- a/nodyx-docs/src/lib/langs.ts
+++ b/nodyx-docs/src/lib/langs.ts
@@ -1,0 +1,44 @@
+// ─── Les langues de la documentation ─────────────────────────────────────────
+//
+// Ce module est volontairement SANS dépendance serveur : la barre latérale et le
+// sélecteur en ont besoin dans le navigateur, et `docs.server.ts` ne peut pas y
+// être importé.
+//
+// `docs/` contient aussi `articles`, `audits`, `ideas`, `img`, `seo`, `specs`,
+// qui ne sont pas des langues. On liste donc explicitement plutôt que de deviner
+// à partir des dossiers présents.
+//
+// Mesure du 2026-08-19 : `docs/fr` comptait 14 pages traduites et `docs/es` 9,
+// et AUCUNE n'était servie. Le site lisait `docs/en` en dur. Des contributeurs
+// avaient traduit dans le vide, ce que ce module existe pour empêcher.
+
+export const DOC_LANGS = [
+  { code: 'en', label: 'English'  },
+  { code: 'fr', label: 'Français' },
+  { code: 'es', label: 'Español'  },
+  { code: 'de', label: 'Deutsch'  },
+  { code: 'it', label: 'Italiano' },
+] as const
+
+export type DocLang = (typeof DOC_LANGS)[number]['code']
+
+export function isDocLang(v: string | undefined): v is DocLang {
+  return !!v && DOC_LANGS.some((l) => l.code === v)
+}
+
+/** L'anglais vit à la racine, les autres langues sous leur code. */
+export function langPrefix(lang: string): string {
+  return lang === 'en' ? '' : `/${lang}`
+}
+
+/**
+ * Sépare la langue du chemin. `/fr/relay` donne `fr` et `relay`, `/relay` donne
+ * `en` et `relay`. Utilisé par le layout, qui n'a que l'URL sous la main.
+ */
+export function splitLangPath(pathname: string): { lang: DocLang; slug: string } {
+  const parts = pathname.replace(/^\/+/, '').split('/').filter(Boolean)
+  if (parts.length && isDocLang(parts[0])) {
+    return { lang: parts[0], slug: parts.slice(1).join('/') || 'readme' }
+  }
+  return { lang: 'en', slug: parts.join('/') || 'readme' }
+}

--- a/nodyx-docs/src/routes/+layout.svelte
+++ b/nodyx-docs/src/routes/+layout.svelte
@@ -3,12 +3,15 @@
   import Header  from '$lib/components/Header.svelte'
   import Sidebar from '$lib/components/Sidebar.svelte'
   import { page } from '$app/stores'
+  import { splitLangPath } from '$lib/langs.js'
 
   const { children, data } = $props()
 
-  const currentSlug = $derived(
-    $page.url.pathname.replace(/^\//, '') || 'readme'
-  )
+  // L'URL porte desormais la langue en tete (/fr/relay). Sans la retirer ici,
+  // aucun element de la barre laterale ne serait jamais marque comme actif.
+  const chemin      = $derived(splitLangPath($page.url.pathname))
+  const currentSlug = $derived(chemin.slug)
+  const langue      = $derived(chemin.lang)
 </script>
 
 <div class="app">
@@ -17,7 +20,7 @@
     {@render children()}
   {:else}
     <div class="body">
-      <Sidebar {currentSlug} />
+      <Sidebar {currentSlug} lang={langue} />
       <main class="content" id="main-content">
         {@render children()}
       </main>

--- a/nodyx-docs/src/routes/[...slug]/+page.server.ts
+++ b/nodyx-docs/src/routes/[...slug]/+page.server.ts
@@ -1,16 +1,32 @@
 import { error, redirect }     from '@sveltejs/kit'
-import { renderDoc }           from '$lib/docs.server.js'
+import { renderDoc, isDocLang, availableDocLangs } from '$lib/docs.server.js'
+import type { DocLang }        from '$lib/docs.server.js'
 import { findPage, prevNext }  from '$lib/nav.js'
 
 export async function load({ params }) {
   let slug = params.slug || 'readme'
 
-  // Redirect /FOO.md or /foo.md → /foo (people copy filenames from GitHub)
-  if (slug.endsWith('.md')) {
-    redirect(301, '/' + slug.slice(0, -3).toLowerCase())
+  // Une langue en tête d'URL : /fr/relay, /es/install. La route est déjà un
+  // attrape-tout, aucun fichier de route supplémentaire n'est nécessaire.
+  // Les URL existantes (/relay) restent inchangées et valent l'anglais.
+  let lang: DocLang = 'en'
+  const [premier, ...reste] = slug.split('/')
+  if (isDocLang(premier) && reste.length > 0) {
+    lang = premier
+    slug = reste.join('/')
+  } else if (isDocLang(premier) && reste.length === 0) {
+    // /fr tout seul : la page d'accueil de la documentation, dans cette langue.
+    lang = premier
+    slug = 'readme'
   }
 
-  const doc = await renderDoc(slug)
+  // Redirect /FOO.md or /foo.md → /foo (people copy filenames from GitHub)
+  if (slug.endsWith('.md')) {
+    const base = lang === 'en' ? '' : `/${lang}`
+    redirect(301, `${base}/` + slug.slice(0, -3).toLowerCase())
+  }
+
+  const doc = await renderDoc(slug, lang)
   if (!doc) error(404, `Documentation page "${slug}" not found`)
 
   const page   = findPage(slug)
@@ -18,6 +34,11 @@ export async function load({ params }) {
 
   return {
     slug,
+    lang:        doc.lang,
+    requested:   doc.requested,
+    /** Vrai quand la page n'existe pas encore dans la langue demandée. */
+    fallback:    doc.lang !== doc.requested,
+    langs:       await availableDocLangs(),
     html:        doc.html,
     headings:    doc.headings,
     title:       page?.title ?? doc.title,

--- a/nodyx-docs/src/routes/[...slug]/+page.svelte
+++ b/nodyx-docs/src/routes/[...slug]/+page.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import type { Heading } from '$lib/docs.server.js'
+  import { langPrefix } from '$lib/langs.js'
 
   const { data } = $props()
+
+  // L'anglais vit a la racine, les autres langues sous leur code.
+  const prefixe = $derived(langPrefix(data.lang))
 
   // Copy button handler (injected into rendered HTML)
   onMount(() => {
@@ -170,13 +174,40 @@
 
 <!-- Breadcrumb -->
 <nav class="breadcrumb" aria-label="Breadcrumb">
-  <a href="/">Docs</a>
+  <a href="{prefixe}/">Docs</a>
   <span aria-hidden="true">/</span>
   <span aria-current="page">{data.title}</span>
 </nav>
 
-<!-- Reading time -->
-<div class="reading-time" aria-label="Reading time">{data.readingTime}</div>
+<!-- Reading time + langues -->
+<div class="meta-bar">
+  <div class="reading-time" aria-label="Reading time">{data.readingTime}</div>
+
+  {#if data.langs.length > 1}
+    <nav class="langues" aria-label="Language">
+      {#each data.langs as l}
+        <a
+          href="{l.code === 'en' ? '' : '/' + l.code}/{data.slug}"
+          class="langue"
+          class:actif={l.code === data.requested}
+          hreflang={l.code}
+          aria-current={l.code === data.requested ? 'true' : undefined}
+        >{l.label}</a>
+      {/each}
+    </nav>
+  {/if}
+</div>
+
+{#if data.fallback}
+  <!-- Servir de l'anglais sous une URL /fr/ SANS le dire laisserait croire que
+       la page est traduite. Au 19/08, le francais couvrait 14 pages sur 21. -->
+  <p class="pas-traduit" role="note">
+    Cette page n'est pas encore traduite. Vous lisez la version anglaise.
+    <a href="https://github.com/Pokled/nodyx/blob/main/docs/en/{data.slug.toUpperCase()}.md">
+      Contribuer a sa traduction
+    </a>
+  </p>
+{/if}
 
 <div class="doc-layout">
   <!-- Main content -->
@@ -213,7 +244,7 @@
   <nav class="doc-nav" aria-label="Previous and next pages">
     <div class="doc-nav-inner">
       {#if data.prev}
-        <a href="/{data.prev.slug}" class="doc-nav-btn doc-nav-prev">
+        <a href="{prefixe}/{data.prev.slug}" class="doc-nav-btn doc-nav-prev">
           <span class="doc-nav-label">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
               <path d="M15 18l-6-6 6-6"/>
@@ -226,7 +257,7 @@
         <div></div>
       {/if}
       {#if data.next}
-        <a href="/{data.next.slug}" class="doc-nav-btn doc-nav-next">
+        <a href="{prefixe}/{data.next.slug}" class="doc-nav-btn doc-nav-next">
           <span class="doc-nav-label">
             Next
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
@@ -441,4 +472,29 @@
   .toc { display: none; }
   .doc-layout { display: block; }
 }
+
+/* ── Langues de la documentation ─────────────────────────────────────────── */
+.meta-bar {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 1rem; flex-wrap: wrap;
+}
+.langues { display: flex; gap: .35rem; flex-wrap: wrap; }
+.langue {
+  font-size: .78rem; padding: .2rem .55rem; border-radius: 999px;
+  text-decoration: none; color: var(--text-muted, #94a3b8);
+  border: 1px solid transparent;
+}
+.langue:hover { color: var(--text, #e2e8f0); background: rgb(148 163 184 / .12); }
+.langue.actif {
+  color: var(--accent, #a78bfa);
+  border-color: color-mix(in srgb, var(--accent, #a78bfa) 45%, transparent);
+}
+.pas-traduit {
+  margin: .9rem 0 0; padding: .6rem .8rem; border-radius: .5rem;
+  font-size: .85rem; line-height: 1.55;
+  color: var(--text-muted, #94a3b8);
+  background: rgb(148 163 184 / .09);
+  border-left: 3px solid var(--accent, #a78bfa);
+}
+.pas-traduit a { color: var(--accent, #a78bfa); }
 </style>


### PR DESCRIPTION
## Le constat

`nodyx.dev` lisait `docs/en` **en dur** :

```ts
const DOCS_DIR = join(REPO_ROOT, 'docs', 'en')
```

Or le dépôt contient **14 pages françaises** et **9 espagnoles**, traduites par des contributeurs. Aucune n'a jamais été servie.

Des gens ont traduit dans le vide, et personne ne le savait.

Découvert en préparant la réponse à l'[issue #601](https://github.com/Pokled/nodyx/issues/601), dont l'auteur annonce vouloir traduire « interface **et** documentation ». On s'apprêtait à l'y envoyer à son tour.

## Le routage

La langue se lit en tête d'URL : `/fr/relay`, `/es/install`. La route étant déjà un attrape-tout, **aucun fichier de route n'est ajouté**. Les URL existantes ne bougent pas et valent l'anglais.

## Le repli, et pourquoi il doit se voir

Le repli vers l'anglais est indispensable, pas cosmétique : le français couvre 14 pages sur 21. Sans lui, deux tiers des liens d'un lecteur francophone finiraient en 404.

Mais servir de l'anglais sous une URL `/fr/` **sans le dire** laisserait croire que la page est traduite, et découragerait quelqu'un de la traduire. La page l'annonce donc, avec un lien direct vers le fichier à traduire.

## Le sélecteur n'affiche que ce qui existe

`docs/de` et `docs/it` sont des dossiers **vides**. Proposer une langue qui renvoie systématiquement de l'anglais est pire que ne pas la proposer, donc le sélecteur compte les pages avant d'afficher une langue.

## Deux pièges traités

**Les liens de la barre latérale** portent maintenant la langue. Sans ça, un lecteur arrive sur `/fr/relay` et retombe en anglais au premier clic, ce qui aurait vidé la fonctionnalité de son sens.

**L'index de recherche reste anglophone.** C'est la seule langue complète, et mélanger les langues dans un index unique renverrait des résultats que le lecteur ne peut pas lire.

## Vérification, par requêtes réelles

Ce site n'a pas de cadre de test et sa CI ne fait que typage et compilation. J'ai donc mesuré sur un serveur réel plutôt que d'ajouter des tests que la CI n'exécuterait pas.

| URL | résultat |
|---|---|
| `/relay` | anglais, inchangé |
| `/fr/relay` | **traduction française**, sans avertissement |
| `/fr/install` | **traduction française**, sans avertissement |
| `/es/relay` | **traduction espagnole**, sans avertissement |
| `/fr/octoguard` | anglais **avec** l'avertissement, la page n'est pas traduite |
| `/de/relay` | 200, repli anglais |
| sélecteur | `en`, `fr`, `es` ; `de` et `it` exclus |

`svelte-check` à 0 erreur.

## Suite possible

Un cadre de test sur `nodyx-docs` pour couvrir `splitLangPath` et `langPrefix`, ce qui suppose d'ajouter l'exécution des tests à sa CI.
