### PR TITLE
chore(ops): un retour arriere eprouve avant de toucher a Caddy en production

### DIFF
--- a/scripts/ops/caddy/README.md
+++ b/scripts/ops/caddy/README.md
@@ -1,0 +1,90 @@
+# Modifier Caddy en production sans perdre le domaine
+
+Ces scripts existent pour une raison précise : sur ce serveur, la configuration
+Caddy **vivante ne vient pas de `/etc/caddy/Caddyfile`**. Elle est chargée depuis
+`/var/lib/caddy/.config/caddy/autosave.json`, que Caddy restaure au démarrage. Le
+Caddyfile sur disque est un vestige minimal de l'installateur de tunnel, sans bloc
+HTTPS pour `nodyx.org`.
+
+Conséquence : `systemctl reload caddy` ou `caddy reload` bascule Caddy sur le
+fichier disque et **fait tomber le HTTPS de nodyx.org instantanément**. Toute
+modification passe donc par l'API d'administration, jamais par un rechargement.
+
+## Les quatre scripts
+
+| script | rôle |
+|---|---|
+| `sauvegarder.sh` | photographie l'état avant toute modification |
+| `verifier.sh` | dit si le domaine va bien, en comparant à un relevé |
+| `poser-route-tunnel.sh` | pose la route du tunnel WebSocket, avec repli automatique |
+| `annuler-route-tunnel.sh` | retire cette route |
+| `restaurer.sh` | remet un état sauvegardé |
+
+## Le retour arrière, à trois niveaux
+
+**Niveau 1, chirurgical.** `annuler-route-tunnel.sh` retrouve la route par son
+contenu (hôte et destination), jamais par un index noté quelque part, et la
+supprime. C'est le retour arrière normal.
+
+**Niveau 2, les routes.** `restaurer.sh <sauvegarde.json>` réécrit le tableau de
+routes complet de `srv1` depuis une sauvegarde. À employer si le niveau 1 ne
+suffit pas.
+
+**Niveau 3, l'état initial.** `etat-initial.json` est écrit **une seule fois**, à
+la première sauvegarde, et n'est jamais réécrit. C'est le point de retour quand
+plus rien d'autre n'est sûr :
+
+```bash
+./restaurer.sh /var/backups/nodyx/caddy/etat-initial.json
+```
+
+> **Pourquoi pas simplement « la dernière sauvegarde »** : `poser-route-tunnel.sh`
+> sauvegarde au début de son exécution. Un second passage photographierait donc
+> l'état **déjà modifié** et le déposerait parmi les points de retour, où il
+> serait pris pour l'état d'avant. Le piège s'est produit pendant la mise au
+> point de ces scripts, sur maquette.
+
+## Le piège du rechargement complet
+
+`restaurer.sh --complet` fait un `POST /load`, qui remplace la configuration
+**entière**, bloc `admin` compris.
+
+La configuration vivante de cette production **ne contient aucun bloc `admin`** :
+Caddy écoute sur l'endpoint par défaut, `localhost:2019`, de façon implicite.
+Recharger une sauvegarde qui déplacerait cet endpoint reviendrait à se couper la
+seule porte par où passer pour revenir en arrière. `restaurer.sh` refuse ce cas
+plutôt que de faire confiance.
+
+C'est pour cela que le mode par défaut est chirurgical, et `--complet` un
+dernier recours.
+
+## Critères d'arrêt
+
+Faire machine arrière **immédiatement**, sans chercher à comprendre d'abord, si
+l'un de ces points est constaté :
+
+- un hôte du relevé change de code de retour, quel qu'il soit ;
+- `localhost:2019` ne répond plus, l'API d'administration étant la seule porte
+  de retour ;
+- le port 7443 se ferme, une instance tunnelisée sur trois continents en dépend ;
+- la route `*.nodyx.org` disparaît, elle sert **toutes** les instances
+  tunnelisées d'un coup.
+
+`poser-route-tunnel.sh` applique lui-même le premier critère : si le contrôle
+détecte un écart après la pose, il annule sans attendre et sort en erreur.
+
+## Comment ces scripts ont été éprouvés
+
+Sept essais sur un Caddy factice reproduisant la forme de la production, hors
+production, avant tout usage réel :
+
+1. pose complète, du relevé au contrôle final ;
+2. `PUT` sur un index : **insère**, ne remplace pas. 4 routes deviennent 5, le
+   joker `*.nodyx.org` survit et glisse d'un rang. C'était l'inconnue qui
+   pouvait tout détruire ;
+3. seconde pose : refusée avant toute sauvegarde ;
+4. annulation : route retrouvée par contenu, retirée, compte revenu à 4 ;
+5. restauration après suppression volontaire d'une route : rétablie ;
+6. `etat-initial.json` : créé une fois, non contaminé par un second passage ;
+7. contrôle en échec après la pose : repli automatique, joker intact, sortie
+   non nulle.

