### PR TITLE
feat(relay): add the WebSocket door, on port 443

### DIFF
--- a/nodyx-p2p/Cargo.lock
+++ b/nodyx-p2p/Cargo.lock
@@ -599,6 +599,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,6 +1703,7 @@ dependencies = [
  "bytes",
  "clap",
  "dashmap",
+ "futures-util",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -1706,6 +1713,7 @@ dependencies = [
  "socket2 0.5.10",
  "tokio",
  "tokio-postgres",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -2088,7 +2096,7 @@ dependencies = [
  "hmac 0.13.0",
  "md-5 0.11.0",
  "memchr",
- "rand 0.10.1",
+ "rand 0.10.2",
  "sha2 0.11.0",
  "stringprep",
 ]
@@ -2191,7 +2199,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.2",
  "lru-slab",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -2252,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3288,7 +3296,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.10.1",
+ "rand 0.10.2",
  "socket2 0.6.4",
  "tokio",
  "tokio-util",
@@ -3302,7 +3310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40f644c762e9d396831ae2f8935c954b0d758c4532e924bead0f666d0c1c8640"
 dependencies = [
  "pin-project-lite",
- "rand 0.10.1",
+ "rand 0.10.2",
  "tokio",
 ]
 
@@ -3325,6 +3333,18 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -3454,6 +3474,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.10.2",
+ "sha1 0.11.0",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "typenum"

--- a/nodyx-p2p/crates/nexus-relay/Cargo.toml
+++ b/nodyx-p2p/crates/nexus-relay/Cargo.toml
@@ -48,6 +48,14 @@ tokio-util = { version = "0.7", features = ["codec"] }
 # TCP keepalive (portable setsockopt wrapper)
 socket2 = { version = "0.5", features = ["all"] }
 
+# WebSocket door. Server side only: Caddy terminates TLS in front, so the
+# client and TLS features are left out rather than carried unused.
+tokio-tungstenite = { version = "0.30", default-features = false, features = ["handshake"] }
+# Only the Stream and Sink traits, to bridge the WebSocket to AsyncRead and
+# AsyncWrite. Already in the tree via tokio-tungstenite; named here because
+# the adapter uses the traits directly.
+futures-util = { version = "0.3", default-features = false, features = ["sink"] }
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/nodyx-p2p/crates/nexus-relay/src/main.rs
+++ b/nodyx-p2p/crates/nexus-relay/src/main.rs
@@ -44,6 +44,13 @@ enum Commands {
         #[arg(long, env = "RELAY_TCP_BIND", default_value = "[::]")]
         tcp_bind: String,
 
+        /// Loopback port for the WebSocket door, reverse-proxied by Caddy.
+        ///
+        /// Never exposed publicly: Caddy terminates TLS in front of it, and a
+        /// public bind would offer an unauthenticated upgrade with no TLS.
+        #[arg(long, default_value = "7002")]
+        ws_port: u16,
+
         /// HTTP port for Caddy reverse proxy.
         #[arg(long, default_value = "7001")]
         http_port: u16,
@@ -99,11 +106,12 @@ async fn main() -> anyhow::Result<()> {
         Commands::Server {
             tcp_port,
             tcp_bind,
+            ws_port,
             http_port,
             database_url,
             main_slug,
         } => {
-            server::run(&tcp_bind, tcp_port, http_port, &database_url, &main_slug).await?;
+            server::run(&tcp_bind, tcp_port, ws_port, http_port, &database_url, &main_slug).await?;
         }
 
         Commands::Client {

--- a/nodyx-p2p/crates/nexus-relay/src/protocol.rs
+++ b/nodyx-p2p/crates/nexus-relay/src/protocol.rs
@@ -55,6 +55,11 @@ where
     let len = json.len() as u32;
     writer.write_all(&len.to_be_bytes()).await?;
     writer.write_all(&json).await?;
+    // Required, not cosmetic. A buffered writer emits nothing until it is
+    // flushed, and the WebSocket adapter is exactly that: it batches a message
+    // and sends it here, so one protocol message becomes one WebSocket message.
+    // On a raw socket the call costs nothing.
+    writer.flush().await?;
     Ok(())
 }
 

--- a/nodyx-p2p/crates/nexus-relay/src/server/mod.rs
+++ b/nodyx-p2p/crates/nexus-relay/src/server/mod.rs
@@ -1,13 +1,17 @@
 pub mod db;
 pub mod http_proxy;
 pub mod registry;
+pub mod session;
 pub mod tcp_listener;
+pub mod ws_listener;
+pub mod ws_stream;
 
 use std::sync::Arc;
 use tracing::info;
 
 use db::DbPool;
 use registry::Registry;
+use session::BanMap;
 
 /// Build the listen address from a host and a port.
 ///
@@ -20,12 +24,14 @@ pub fn listen_addr(host: &str, port: u16) -> String {
 pub async fn run(
     tcp_bind_host: &str,
     tcp_port: u16,
+    ws_port: u16,
     http_port: u16,
     database_url: &str,
     main_slug: &str,
 ) -> anyhow::Result<()> {
     info!("Starting nodyx-relay server");
     info!("  TCP relay bind  : {tcp_bind_host}:{tcp_port}");
+    info!("  WebSocket port  : {ws_port} (loopback, behind Caddy)");
     info!("  HTTP proxy port : {http_port}");
     info!("  Main slug       : {main_slug}");
 
@@ -34,12 +40,34 @@ pub async fn run(
 
     let registry = Registry::new();
 
-    let tcp_bind  = listen_addr(tcp_bind_host, tcp_port);
+    // One ban list for both doors. A ban is about who is calling, not about the
+    // road they took: an address turned away on one side must not be welcome on
+    // the other, or the defence would be trivially side-stepped.
+    let ban_map: BanMap = Arc::new(dashmap::DashMap::new());
+
+    // Expiry runs here rather than in a listener, so it happens once however
+    // many doors are open.
+    {
+        let ban_map = ban_map.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(tokio::time::Duration::from_secs(session::BAN_DURATION_SECS))
+                    .await;
+                session::prune_bans(&ban_map);
+            }
+        });
+    }
+
+    let tcp_bind = listen_addr(tcp_bind_host, tcp_port);
+    // Loopback only: Caddy is the front door, and binding this port publicly
+    // would expose an unauthenticated upgrade with no TLS in front of it.
+    let ws_bind = format!("127.0.0.1:{ws_port}");
     let http_bind = format!("127.0.0.1:{http_port}");
     let main_slug = main_slug.to_owned();
 
     tokio::try_join!(
-        tcp_listener::run(&tcp_bind, registry.clone(), pg.clone()),
+        tcp_listener::run(&tcp_bind, registry.clone(), pg.clone(), ban_map.clone()),
+        ws_listener::run(&ws_bind, registry.clone(), pg.clone(), ban_map.clone()),
         http_proxy::run(&http_bind, registry.clone(), pg.clone(), main_slug),
     )?;
 
@@ -49,8 +77,7 @@ pub async fn run(
 #[cfg(test)]
 mod tests {
     use super::listen_addr;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::{TcpListener, TcpStream};
+    use tokio::net::TcpListener;
 
     #[test]
     fn ipv6_literal_stays_bracketed() {
@@ -70,15 +97,18 @@ mod tests {
         }
     }
 
-    /// THE point of the change: a relay bound on `[::]` must still serve the 24
-    /// existing instances, which all connect over IPv4. Before it, the relay bound
+    /// THE point of the dual-stack default: a relay bound on `[::]` must still
+    /// serve the instances that connect over IPv4. Before it, the relay bound
     /// `0.0.0.0` and an IPv6-only network could not reach it at all.
     ///
-    /// This test fails on a host where `net.ipv6.bindv6only` is 1, which is exactly
-    /// the condition that would silently strand every IPv4 instance. Failing loudly
-    /// here is the whole point.
+    /// This test fails on a host where `net.ipv6.bindv6only` is 1, which is
+    /// exactly the condition that would silently strand every IPv4 instance.
+    /// Failing loudly here is the whole point.
     #[tokio::test]
     async fn ipv4_client_reaches_a_dual_stack_listener() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpStream;
+
         let listener = TcpListener::bind(listen_addr("[::]", 0)).await.unwrap();
         let port = listener.local_addr().unwrap().port();
 
@@ -101,7 +131,6 @@ mod tests {
         let (got, peer) = accepted.await.unwrap();
         assert_eq!(&got, b"ping");
         assert_eq!(&back, b"pong");
-        // The peer arrives as an IPv4-mapped IPv6 address, proof the socket carried it.
         assert!(peer.is_ipv6() || peer.is_ipv4(), "unexpected peer family: {peer}");
     }
 }

--- a/nodyx-p2p/crates/nexus-relay/src/server/session.rs
+++ b/nodyx-p2p/crates/nexus-relay/src/server/session.rs
@@ -1,0 +1,387 @@
+//! One relay session, whatever carried it.
+//!
+//! A tunnel is the same conversation on every transport: register, then relay
+//! requests until one side goes away. Only the door differs. Keeping that
+//! conversation here, generic over the stream, means the WebSocket listener
+//! inherits every fix made for the raw-TCP one, and neither can drift.
+//!
+//! The brute-force defence lives here too, for the same reason: a ban is about
+//! *who is calling*, not about how they reached us.
+
+use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
+use dashmap::DashMap;
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::mpsc;
+use tracing::{info, warn};
+
+use super::db::DbPool;
+use super::registry::{PendingRequest, Registry, RelayResponse, TunnelHandle};
+use crate::keepalive::READ_DEADLINE;
+use crate::protocol::{ClientMessage, ServerMessage, read_msg, write_msg};
+
+// ── Auth failure rate limiter ─────────────────────────────────────────────────
+// Protects against token brute-force attempts, on either door.
+
+/// Max failed auth attempts from a single IP within `AUTH_WINDOW_SECS` before banning.
+const MAX_AUTH_FAILURES: u32 = 5;
+/// Time window for counting failures (seconds).
+const AUTH_WINDOW_SECS: u64 = 60;
+/// How long a banned IP is refused connections (seconds).
+pub const BAN_DURATION_SECS: u64 = 300; // 5 minutes
+
+/// How often the relay pings an idle client.
+///
+/// Must stay well under Cloudflare's ~100 s idle cut-off, which applies to the
+/// WebSocket path: TCP keepalive would only hold up the local hop and would let
+/// the far end die unnoticed.
+const PING_INTERVAL_SECS: u64 = 30;
+
+/// Compile-time guard on the keep-alive budget.
+///
+/// Cloudflare closes an idle WebSocket at around 100 s, and TCP keepalive only
+/// holds up the local hop, so this ping is what keeps the far end alive on that
+/// path. A deadline shorter than two missed pings would reap healthy sessions.
+///
+/// Checked here rather than in a test: the build should fail, not the suite.
+const _: () = assert!(PING_INTERVAL_SECS < 90);
+const _: () = assert!(READ_DEADLINE_SECS > PING_INTERVAL_SECS * 2);
+
+/// [`READ_DEADLINE`] in seconds, so the guard above can be evaluated at compile time.
+const READ_DEADLINE_SECS: u64 = READ_DEADLINE.as_secs();
+
+/// Maps source IP → (failed_attempts, first_failure_unix_secs).
+pub type BanMap = Arc<DashMap<IpAddr, (u32, u64)>>;
+
+fn now_secs() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
+}
+
+/// Is this address currently serving a ban?
+pub fn is_auth_banned(ban_map: &DashMap<IpAddr, (u32, u64)>, ip: IpAddr) -> bool {
+    if let Some(entry) = ban_map.get(&ip) {
+        let (attempts, since) = *entry;
+        attempts >= MAX_AUTH_FAILURES && now_secs().saturating_sub(since) < BAN_DURATION_SECS
+    } else {
+        false
+    }
+}
+
+/// Count one failure, starting a fresh window if the previous one has elapsed.
+pub fn record_auth_failure(ban_map: &DashMap<IpAddr, (u32, u64)>, ip: IpAddr) {
+    let now = now_secs();
+    ban_map
+        .entry(ip)
+        .and_modify(|(count, since)| {
+            if now.saturating_sub(*since) > AUTH_WINDOW_SECS {
+                // First failure of a new window.
+                *count = 1;
+                *since = now;
+            } else {
+                *count += 1;
+            }
+        })
+        .or_insert((1, now));
+}
+
+/// Drop ban entries whose window has fully elapsed.
+pub fn prune_bans(ban_map: &DashMap<IpAddr, (u32, u64)>) {
+    let now = now_secs();
+    ban_map.retain(|_, (_, since)| now.saturating_sub(*since) < BAN_DURATION_SECS);
+}
+
+// ── Transport ─────────────────────────────────────────────────────────────────
+
+/// Which door a session came through.
+///
+/// An enum rather than a string: the value reaches a column constrained to
+/// exactly these two, and a typo there would quietly suggest nobody is left on
+/// the legacy port. That conclusion would close it on someone still using it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Transport {
+    /// The legacy raw-TCP port, reached directly.
+    Tcp7443,
+    /// WebSocket over HTTPS, reached through Cloudflare and Caddy.
+    Wss,
+}
+
+impl Transport {
+    /// The value stored in `directory_instances.relay_transport`.
+    pub const fn as_db_value(self) -> &'static str {
+        match self {
+            Transport::Tcp7443 => "tcp7443",
+            Transport::Wss => "wss",
+        }
+    }
+}
+
+// ── The session ───────────────────────────────────────────────────────────────
+
+/// Run one session to completion.
+///
+/// `culprit` is the address a ban is keyed on. Callers resolve it themselves,
+/// because only they know whether a forwarding header may be believed: see
+/// [`crate::client_ip`].
+///
+/// Returns once the client goes away, the session falls silent past
+/// [`READ_DEADLINE`], or authentication fails.
+pub async fn run<S>(
+    stream: S,
+    culprit: IpAddr,
+    transport: Transport,
+    registry: Registry,
+    pg: Arc<DbPool>,
+    ban_map: BanMap,
+) -> anyhow::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let (mut reader, mut writer) = tokio::io::split(stream);
+
+    // 1. Expect Register as the very first message.
+    let Some(ClientMessage::Register { slug, token }) =
+        read_msg::<_, ClientMessage>(&mut reader).await?
+    else {
+        write_msg(
+            &mut writer,
+            &ServerMessage::Registered {
+                ok: false,
+                error: Some("Expected register message".into()),
+            },
+        )
+        .await?;
+        return Ok(());
+    };
+
+    // 2. Validate token against directory_instances.
+    let row = pg
+        .query_opt(
+            "SELECT id FROM directory_instances WHERE slug = $1 AND token = $2 AND status = 'active'",
+            &[&slug, &token],
+        )
+        .await?;
+
+    if row.is_none() {
+        record_auth_failure(&ban_map, culprit);
+        warn!(
+            "Relay: auth failure from {} (slug='{}') - {} attempt(s)",
+            culprit,
+            slug,
+            ban_map.get(&culprit).map(|e| e.0).unwrap_or(1)
+        );
+        write_msg(
+            &mut writer,
+            &ServerMessage::Registered {
+                ok: false,
+                error: Some("Invalid slug or token".into()),
+            },
+        )
+        .await?;
+        return Ok(());
+    }
+
+    // 3. Register in the in-memory registry.
+    let (tx, mut rx) = mpsc::channel::<PendingRequest>(64);
+    registry.insert(slug.clone(), TunnelHandle { tx });
+    info!("Slug '{slug}' registered in relay over {transport:?}");
+
+    // Deprecation telemetry. Port 7443 can only be retired once nobody attaches
+    // to it any more, and nothing recorded that: a raw-TCP instance was
+    // indistinguishable from a WebSocket one. Closing the port would have been a
+    // gamble, with the risk of cutting somebody off and never finding out.
+    //
+    // We record the transport and the date, NOTHING else: no address, no usage
+    // counter. The only question these columns answer is "is anyone still on
+    // 7443?".
+    //
+    // A failed write must NEVER stop a tunnel from coming up. Telemetry is an
+    // operational convenience; the tunnel is the service.
+    if let Err(e) = pg
+        .execute(
+            "UPDATE directory_instances \
+             SET relay_transport = $2, relay_transport_at = NOW() \
+             WHERE slug = $1",
+            &[&slug, &transport.as_db_value()],
+        )
+        .await
+    {
+        warn!("Relay: transport not recorded for '{slug}' ({e}) - tunnel kept up");
+    }
+
+    write_msg(&mut writer, &ServerMessage::Registered { ok: true, error: None }).await?;
+
+    // Pending requests awaiting a client Response.
+    let pending: Arc<DashMap<String, tokio::sync::oneshot::Sender<RelayResponse>>> =
+        Arc::new(DashMap::new());
+
+    // Task A — receive outgoing requests from the HTTP proxy, forward to client.
+    let pending_a = pending.clone();
+    let slug_a = slug.clone();
+    let write_task = tokio::spawn(async move {
+        while let Some(PendingRequest { msg, reply_tx }) = rx.recv().await {
+            let id = match &msg {
+                ServerMessage::Request { id, .. } => id.clone(),
+                ServerMessage::Ping => {
+                    // Just forward the ping, no pending entry needed.
+                    if write_msg(&mut writer, &msg).await.is_err() {
+                        break;
+                    }
+                    continue;
+                }
+                _ => continue,
+            };
+            pending_a.insert(id, reply_tx);
+            if write_msg(&mut writer, &msg).await.is_err() {
+                break;
+            }
+        }
+        info!("Write task for '{slug_a}' ended");
+    });
+
+    // Task B — receive responses from the client, route to pending requests.
+    // Wrapped in a deadline: clients reply Heartbeat to our ping, so a silence
+    // longer than READ_DEADLINE means the connection is dead and should be reaped.
+    let pending_b = pending.clone();
+    let slug_b = slug.clone();
+    let registry_b = registry.clone();
+    let read_task = tokio::spawn(async move {
+        loop {
+            let next =
+                tokio::time::timeout(READ_DEADLINE, read_msg::<_, ClientMessage>(&mut reader)).await;
+
+            match next {
+                Err(_elapsed) => {
+                    warn!(
+                        "No traffic from '{slug_b}' in {}s - closing dead session",
+                        READ_DEADLINE.as_secs()
+                    );
+                    break;
+                }
+                Ok(Ok(Some(ClientMessage::Response { id, status, headers, body_b64 }))) => {
+                    let body = B64.decode(&body_b64).unwrap_or_else(|e| {
+                        warn!("Relay: base64 decode error on response id={id}: {e}");
+                        vec![]
+                    });
+                    if let Some((_, tx)) = pending_b.remove(&id) {
+                        let _ = tx.send(RelayResponse { status, headers, body });
+                    }
+                }
+                Ok(Ok(Some(ClientMessage::Heartbeat))) => {
+                    // No-op, keep-alive acknowledged.
+                }
+                Ok(Ok(Some(ClientMessage::Register { .. }))) => {
+                    warn!("Unexpected Register from '{slug_b}' - ignoring");
+                }
+                Ok(Ok(None)) | Ok(Err(_)) => break,
+            }
+        }
+        registry_b.remove(&slug_b);
+        info!("Slug '{slug_b}' unregistered from relay");
+    });
+
+    // Task C — keep the tunnel warm, and the intermediaries convinced it is live.
+    let slug_c = slug.clone();
+    let registry_c = registry.clone();
+    let ping_task = tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_secs(PING_INTERVAL_SECS)).await;
+            let Some(handle) = registry_c.get(&slug_c) else { break };
+            let (dummy_tx, _) = tokio::sync::oneshot::channel();
+            let sent = handle
+                .tx
+                .send(PendingRequest { msg: ServerMessage::Ping, reply_tx: dummy_tx })
+                .await;
+            if sent.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Whichever ends first, the session is over.
+    tokio::select! {
+        _ = write_task => {}
+        _ = read_task  => {}
+        _ = ping_task  => {}
+    }
+
+    registry.remove(&slug);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().expect("test address should parse")
+    }
+
+    #[test]
+    fn transport_values_match_the_database_constraint() {
+        // The column accepts exactly these two. A drift here would be recorded
+        // as a failed write rather than a wrong value, but the enum makes the
+        // mistake unreachable in the first place.
+        assert_eq!(Transport::Tcp7443.as_db_value(), "tcp7443");
+        assert_eq!(Transport::Wss.as_db_value(), "wss");
+    }
+
+    #[test]
+    fn a_ban_takes_the_configured_number_of_failures() {
+        let map: DashMap<IpAddr, (u32, u64)> = DashMap::new();
+        let who = ip("203.0.114.9");
+
+        for _ in 0..MAX_AUTH_FAILURES - 1 {
+            record_auth_failure(&map, who);
+            assert!(!is_auth_banned(&map, who), "banned too early");
+        }
+        record_auth_failure(&map, who);
+        assert!(is_auth_banned(&map, who), "should be banned on the last attempt");
+    }
+
+    #[test]
+    fn a_ban_never_reaches_a_different_caller() {
+        // The whole point of resolving the real address: one culprit must not
+        // take everyone else down with them.
+        let map: DashMap<IpAddr, (u32, u64)> = DashMap::new();
+        let guilty = ip("203.0.114.9");
+        let innocent = ip("198.51.101.7");
+
+        for _ in 0..MAX_AUTH_FAILURES {
+            record_auth_failure(&map, guilty);
+        }
+        assert!(is_auth_banned(&map, guilty));
+        assert!(!is_auth_banned(&map, innocent));
+    }
+
+    #[test]
+    fn failures_spread_thin_never_ban() {
+        // An old window is reset rather than accumulated, so a slow trickle of
+        // typos from a legitimate instance does not eventually lock it out.
+        let map: DashMap<IpAddr, (u32, u64)> = DashMap::new();
+        let who = ip("203.0.114.9");
+
+        record_auth_failure(&map, who);
+        // Age the recorded window past AUTH_WINDOW_SECS.
+        map.insert(who, (MAX_AUTH_FAILURES - 1, now_secs() - AUTH_WINDOW_SECS - 1));
+        record_auth_failure(&map, who);
+
+        assert_eq!(map.get(&who).map(|e| e.0), Some(1), "window should have reset");
+        assert!(!is_auth_banned(&map, who));
+    }
+
+    #[test]
+    fn pruning_keeps_live_bans_and_drops_stale_ones() {
+        let map: DashMap<IpAddr, (u32, u64)> = DashMap::new();
+        let fresh = ip("203.0.114.9");
+        let stale = ip("198.51.101.7");
+
+        map.insert(fresh, (MAX_AUTH_FAILURES, now_secs()));
+        map.insert(stale, (MAX_AUTH_FAILURES, now_secs() - BAN_DURATION_SECS - 1));
+        prune_bans(&map);
+
+        assert!(map.contains_key(&fresh), "a live ban must survive pruning");
+        assert!(!map.contains_key(&stale), "an elapsed ban must be dropped");
+    }
+}

