### PR TITLE
fix(editeur): le sommaire ouvrait un onglet vide au lieu de descendre

### DIFF
--- a/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
+++ b/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
@@ -280,6 +280,28 @@
 		// donc au rechargement l'extension ne reconnaissait plus son wrapper et
 		// JETAIT l'iframe (vidéos qui disparaissent à la réédition). On ajoute
 		// une règle parseHTML qui reparse aussi un <iframe> nu d'origine YouTube.
+		// ── Liens : une ancre interne ne s'ouvre pas dans un onglet ──────────
+		//
+		// L'extension Link applique par DÉFAUT `target="_blank"` et
+		// `rel="noopener noreferrer nofollow"` à tous les liens, sans distinguer
+		// leur destination. Appliqué à une ancre `#section`, ça ouvre un onglet
+		// VIDE au lieu de descendre dans la page : tout sommaire éditable était
+		// donc cassé dès la première réouverture de l'article. Constaté en
+		// production le 2026-08-19.
+		//
+		// On ne retire ces attributs que pour les ancres, jamais pour les liens
+		// sortants, où ils restent la bonne pratique.
+		const SmartLink = Link.extend({
+			renderHTML({ HTMLAttributes }: any) {
+				const href = HTMLAttributes?.href
+				if (typeof href === 'string' && href.startsWith('#')) {
+					const { target: _t, rel: _r, ...interne } = HTMLAttributes
+					return ['a', mergeAttributes(interne), 0]
+				}
+				return ['a', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0]
+			},
+		})
+
 		const RobustYoutube = Youtube.extend({
 			parseHTML() {
 				return [
@@ -627,7 +649,7 @@
 				StarterKit.configure({ codeBlock: false, link: false, underline: false }),
 				Underline,
 				TextAlign.configure({ types: ['heading', 'paragraph', 'image'] }),
-				Link.configure({ openOnClick: false, autolink: true }),
+				SmartLink.configure({ openOnClick: false, autolink: true }),
 				AlignableImage,
 				RobustYoutube.configure({ nocookie: true }),
 				Table.configure({ resizable: false }),

--- a/nodyx-frontend/src/lib/editorLinkAnchors.test.ts
+++ b/nodyx-frontend/src/lib/editorLinkAnchors.test.ts
@@ -1,0 +1,59 @@
+// ─── Une ancre interne ne doit pas s'ouvrir dans un onglet ───────────────────
+//
+// Le 2026-08-19, un rédacteur a rouvert un article dans l'éditeur. Les liens de
+// son sommaire en sont ressortis ainsi :
+//
+//     <a target="_blank" rel="noopener noreferrer nofollow" href="#parcours">
+//
+// Cliquer une entrée du sommaire ouvrait donc un onglet VIDE au lieu de
+// descendre dans la page. Tout sommaire éditable était cassé dès la première
+// réouverture.
+//
+// La cause n'est pas une faute de frappe : c'est le DÉFAUT de l'extension Link,
+// appliqué sans distinguer la destination du lien.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import Link from '@tiptap/extension-link'
+
+const COMPOSANT = new URL('./components/editor/NodyxEditor.svelte', import.meta.url).pathname
+const src = readFileSync(COMPOSANT, 'utf-8')
+
+describe("le danger vient du paquet, pas de notre code", () => {
+  it("l'extension Link ouvre TOUT dans un onglet par défaut", () => {
+    // La démonstration du piège : ces attributs sont posés sur chaque lien,
+    // y compris une ancre `#section` pour laquelle ils n'ont aucun sens.
+    const defauts = (Link as unknown as { options?: Record<string, unknown> }).options
+      ?.HTMLAttributes as Record<string, string> | undefined
+    expect(defauts?.target).toBe('_blank')
+    expect(defauts?.rel).toContain('noopener')
+  })
+})
+
+describe("l'éditeur neutralise ces attributs pour les ancres", () => {
+  // L'extension est construite derrière un import dynamique et n'est pas
+  // exportable sans refactor du composant : on garde la décision en lisant le
+  // fichier, comme le font les contrôles de migrations du cœur.
+
+  it('un SmartLink est défini et remplace Link dans les extensions', () => {
+    expect(src).toContain('const SmartLink = Link.extend({')
+    expect(src).toMatch(/SmartLink\.configure\(\{[^}]*openOnClick/)
+    // L'ancien branchement ne doit plus exister, sinon le correctif est inerte.
+    expect(src).not.toMatch(/\n\s*Link\.configure\(\{/)
+  })
+
+  it('il ne retire target et rel que pour un href commençant par #', () => {
+    const i = src.indexOf('const SmartLink = Link.extend({')
+    const bloc = src.slice(i, i + 700)
+    expect(bloc).toContain("href.startsWith('#')")
+    expect(bloc).toMatch(/target:\s*_t,\s*rel:\s*_r/)
+  })
+
+  it('les liens sortants gardent leur ouverture en onglet', () => {
+    // On corrige une ancre cassée, on ne supprime pas une bonne pratique :
+    // un lien externe doit continuer de sortir avec son `rel` de sécurité.
+    const i = src.indexOf('const SmartLink = Link.extend({')
+    const bloc = src.slice(i, i + 700)
+    expect(bloc).toContain('this.options.HTMLAttributes')
+  })
+})


### PR DESCRIPTION
Troisième défaut de la même famille, trouvé en rouvrant un article publié dans l'éditeur. Les liens du sommaire en ressortaient ainsi :

```html
<a target="_blank" rel="noopener noreferrer nofollow" href="#parcours">
```

**Cliquer une entrée du sommaire ouvrait un onglet vide** au lieu de descendre dans la page. Tout sommaire éditable était cassé dès la première réouverture.

## La cause n'est pas notre code

L'extension Link de TipTap applique **par défaut** ces attributs à tous les liens, sans distinguer leur destination. Vérifié directement dans le paquet :

```
HTMLAttributes par défaut : {"target":"_blank","rel":"noopener noreferrer nofollow","class":null}
```

Sur une ancre `#section`, ils n'ont aucun sens : il n'y a pas de page à ouvrir, il y a une position à atteindre.

## Le correctif

`SmartLink` surcharge `renderHTML` et ne retire ces deux attributs que pour un `href` commençant par `#`.

Les liens sortants **gardent** leur ouverture en onglet et leur `rel` de sécurité. On corrige une ancre cassée, on ne supprime pas une bonne pratique.

## Vérification

4 contrôles. Le premier démontre le **danger à sa source**, en lisant les attributs par défaut du paquet : le test échouerait si TipTap changeait ce défaut, et on saurait pourquoi.

Les autres gardent la décision, dont un qui vérifie que l'ancien branchement `Link.configure` **n'existe plus** dans le fichier : sans lui, on pourrait définir `SmartLink` sans jamais le brancher, et le correctif serait inerte tout en ayant l'air fait.

138 tests, 4 portes i18n vertes, `svelte-check` à 0 erreur.

## L'article touché est réparé

10 ancres nettoyées de leurs attributs, sommaire vérifié à 10 liens pour 10 ancres, 0 cassé.

L'enveloppe responsive de la vidéo, elle aussi perdue au passage dans l'éditeur, a été rétablie : l'iframe retrouve son ratio, **322x180** au lieu de 324x360.

## Ce qui reste, et que je ne corrige pas ici

L'extension Youtube **perd la classe `youtube-wrapper`** à chaque aller-retour dans l'éditeur. Mesuré : sans elle l'iframe garde une hauteur de 360 px pour 324 de large, donc un ratio faux. Elle ne déborde pas et rien n'est cassé, c'est de la dégradation cosmétique.

C'est un quatrième défaut de la même famille, il mérite son propre lot plutôt qu'un correctif ajouté à la hâte en fin de session.