--- a/scripts/ops/caddy/annuler-route-tunnel.sh
+++ b/scripts/ops/caddy/annuler-route-tunnel.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Retire la route du tunnel WebSocket. C'est le retour arriere de premier niveau.
+#
+# La route est retrouvee par son CONTENU (hote + destination), jamais par un
+# index note quelque part : entre la pose et l'annulation, une autre operation a
+# pu decaler les routes, et supprimer l'index 16 par habitude reviendrait a
+# supprimer le joker `*.nodyx.org` dont depend chaque instance tunnelisee.
+set -euo pipefail
+
+API="${CADDY_API:-http://localhost:2019}"
+HOTE=tunnel.nodyx.org
+CIBLE=127.0.0.1:7002
+
+INDEX=$(curl -sf -m 15 "$API/config/apps/http/servers/srv1/routes" | python3 -c "
+import json, sys
+routes = json.load(sys.stdin)
+trouves = []
+for i, r in enumerate(routes):
+    hotes = {h for m in r.get('match', []) for h in m.get('host', [])}
+    dests = set()
+    def creuser(o):
+        if isinstance(o, dict):
+            for u in o.get('upstreams', []) or []: dests.add(u.get('dial',''))
+            for v in o.values(): creuser(v)
+        elif isinstance(o, list):
+            for v in o: creuser(v)
+    creuser(r)
+    if '$HOTE' in hotes and '$CIBLE' in dests:
+        trouves.append(i)
+if len(trouves) == 0:
+    sys.exit('ABSENTE')
+if len(trouves) > 1:
+    sys.exit('MULTIPLE')
+print(trouves[0])
+") || {
+  case "$?" in
+    *) echo "  Rien a annuler : aucune route unique pour $HOTE -> $CIBLE." >&2
+       echo "  Inspecter a la main : curl -s $API/config/apps/http/servers/srv1/routes | python3 -m json.tool" >&2
+       exit 1 ;;
+  esac
+}
+
+echo "  Route trouvee a l'index $INDEX ($HOTE -> $CIBLE)"
+curl -sf -X DELETE "$API/config/apps/http/servers/srv1/routes/$INDEX" \
+  && echo "  Retiree." \
+  || { echo "  ECHEC de la suppression, configuration intacte" >&2; exit 1; }
+
+echo
+"$(dirname "$0")/verifier.sh" || true