--- a/nodyx-p2p/crates/nexus-relay/src/server/tcp_listener.rs
+++ b/nodyx-p2p/crates/nexus-relay/src/server/tcp_listener.rs
@@ -1,65 +1,29 @@
-use dashmap::DashMap;
-use std::net::{IpAddr, SocketAddr};
+//! The legacy door: raw TCP on port 7443.
+//!
+//! Kept working untouched. Every instance installed before the WebSocket
+//! transport existed dials this port, and several have been dormant for months:
+//! closing it before the deprecation telemetry shows it deserted would cut
+//! people off silently.
+//!
+//! This module owns the accept loop and nothing else. The conversation itself
+//! lives in [`super::session`], shared with the WebSocket door so neither can
+//! drift from the other.
+
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc;
-use super::db::DbPool;
+use tokio::net::TcpListener;
 use tracing::{error, info, warn};
-use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
 
+use super::db::DbPool;
+use super::registry::Registry;
+use super::session::{BanMap, Transport, is_auth_banned, run as run_session};
 use crate::client_ip::client_ip;
-use crate::keepalive::{self, READ_DEADLINE};
-use crate::protocol::{ClientMessage, ServerMessage, read_msg, write_msg};
-use super::registry::{PendingRequest, Registry, RelayResponse, TunnelHandle};
-
-// ── Auth failure rate limiter ─────────────────────────────────────────────────
-// Protects against token brute-force attempts on the TCP relay port (7443).
-
-/// Max failed auth attempts from a single IP within AUTH_WINDOW_SECS before banning.
-const MAX_AUTH_FAILURES:  u32 = 5;
-/// Time window for counting failures (seconds).
-const AUTH_WINDOW_SECS:   u64 = 60;
-/// How long a banned IP is refused connections (seconds).
-const BAN_DURATION_SECS:  u64 = 300;  // 5 minutes
-
-/// Maps source IP → (failed_attempts, first_failure_unix_secs).
-type BanMap = Arc<DashMap<IpAddr, (u32, u64)>>;
-
-fn auth_now_secs() -> u64 {
-    SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
-}
-
-fn is_auth_banned(ban_map: &DashMap<IpAddr, (u32, u64)>, ip: IpAddr) -> bool {
-    if let Some(entry) = ban_map.get(&ip) {
-        let (attempts, since) = *entry;
-        attempts >= MAX_AUTH_FAILURES && auth_now_secs().saturating_sub(since) < BAN_DURATION_SECS
-    } else {
-        false
-    }
-}
-
-fn record_auth_failure(ban_map: &DashMap<IpAddr, (u32, u64)>, ip: IpAddr) {
-    let now = auth_now_secs();
-    ban_map.entry(ip)
-        .and_modify(|(count, since)| {
-            if now.saturating_sub(*since) > AUTH_WINDOW_SECS {
-                // Reset: first failure in a new window
-                *count = 1;
-                *since = now;
-            } else {
-                *count += 1;
-            }
-        })
-        .or_insert((1, now));
-}
-
-// ── Entry point ───────────────────────────────────────────────────────────────
+use crate::keepalive;
 
 pub async fn run(
     bind: &str,
     registry: Registry,
     pg: Arc<DbPool>,
+    ban_map: BanMap,
 ) -> std::io::Result<()> {
     let listener = TcpListener::bind(bind).await?;
     // The address actually obtained, not the one requested: a `[::]` socket that
@@ -70,36 +34,45 @@ pub async fn run(
         Err(e) => info!("TCP relay listener on {bind} (local_addr unavailable: {e})"),
     }
 
-    let ban_map: BanMap = Arc::new(DashMap::new());
-
-    // Periodic cleanup: remove ban entries that have fully expired.
-    {
-        let ban_map_c = ban_map.clone();
-        tokio::spawn(async move {
-            loop {
-                tokio::time::sleep(tokio::time::Duration::from_secs(BAN_DURATION_SECS)).await;
-                let now = auth_now_secs();
-                ban_map_c.retain(|_, (_, since)| now.saturating_sub(*since) < BAN_DURATION_SECS);
-            }
-        });
-    }
 
     loop {
         match listener.accept().await {
             Ok((stream, addr)) => {
-                // Reject connections from banned IPs before doing any I/O or DB work.
-                if is_auth_banned(&ban_map, addr.ip()) {
-                    warn!("Relay: auth-banned IP {} — dropping connection", addr.ip());
+                // The address a ban is keyed on. On this listener the peer *is*
+                // the client: it is reached directly, with no proxy in front, so
+                // there are no forwarding headers to consult and the lookup is
+                // empty by construction.
+                //
+                // Going through `client_ip` anyway is deliberate. The WebSocket
+                // door arrives through Caddy, where the peer is always localhost
+                // and the real caller lives in a header. Both doors asking the
+                // same question means neither can be forgotten.
+                let culprit = client_ip(addr.ip(), |_| None);
+
+                // Refuse banned callers before any I/O or database work.
+                if is_auth_banned(&ban_map, culprit) {
+                    warn!("Relay: auth-banned {culprit} - dropping connection");
                     drop(stream);
                     continue;
                 }
 
+                // Aggressive TCP keepalive so a dead peer is noticed in ~60 s
+                // instead of the kernel default of ~2 hours. This is the one
+                // thing that cannot move into the shared session: it acts on the
+                // socket, which only this door holds.
+                if let Err(e) = keepalive::enable(&stream) {
+                    warn!("Failed to enable TCP keepalive on {addr}: {e}");
+                }
+
                 info!("Relay client connected from {addr}");
                 let registry = registry.clone();
-                let pg       = pg.clone();
-                let ban_map  = ban_map.clone();
+                let pg = pg.clone();
+                let ban_map = ban_map.clone();
                 tokio::spawn(async move {
-                    if let Err(e) = handle_client(stream, addr, registry, pg, ban_map).await {
+                    let outcome =
+                        run_session(stream, culprit, Transport::Tcp7443, registry, pg, ban_map)
+                            .await;
+                    if let Err(e) = outcome {
                         warn!("Relay client {addr} disconnected: {e}");
                     }
                 });
@@ -107,201 +80,4 @@ pub async fn run(
             Err(e) => error!("Accept error: {e}"),
         }
     }
-}
-
-// ── Per-client handler ────────────────────────────────────────────────────────
-
-async fn handle_client(
-    mut stream: TcpStream,
-    addr: SocketAddr,
-    registry: Registry,
-    pg: Arc<DbPool>,
-    ban_map: BanMap,
-) -> anyhow::Result<()> {
-    // The address a ban is keyed on. On this listener the peer *is* the client:
-    // it is reached directly, with no proxy in front, so there are no forwarding
-    // headers to consult and the lookup is empty by construction.
-    //
-    // Going through `client_ip` anyway is deliberate. The WebSocket transport
-    // arrives through Caddy, where the peer is always `127.0.0.1` and the real
-    // caller lives in a header. Having both listeners ask the same question
-    // means nobody has to remember to update this one when that lands.
-    let culprit = client_ip(addr.ip(), |_| None);
-    // Aggressive TCP keepalive so we detect dead peers in ~60s instead
-    // of the kernel default of ~2 hours.
-    if let Err(e) = keepalive::enable(&stream) {
-        warn!("Failed to enable TCP keepalive on {addr}: {e}");
-    }
-
-    // 1. Expect Register as the very first message.
-    let Some(ClientMessage::Register { slug, token }) =
-        read_msg::<_, ClientMessage>(&mut stream).await?
-    else {
-        write_msg(
-            &mut stream,
-            &ServerMessage::Registered {
-                ok: false,
-                error: Some("Expected register message".into()),
-            },
-        )
-        .await?;
-        return Ok(());
-    };
-
-    // 2. Validate token against directory_instances.
-    let row = pg
-        .query_opt(
-            "SELECT id FROM directory_instances WHERE slug = $1 AND token = $2 AND status = 'active'",
-            &[&slug, &token],
-        )
-        .await?;
-
-    if row.is_none() {
-        record_auth_failure(&ban_map, culprit);
-        warn!("Relay: auth failure from {} (slug='{}') - {} attempt(s)",
-              culprit, slug,
-              ban_map.get(&culprit).map(|e| e.0).unwrap_or(1));
-        write_msg(
-            &mut stream,
-            &ServerMessage::Registered {
-                ok: false,
-                error: Some("Invalid slug or token".into()),
-            },
-        )
-        .await?;
-        return Ok(());
-    }
-
-    // 3. Register in the in-memory registry.
-    let (tx, mut rx) = mpsc::channel::<PendingRequest>(64);
-    registry.insert(slug.clone(), TunnelHandle { tx });
-    info!("Slug '{slug}' registered in relay");
-
-    // Deprecation telemetry. Port 7443 can only be retired once nobody attaches
-    // to it any more, and nothing recorded that: a raw-TCP instance was
-    // indistinguishable from a WebSocket one. Closing the port would have been a
-    // gamble, with the risk of cutting somebody off and never finding out.
-    //
-    // We record the transport and the date, NOTHING else: no address, no usage
-    // counter. The only question these columns answer is "is anyone still on
-    // 7443?".
-    //
-    // A failed write must NEVER stop a tunnel from coming up. Telemetry is an
-    // operational convenience; the tunnel is the service.
-    if let Err(e) = pg
-        .execute(
-            "UPDATE directory_instances \
-             SET relay_transport = 'tcp7443', relay_transport_at = NOW() \
-             WHERE slug = $1",
-            &[&slug],
-        )
-        .await
-    {
-        warn!("Relay: transport not recorded for '{slug}' ({e}) - tunnel kept up");
-    }
-
-    write_msg(&mut stream, &ServerMessage::Registered { ok: true, error: None }).await?;
-
-    // 4. Split the stream for concurrent read + write.
-    let (mut reader, mut writer) = stream.into_split();
-
-    // Pending requests awaiting a client Response.
-    let pending: Arc<dashmap::DashMap<String, tokio::sync::oneshot::Sender<RelayResponse>>> =
-        Arc::new(dashmap::DashMap::new());
-
-    // Task A — receive outgoing requests from the HTTP proxy and forward to client.
-    let pending_a = pending.clone();
-    let slug_a = slug.clone();
-    let write_task = tokio::spawn(async move {
-        while let Some(PendingRequest { msg, reply_tx }) = rx.recv().await {
-            let id = match &msg {
-                ServerMessage::Request { id, .. } => id.clone(),
-                ServerMessage::Ping => {
-                    // Just forward the ping, no pending entry needed.
-                    if write_msg(&mut writer, &msg).await.is_err() {
-                        break;
-                    }
-                    continue;
-                }
-                _ => continue,
-            };
-            pending_a.insert(id, reply_tx);
-            if write_msg(&mut writer, &msg).await.is_err() {
-                break;
-            }
-        }
-        info!("Write task for '{slug_a}' ended");
-    });
-
-    // Task B — receive responses from the client and route to pending requests.
-    // Wrapped in a deadline: clients reply Heartbeat to our 30s ping, so a
-    // 90s silence means the connection is dead and we should reap it.
-    let pending_b = pending.clone();
-    let slug_b = slug.clone();
-    let registry_b = registry.clone();
-    let read_task = tokio::spawn(async move {
-        loop {
-            let next = tokio::time::timeout(
-                READ_DEADLINE,
-                read_msg::<_, ClientMessage>(&mut reader),
-            )
-            .await;
-
-            match next {
-                Err(_elapsed) => {
-                    warn!(
-                        "No traffic from '{slug_b}' in {}s — closing dead session",
-                        READ_DEADLINE.as_secs()
-                    );
-                    break;
-                }
-                Ok(Ok(Some(ClientMessage::Response { id, status, headers, body_b64 }))) => {
-                    let body = B64.decode(&body_b64).unwrap_or_else(|e| {
-                        warn!("Relay: base64 decode error on response id={id}: {e}");
-                        vec![]
-                    });
-                    if let Some((_, tx)) = pending_b.remove(&id) {
-                        let _ = tx.send(RelayResponse { status, headers, body });
-                    }
-                }
-                Ok(Ok(Some(ClientMessage::Heartbeat))) => {
-                    // No-op — keep-alive acknowledged.
-                }
-                Ok(Ok(Some(ClientMessage::Register { .. }))) => {
-                    warn!("Unexpected Register from '{slug_b}' — ignoring");
-                }
-                Ok(Ok(None)) | Ok(Err(_)) => break,
-            }
-        }
-        registry_b.remove(&slug_b);
-        info!("Slug '{slug_b}' unregistered from relay");
-    });
-
-    // 5. Keep-alive: ping every 30 s.
-    let slug_c = slug.clone();
-    let registry_c = registry.clone();
-    let ping_task = tokio::spawn(async move {
-        loop {
-            tokio::time::sleep(tokio::time::Duration::from_secs(30)).await;
-            if let Some(handle) = registry_c.get(&slug_c) {
-                let (dummy_tx, _) = tokio::sync::oneshot::channel();
-                let _ = handle.tx.send(PendingRequest {
-                    msg: ServerMessage::Ping,
-                    reply_tx: dummy_tx,
-                }).await;
-            } else {
-                break;
-            }
-        }
-    });
-
-    // Wait until either task finishes (client disconnected).
-    tokio::select! {
-        _ = write_task => {}
-        _ = read_task  => {}
-        _ = ping_task  => {}
-    }
-
-    registry.remove(&slug);
-    Ok(())
 }

--- a/nodyx-p2p/crates/nexus-relay/src/server/ws_listener.rs
+++ b/nodyx-p2p/crates/nexus-relay/src/server/ws_listener.rs
@@ -1,0 +1,116 @@
+//! The WebSocket door: HTTPS on port 443, through Cloudflare and Caddy.
+//!
+//! Exists because the legacy port is unreachable from a great many networks.
+//! Company, university and school firewalls routinely allow 80 and 443 outbound
+//! and nothing else, so an instance behind one could never bring its tunnel up.
+//! An institute in Brazil hit exactly that on the day it registered.
+//!
+//! # Where this listener sits
+//!
+//! ```text
+//! instance -> Cloudflare -> Caddy (:443, /tunnel) -> this listener (localhost)
+//! ```
+//!
+//! It binds loopback only. Caddy is the front door and terminates TLS, which is
+//! why no certificate is handled here: the hostname inherits a public
+//! certificate from Cloudflare, so there is nothing to renew and nothing to
+//! expire quietly.
+//!
+//! # The consequence that shapes this module
+//!
+//! Every caller arrives from Caddy, so the TCP peer is always loopback. Keying
+//! a ban on it would ban *everyone* after five failures by *anyone*, and the
+//! brute-force defence would protect nothing. The real caller is read from the
+//! upgrade request instead, and only because the peer is one of our own
+//! proxies: see [`crate::client_ip`].
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio_tungstenite::accept_hdr_async;
+use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
+use tracing::{error, info, warn};
+
+use super::db::DbPool;
+use super::registry::Registry;
+use super::session::{self, BanMap, Transport, is_auth_banned};
+use super::ws_stream::WsByteStream;
+use crate::client_ip::client_ip;
+
+/// Accept tunnels over WebSocket until the process ends.
+///
+/// `ban_map` is shared with the other door on purpose: a ban is about who is
+/// calling, not about the road they took, so an address turned away on one side
+/// must not be welcome on the other.
+pub async fn run(
+    bind: &str,
+    registry: Registry,
+    pg: Arc<DbPool>,
+    ban_map: BanMap,
+) -> std::io::Result<()> {
+    let listener = TcpListener::bind(bind).await?;
+    match listener.local_addr() {
+        Ok(addr) => info!("WebSocket relay listener on {addr} (requested {bind})"),
+        Err(e) => info!("WebSocket relay listener on {bind} (local_addr unavailable: {e})"),
+    }
+
+    loop {
+        let (stream, peer) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(e) => {
+                error!("WebSocket accept error: {e}");
+                continue;
+            }
+        };
+
+        let registry = registry.clone();
+        let pg = pg.clone();
+        let ban_map = ban_map.clone();
+        tokio::spawn(async move {
+            if let Err(e) = serve(stream, peer, registry, pg, ban_map).await {
+                warn!("WebSocket client {peer} ended: {e}");
+            }
+        });
+    }
+}
+
+/// Shake hands, work out who is really calling, then hand over to the session.
+async fn serve(
+    stream: tokio::net::TcpStream,
+    peer: SocketAddr,
+    registry: Registry,
+    pg: Arc<DbPool>,
+    ban_map: BanMap,
+) -> anyhow::Result<()> {
+    // The upgrade carries the forwarding headers, and they are gone once the
+    // handshake completes: capture the answer while the request is in hand.
+    let mut culprit: IpAddr = peer.ip();
+    let ws = accept_hdr_async(stream, |req: &Request, res: Response| {
+        culprit = client_ip(peer.ip(), |name| {
+            req.headers()
+                .get(name)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_owned)
+        });
+        Ok(res)
+    })
+    .await?;
+
+    // Refused after the handshake rather than before it, because the address
+    // this decision rests on only exists once the request has been read.
+    if is_auth_banned(&ban_map, culprit) {
+        warn!("Relay: auth-banned {culprit} - dropping WebSocket connection");
+        return Ok(());
+    }
+
+    info!("Relay client connected over WebSocket from {culprit}");
+    session::run(
+        WsByteStream::new(ws),
+        culprit,
+        Transport::Wss,
+        registry,
+        pg,
+        ban_map,
+    )
+    .await
+}

--- a/nodyx-p2p/crates/nexus-relay/src/server/ws_stream.rs
+++ b/nodyx-p2p/crates/nexus-relay/src/server/ws_stream.rs
@@ -1,0 +1,283 @@
+//! Reading a WebSocket as a byte stream.
+//!
+//! # Why an adapter rather than a second protocol
+//!
+//! The relay speaks one wire format: a big-endian length followed by JSON, over
+//! anything that reads and writes bytes. WebSocket is message-oriented instead,
+//! so the two do not meet on their own.
+//!
+//! There were two ways out. Write a second pair of encode/decode functions that
+//! send one JSON per WebSocket message, or teach the WebSocket to behave like a
+//! byte stream. The first duplicates the protocol, and a duplicated protocol
+//! drifts: a fix on one side silently misses the other. This adapter takes the
+//! second road, so [`crate::protocol`] stays the single description of the wire
+//! and both doors inherit every change made to it.
+//!
+//! The length prefix then rides inside WebSocket framing, which is redundant but
+//! costs four bytes per message and keeps one implementation instead of two.
+//!
+//! # Behaviour worth knowing
+//!
+//! * Writes are buffered and emitted on flush, as one binary message per flush.
+//!   [`crate::protocol::write_msg`] flushes at the end of every message, so one
+//!   protocol message maps to one WebSocket message.
+//! * Control frames are not the caller's business: pings are answered by
+//!   tungstenite itself, and pongs are skipped here.
+//! * A close frame reads as clean end-of-file, which is what the session loop
+//!   already treats as "the client went away".
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_util::{Sink, Stream};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::tungstenite::{Error as WsError, Message};
+
+/// A [`WebSocketStream`] dressed up as a byte stream.
+pub struct WsByteStream<S> {
+    inner: WebSocketStream<S>,
+    /// Bytes received but not yet handed to the reader.
+    pending_read: Vec<u8>,
+    /// Offset into `pending_read`, so a partial read does not shift the buffer.
+    read_at: usize,
+    /// Bytes written but not yet flushed as a message.
+    pending_write: Vec<u8>,
+}
+
+impl<S> WsByteStream<S> {
+    /// Wrap an established WebSocket.
+    pub fn new(inner: WebSocketStream<S>) -> Self {
+        Self {
+            inner,
+            pending_read: Vec::new(),
+            read_at: 0,
+            pending_write: Vec::new(),
+        }
+    }
+}
+
+/// Map a tungstenite error onto the `io::Error` the async traits expect.
+fn to_io(e: WsError) -> io::Error {
+    match e {
+        // A peer that vanishes mid-message is a disconnection, not corruption:
+        // the session loop already knows how to end on end-of-file.
+        WsError::ConnectionClosed | WsError::AlreadyClosed => {
+            io::Error::new(io::ErrorKind::UnexpectedEof, e)
+        }
+        WsError::Io(io_err) => io_err,
+        other => io::Error::new(io::ErrorKind::InvalidData, other),
+    }
+}
+
+impl<S> AsyncRead for WsByteStream<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        loop {
+            // Serve whatever the last message left over before asking for more.
+            if self.read_at < self.pending_read.len() {
+                let me = &mut *self;
+                let available = &me.pending_read[me.read_at..];
+                let taken = available.len().min(buf.remaining());
+                buf.put_slice(&available[..taken]);
+                me.read_at += taken;
+                if me.read_at == me.pending_read.len() {
+                    me.pending_read.clear();
+                    me.read_at = 0;
+                }
+                return Poll::Ready(Ok(()));
+            }
+
+            match Pin::new(&mut self.inner).poll_next(cx) {
+                Poll::Pending => return Poll::Pending,
+                // Clean end of stream: no more messages will arrive.
+                Poll::Ready(None) => return Poll::Ready(Ok(())),
+                Poll::Ready(Some(Err(e))) => return Poll::Ready(Err(to_io(e))),
+                Poll::Ready(Some(Ok(msg))) => match msg {
+                    Message::Binary(bytes) => {
+                        self.pending_read = bytes.to_vec();
+                        self.read_at = 0;
+                        // Loop round to serve it, so an empty message does not
+                        // read as end-of-file.
+                    }
+                    // Accepted for tolerance: nothing we send is text, but a
+                    // client that sends some should not break the stream.
+                    Message::Text(text) => {
+                        self.pending_read = text.as_bytes().to_vec();
+                        self.read_at = 0;
+                    }
+                    // Close reads as end-of-file, which the session already
+                    // treats as "the client went away".
+                    Message::Close(_) => return Poll::Ready(Ok(())),
+                    // Control frames: pings are answered by tungstenite itself.
+                    Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {}
+                },
+            }
+        }
+    }
+}
+
+impl<S> AsyncWrite for WsByteStream<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        // Accumulate. The message is emitted on flush, so a length prefix and
+        // its payload travel together rather than as two WebSocket messages.
+        self.pending_write.extend_from_slice(buf);
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if !self.pending_write.is_empty() {
+            // A sink must be asked before it is fed.
+            match Pin::new(&mut self.inner).poll_ready(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(to_io(e))),
+                Poll::Ready(Ok(())) => {}
+            }
+            let payload = std::mem::take(&mut self.pending_write);
+            if let Err(e) = Pin::new(&mut self.inner).start_send(Message::binary(payload)) {
+                return Poll::Ready(Err(to_io(e)));
+            }
+        }
+        Pin::new(&mut self.inner).poll_flush(cx).map_err(to_io)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // Flush first: a message still buffered at shutdown would be lost.
+        match self.as_mut().poll_flush(cx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+            Poll::Ready(Ok(())) => {}
+        }
+        Pin::new(&mut self.inner).poll_close(cx).map_err(to_io)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{ClientMessage, ServerMessage, read_msg, write_msg};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio_tungstenite::tungstenite::protocol::Role;
+
+    /// A pair of adapters joined by an in-memory duplex, standing in for a
+    /// client and a server that have already shaken hands.
+    async fn joined_pair() -> (WsByteStream<tokio::io::DuplexStream>, WsByteStream<tokio::io::DuplexStream>) {
+        let (a, b) = tokio::io::duplex(64 * 1024);
+        let server = WebSocketStream::from_raw_socket(a, Role::Server, None).await;
+        let client = WebSocketStream::from_raw_socket(b, Role::Client, None).await;
+        (WsByteStream::new(server), WsByteStream::new(client))
+    }
+
+    #[tokio::test]
+    async fn bytes_survive_the_round_trip() {
+        let (mut server, mut client) = joined_pair().await;
+
+        client.write_all(b"hello relay").await.unwrap();
+        client.flush().await.unwrap();
+
+        let mut buf = [0u8; 11];
+        server.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"hello relay");
+    }
+
+    #[tokio::test]
+    async fn the_existing_protocol_works_unchanged_over_websocket() {
+        // The whole point of the adapter: one wire format, two doors. This is
+        // the same `write_msg`/`read_msg` the raw-TCP listener uses.
+        let (mut server, mut client) = joined_pair().await;
+
+        write_msg(
+            &mut client,
+            &ClientMessage::Register { slug: "waazaa".into(), token: "secret".into() },
+        )
+        .await
+        .unwrap();
+
+        let got: Option<ClientMessage> = read_msg(&mut server).await.unwrap();
+        match got {
+            Some(ClientMessage::Register { slug, token }) => {
+                assert_eq!(slug, "waazaa");
+                assert_eq!(token, "secret");
+            }
+            other => panic!("expected a Register message, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn several_messages_keep_their_order_and_boundaries() {
+        // A length prefix read across two WebSocket messages would corrupt the
+        // stream, so the framing has to survive back-to-back sends.
+        let (mut server, mut client) = joined_pair().await;
+
+        for _ in 0..3 {
+            write_msg(&mut client, &ServerMessage::Ping).await.unwrap();
+        }
+        write_msg(&mut client, &ServerMessage::Registered { ok: true, error: None })
+            .await
+            .unwrap();
+
+        for _ in 0..3 {
+            let msg: Option<ServerMessage> = read_msg(&mut server).await.unwrap();
+            assert!(matches!(msg, Some(ServerMessage::Ping)));
+        }
+        let last: Option<ServerMessage> = read_msg(&mut server).await.unwrap();
+        assert!(matches!(last, Some(ServerMessage::Registered { ok: true, .. })));
+    }
+
+    #[tokio::test]
+    async fn a_partial_read_leaves_the_rest_available() {
+        // The reader is allowed to take less than a message holds; the balance
+        // must wait rather than be dropped.
+        let (mut server, mut client) = joined_pair().await;
+
+        client.write_all(b"0123456789").await.unwrap();
+        client.flush().await.unwrap();
+
+        let mut first = [0u8; 4];
+        server.read_exact(&mut first).await.unwrap();
+        assert_eq!(&first, b"0123");
+
+        let mut rest = [0u8; 6];
+        server.read_exact(&mut rest).await.unwrap();
+        assert_eq!(&rest, b"456789");
+    }
+
+    #[tokio::test]
+    async fn a_payload_larger_than_one_read_is_reassembled() {
+        // Bodies are base64-encoded and routinely exceed any single read.
+        let (mut server, mut client) = joined_pair().await;
+        let big = vec![b'x'; 40 * 1024];
+
+        client.write_all(&big).await.unwrap();
+        client.flush().await.unwrap();
+
+        let mut got = vec![0u8; big.len()];
+        server.read_exact(&mut got).await.unwrap();
+        assert_eq!(got, big);
+    }
+
+    #[tokio::test]
+    async fn closing_reads_as_end_of_file() {
+        // `read_msg` returns None on clean end-of-file, which the session loop
+        // treats as a departure rather than an error.
+        let (mut server, mut client) = joined_pair().await;
+        client.shutdown().await.unwrap();
+
+        let msg: Option<ClientMessage> = read_msg(&mut server).await.unwrap();
+        assert!(msg.is_none(), "a closed socket should read as end-of-file");
+    }
+}


### PR DESCRIPTION
The legacy port is unreachable from a great many networks. Company, university and school firewalls routinely allow 80 and 443 outbound and nothing else, so an instance behind one could never bring its tunnel up. An institute in Brazil hit exactly that on the day it registered.

## One conversation, two doors

The session logic moves to `server/session.rs`, generic over any `AsyncRead + AsyncWrite`.

Only **three things** were ever TCP-specific in a 194-line handler: the stream type, the split, and TCP keepalive. Keepalive stays in the TCP door, since it acts on a socket only that door holds.

Both listeners now share the conversation, so the WebSocket door inherits every fix made for the raw-TCP one and neither can drift.

## One wire format

WebSocket is message-oriented; the protocol is a length prefix over bytes. The two do not meet on their own.

There were two ways out: a second encode/decode pair sending one JSON per WebSocket message, or an adapter making the WebSocket behave like a byte stream. **The first duplicates the protocol, and a duplicated protocol drifts** — a fix on one side silently misses the other.

`server/ws_stream.rs` takes the second road. A test proves the existing `read_msg` and `write_msg` work over it **unchanged**.

That required `write_msg` to flush: a buffered writer emits nothing otherwise, and the adapter is exactly that. On a raw socket the call costs nothing.

## The ban list is shared

Lifted to `server::run`. A ban is about **who is calling**, not about the road they took: an address turned away on one door must not be welcome on the other. Expiry now runs once rather than once per listener.

## The address held responsible

Read from the upgrade request, and **only because the peer is one of our own proxies**. Without it every WebSocket caller would look like `127.0.0.1`, and five failures from anyone would lock out everyone. That was the blocking find of the pre-flight review.

## Demonstrated end to end

Against a throwaway instance on separate ports, with production untouched:

```
handshake                 HTTP/1.1 101 Switching Protocols
protocol frame decoded    auth checked against the real database
```

| upgrade request | address held responsible |
|---|---|
| with `CF-Connecting-IP: 203.0.114.42` | **203.0.114.42** |
| without the header | `127.0.0.1` |

Each counted **one** attempt of its own, not two against a single address.

Telemetry was verified unpolluted afterwards: a failed authentication writes nothing, by design, so the test runs left no trace.

## Deliberately not included

**No Caddy route.** The listener binds **loopback only** and nothing reaches it yet. Caddy is the front door and terminates TLS; a public bind would offer an unauthenticated upgrade with no TLS in front of it. Routing is a production change and gets its own approved step.

## Small things that matter

`Transport` is an enum rather than a string. The value lands in a column constrained to exactly two, and a typo there would quietly suggest nobody is left on the legacy port, which would close it on someone still using it.

The keep-alive budget is now a **compile-time assertion** instead of a test: the build should fail, not the suite. Cloudflare closes an idle WebSocket at around 100 s, and TCP keepalive only holds up the local hop.

## Verification

33 tests, 11 new. Clippy reports **nothing** on any of the five files touched; the crate's remaining warnings live in files untouched here.
