### PR TITLE
fix(i18n): la porte annoncait « 0 chaine en dur » sans les voir

### DIFF
--- a/nodyx-frontend/scripts/i18n/scan.mjs
+++ b/nodyx-frontend/scripts/i18n/scan.mjs
@@ -15,6 +15,7 @@
 import { readFileSync, readdirSync } from 'node:fs'
 import { join, dirname, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { stripI18n } from './strip.mjs'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const SRC = join(HERE, '..', '..', 'src')
@@ -78,7 +79,16 @@ for (const f of files) {
     ATTR.lastIndex = 0
     for (let m; (m = ATTR.exec(l)); ) { if (LETTER.test(m[1])) { attrHit = true; break } }
     // (b) French text sitting outside an i18n call
-    const frHit = !l.includes('tFn(') && !l.includes('$t(') && (ACC.test(l) || FR.test(l) || FR_FUNC.test(l))
+    //
+    // On NEUTRALISE les appels i18n au lieu d'exempter la ligne entiere. Avant,
+    // `!l.includes('tFn(')` laissait passer TOUTE ligne contenant un appel, donc
+    // celle-ci echappait au controle alors qu'elle porte une chaine en dur :
+    //
+    //     {cond ? 'Remplacer' : tFn('editor.insert')}
+    //
+    // Cas reel, trouve le 2026-08-19 : la porte annoncait 0 chaine en dur.
+    const reste = stripI18n(l)
+    const frHit = ACC.test(reste) || FR.test(reste) || FR_FUNC.test(reste)
     if (attrHit || frHit) hits.push({ n: i + 1, s: s.slice(0, 100) })
   })
   if (hits.length) { perFile.push({ f: relative(SRC, f), hits }); total += hits.length }

--- a/nodyx-frontend/scripts/i18n/strip.mjs
+++ b/nodyx-frontend/scripts/i18n/strip.mjs
@@ -1,0 +1,61 @@
+/**
+ * Neutralisation des portions d'une ligne qui NE SONT PAS de l'interface.
+ *
+ * Extrait de `scan.mjs` pour être testable : la porte i18n avait un angle mort
+ * qu'aucun test ne pouvait attraper tant que cette logique vivait dans un script
+ * exécuté au chargement.
+ *
+ * L'ANGLE MORT, trouvé le 2026-08-19. `scan.mjs` exemptait la ligne ENTIÈRE dès
+ * qu'elle contenait `tFn(` :
+ *
+ *     const frHit = !l.includes('tFn(') && ... // toute la ligne échappe
+ *
+ * Donc ceci passait, et la porte annonçait « 0 chaîne en dur » :
+ *
+ *     {cond ? 'Remplacer' : tFn('editor.insert')}
+ *
+ * On neutralise désormais les appels i18n et on examine ce qui reste.
+ */
+
+/**
+ * Remplace par des espaces ce qui ne doit pas être analysé, en PRÉSERVANT la
+ * longueur pour que les colonnes rapportées restent justes.
+ *
+ * Deux catégories :
+ *   - les appels `tFn(...)` et `$t(...)`, déjà traduits par construction ;
+ *   - les tableaux `keywords: [...]`, qui alimentent uniquement la recherche de
+ *     la palette de commandes et ne sont jamais affichés. Ces alias sont
+ *     volontairement bilingues pour qu'un francophone tape « paramètres » et
+ *     trouve Settings : les signaler pousserait à les supprimer, donc à casser
+ *     la recherche en français.
+ *
+ * @param {string} line
+ * @returns {string} la ligne, appels i18n et alias de recherche blanchis
+ */
+export function stripI18n(line) {
+  line = line.replace(/\bkeywords\s*:\s*\[[^\]]*\]/g, (m) => ' '.repeat(m.length))
+
+  let out = ''
+  for (let i = 0; i < line.length; ) {
+    const m = /^(?:tFn|\$t)\s*\(/.exec(line.slice(i))
+    if (!m) { out += line[i]; i++; continue }
+
+    // Comptage de parenthèses, en ignorant celles vivant dans une chaîne :
+    // `tFn('clé', { n: f(1) })` doit être neutralisé en entier.
+    let prof = 0, guill = null
+    let j = i + m[0].length - 1
+    for (; j < line.length; j++) {
+      const c = line[j]
+      if (guill) {
+        if (c === guill && line[j - 1] !== '\\') guill = null
+        continue
+      }
+      if (c === "'" || c === '"' || c === '`') { guill = c; continue }
+      if (c === '(') prof++
+      else if (c === ')') { prof--; if (prof === 0) { j++; break } }
+    }
+    out += ' '.repeat(j - i)
+    i = j
+  }
+  return out
+}

