### PR TITLE
fix(annuaire): n'importe qui pouvait reserver un sous-domaine d'infrastructure

### DIFF
--- a/nodyx-core/src/routes/directory.ts
+++ b/nodyx-core/src/routes/directory.ts
@@ -7,6 +7,7 @@ import http from 'http';
 import sanitizeHtml from 'sanitize-html';
 import { db, redis } from '../config/database';
 import { getClientIp, estPubliquementRoutable } from '../utils/clientIp'
+import { isReservedSlug } from '../utils/reservedSlugs'
 
 // Strict rate-limit for public search endpoint (30 req/min per IP)
 async function searchRateLimit(request: FastifyRequest, reply: FastifyReply): Promise<void> {
@@ -198,6 +199,18 @@ export default async function directoryRoutes(app: FastifyInstance) {
 
     if (!/^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$/.test(slug)) {
       return reply.status(400).send({ error: 'Invalid slug format (lowercase alphanumeric and hyphens, 3-63 chars)' });
+    }
+
+    // Un slug revendique `<slug>.nodyx.org`. Plusieurs sous-domaines portent
+    // deja de l'infrastructure, et la validation ci-dessus est purement
+    // formelle : sans ce controle, `olympus`, `relay` ou `tunnel` etaient
+    // inscriptibles. Voir utils/reservedSlugs.ts pour ce que ca permettait.
+    if (isReservedSlug(slug)) {
+      return reply.status(400).send({
+        error: 'This slug is reserved for Nodyx infrastructure',
+        code: 'SLUG_RESERVED',
+        hint: 'Choisissez un autre nom : celui-ci designe un service de la plateforme.',
+      });
     }
 
     try {

--- a/nodyx-core/src/tests/reserved-slugs.test.ts
+++ b/nodyx-core/src/tests/reserved-slugs.test.ts
@@ -1,0 +1,91 @@
+// ─── Personne ne doit pouvoir réserver un sous-domaine d'infrastructure ──────
+//
+// Mesuré le 2026-08-20. La validation du slug à l'inscription était PUREMENT
+// formelle : `^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$`, et rien d'autre. `olympus`,
+// `relay` ou `tunnel` étaient donc inscriptibles par n'importe qui.
+//
+// CE QUE ÇA NE PERMETTAIT PAS. Caddy évalue ses routes dans l'ordre, et les
+// hôtes explicites précèdent le générique `*.nodyx.org` : aucun trafic n'aurait
+// été détourné. Vérifié sur la configuration vivante, 18 routes, générique en
+// avant-dernier.
+//
+// CE QUE ÇA PERMETTAIT QUAND MÊME :
+//   - une entrée trompeuse dans l'annuaire PUBLIC, annonçant une communauté à
+//     l'adresse de notre panneau d'administration ;
+//   - une instance muette, que Caddy ignore, sans que son propriétaire puisse
+//     comprendre pourquoi ;
+//   - et surtout, le jour où `CF_TOKEN` sera configuré : l'inscription appelle
+//     `createCloudflareSubdomain`, qui créerait un enregistrement DNS MANDATÉ
+//     pour ce nom. Un `tunnel` inscrit masquerait alors l'endpoint du relais.
+
+import { describe, it, expect } from 'vitest'
+import { isReservedSlug, RESERVED_SLUGS } from '../utils/reservedSlugs'
+
+describe('slugs réservés : ce qui doit être refusé', () => {
+  it("refuse les sous-domaines servis aujourd'hui par Caddy", () => {
+    // Relevés sur la configuration vivante, pas de mémoire.
+    for (const s of ['olympus', 'library', 'extensions', 'start', 'code', 'signet']) {
+      expect(isReservedSlug(s), s).toBe(true)
+    }
+  })
+
+  it('refuse le relais et ses portes', () => {
+    // `relay` et `relay6` portent des enregistrements DNS explicites, et
+    // `tunnel` portera l'endpoint WebSocket. Il est réservé AVANT d'exister :
+    // l'inverse serait une course.
+    for (const s of ['relay', 'relay6', 'tunnel']) {
+      expect(isReservedSlug(s), s).toBe(true)
+    }
+  })
+
+  it("refuse les noms d'infrastructure usuels", () => {
+    for (const s of ['www', 'api', 'admin', 'mail', 'cdn', 'static']) {
+      expect(isReservedSlug(s), s).toBe(true)
+    }
+  })
+
+  it('ignore la casse et les espaces autour', () => {
+    // Le slug arrive du corps de la requête : on ne fait pas confiance à sa forme.
+    for (const s of ['TUNNEL', ' relay ', 'OlYmPuS']) {
+      expect(isReservedSlug(s), s).toBe(true)
+    }
+  })
+})
+
+describe('slugs réservés : ce qui doit rester libre', () => {
+  it("n'empêche pas une vraie communauté de s'inscrire", () => {
+    // Noms réels ou plausibles : la liste ne doit pas mordre sur le légitime.
+    for (const s of ['waazaa', 'trik-teste', 'instituto-kairos', 'agora',
+                     'french-godot', 'ma-communaute', 'relais', 'tunnelier']) {
+      expect(isReservedSlug(s), s).toBe(false)
+    }
+  })
+
+  it('ne réserve pas par simple ressemblance', () => {
+    // `relay6` est réservé, `relay60` ne l'est pas : la comparaison est exacte,
+    // pas un préfixe. Une règle par préfixe volerait des noms légitimes.
+    expect(isReservedSlug('relay60')).toBe(false)
+    expect(isReservedSlug('apiculture')).toBe(false)
+    expect(isReservedSlug('wwwx')).toBe(false)
+  })
+})
+
+describe('la liste elle-même', () => {
+  it('couvre les instances maison déjà inscrites', () => {
+    // `demo`, `sleemstudio` et `vieuxlooters` sont déjà protégés par le conflit
+    // de slug (409). Les lister ne change rien pour eux, mais évite qu'un nom
+    // libéré un jour soit repris par quelqu'un d'autre.
+    for (const s of ['demo', 'sleemstudio', 'vieuxlooters']) {
+      expect(RESERVED_SLUGS.has(s), s).toBe(true)
+    }
+  })
+
+  it('ne contient que des noms en minuscules, sans espace', () => {
+    // Une entrée mal formée serait silencieusement inefficace, puisque la
+    // comparaison passe le slug en minuscules.
+    for (const s of RESERVED_SLUGS) {
+      expect(s, s).toBe(s.trim().toLowerCase())
+      expect(s.length, s).toBeGreaterThan(1)
+    }
+  })
+})

--- a/nodyx-core/src/utils/reservedSlugs.ts
+++ b/nodyx-core/src/utils/reservedSlugs.ts
@@ -1,0 +1,44 @@
+// ─── Les sous-domaines que personne ne doit pouvoir réserver ─────────────────
+//
+// Une instance inscrite au slug `x` revendique `x.nodyx.org`. Or plusieurs
+// sous-domaines portent déjà de l'infrastructure : le panneau d'administration,
+// la documentation, la médiathèque, le relais lui-même.
+//
+// Mesuré le 2026-08-20 : la validation du slug était **purement formelle**
+// (`^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$`), sans aucune liste de réservation.
+// N'importe qui pouvait donc inscrire `olympus`, `relay` ou `tunnel`.
+//
+// CE QUE ÇA NE PERMETTAIT PAS. Caddy évalue ses routes dans l'ordre et les hôtes
+// explicites précèdent le générique `*.nodyx.org` : une inscription ne
+// détournait donc aucun trafic. Vérifié sur la configuration vivante.
+//
+// CE QUE ÇA PERMETTAIT QUAND MÊME, et qui suffit à justifier cette liste :
+//   - une entrée trompeuse dans l'annuaire PUBLIC, annonçant une communauté à
+//     une adresse qui est en réalité notre panneau d'administration ;
+//   - une instance qui ne fonctionnerait jamais, sans que son propriétaire
+//     puisse comprendre pourquoi, puisque Caddy l'ignore silencieusement.
+//
+// Les noms déjà inscrits (`demo`, `sleemstudio`, `vieuxlooters`) sont de toute
+// façon protégés par le conflit de slug existant, qui répond 409. Cette liste
+// s'applique AVANT lui, pour donner un message qui explique au lieu de laisser
+// croire à une course perdue.
+
+/** Sous-domaines portant de l'infrastructure, ou qui en porteront. */
+export const RESERVED_SLUGS: ReadonlySet<string> = new Set([
+  // Routes explicites servies par Caddy aujourd'hui.
+  'code', 'demo', 'extensions', 'library', 'olympus', 'signet',
+  'sleemstudio', 'start', 'vieuxlooters',
+
+  // Le relais et ses portes. `tunnel` est réservé AVANT que l'endpoint
+  // n'existe : le contraire serait une course.
+  'relay', 'relay6', 'tunnel',
+
+  // Noms d'infrastructure usuels, qu'une communauté ne doit jamais porter.
+  'admin', 'api', 'assets', 'cdn', 'mail', 'ns1', 'ns2', 'static', 'status',
+  'support', 'www',
+])
+
+/** Le slug est-il réservé ? La comparaison est insensible à la casse. */
+export function isReservedSlug(slug: string): boolean {
+  return RESERVED_SLUGS.has(slug.trim().toLowerCase())
+}


### PR DESCRIPTION
Trouvé en préparant l'endpoint `tunnel.nodyx.org`. La validation du slug à l'inscription était **purement formelle** :

```
^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$
```

Aucune liste de réservation. `olympus`, `relay` ou `tunnel` étaient inscriptibles par n'importe qui.

## Ce que ça ne permettait pas

Caddy évalue ses routes dans l'ordre, et les hôtes explicites précèdent le générique `*.nodyx.org`. Vérifié sur la configuration vivante : 18 routes, générique en avant-dernier. **Aucun trafic n'aurait été détourné**, le panneau d'administration n'était pas prenable.

Je le dis parce que la tentation serait de présenter ça comme plus grave que ça ne l'est.

## Ce que ça permettait quand même

- une **entrée trompeuse dans l'annuaire public**, annonçant une communauté à l'adresse de notre panneau d'administration
- une instance **muette**, que Caddy ignore, sans que son propriétaire puisse comprendre pourquoi
- et surtout un **risque latent** : l'inscription appelle déjà `createCloudflareSubdomain`, qui crée un enregistrement DNS **mandaté**. Les identifiants Cloudflare ne sont pas configurés aujourd'hui, donc l'appel échoue et rien n'est créé. Le jour où ils le seront, un slug `tunnel` inscrit créerait un enregistrement qui **masquerait l'endpoint du relais**.

## Démontré, pas supposé

Une inscription au slug `tunnel` a été tentée sur la production **avant** correctif :

```
{"message":"Instance registered. DNS subdomain will be created within 30 seconds.",
 "subdomain":"tunnel.nodyx.org", ...}
```

Acceptée, entrée créée, sous-domaine promis. L'entrée d'essai a été supprimée dans la foulée et le parc vérifié à 24 instances.

## La liste

Bâtie depuis le réel, pas d'imagination : hôtes explicites relevés dans la configuration Caddy vivante, enregistrements DNS existants, plus les noms d'infrastructure usuels.

`tunnel` y figure **avant que l'endpoint existe**. L'inverse serait une course.

Réponse **400** avec un code stable `SLUG_RESERVED`, conformément à la règle du cœur sur les nouvelles réponses d'erreur.

## Vérification

8 contrôles. Les plus importants sont ceux qui vérifient que la liste **ne mord pas sur le légitime** :

| slug | attendu |
|---|---|
| `relay60`, `apiculture`, `wwwx` | **libres**, la comparaison est exacte et non par préfixe |
| `waazaa`, `trik-teste`, `agora` | **libres** |
| `TUNNEL`, ` relay `, `OlYmPuS` | refusés, casse et espaces ignorés |

Une règle par préfixe aurait volé des noms légitimes : c'est le piège que ces contrôles interdisent.

909 tests cœur, build à 0.
