### PR TITLE
fix(editeur): toute video inseree perdait sa mise en forme

### DIFF
--- a/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
+++ b/nodyx-frontend/src/lib/components/editor/NodyxEditor.svelte
@@ -303,6 +303,27 @@
 		})
 
 		const RobustYoutube = Youtube.extend({
+			// L'extension enveloppe l'iframe dans `<div data-youtube-video>`. Or
+			// l'assainisseur du coeur n'autorise pas cet attribut : il le retire et
+			// laisse un `<div>` NU, sans aucune prise pour le style. Consequence
+			// mesuree le 2026-08-20 : toute video inseree depuis l'editeur perdait
+			// sa mise en forme, gardant 360 px de haut pour 324 de large, donc un
+			// ratio faux. Ce n'etait pas un defaut d'aller-retour, c'etait le cas
+			// NORMAL, et les videos ecrites a la main etaient l'exception.
+			//
+			// `class` fait partie des attributs autorises : on y accroche la classe
+			// que la feuille de style attend deja, sans rien retirer de ce que
+			// l'extension produit pour son propre usage dans l'editeur.
+			renderHTML(props: any) {
+				// `this.parent!` et non `?.` : sur une extension derivee le parent est
+				// toujours defini, et `renderHTML` doit rendre un DOMOutputSpec, jamais
+				// `undefined`. Meme contrainte que pour `addOptions` plus bas.
+				const rendu = this.parent!(props)
+				if (Array.isArray(rendu) && rendu[0] === 'div' && rendu[1] && typeof rendu[1] === 'object') {
+					rendu[1] = mergeAttributes(rendu[1], { class: 'youtube-wrapper' })
+				}
+				return rendu
+			},
 			parseHTML() {
 				return [
 					...(this.parent?.() ?? []),

--- a/nodyx-frontend/src/lib/editorYoutubeWrapper.test.ts
+++ b/nodyx-frontend/src/lib/editorYoutubeWrapper.test.ts
@@ -1,0 +1,61 @@
+// ─── Une vidéo insérée depuis l'éditeur doit garder sa mise en forme ─────────
+//
+// Mesuré le 2026-08-20. L'extension Youtube enveloppe l'iframe dans
+// `<div data-youtube-video>`. Or l'assainisseur du cœur n'autorise pas cet
+// attribut : il le retire et laisse un `<div>` NU, sans aucune prise pour la
+// feuille de style, qui vise `.youtube-wrapper`.
+//
+// Ce n'était donc pas un défaut d'aller-retour comme les trois précédents :
+// c'était le cas NORMAL. Toute vidéo insérée depuis l'éditeur perdait sa mise
+// en forme, et les vidéos écrites à la main en HTML étaient l'exception.
+//
+// Effet visible : l'iframe gardait 360 px de haut pour 324 de large, soit un
+// ratio faux, au lieu des 322x180 attendus en 16:9.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+const COMPOSANT = new URL('./components/editor/NodyxEditor.svelte', import.meta.url).pathname
+const src = readFileSync(COMPOSANT, 'utf-8')
+
+const CSS = new URL('../app.css', import.meta.url).pathname
+const css = readFileSync(CSS, 'utf-8')
+
+describe("l'enveloppe de la vidéo porte la classe attendue", () => {
+  it('RobustYoutube surcharge renderHTML pour poser la classe', () => {
+    const i = src.indexOf('const RobustYoutube = Youtube.extend({')
+    expect(i).toBeGreaterThan(-1)
+    const bloc = src.slice(i, i + 1400)
+    expect(bloc).toContain('renderHTML')
+    expect(bloc).toContain("class: 'youtube-wrapper'")
+  })
+
+  it("s'appuie sur le rendu du parent au lieu de le réécrire", () => {
+    // Réécrire l'enveloppe à la main casserait au premier changement de
+    // l'extension. On ajoute la classe à ce qu'elle produit, rien de plus.
+    const i = src.indexOf('const RobustYoutube = Youtube.extend({')
+    const bloc = src.slice(i, i + 1400)
+    expect(bloc).toContain('this.parent!(props)')
+    expect(bloc).toContain('mergeAttributes')
+  })
+
+  it('la classe visée est bien celle que la feuille de style attend', () => {
+    // Le contrôle qui relie les deux moitiés : poser une classe que le style
+    // ignore ne servirait à rien, et le défaut serait invisible.
+    expect(css).toMatch(/\.nodyx-prose\s+\.youtube-wrapper/)
+    expect(css).toMatch(/\.youtube-wrapper\s*\{[\s\S]{0,200}position:\s*relative/)
+  })
+})
+
+describe("ce que l'assainisseur laisse passer", () => {
+  it('la classe est un attribut autorisé, contrairement à data-youtube-video', () => {
+    // La raison du choix : `class` traverse l'assainissement, l'attribut de
+    // l'extension non. Vérifié dans la liste du cœur.
+    const sanit = readFileSync(
+      new URL('../../../nodyx-core/src/utils/sanitize.ts', import.meta.url).pathname,
+      'utf-8',
+    )
+    expect(sanit).toMatch(/'\*':\s*\[[^\]]*'class'/)
+    expect(sanit).not.toContain('data-youtube-video')
+  })
+})


### PR DESCRIPTION
Quatrième défaut de la même famille, et **le plus large des quatre** : ce n'était pas un problème d'aller-retour dans l'éditeur, c'était le cas normal.

## La chaîne complète, mesurée

1. l'extension Youtube enveloppe l'iframe dans `<div data-youtube-video>`
2. l'assainisseur du cœur **n'autorise pas cet attribut**, il le retire
3. il reste un `<div>` **nu**, sans aucune prise pour la feuille de style, qui vise `.youtube-wrapper`

Vérifié directement sur l'assainisseur déployé :

```
ce que produit l'éditeur   ->  <div><iframe src="..."></iframe></div>
avec une classe            ->  <div class="youtube-wrapper"><iframe src="..."></iframe></div>
```

Donc **toute vidéo insérée depuis l'éditeur sortait sans mise en forme**, et les vidéos écrites à la main en HTML étaient l'exception, pas la règle.

Effet visible : l'iframe gardait **360 px de haut pour 324 de large**, ratio faux, là où le 16:9 attendu donne 322x180.

## Le correctif

`renderHTML` ajoute la classe `youtube-wrapper` à l'enveloppe produite par l'extension.

Pourquoi la classe plutôt qu'élargir la liste du cœur : **`class` traverse l'assainissement**, `data-youtube-video` non. On accroche donc la mise en forme à un attribut déjà autorisé, sans toucher au sanctuaire.

Et on s'appuie sur le rendu du parent au lieu de le réécrire : réécrire l'enveloppe à la main casserait au premier changement de l'extension.

## Vérification

4 contrôles, dont **2 tombent** quand on retire la surcharge, vérifié en la retirant.

Le troisième est celui qui compte le plus : il **relie les deux moitiés** en vérifiant que la classe posée est bien celle que la feuille de style attend. Sans lui, on pourrait poser une classe que le CSS ignore, et le correctif serait inerte tout en ayant l'air fait.

Le quatrième documente la raison du choix, en vérifiant que `class` est autorisé par le cœur et que `data-youtube-video` ne l'est pas.

142 tests, 4 portes i18n vertes, `svelte-check` à 0 erreur.

## Ampleur en base

3 billets contiennent une vidéo, 1 était touché. Le défaut comptait surtout pour l'avenir : chaque vidéo à venir aurait été concernée.