--- a/nodyx-frontend/src/lib/components/CommandPalette.svelte
+++ b/nodyx-frontend/src/lib/components/CommandPalette.svelte
@@ -108,7 +108,7 @@
         { id: 'profile',       group: 'GO TO',    label: tFn('nav.my_profile'),          sub: `/users/${user.username}`, paths: ICONS.user,    action: () => navigate(`/users/${user.username}`), keywords: ['profile', 'profil', 'compte', user.username] },
         { id: 'notifications', group: 'GO TO',    label: tFn('nav.notifications'),       sub: '/notifications',          paths: ICONS.bell,    action: () => navigate('/notifications'),          keywords: ['notif', 'notifications', 'alertes'] },
         { id: 'dm',            group: 'GO TO',    label: tFn('nav.direct_messages'),     sub: '/dm',                     paths: ICONS.dm,      action: () => navigate('/dm'),                    keywords: ['dm', 'message', 'privé', 'direct'] },
-        { id: 'new-thread',    group: 'ACTIONS',  label: tFn('nav.new_thread'),       sub: 'Créer une discussion',    paths: ICONS.plus,    action: () => navigate('/forum'),                 keywords: ['new', 'thread', 'sujet', 'créer', 'post', 'nouveau'] },
+        { id: 'new-thread',    group: 'ACTIONS',  label: tFn('nav.new_thread'),       sub: '/forum',    paths: ICONS.plus,    action: () => navigate('/forum'),                 keywords: ['new', 'thread', 'sujet', 'créer', 'post', 'nouveau'] },
         { id: 'settings',      group: 'ACTIONS',  label: tFn('nav.account_settings'), sub: '/settings',             paths: ICONS.gear,    action: () => navigate('/settings'),              keywords: ['settings', 'paramètres', 'compte', 'config'] },
       )
     }

--- a/nodyx-frontend/src/lib/components/homepage/widgets/Header.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/Header.svelte
@@ -170,7 +170,7 @@
 		<div class="hdr-stats-dock">
 			<div class="hdr-stat">
 				<span class="hdr-stat-num hdr-stat--purple">{dispMembers.toLocaleString()}</span>
-				<span class="hdr-stat-label">{tFn('common.members') || 'membres'}</span>
+				<span class="hdr-stat-label">{tFn('common.members')}</span>
 			</div>
 			<div class="hdr-stat-sep" aria-hidden="true"></div>
 			<div class="hdr-stat">

--- a/nodyx-frontend/src/lib/components/homepage/widgets/HeroBanner.svelte
+++ b/nodyx-frontend/src/lib/components/homepage/widgets/HeroBanner.svelte
@@ -173,7 +173,7 @@
 		<div class="hb-stats-dock">
 			<div class="hb-stat">
 				<span class="hb-stat-num hb-stat--purple">{dispMembers.toLocaleString()}</span>
-				<span class="hb-stat-label">{tFn('common.members') || 'membres'}</span>
+				<span class="hb-stat-label">{tFn('common.members')}</span>
 			</div>
 			<div class="hb-stat-sep" aria-hidden="true"></div>
 			<div class="hb-stat">

