### PR TITLE
feat(relais): savoir quand le port 7443 pourra etre retire

### DIFF
--- a/nodyx-core/src/migrations/116_relais_transport.sql
+++ b/nodyx-core/src/migrations/116_relais_transport.sql
@@ -1,0 +1,49 @@
+-- ─── Savoir quand le port 7443 pourra être retiré ───────────────────────────
+--
+-- Le chantier relais ajoute une seconde porte, en WebSocket sur 443, sans
+-- toucher au port 7443 hérité dont dépendent les instances déjà installées.
+-- Le CDC prévoit de retirer 7443 « quand la télémétrie montre que plus personne
+-- ne l'utilise ».
+--
+-- Cette télémétrie n'existait pas. Rien ne distinguait une instance connectée en
+-- TCP brut d'une instance en WebSocket : la dépréciation aurait été un pari, et
+-- fermer le port aurait pu couper quelqu'un sans qu'on le sache jamais.
+--
+-- CE QU'ON ENREGISTRE, ET RIEN DE PLUS. Le nom du transport et la date. Pas
+-- d'adresse, pas de compteur d'usage, pas d'horodatage de requête. Nodyx
+-- revendique zéro analytique : la seule question à laquelle ces colonnes servent
+-- à répondre est « reste-t-il quelqu'un sur 7443 ? ».
+--
+-- La colonne reste NULL tant qu'une instance ne s'est pas connectée depuis la
+-- mise en service : NULL veut dire « on ne sait pas », jamais « migré ».
+
+ALTER TABLE directory_instances
+  ADD COLUMN IF NOT EXISTS relay_transport    TEXT,
+  ADD COLUMN IF NOT EXISTS relay_transport_at TIMESTAMPTZ;
+
+-- Deux valeurs seulement, et la contrainte les fige : une faute de frappe côté
+-- relais ferait croire à tort que personne n'est resté sur l'ancien port.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'directory_instances_relay_transport'
+  ) THEN
+    ALTER TABLE directory_instances
+      ADD CONSTRAINT directory_instances_relay_transport
+      CHECK (relay_transport IS NULL OR relay_transport IN ('tcp7443', 'wss'));
+  END IF;
+END $$;
+
+-- L'index sert l'unique requête de décision : qui est encore sur l'ancien port,
+-- et quand l'a-t-on vu pour la dernière fois.
+CREATE INDEX IF NOT EXISTS idx_directory_relay_transport
+  ON directory_instances (relay_transport, relay_transport_at DESC)
+  WHERE relay_transport IS NOT NULL;
+
+COMMENT ON COLUMN directory_instances.relay_transport IS
+  'Transport utilisé au dernier rattachement au relais : tcp7443 (hérité) ou wss. '
+  'NULL = jamais observé depuis la mise en service, ce qui ne veut PAS dire migré.';
+
+COMMENT ON COLUMN directory_instances.relay_transport_at IS
+  'Date du dernier rattachement observé. Sert à ne pas conclure sur une instance '
+  'dormante depuis des mois.';

