### PR TITLE
fix(editeur): un article se disloquait des qu'on le rouvrait

### DIFF
--- a/nodyx-core/src/tests/sanitize-heading-anchors.test.ts
+++ b/nodyx-core/src/tests/sanitize-heading-anchors.test.ts
@@ -1,0 +1,54 @@
+// ─── Une ancre ne doit pas mourir parce qu'on a changé un niveau de titre ────
+//
+// Le 2026-08-19, un rédacteur a passé deux titres de section de `h2` à `h1`
+// depuis l'éditeur. TipTap avait correctement conservé leur `id`, mais la liste
+// d'attributs de l'assainisseur ne l'autorisait que sur `h2`, `h3` et `h4`.
+// L'attribut a donc été retiré à l'enregistrement, et deux entrées du sommaire
+// pointaient dans le vide, SANS le moindre message.
+//
+// Perdre une ancre en silence est un piège, pas une protection.
+
+import { describe, it, expect } from 'vitest'
+import { sanitize } from '../utils/sanitize'
+
+/** L'id survit-il à l'assainissement, pour ce niveau de titre ? */
+const gardeId = (n: number) =>
+  sanitize(`<h${n} id="section">Titre</h${n}>`).includes('id="section"')
+
+describe("ancres de titres : les quatre niveaux se comportent pareil", () => {
+  it("conserve l'id sur h1, le cas qui a cassé un sommaire en production", () => {
+    expect(gardeId(1)).toBe(true)
+  })
+
+  it("conserve l'id sur h2, h3 et h4, comme avant", () => {
+    for (const n of [2, 3, 4]) expect(gardeId(n), `h${n}`).toBe(true)
+  })
+
+  it("un sommaire survit au passage d'un titre de h2 à h1", () => {
+    // Le scénario exact : le lien du sommaire et le titre doivent continuer de
+    // se répondre après l'édition.
+    const html = sanitize(
+      '<div class="toc"><a href="#kaon">KAON</a></div><h1 id="kaon">KAON</h1>',
+    )
+    expect(html).toContain('href="#kaon"')
+    expect(html).toContain('id="kaon"')
+  })
+
+  it('centre un titre sans lui faire perdre son ancre', () => {
+    // L'auteur avait aussi centré ses titres : `style` et `id` doivent survivre
+    // ensemble, sinon on répare un défaut en en laissant un autre.
+    const html = sanitize('<h1 style="text-align:center" id="kaon">KAON</h1>')
+    expect(html).toContain('id="kaon"')
+    expect(html).toContain('text-align:center')
+  })
+})
+
+describe("ancres de titres : ce qui reste refusé", () => {
+  it("n'autorise pas l'id sur un élément quelconque", () => {
+    // La raison d'être de la restriction d'origine : limiter le DOM clobbering.
+    // Elle tient toujours partout ailleurs que sur les titres.
+    expect(sanitize('<p id="x">t</p>')).not.toContain('id="x"')
+    expect(sanitize('<div id="x">t</div>')).not.toContain('id="x"')
+    expect(sanitize('<span id="x">t</span>')).not.toContain('id="x"')
+  })
+})