--- a/nodyx-frontend/src/lib/i18nScan.test.ts
+++ b/nodyx-frontend/src/lib/i18nScan.test.ts
@@ -1,0 +1,89 @@
+// ─── La porte i18n doit voir ce qu'elle prétend voir ─────────────────────────
+//
+// Le 2026-08-19, `npm run i18n:check` annonçait « 0 hardcoded French string »
+// alors que l'éditeur affichait `'Remplacer'` en dur. La porte exemptait la
+// LIGNE ENTIÈRE dès qu'elle contenait un appel `tFn(` :
+//
+//     const frHit = !l.includes('tFn(') && ...
+//
+// Une ligne mêlant un appel traduit et une chaîne en dur passait donc
+// intégralement sous le radar. Quatre portes protègent l'i18n de ce dépôt, et
+// l'une d'elles avait un angle mort que rien ne pouvait détecter.
+//
+// Ces contrôles échouent sur l'ancienne logique : ils sont la garde de la garde.
+
+import { describe, it, expect } from 'vitest'
+// Module d'outillage en JS pur, hors du graphe TypeScript de l'application :
+// il est importé tel quel, ses annotations JSDoc suffisent au typage.
+import { stripI18n } from '../../scripts/i18n/strip.mjs'
+
+/** Ce que la porte examine réellement, une fois les appels i18n neutralisés. */
+const reste = (ligne: string) => stripI18n(ligne).trim()
+
+describe('porte i18n : neutralisation des appels traduits', () => {
+  it('LAISSE VISIBLE une chaîne en dur voisine d un appel traduit', () => {
+    // LE cas qui a échappé à la porte. Sur l'ancienne logique, toute la ligne
+    // était ignorée et « Remplacer » restait invisible.
+    const l = `{cond ? 'Remplacer' : tFn('editor.insert')}`
+    expect(reste(l)).toContain('Remplacer')
+    expect(reste(l)).not.toContain('editor.insert')
+  })
+
+  it('attrape aussi les replis en dur, morts mais bien réels', () => {
+    // `tFn` renvoie la clef quand la traduction manque, jamais null : ces replis
+    // sont du code mort ET une chaîne non traduite.
+    for (const l of [
+      `title={tFn('dm.reply') ?? 'Répondre'}`,
+      `<span>{tFn('common.members') || 'membres'}</span>`,
+    ]) {
+      expect(reste(l), l).toMatch(/Répondre|membres/)
+    }
+  })
+
+  it('neutralise un appel entier, y compris ses arguments imbriqués', () => {
+    // Les parenthèses imbriquées doivent être comptées, sinon la neutralisation
+    // s'arrêterait à la première `)` et laisserait la fin de l'appel visible,
+    // ce qui produirait un faux positif à chaque appel un peu riche.
+    const l = `<p>{tFn('a.b', { n: compte(1), x: f(g(2)) })}</p>`
+    const r = stripI18n(l)
+    expect(r).not.toContain('a.b')
+    expect(r).not.toContain('compte')
+    // Le balisage autour, lui, doit survivre intact.
+    expect(r.startsWith('<p>{')).toBe(true)
+    expect(r.endsWith('}</p>')).toBe(true)
+  })
+
+  it('ne se laisse pas piéger par une parenthèse dans une chaîne', () => {
+    const l = `{tFn('chat.send')} garde`
+    expect(reste(l)).toContain('garde')
+    expect(reste(l)).not.toContain('chat.send')
+  })
+
+  it('préserve la longueur, pour que les colonnes rapportées restent justes', () => {
+    for (const l of [
+      `{cond ? 'Remplacer' : tFn('editor.insert')}`,
+      `title={tFn('dm.reply')}`,
+      `keywords: ['profil', 'compte'],`,
+    ]) {
+      expect(stripI18n(l).length, l).toBe(l.length)
+    }
+  })
+})
+
+describe('porte i18n : les alias de recherche ne sont pas de l interface', () => {
+  it('ignore keywords, jamais affiché et volontairement bilingue', () => {
+    // `keywords` alimente uniquement le champ de recherche de la palette. Les
+    // signaler pousserait à supprimer « paramètres » ou « réseau », donc à
+    // casser la recherche pour un francophone.
+    const l = `{ id: 'settings', label: tFn('nav.account_settings'), keywords: ['settings', 'paramètres', 'compte'] }`
+    expect(reste(l)).not.toContain('paramètres')
+    expect(reste(l)).not.toContain('compte')
+  })
+
+  it("n'étend pas cette tolérance au reste de la ligne", () => {
+    // Un libellé affiché reste visible, même quand la ligne porte des alias.
+    const l = `{ sub: 'Créer une discussion', keywords: ['créer', 'nouveau'] }`
+    expect(reste(l)).toContain('Créer une discussion')
+    expect(reste(l)).not.toContain("'créer'")
+  })
+})

--- a/nodyx-frontend/src/routes/chat/+page.svelte
+++ b/nodyx-frontend/src/routes/chat/+page.svelte
@@ -1778,7 +1778,7 @@
 					disabled={!richContent.trim()}
 					class="px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 text-sm text-white font-medium transition-colors"
 				>
-					{editingRichId ? 'Enregistrer' : tFn('chat.send')}
+					{editingRichId ? tFn('common.save') : tFn('chat.send')}
 				</button>
 			</div>
 		</div>

--- a/nodyx-frontend/src/routes/dm/[id]/+page.svelte
+++ b/nodyx-frontend/src/routes/dm/[id]/+page.svelte
@@ -1530,7 +1530,7 @@
 									<!-- Bouton répondre (visible pour tous, sauf messages systèmes) -->
 									<button onclick={() => startReply(msg)}
 										class="p-1 rounded-md hover:bg-white/[0.08] text-gray-600 hover:text-indigo-400 transition-colors"