--- a/scripts/ops/caddy/poser-route-tunnel.sh
+++ b/scripts/ops/caddy/poser-route-tunnel.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Pose la route qui expose la porte WebSocket du relais en HTTPS.
+#
+#   instance -> Cloudflare -> Caddy :443 tunnel.nodyx.org/tunnel -> 127.0.0.1:7002
+#
+# Deux precautions structurent ce script :
+#
+# 1. La route est inseree JUSTE AVANT le joker `*.nodyx.org`, pas en tete. En
+#    tete, un filtre mal ecrit capterait le trafic de tous les hotes nommes. A
+#    cette position, il ne peut au pire capter que ce qui serait alle au joker.
+#
+# 2. Rien ne se fait sans sauvegarde fraiche. `autosave.json` est reecrit par
+#    Caddy juste apres la modification : sans copie prealable, l'etat d'avant
+#    n'existe plus nulle part.
+set -euo pipefail
+
+API="${CADDY_API:-http://localhost:2019}"
+HOTE=tunnel.nodyx.org
+CIBLE=127.0.0.1:7002
+SAUVE="${CADDY_SAUVE:-/var/backups/nodyx/caddy}"
+ICI="$(cd "$(dirname "$0")" && pwd)"
+
+echo "=== 0. la route est-elle deja posee ? ==="
+# Avant toute chose, y compris la sauvegarde : un second passage prendrait
+# sinon une photo de l'etat deja modifie et la deposerait parmi les points de
+# retour, ou elle serait prise pour l'etat d'avant.
+DEJA=$(curl -sf -m 15 "$API/config/apps/http/servers/srv1/routes" | python3 -c "
+import json, sys
+routes = json.load(sys.stdin)
+for r in routes:
+    hotes = {h for m in r.get('match', []) for h in m.get('host', [])}
+    if '$HOTE' in hotes:
+        print('oui'); break
+else:
+    print('non')
+")
+if [ "$DEJA" = "oui" ]; then
+  echo "  Une route $HOTE existe deja. Rien a faire."
+  echo "  Pour la retirer : $ICI/annuler-route-tunnel.sh"
+  exit 0
+fi
+echo "  non, on peut poser"
+
+echo
+echo "=== 1. sauvegarde prealable ==="
+"$ICI/sauvegarder.sh" "$SAUVE"
+
+echo
+echo "=== 2. releve de reference du domaine ==="
+"$ICI/verifier.sh" --releve
+
+echo
+echo "=== 3. position d'insertion ==="
+INDEX=$(curl -sf -m 15 "$API/config/apps/http/servers/srv1/routes" | python3 -c "
+import json, sys
+routes = json.load(sys.stdin)
+for i, r in enumerate(routes):
+    hotes = {h for m in r.get('match', []) for h in m.get('host', [])}
+    dests = set()
+    def creuser(o):
+        if isinstance(o, dict):
+            for u in o.get('upstreams', []) or []: dests.add(u.get('dial',''))
+            for v in o.values(): creuser(v)
+        elif isinstance(o, list):
+            for v in o: creuser(v)
+    creuser(r)
+    if '$HOTE' in hotes and '$CIBLE' in dests:
+        sys.exit('DEJA_POSEE : la route existe deja, rien a faire.\n                 Pour la retirer : annuler-route-tunnel.sh')
+# juste avant le joker qui sert les instances tunnelisees
+for i, r in enumerate(routes):
+    hotes = {h for m in r.get('match', []) for h in m.get('host', [])}
+    if '*.nodyx.org' in hotes:
+        print(i); break
+else:
+    sys.exit('JOKER_INTROUVABLE : aucune route *.nodyx.org.\n             La configuration n\\'est pas celle attendue, on ne touche a rien.')
+")
+echo "  joker *.nodyx.org a l'index $INDEX, insertion a cette position"
+
+cat > /tmp/.route-tunnel.$$ <<JSON
+{
+  "match": [{ "host": ["$HOTE"], "path": ["/tunnel*"] }],
+  "handle": [{ "handler": "reverse_proxy", "upstreams": [{ "dial": "$CIBLE" }] }],
+  "terminal": true
+}
+JSON
+
+echo
+echo "=== 4. pose ==="
+# PUT sur un index INSERE, il ne remplace pas. Caddy valide la configuration
+# entiere avant de l'appliquer : un refus laisse la production intacte.
+curl -sf -X PUT "$API/config/apps/http/servers/srv1/routes/$INDEX" \
+     -H 'Content-Type: application/json' \
+     --data-binary "@/tmp/.route-tunnel.$$" \
+  && echo "  posee" \
+  || { echo "  REFUSEE par Caddy, configuration en cours intacte" >&2; rm -f "/tmp/.route-tunnel.$$"; exit 1; }
+rm -f "/tmp/.route-tunnel.$$"
+
+echo
+echo "=== 5. verification ==="
+sleep 2
+"$ICI/verifier.sh" || {
+  echo
+  echo "!!! ECART DETECTE, annulation automatique !!!" >&2
+  "$ICI/annuler-route-tunnel.sh"
+  exit 1
+}
+
+echo
+echo "Pour annuler : $ICI/annuler-route-tunnel.sh"

--- a/scripts/ops/caddy/restaurer.sh
+++ b/scripts/ops/caddy/restaurer.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Remet Caddy dans l'etat decrit par une sauvegarde.
+#
+# Par defaut, ne restaure QUE le tableau de routes de srv1, c'est-a-dire tout ce
+# que nos manipulations touchent. C'est volontairement etroit : l'operation la
+# plus sure est celle qui ne peut pas atteindre ce qu'on ne voulait pas changer.
+#
+# `--complet` recharge la configuration ENTIERE. A n'employer que si la premiere
+# forme n'a pas suffi, et en connaissant ce piege :
+#
+#   La configuration vivante de cette production ne contient AUCUN bloc `admin`.
+#   Caddy ecoute donc sur l'endpoint par defaut (localhost:2019) de maniere
+#   implicite. Un `POST /load` remplace la configuration entiere, bloc `admin`
+#   compris : recharger une sauvegarde qui n'en a pas laisse l'endpoint par
+#   defaut, donc le meme. Recharger une sauvegarde qui en aurait un DIFFERENT
+#   deplacerait l'API d'administration, et le prochain retour arriere n'aurait
+#   plus de porte par ou passer.
+#
+# Le script verifie ce point avant d'agir plutot que de faire confiance.
+set -euo pipefail
+
+FICHIER="${1:-}"
+MODE="${2:-}"
+API="${CADDY_API:-http://localhost:2019}"
+
+if [ -z "$FICHIER" ] || [ ! -f "$FICHIER" ]; then
+  echo "usage : $0 <sauvegarde.json> [--complet]" >&2
+  echo "        sauvegardes disponibles :" >&2
+  ls -1t /var/backups/nodyx/caddy/live-*.json 2>/dev/null | head -5 | sed 's/^/          /' >&2
+  exit 1
+fi
+
+# Une sauvegarde illisible ou tronquee doit etre rejetee AVANT d'avoir touche
+# quoi que ce soit, pas au milieu de la restauration.
+python3 - "$FICHIER" "$MODE" <<'PY'
+import json, sys
+chemin, mode = sys.argv[1], sys.argv[2]
+try:
+    d = json.load(open(chemin))
+except Exception as e:
+    sys.exit(f"  sauvegarde illisible : {e}")
+
+try:
+    routes = d["apps"]["http"]["servers"]["srv1"]["routes"]
+except KeyError as e:
+    sys.exit(f"  sauvegarde incomplete, cle absente : {e}")
+
+if not routes:
+    sys.exit("  sauvegarde sans aucune route : restauration refusee")
+
+hotes = sorted({h for r in routes for m in r.get("match", []) for h in m.get("host", [])})
+print(f"  {len(routes)} routes, {len(hotes)} hotes")
+print(f"  dont : {', '.join(hotes[:6])}{' ...' if len(hotes) > 6 else ''}")
+
+if mode == "--complet":
+    admin = d.get("admin")
+    if admin is None:
+        print("  bloc admin : absent, l'endpoint par defaut sera conserve (localhost:2019)")
+    else:
+        ecoute = admin.get("listen", "(defaut)")
+        print(f"  bloc admin : PRESENT, ecoute {ecoute}")
+        if "2019" not in str(ecoute):
+            sys.exit("  ARRET : cette sauvegarde deplacerait l'API d'administration.\n"
+                     "         Le prochain retour arriere n'aurait plus de porte.")
+PY
+
+echo
+if [ "$MODE" = "--complet" ]; then
+  echo "--- restauration COMPLETE (POST /load) ---"
+  read -rp "  Recharger la configuration entiere ? tapez 'complet' : " r
+  [ "$r" = "complet" ] || { echo "  annule"; exit 1; }
+  curl -sf -X POST "$API/load" -H 'Content-Type: application/json' \
+       --data-binary "@$FICHIER" \
+    && echo "  recharge" \
+    || { echo "  ECHEC : la configuration en cours est intacte (Caddy valide avant d'appliquer)" >&2; exit 1; }
+else
+  echo "--- restauration des routes de srv1 (PUT, chirurgical) ---"
+  python3 -c "
+import json,sys
+d=json.load(open('$FICHIER'))
+json.dump(d['apps']['http']['servers']['srv1']['routes'], open('/tmp/.caddy-routes.$$','w'))
+"
+  curl -sf -X PATCH "$API/config/apps/http/servers/srv1/routes" \
+       -H 'Content-Type: application/json' \
+       --data-binary "@/tmp/.caddy-routes.$$" \
+    && echo "  routes restaurees" \
+    || { echo "  ECHEC : configuration en cours intacte" >&2; rm -f "/tmp/.caddy-routes.$$"; exit 1; }
+  rm -f "/tmp/.caddy-routes.$$"
+fi
+
+echo
+echo "Verifier maintenant : $(dirname "$0")/verifier.sh"

--- a/scripts/ops/caddy/sauvegarder.sh
+++ b/scripts/ops/caddy/sauvegarder.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Photographie l'etat de Caddy AVANT toute modification.
+#
+# Deux fichiers, parce qu'ils peuvent diverger :
+#   - la configuration VIVANTE, lue par l'API d'administration ;
+#   - `autosave.json`, que Caddy restaure au demarrage. Il est REECRIT apres
+#     chaque modification par l'API : sans cette copie, l'etat d'avant est perdu
+#     des la premiere commande.
+#
+# La sauvegarde vit hors du depot : elle decrit l'infrastructure.
+set -euo pipefail
+
+DEST="${1:-/var/backups/nodyx/caddy}"
+AUTOSAVE=/var/lib/caddy/.config/caddy/autosave.json
+HORODATE="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+
+mkdir -p "$DEST"
+
+echo "--- configuration vivante ---"
+if ! curl -sf -m 15 "${CADDY_API:-http://localhost:2019}/config/" > "$DEST/live-$HORODATE.json"; then
+  echo "  ECHEC : l'API d'administration ne repond pas. On ne modifie RIEN." >&2
+  exit 1
+fi
+
+# Une sauvegarde tronquee est pire que pas de sauvegarde : elle donne
+# l'illusion d'un retour arriere possible.
+python3 - "$DEST/live-$HORODATE.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+routes = d["apps"]["http"]["servers"]["srv1"]["routes"]
+assert len(routes) > 0, "configuration sans route : sauvegarde refusee"
+print(f"  {len(routes)} routes, {len(json.dumps(d))} octets")
+PY
+
+echo "--- autosave, restaure au demarrage ---"
+if [ -f "$AUTOSAVE" ]; then
+  cp -a "$AUTOSAVE" "$DEST/autosave-$HORODATE.json"
+  echo "  copie ($(stat -c%s "$AUTOSAVE") octets)"
+else
+  echo "  ABSENT : Caddy repartirait du Caddyfile disque au prochain demarrage" >&2
+fi
+
+ln -sfn "live-$HORODATE.json" "$DEST/derniere-live.json"
+
+# Le tout premier etat connu, ecrit UNE SEULE FOIS et jamais reecrit.
+#
+# « La sauvegarde la plus recente » est un mauvais point de retour : ce script
+# tourne au debut de chaque pose, donc un second passage photographie l'etat
+# DEJA modifie. Qui restaurerait la derniere sauvegarde en situation d'incident
+# remettrait l'etat casse en croyant revenir en arriere.
+#
+# `etat-initial.json` est immuable : c'est vers lui qu'on revient quand plus
+# rien d'autre n'est sur.
+if [ ! -f "$DEST/etat-initial.json" ]; then
+  cp -a "$DEST/live-$HORODATE.json" "$DEST/etat-initial.json"
+  echo "  etat-initial.json cree (point de retour immuable)"
+else
+  echo "  etat-initial.json deja present, laisse intact ($(stat -c%s "$DEST/etat-initial.json") octets)"
+fi
+echo
+echo "Sauvegarde : $DEST/live-$HORODATE.json"
+echo "Restauration complete : $(dirname "$0")/restaurer.sh $DEST/live-$HORODATE.json"

--- a/scripts/ops/caddy/verifier.sh
+++ b/scripts/ops/caddy/verifier.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Dit si le domaine va bien, en comparant a un releve pris AVANT la modification.
+#
+# On ne verifie pas que tout repond 200 : `code.nodyx.org` redirige vers une
+# authentification, un hote peut legitimement repondre 302 ou 401. Comparer a
+# l'etat d'avant est la seule mesure qui distingue « c'etait deja comme ca » de
+# « je viens de le casser ».
+#
+#   verifier.sh --releve   enregistre l'etat courant comme reference
+#   verifier.sh            compare l'etat courant a la reference
+set -euo pipefail
+
+REF="${REF:-/var/backups/nodyx/caddy/releve.txt}"
+MODE="${1:-}"
+
+HOTES=(
+  nodyx.org
+  nodyx.dev
+  olympus.nodyx.org
+  demo.nodyx.org
+  sleemstudio.nodyx.org
+  vieuxlooters.nodyx.org
+  start.nodyx.org
+  library.nodyx.org
+  extensions.nodyx.org
+  code.nodyx.org
+  signet.nodyx.org
+  nexusnode.app
+)
+
+mesurer() {
+  for h in "${HOTES[@]}"; do
+    code=$(curl -s -o /dev/null -w '%{http_code}' -m 12 "https://$h/" 2>/dev/null || echo 000)
+    echo "https  $h $code"
+  done
+  # Le relais historique : une instance tunnelisee sur trois continents en depend.
+  for p in 7443 7001 3478; do
+    if timeout 5 bash -c "</dev/tcp/127.0.0.1/$p" 2>/dev/null; then
+      echo "port   127.0.0.1:$p ouvert"
+    else
+      echo "port   127.0.0.1:$p FERME"
+    fi
+  done
+  # L'API d'administration : sans elle, plus aucun retour arriere n'est possible.
+  if curl -sf -o /dev/null -m 8 "${CADDY_API:-http://localhost:2019}/config/"; then
+    echo "admin  localhost:2019 repond"
+  else
+    echo "admin  localhost:2019 MUET"
+  fi
+}
+
+if [ "$MODE" = "--releve" ]; then
+  mkdir -p "$(dirname "$REF")"
+  mesurer > "$REF"
+  echo "Releve de reference ecrit dans $REF :"
+  sed 's/^/  /' "$REF"
+  exit 0
+fi
+
+if [ ! -f "$REF" ]; then
+  echo "Aucun releve de reference. Lancez d'abord : $0 --releve" >&2
+  exit 1
+fi
+
+MAINTENANT=$(mktemp)
+mesurer > "$MAINTENANT"
+
+ECARTS=0
+while read -r type cible avant; do
+  apres=$(awk -v c="$cible" '$2==c {print $3}' "$MAINTENANT")
+  if [ "$avant" = "$apres" ]; then
+    printf '  ok        %-28s %s\n' "$cible" "$apres"
+  else
+    printf '  ECART     %-28s %s -> %s\n' "$cible" "$avant" "$apres"
+    ECARTS=$((ECARTS+1))
+  fi
+done < "$REF"
+rm -f "$MAINTENANT"
+
+echo
+if [ "$ECARTS" -eq 0 ]; then
+  echo "VERDICT : rien n'a bouge ($(wc -l < "$REF") controles)"
+  exit 0
+fi
+echo "VERDICT : $ECARTS ECART(S) - faire machine arriere :"
+echo "  $(dirname "$0")/annuler-route-tunnel.sh"
+exit 1


### PR DESCRIPTION
## Pourquoi

La porte WebSocket du relais est prete cote Rust (#615, #616). Il reste a
l'exposer en HTTPS, ce qui veut dire toucher a Caddy en production.

Or sur ce serveur, la configuration Caddy vivante ne vient **pas** du Caddyfile
sur disque mais de `autosave.json`. Un `reload` fait tomber le HTTPS de
nodyx.org instantanement. On ne fait pas ce genre de modification sans savoir
revenir en arriere, et sans l'avoir prouve ailleurs qu'en production.

Ce lot ne modifie rien en production. Il pose le filet.

## Le retour arriere, a trois niveaux

**Niveau 1, chirurgical.** `annuler-route-tunnel.sh` retrouve la route par son
**contenu** (hote et destination), jamais par un index note quelque part. Entre
la pose et l'annulation, une autre operation peut avoir decale les routes :
supprimer l'index 16 par habitude reviendrait a supprimer le joker
`*.nodyx.org` dont depend **chaque** instance tunnelisee.

**Niveau 2.** `restaurer.sh` reecrit le tableau de routes depuis une sauvegarde.
Chirurgical par defaut. Le mode `--complet` (`POST /load`) refuse une sauvegarde
qui deplacerait l'API d'administration : ce serait se couper la seule porte par
ou revenir en arriere.

**Niveau 3.** `etat-initial.json`, ecrit une seule fois, jamais reecrit.

## Le piege rencontre en chemin

Le niveau 3 n'etait pas prevu. Il vient d'un essai sur maquette :
`poser-route-tunnel.sh` sauvegarde au debut de son execution, donc un second
passage photographiait l'etat **deja modifie** et le deposait parmi les points de
retour. En incident reel, restaurer « la derniere sauvegarde » aurait remis
l'etat casse.

Deux corrections : la garde anti-doublon s'execute maintenant **avant** la
sauvegarde, et l'ancrage initial est immuable.

## Le controle de sante

`verifier.sh` compare a un releve pris **avant**, plutot que d'attendre 200
partout : `code.nodyx.org` redirige vers une authentification, `olympus` repond
303, `nexusnode.app` 301. Comparer est la seule mesure qui distingue « c'etait
deja comme ca » de « je viens de le casser ».

Il couvre 12 hotes, les ports 7443 / 7001 / 3478, et l'API d'administration.
`poser-route-tunnel.sh` annule de lui-meme au moindre ecart.

## Sept essais, sur maquette, hors production

| # | essai | resultat |
|---|---|---|
| 1 | pose complete | releve, insertion, controle, verdict |
| 2 | **`PUT` sur un index insere-t-il ou remplace-t-il ?** | **insere** : 4 routes deviennent 5, le joker survit et glisse d'un rang |
| 3 | seconde pose | refusee avant toute sauvegarde |
| 4 | annulation | route retrouvee par contenu, compte revenu a 4 |
| 5 | restauration apres suppression volontaire | route retablie |
| 6 | `etat-initial.json` | cree une fois, non contamine par un second passage |
| 7 | controle en echec apres la pose | repli automatique, joker intact, sortie non nulle |

L'essai 2 etait l'inconnue qui pouvait tout detruire. S'il avait remplace, la
premiere pose aurait efface le joker et coupe toutes les instances tunnelisees
d'un coup.

## Ou se pose la route

Juste **avant** le joker `*.nodyx.org`, pas en tete. A cette position elle ne
peut au pire capter que du trafic qui serait alle au joker de toute facon, la ou
en tete un filtre mal ecrit capterait tous les hotes nommes.

## Ce que ce lot ne fait pas

Il ne pose pas la route en production. C'est une decision separee, prise une fois
ce filet en place.