--- a/nodyx-core/src/tests/relais-transport.test.ts
+++ b/nodyx-core/src/tests/relais-transport.test.ts
@@ -1,0 +1,65 @@
+// ─── Savoir quand le port 7443 pourra être retiré ────────────────────────────
+//
+// Le chantier relais ajoute une seconde porte en WebSocket sur 443, sans toucher
+// au port 7443 hérité dont dépendent les instances déjà installées. Le CDC
+// prévoit de le retirer « quand la télémétrie montre que plus personne ne
+// l'utilise ».
+//
+// Cette télémétrie n'existait pas. Rien ne distinguait une instance connectée en
+// TCP brut d'une instance en WebSocket : la dépréciation aurait été un pari, et
+// fermer le port aurait pu couper quelqu'un sans qu'on l'apprenne jamais.
+//
+// Ces contrôles lisent la migration, pas la base : ils protègent une décision de
+// conception, pas des données. Même approche que `security-model.test.ts`.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+const SQL = readFileSync(
+  new URL('../migrations/116_relais_transport.sql', import.meta.url).pathname, 'utf-8')
+
+describe('télémétrie de dépréciation du 7443', () => {
+  it("n'enregistre QUE le transport et la date", () => {
+    // Nodyx revendique zéro analytique. La seule question à laquelle ces
+    // colonnes servent est « reste-t-il quelqu'un sur 7443 ? ». Toute colonne
+    // supplémentaire serait de la collecte sans usage.
+    expect(SQL).toMatch(/relay_transport\s+TEXT/i)
+    expect(SQL).toMatch(/relay_transport_at\s+TIMESTAMPTZ/i)
+    for (const interdit of ['ip', 'user_agent', 'count', 'requests']) {
+      expect(SQL.toLowerCase()).not.toMatch(new RegExp(`add column[^;]*\\b${interdit}\\b`))
+    }
+  })
+
+  it('fige les deux seules valeurs possibles', () => {
+    // Une faute de frappe côté relais ferait croire à tort que personne n'est
+    // resté sur l'ancien port, et donc autoriserait une fermeture prématurée.
+    expect(SQL).toMatch(/CHECK\s*\(\s*relay_transport IS NULL OR relay_transport IN \('tcp7443',\s*'wss'\)\s*\)/)
+  })
+
+  it('reste applicable deux fois de suite', () => {
+    // Les migrations sont rejouées au démarrage : une migration non idempotente
+    // ferait échouer le démarrage du cœur au deuxième lancement.
+    expect(SQL).toMatch(/ADD COLUMN IF NOT EXISTS/i)
+    expect(SQL).toMatch(/CREATE INDEX IF NOT EXISTS/i)
+    expect(SQL).toMatch(/IF NOT EXISTS\s*\(\s*SELECT 1 FROM pg_constraint/i)
+  })
+
+  it("indexe l'unique requête de décision", () => {
+    // Qui est encore sur l'ancien port, et quand l'a-t-on vu pour la dernière
+    // fois : c'est le seul axe d'interrogation prévu.
+    expect(SQL).toMatch(/ON directory_instances \(relay_transport, relay_transport_at DESC\)/)
+  })
+
+  it('documente que NULL ne veut pas dire migré', () => {
+    // Le piège de lecture : conclure d'un NULL qu'une instance a migré
+    // autoriserait à fermer le port sur une instance simplement dormante.
+    expect(SQL).toMatch(/NULL[^\n]*ne veut PAS dire migré|NULL = jamais observé/)
+  })
+
+  it('ne touche à aucune donnée existante', () => {
+    // Une migration qui écrirait une valeur par défaut inventerait une
+    // télémétrie qu'on n'a pas observée.
+    expect(SQL).not.toMatch(/UPDATE\s+directory_instances/i)
+    expect(SQL).not.toMatch(/SET DEFAULT/i)
+  })
+})

--- a/nodyx-p2p/crates/nexus-relay/src/server/db.rs
+++ b/nodyx-p2p/crates/nexus-relay/src/server/db.rs
@@ -59,6 +59,39 @@ impl DbPool {
         }
     }
 