-										title={tFn('dm.reply') ?? 'Répondre'}>
+										title={tFn('dm.reply')}>
 										<svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 											<polyline points="9 14 4 9 9 4"/>
 											<path d="M20 20v-7a4 4 0 0 0-4-4H4"/>
@@ -1744,7 +1744,7 @@
 						class="dm-composer-emoji-btn w-8 h-8 rounded-xl flex items-center justify-center
 						       text-gray-500 hover:text-gray-200 hover:bg-white/[0.06]
 						       transition-all duration-150"
-						title={tFn('common.add_emoji') ?? 'Insérer un emoji'}
+						title={tFn('common.add_emoji')}
 						aria-label={tFn('dm.insert_emoji')}
 					>
 						<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">


### PR DESCRIPTION
## Une porte qui annonçait zéro sans regarder

`npm run i18n:check` sortait **0 chaîne en dur** alors que l'éditeur affichait `'Remplacer'` en français.

La cause tenait en une ligne :

```js
const frHit = !l.includes('tFn(') && (ACC.test(l) || FR.test(l) || FR_FUNC.test(l))
```

**La ligne entière était exemptée dès qu'elle contenait un appel traduit.** Donc ceci passait sans être vu :

```svelte
{cond ? 'Remplacer' : tFn('editor.insert')}
```

Quatre portes protègent l'i18n de ce dépôt, et l'une d'elles était aveugle sans que rien ne puisse le détecter. C'est plus grave que la chaîne elle-même : une garde qui dit zéro sans regarder est pire qu'une absence de garde, parce qu'on cesse de vérifier à la main.

## Le correctif

On **neutralise** les appels `tFn(...)` et `$t(...)`, puis on examine ce qui reste. Une ligne peut donc être partiellement couverte, ce qui est le cas réel le plus fréquent.

Comptage de parenthèses, pour survivre aux arguments imbriqués comme `tFn('k', { n: f(g(2)) })` : un simple `[^)]*` se serait arrêté à la première parenthèse fermante et aurait produit un faux positif à chaque appel un peu riche. La longueur est préservée, donc les colonnes rapportées restent justes.

## Un faux positif écarté, et il comptait

En corrigeant la porte, elle a d'abord signalé **11 chaînes**. Six étaient réelles, cinq venaient des tableaux `keywords: [...]` de la palette de commandes.

Ces alias ne sont **jamais affichés** : ils alimentent uniquement le champ de recherche (`const haystack = [cmd.label, cmd.sub, ...cmd.keywords]`). Ils sont volontairement bilingues, pour qu'un francophone tape « paramètres » et trouve Settings.

Les signaler aurait poussé quelqu'un à les supprimer, donc à **casser la recherche en français**. Ce contrôle-là aurait causé plus de dégâts que le défaut qu'il corrigeait. Ils sont exclus, avec le pourquoi écrit dans le code.

## Les six chaînes réelles, corrigées

| chaîne | fichier | traitement |
|---|---|---|
| `?? 'Répondre'` | `dm/[id]` | repli supprimé |
| `?? 'Insérer un emoji'` | `dm/[id]` | repli supprimé |
| `\|\| 'membres'` | `Header` | repli supprimé |
| `\|\| 'membres'` | `HeroBanner` | repli supprimé |
| `'Enregistrer'` | `chat` | clé existante `common.save` |
| `'Créer une discussion'` | `CommandPalette` | aligné sur les autres entrées |

Les quatre replis étaient **en plus du code mort** : `tFn` renvoie la clé quand la traduction manque, jamais `null` ni chaîne vide. Ils ne se seraient jamais déclenchés, tout en imposant du français à un lecteur anglophone si jamais ils l'avaient fait.

## La garde de la garde

La logique est extraite dans `scripts/i18n/strip.mjs`, testable sans déclencher le scan complet, et couverte par **7 tests qui tournent en CI** (`npm test` fait partie du job frontend).

Démontré sur les trois chaînes concernées :

| ligne | ancienne porte | nouvelle porte |
|---|---|---|
| `{cond ? 'Remplacer' : tFn(...)}` | **aveugle** | voit |
| `title={tFn('dm.reply') ?? 'Répondre'}` | **aveugle** | voit |
| `{tFn('common.members') \|\| 'membres'}` | **aveugle** | voit |

4 portes i18n vertes, 126 tests, `svelte-check` à 0 erreur.