--- a/nodyx-core/src/utils/sanitize.ts
+++ b/nodyx-core/src/utils/sanitize.ts
@@ -27,6 +27,14 @@ const ALLOWED_ATTRS: sanitizeHtml.IOptions['allowedAttributes'] = {
   'p':      ['class', 'style', 'data-align', 'data-type'],
   // id sur les titres : permet les sommaires à ancres (#section). Pas d'id
   // ailleurs pour limiter le risque de DOM clobbering.
+  //
+  // h1 EN FAIT PARTIE, et son absence a coûté cher (2026-08-19). Un rédacteur a
+  // passé deux titres ancrés de h2 à h1 depuis l'éditeur : TipTap avait bien
+  // conservé leur id, mais cette liste le retirait, et deux entrées du sommaire
+  // sont mortes SANS le moindre message. Perdre une ancre en silence parce qu'on
+  // a changé un niveau de titre est un piège, pas une protection : les trois
+  // autres niveaux l'autorisaient déjà, la surface de risque est la même.
+  'h1':     ['class', 'id', 'style', 'data-align', 'data-type'],
   'h2':     ['class', 'id', 'style', 'data-align', 'data-type'],
   'h3':     ['class', 'id', 'data-align', 'data-type'],
   'h4':     ['class', 'id', 'data-align', 'data-type'],

--- a/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
+++ b/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
@@ -164,6 +164,24 @@
 
 		// ── Custom Image with alignment ──────────────────────────────────────
 		const AlignableImage = Image.extend({
+			// `inline: true` est STRUCTUREL, pas cosmétique.
+			//
+			// Par défaut l'extension Image crée un nœud de BLOC (`group: 'block'`).
+			// Un nœud de bloc ne peut pas vivre dans un paragraphe : à la lecture,
+			// ProseMirror l'EXTRAIT et le pose entre deux paragraphes. Une icône
+			// posée devant un lien se retrouvait donc seule sur sa ligne dès que
+			// l'auteur rouvrait son article dans l'éditeur, alors qu'elle était
+			// correcte à la publication. Constaté en production le 2026-08-19.
+			//
+			// En `inline`, l'image devient un nœud de ligne : elle reste dans le
+			// paragraphe. Les alignements de bloc (`center`, `full`) continuent de
+			// s'afficher en bloc, c'est le CSS qui les gouverne, pas le schéma.
+			addOptions() {
+				// `this.parent?.()` est typé optionnel, mais il est toujours défini
+				// sur une extension dérivée : sans l'assertion, le type résultant a
+				// des champs facultatifs et ne satisfait plus `ImageOptions`.
+				return { ...this.parent!(), inline: true }
+			},
 			addAttributes() {
 				return {
 					...this.parent?.(),

--- a/nodyx-frontend/src/lib/editorImageSchema.test.ts
+++ b/nodyx-frontend/src/lib/editorImageSchema.test.ts
@@ -1,0 +1,71 @@
+// ─── L'image doit pouvoir vivre DANS un paragraphe ───────────────────────────
+//
+// Le 2026-08-19, un article publié avec des icônes devant ses liens s'est
+// disloqué dès qu'un rédacteur l'a rouvert dans l'éditeur : chaque icône s'est
+// retrouvée SEULE sur sa ligne, au-dessus du lien qu'elle devait précéder.
+//
+// La cause n'était pas le CSS mais le SCHÉMA. L'extension Image de TipTap crée
+// par défaut un nœud de bloc (`group: 'block'`). Un nœud de bloc ne peut pas
+// être contenu dans un paragraphe : à la lecture du HTML, ProseMirror l'extrait
+// et le place entre deux paragraphes. Aucun arrangement du HTML n'y échappe.
+//
+// Ces contrôles échouent sur la configuration d'avant.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { getSchema } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import Image from '@tiptap/extension-image'
+
+const COMPOSANT = new URL('./components/editor/NodyxEditor.svelte', import.meta.url).pathname
+
+/** Le schéma tel que ProseMirror le construira, avec l'option testée. */
+function schemaAvec(inline: boolean) {
+  return getSchema([StarterKit, Image.configure({ inline })])
+}
+
+/** Un paragraphe peut-il contenir ce type de nœud ? C'est toute la question. */
+function paragrapheAccepte(inline: boolean) {
+  const s = schemaAvec(inline)
+  return s.nodes.paragraph.contentMatch.matchType(s.nodes.image) !== null
+}
+
+describe('schéma : une image en ligne reste dans son paragraphe', () => {
+  it('un nœud image de BLOC est refusé par le paragraphe, donc extrait', () => {
+    // La démonstration du défaut : c'est cette configuration qui disloquait
+    // l'article à la première réouverture.
+    expect(paragrapheAccepte(false)).toBe(false)
+  })
+
+  it('un nœud image EN LIGNE est accepté, donc conservé', () => {
+    expect(paragrapheAccepte(true)).toBe(true)
+  })
+
+  it("le groupe du nœud suit l'option, c'est lui qui décide", () => {
+    expect(schemaAvec(false).nodes.image.spec.group).toBe('block')
+    expect(schemaAvec(true).nodes.image.spec.group).toBe('inline')
+    expect(schemaAvec(true).nodes.image.isInline).toBe(true)
+  })
+})
+
+describe("l'éditeur configure bien son image en ligne", () => {
+  // Même approche que les contrôles de migrations du cœur : on lit le fichier,
+  // parce que l'extension est construite derrière un import dynamique et n'est
+  // pas exportable sans refactor du composant.
+  const src = readFileSync(COMPOSANT, 'utf-8')
+
+  it('AlignableImage déclare inline: true dans ses options', () => {
+    // Fenêtre large : le bloc porte un commentaire expliquant pourquoi l'option
+    // est structurelle, et un contrôle trop serré casserait au premier mot ajouté.
+    expect(src).toMatch(/addOptions\(\)\s*\{[\s\S]{0,400}?inline:\s*true/)
+  })
+
+  it("l'option est posée sur AlignableImage, pas ailleurs", () => {
+    const i = src.indexOf('const AlignableImage = Image.extend({')
+    expect(i).toBeGreaterThan(-1)
+    // On borne la recherche au bloc de l'extension, pour qu'un `inline: true`
+    // apparaissant ailleurs dans ce fichier de 1700 lignes ne fasse pas passer
+    // ce contrôle par accident.
+    expect(src.slice(i, i + 900)).toContain('inline: true')
+  })
+})


### PR DESCRIPTION
Signalé par un rédacteur sur un article publié : après une simple édition (un séparateur ajouté, deux titres centrés), **les icônes posées devant les liens se sont retrouvées seules sur leur ligne** et deux entrées du sommaire pointaient dans le vide. Il n'y avait pourtant pas touché.

Deux défauts indépendants, tous les deux silencieux. C'est la première chose que voit quelqu'un qui vient écrire un article.

## 1. Le nœud image était de bloc

L'extension Image de TipTap crée par défaut un nœud `group: 'block'`. Un nœud de bloc **ne peut pas être contenu dans un paragraphe** : à la lecture du HTML, ProseMirror l'extrait et le pose entre deux paragraphes.

Avant :
```html
<p><img data-align="inline" /> <a>Sa chaîne Twitch</a>, pour le voir avancer</p>
```

Après une réouverture dans l'éditeur :
```html
<p></p><img data-align="inline" /><p><a>Sa chaîne Twitch</a>, …</p>
```

L'attribut survivait, l'image non. **Aucun arrangement du HTML n'y échappe, c'est le schéma qui décide.** L'alignement en ligne livré plus tôt survivait donc à une publication par l'API, mais pas à une édition : un demi-travail.

`inline: true` sur `AlignableImage`. Les alignements de bloc continuent de s'afficher en bloc, c'est le CSS qui les gouverne, pas le schéma.

## 2. L'assainisseur retirait l'id des h1

Le rédacteur a passé deux titres ancrés de `h2` à `h1`. TipTap avait **correctement conservé** leur `id`, son extension fait son travail. Mais la liste d'attributs du cœur ne l'autorisait que sur `h2`, `h3` et `h4`.

L'attribut a donc été retiré à l'enregistrement, et deux ancres sont mortes **sans le moindre message**.

Perdre une ancre parce qu'on a changé un niveau de titre est un piège, pas une protection. Les trois autres niveaux l'autorisaient déjà : la surface de risque est identique. `style` est aligné aussi, sinon centrer un `h1` lui faisait perdre son centrage, exactement le second geste du rédacteur.

**Cette partie touche `nodyx-core`** : une ligne dans la liste d'attributs de `sanitize.ts`.

## Vérification

10 tests, répartis sur les deux dépôts.

**Côté schéma**, la démonstration du défaut lui-même :

| contrôle | résultat |
|---|---|
| un paragraphe accepte un nœud image de **bloc** | **non**, d'où l'extraction |
| un paragraphe accepte un nœud image **en ligne** | oui |
| le groupe du nœud suit l'option | `block` puis `inline` |

**Côté assainisseur**, les 3 contrôles sur `h1` **tombent** quand on retire la ligne, vérifié en la retirant. Et ce qui doit rester refusé l'est toujours : pas d'`id` sur `p`, `div` ou `span`, la raison d'être de la restriction d'origine.

901 tests cœur, 131 frontend, 4 portes i18n vertes, `svelte-check` à 0 erreur.

## Réparé en production

L'article touché a été remis d'aplomb en parallèle : titres rendus à `h2` avec leurs ancres, centrage conservé, icônes remontées dans leur paragraphe, 9 paragraphes vides laissés par l'édition nettoyés. 10 ancres sur 10 valides.