+    /// Exécute une écriture. Même logique de reconnexion que `query_opt` : sans
+    /// elle, une coupure de PostgreSQL rendrait le client définitivement cassé.
+    ///
+    /// Renvoie le nombre de lignes touchées, ce qui permet à l'appelant de
+    /// distinguer « écrit » de « aucune ligne ne correspondait ».
+    pub async fn execute(
+        &self,
+        sql: &str,
+        params: &[&(dyn tokio_postgres::types::ToSql + Sync)],
+    ) -> anyhow::Result<u64> {
+        {
+            let guard = self.client.lock().await;
+            if let Some(c) = guard.as_ref() {
+                match c.execute(sql, params).await {
+                    Ok(n) => return Ok(n),
+                    Err(e) => warn!("DB execute failed ({e}), reconnecting…"),
+                }
+            }
+        }
+
+        match Self::new_connection(&self.database_url).await {
+            Ok(fresh) => {
+                let n = fresh.execute(sql, params).await?;
+                *self.client.lock().await = Some(fresh);
+                Ok(n)
+            }
+            Err(e) => {
+                *self.client.lock().await = None;
+                Err(e)
+            }
+        }
+    }
+
     async fn new_connection(database_url: &str) -> anyhow::Result<Client> {
         let (client, conn) = tokio_postgres::connect(database_url, NoTls).await?;
         tokio::spawn(async move {

--- a/nodyx-p2p/crates/nexus-relay/src/server/tcp_listener.rs
+++ b/nodyx-p2p/crates/nexus-relay/src/server/tcp_listener.rs
@@ -167,6 +167,30 @@ async fn handle_client(
     registry.insert(slug.clone(), TunnelHandle { tx });
     info!("Slug '{slug}' registered in relay");
 
+    // Telemetrie de depreciation. Le port 7443 ne pourra etre retire que le jour
+    // ou plus personne ne s'y rattache, et rien ne permettait de le savoir : une
+    // instance en TCP brut etait indistinguable d'une instance en WebSocket.
+    // Fermer le port aurait donc ete un pari, avec le risque de couper quelqu'un
+    // sans jamais l'apprendre.
+    //
+    // On enregistre le transport et la date, RIEN d'autre : pas d'adresse, pas de
+    // compteur. La seule question a laquelle ca sert a repondre est « reste-t-il
+    // quelqu'un sur 7443 ? ».
+    //
+    // Une ecriture en echec ne doit JAMAIS empecher un tunnel de monter : la
+    // telemetrie est un confort d'exploitation, le tunnel est le service.
+    if let Err(e) = pg
+        .execute(
+            "UPDATE directory_instances \
+             SET relay_transport = 'tcp7443', relay_transport_at = NOW() \
+             WHERE slug = $1",
+            &[&slug],
+        )
+        .await
+    {
+        warn!("Relay: transport non enregistre pour '{slug}' ({e}) — tunnel maintenu");
+    }
+
     write_msg(&mut stream, &ServerMessage::Registered { ok: true, error: None }).await?;
 
     // 4. Split the stream for concurrent read + write.


### PR DESCRIPTION
Le chantier relais ajoute une seconde porte en WebSocket sur 443, sans toucher au `7443` hérité dont dépendent les instances déjà installées. Le CDC prévoit de le retirer « quand la télémétrie montre que plus personne ne l'utilise ».

**Cette télémétrie n'existait pas.** Rien ne distinguait une instance connectée en TCP brut d'une instance en WebSocket. La dépréciation aurait donc été un pari, et fermer le port aurait pu couper quelqu'un sans qu'on l'apprenne jamais.

## Ce qu'on enregistre, et rien de plus

Le nom du transport et la date. **Pas d'adresse, pas de compteur d'usage, pas d'horodatage de requête.**

Nodyx revendique zéro analytique. La seule question à laquelle ces deux colonnes servent à répondre est : *reste-t-il quelqu'un sur 7443 ?* Un contrôle interdit d'ailleurs d'y ajouter une colonne de collecte.

## Le piège de lecture, écrit dans la migration

`NULL` veut dire **« jamais observé depuis la mise en service »**, jamais « migré ».

Conclure l'inverse autoriserait à fermer le port sur une instance simplement dormante, ce qui est exactement l'accident qu'on cherche à éviter. Le commentaire de colonne le dit, et un contrôle vérifie qu'il y est.

## Côté relais

Une méthode `execute` est ajoutée, **calquée sur `query_opt`** et sa logique de reconnexion : sans elle, une coupure de PostgreSQL casserait définitivement le client, ce que le commentaire d'en-tête du fichier explique déjà.

Et une écriture en échec **n'empêche jamais un tunnel de monter** : elle est journalisée puis ignorée. La télémétrie est un confort d'exploitation, le tunnel est le service.

## Vérifié sur la base réelle, avant livraison

| vérification | résultat |
|---|---|
| colonnes créées | `relay_transport` (text), `relay_transport_at` (timestamptz) |
| index créé | oui |
| contrainte refuse `tcp7444` | **oui**, violation levée |
| contrainte accepte `tcp7443` et `wss` | oui |

L'essai a été remis à zéro derrière.

## Vérification automatisée

6 contrôles sur la migration, dont deux qui comptent particulièrement :

- celui qui vérifie qu'elle est **rejouable** : les migrations tournent à chaque démarrage, une migration non idempotente ferait échouer le cœur au deuxième lancement
- celui qui vérifie qu'elle **ne touche aucune donnée existante** : écrire une valeur par défaut inventerait une télémétrie qu'on n'a jamais observée

915 tests cœur, 6 tests relais, builds à 0.
