### PR TITLE
fix(translate): la page defilait de 337 px vers une zone vide

### DIFF
--- a/nodyx-frontend/src/lib/translateScroll.test.ts
+++ b/nodyx-frontend/src/lib/translateScroll.test.ts
@@ -1,0 +1,52 @@
+// ─── /translate ne doit pas défiler horizontalement ──────────────────────────
+//
+// La page défilait de 337 px sous 727 px de large, sans qu'aucun élément visible
+// ne dépasse : la zone à droite était entièrement vide. Le défaut a résisté à
+// deux tentatives avant d'être compris.
+//
+// CAUSE. Les libellés `.sr`, réservés aux lecteurs d'écran, sont en
+// `position: absolute`. Sans ancêtre positionné, leur bloc conteneur est le bloc
+// conteneur INITIAL et non le conteneur défilant qui les entoure : ils lui
+// échappaient et étendaient la zone défilable du document jusqu'à 727 px, là où
+// se trouve le dernier d'entre eux dans la table de 800 px.
+//
+// SIGNATURE, utile ailleurs : `body` ne débordait pas (390 pour 390), seul
+// `html` débordait. Quand seul l'élément racine déborde, chercher un élément
+// positionné par rapport au bloc conteneur initial, pas un élément trop large.
+//
+// Une mise en page ne se teste pas sans navigateur. Ce contrôle garde donc la
+// DÉCISION, sur le modèle des contrôles de migrations du cœur : si quelqu'un
+// retire `position: relative` en le croyant inutile, il saura pourquoi il était
+// là.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+const PAGE = new URL('../routes/translate/+page.svelte', import.meta.url).pathname
+const src = readFileSync(PAGE, 'utf-8')
+
+/** La règle CSS d'un sélecteur, telle qu'écrite dans le composant. */
+function regle(selecteur: string): string {
+  const m = new RegExp(`\\${selecteur}\\s*\\{([^}]*)\\}`).exec(src)
+  return m ? m[1] : ''
+}
+
+describe('/translate : le conteneur de table contient ses absolus', () => {
+  it('.tscroll est positionné, sinon les .sr lui échappent', () => {
+    expect(regle('.tscroll')).toMatch(/position:\s*relative/)
+  })
+
+  it('.tscroll garde son défilement horizontal, la table fait 800 px', () => {
+    // Les deux vont ensemble : `overflow-x` sans `position` laissait fuir les
+    // absolus, `position` sans `overflow-x` casserait la lecture de la table.
+    expect(regle('.tscroll')).toMatch(/overflow-x:\s*auto/)
+  })
+
+  it('les libellés lecteurs d écran restent en position absolue', () => {
+    // On ne corrige pas le débordement en cassant l'accessibilité : `.sr` doit
+    // rester la technique de masquage visuel habituelle.
+    const sr = regle('.sr')
+    expect(sr).toMatch(/position:\s*absolute/)
+    expect(sr).toMatch(/width:\s*1px/)
+  })
+})

--- a/nodyx-frontend/src/routes/translate/+page.svelte
+++ b/nodyx-frontend/src/routes/translate/+page.svelte
@@ -328,7 +328,19 @@
 	.search input:focus-visible { border-color: var(--nx-accent); box-shadow: 0 0 0 3px rgb(109 118 245 / 0.15); }
 	.search input::placeholder { color: #61647a; }
 
-	.tscroll { overflow-x: auto; }
+	/* `position: relative` N'EST PAS DECORATIF, il corrige un debordement.
+	   La page defilait horizontalement de 337 px sous 727 px de large, sans
+	   qu'aucun element visible ne depasse : la zone a droite etait vide.
+	   Cause, trouvee au troisieme essai. Les libelles `.sr` reserves aux lecteurs
+	   d'ecran sont en `position: absolute`. Sans ancetre positionne, leur bloc
+	   conteneur est le bloc conteneur INITIAL, pas ce conteneur defilant : ils
+	   lui echappaient et etendaient la zone defilable du document jusqu'a 727 px,
+	   la ou se trouve le dernier d'entre eux dans la table de 800 px.
+	   Mesure : `body` ne debordait pas (390 pour 390), seul `html` debordait.
+	   C'est la signature d'un element positionne par rapport au bloc initial.
+	   En rendant ce conteneur positionne, les `.sr` redeviennent les siens, donc
+	   contenus et rognes. Ils restent lus par les lecteurs d'ecran. */
+	.tscroll { overflow-x: auto; position: relative; }
 	table { width: 100%; border-collapse: collapse; min-width: 720px; }
 	th { text-align: left; padding: 0; border-bottom: 1px solid #1c1e28; white-space: nowrap; }
 	th.mid { padding: 11px 16px; text-align: center; }


### PR DESCRIPTION
Sous 727 px de large, `/translate` défilait horizontalement de **337 px**. La zone à droite était **entièrement vide** : aucun élément visible n'y figurait.

Le défaut a résisté à deux tentatives, notées honnêtement comme « cause racine non trouvée ».

## La cause

Les libellés `.sr`, réservés aux lecteurs d'écran, sont en `position: absolute`. **Aucun de leurs ancêtres n'était positionné**, donc leur bloc conteneur était le bloc conteneur **initial**, pas le conteneur défilant qui les entoure.

Ils lui échappaient et étendaient la zone défilable du document jusqu'à 727 px, exactement là où se trouve le dernier d'entre eux dans la table de 800 px.

Le point contre-intuitif : **`overflow-x: auto` ne contient pas un descendant absolu** si l'élément n'est pas lui-même positionné. C'est ce qui rendait le défaut invisible à l'inspection, puisque la table, elle, était correctement contenue.

## La signature qui aurait dû me mettre sur la piste

| élément | largeur | scrollWidth |
|---|---|---|
| `div.tscroll` | 344 | 800, contenu correctement |
| `section.panel` | 346 | 359 |
| `div.wrap` | 390 | 390 |
| **`body`** | **390** | **390, aucun débordement** |
| **`html`** | **390** | **727** |

**`body` ne débordait pas, seul `html` débordait.** Quand seul l'élément racine déborde, la cause est un élément positionné par rapport au bloc conteneur initial, pas un élément trop large. C'est une signature réutilisable.

## Ce qui m'avait égaré

`scrollWidth` et `getBoundingClientRect` gonflent tous les deux sur un élément rogné par un conteneur défilant. Les deux désignaient la table, qui n'y était pour rien.

Ce qui a fini par marcher : mesurer le **symptôme réel**, « la page bouge-t-elle quand on la pousse à droite », puis parcourir la chaîne d'ancêtres jusqu'à voir où le débordement s'échappe.

## Le correctif

`position: relative` sur le conteneur défilant. Les `.sr` redeviennent les siens, donc contenus et rognés, et **restent lus par les lecteurs d'écran** : on ne corrige pas une mise en page en cassant l'accessibilité.

| mesure | avant | après |
|---|---|---|
| décalage horizontal | 337 px | **0** |
| `documentElement.scrollWidth` | 727 | **390** |

Vérifié aussi en masquant les `.sr` : même résultat, ce qui confirme la cause.

## Vérification

Une mise en page ne se teste pas sans navigateur. Les 3 contrôles gardent donc la **décision**, sur le modèle des contrôles de migrations du cœur : l'un d'eux **tombe** si l'on retire `position: relative`, et un autre vérifie que `.sr` reste bien la technique de masquage habituelle.

134 tests frontend, 4 portes i18n vertes, `svelte-check` à 0 erreur.
