### PR TITLE
feat(relais): l'installeur bascule seul sur la porte HTTPS quand 7443 est mure

### DIFF
--- a/docs/en/RELAY.md
+++ b/docs/en/RELAY.md
@@ -207,9 +207,38 @@ python3 -c "import socket;socket.create_connection(('relay.nodyx.org',7443),time
 
 #### If your network filters the port
 
-You have three ways out, easiest first.
+**Since August 2026 the installer handles this for you.** It tries the direct port first, then IPv6, then the same tunnel carried over HTTPS on port `443`. A network that lets you browse the web at all will let that last one through. If you are installing today there is nothing to do: the installer says which road it took.
 
-**1. Ask for the port to be opened, outbound only.**
+The rest of this section is for instances installed before that, and for anyone who prefers to switch by hand.
+
+**1. Take the HTTPS door.**
+
+The relay accepts the very same tunnel as a WebSocket over HTTPS, on port `443`, the port your browser already uses. Same slug, same token, same behaviour. Only the road differs.
+
+```bash
+sudo systemctl edit --full nodyx-relay-client
+# in the ExecStart line, replace:
+# --server relay.nodyx.org:7443
+# with:
+# --server wss://tunnel.nodyx.org/tunnel
+sudo systemctl restart nodyx-relay-client
+```
+
+Check from your machine that the door answers:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -m 5 --http1.1 \
+  -H 'Connection: Upgrade' -H 'Upgrade: websocket' \
+  -H 'Sec-WebSocket-Version: 13' \
+  -H "Sec-WebSocket-Key: $(head -c16 /dev/urandom | base64)" \
+  https://tunnel.nodyx.org/tunnel
+```
+
+`101` means the door is open and the tunnel will come up.
+
+> **Read the number, not curl's exit code.** curl is not a WebSocket client: once it has its `101` it waits for data that never comes, then gives up with exit code `28`. Here, a successful probe is the one that times out. Testing the exit code would reject a door that is wide open.
+
+**2. Ask for the port to be opened, outbound only.**
 
 Network administrators say no to vague requests and yes to precise ones. Here is a paragraph you can copy and send as is:
 
@@ -219,7 +248,7 @@ Network administrators say no to vague requests and yes to precise ones. Here is
 > The connection stays open and carries the traffic of a self-hosted community platform.
 > Thank you.
 
-**2. Use IPv6, if your network provides it.**
+**3. Use IPv6, if your network provides it.**
 
 Since August 2026 the relay also answers on a dedicated IPv6 name. Some networks that filter IPv4 leave IPv6 alone, and IPv6-only networks can now connect at all, which was impossible before.
 
@@ -241,7 +270,7 @@ sudo systemctl restart nodyx-relay-client
 
 > `relay6.nodyx.org` publishes an `AAAA` record only. It is the same relay, the same port, the same token. Only the road differs.
 
-**3. Move the machine to another connection.**
+**4. Move the machine to another connection.**
 
 A 4G or 5G phone share is enough to confirm the diagnosis in two minutes. If the tunnel comes up instantly there, the wall really was your network, not your setup.
 

--- a/docs/fr/RELAY.md
+++ b/docs/fr/RELAY.md
@@ -174,6 +174,111 @@ curl -I https://ton-slug.nodyx.org/
 
 ## 🔧 Dépannage
 
+### Le tunnel ne se connecte jamais, le mur du port 7443
+
+**Commence par là.** C'est la panne la plus fréquente, et la moins devinable, parce que rien n'est mal réglé chez toi.
+
+Ton instance ouvre **une connexion sortante** vers `relay.nodyx.org`, en TCP sur le port `7443`. C'est tout le mécanisme. Rien n'entre, rien n'est redirigé, aucune règle n'est jamais ajoutée sur ta box.
+
+Le piège : beaucoup de réseaux ne laissent sortir que `80` et `443`. Les connexions grand public autorisent presque toujours `7443`. Les réseaux d'entreprise, d'université, d'école et d'institut, souvent pas, et ils ne le disent jamais.
+
+#### Le savoir en cinq secondes
+
+```bash
+nc -zv relay.nodyx.org 7443
+```
+
+Trois réponses sont possibles, et chacune veut dire autre chose :
+
+| Ce que tu vois | Ce que ça signifie | Quoi faire |
+|---|---|---|
+| `succeeded!` ou `Connected` | Le port est ouvert, le trafic passe | Le problème est ailleurs, continue plus bas |
+| `Connection refused` | Quelque chose a répondu, et a dit non. Ton réseau va bien | C'est le relais qui est à terre, [dis-le nous](https://github.com/Pokled/nodyx/discussions) |
+| **Rien, ça reste suspendu, puis ça expire** | Ton réseau jette les paquets en silence | **C'est le mur. Lis la suite** |
+
+> **Relis ce tableau deux fois.** La différence entre *refusé* et *expiré* est le signal le plus utile de toute cette page. Un refus est une réponse. Le silence est un filtre.
+
+Pas de `nc` sur ta machine ? Ceci marche partout où Python est installé :
+
+```bash
+python3 -c "import socket;socket.create_connection(('relay.nodyx.org',7443),timeout=8);print('ouvert')"
+```
+
+#### Si ton réseau filtre le port
+
+**Depuis août 2026, l'installeur s'en charge tout seul.** Il essaie le port direct, puis l'IPv6, puis le même tunnel porté en HTTPS sur le port `443`. Un réseau qui te laisse simplement naviguer sur le web laissera passer ce dernier. Si tu installes aujourd'hui, tu n'as rien à faire : l'installeur t'annonce la route qu'il a prise.
+
+La suite de cette section s'adresse aux instances installées avant, et à qui préfère basculer à la main.
+
+**1. Prendre la porte HTTPS.**
+
+Le relais accepte exactement le même tunnel sous forme de WebSocket en HTTPS, sur le port `443`, celui qu'utilise déjà ton navigateur. Même slug, même token, même comportement. Seule la route change.
+
+```bash
+sudo systemctl edit --full nodyx-relay-client
+# dans la ligne ExecStart, remplace :
+# --server relay.nodyx.org:7443
+# par :
+# --server wss://tunnel.nodyx.org/tunnel
+sudo systemctl restart nodyx-relay-client
+```
+
+Vérifie depuis ta machine que la porte répond :
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -m 5 --http1.1 \
+  -H 'Connection: Upgrade' -H 'Upgrade: websocket' \
+  -H 'Sec-WebSocket-Version: 13' \
+  -H "Sec-WebSocket-Key: $(head -c16 /dev/urandom | base64)" \
+  https://tunnel.nodyx.org/tunnel
+```
+
+`101` veut dire que la porte est ouverte et que le tunnel montera.
+
+> **Lis le nombre, pas le code de sortie de curl.** curl n'est pas un client WebSocket : une fois son `101` obtenu, il attend des données qui ne viendront pas, puis abandonne avec le code `28`. Ici, la sonde qui réussit est celle qui expire. Tester le code de sortie ferait rejeter une porte grande ouverte.
+
+**2. Demander l'ouverture du port, en sortie seulement.**
+
+Les administrateurs réseau disent non aux demandes vagues et oui aux demandes précises. Voici un paragraphe à copier tel quel :
+
+> Bonjour,
+> J'ai besoin d'autoriser le trafic TCP **sortant** depuis ma machine vers `relay.nodyx.org` (`46.225.20.193`) sur le port `7443`.
+> Il s'agit uniquement d'une connexion sortante. Elle ne nécessite **aucune règle entrante**, aucune redirection de port, et aucun service exposé de mon côté. La machine reste injoignable depuis l'extérieur.
+> La connexion reste ouverte et transporte le trafic d'une plateforme communautaire auto-hébergée.
+> Merci.
+
+**3. Passer par l'IPv6, si ton réseau en fournit.**
+
+Depuis août 2026, le relais répond aussi sur un nom IPv6 dédié. Certains réseaux qui filtrent l'IPv4 laissent l'IPv6 tranquille, et les réseaux uniquement IPv6 peuvent enfin se connecter, ce qui était impossible avant.
+
+```bash
+# Ta machine a-t-elle une IPv6 qui marche ?
+python3 -c "import socket;socket.create_connection(('relay6.nodyx.org',7443),timeout=8);print('IPv6 OK')"
+```
+
+Si ça affiche `IPv6 OK`, pointe ton client dessus :
+
+```bash
+sudo systemctl edit --full nodyx-relay-client
+# dans la ligne ExecStart, remplace :
+# --server relay.nodyx.org:7443
+# par :
+# --server relay6.nodyx.org:7443
+sudo systemctl restart nodyx-relay-client
+```
+
+> `relay6.nodyx.org` ne publie qu'un enregistrement `AAAA`. C'est le même relais, le même port, le même token. Seule la route diffère.
+
+**4. Déplacer la machine sur une autre connexion.**
+
+Un partage de connexion 4G ou 5G suffit à confirmer le diagnostic en deux minutes. Si le tunnel monte instantanément là-bas, le mur était bien ton réseau, pas ton installation.
+
+#### Ce que ce n'est pas
+
+- **Pas** un port à ouvrir sur ta box. Il n'y a jamais rien à ouvrir en entrée.
+- **Pas** un problème de pare-feu sur ta propre machine. Le trafic sortant est autorisé par défaut sous Linux.
+- **Pas** une erreur de ta part. Un réseau filtrant ne renvoie aucun message d'erreur de ton côté, et c'est exactement ce qui rend la panne si déroutante.
+
 ### Le service ne démarre pas
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -409,6 +409,10 @@ T_EN[relay_probe_ok]='Outbound port 7443 is open. The tunnel will work.'
 T_FR[relay_probe_ok]='Le port 7443 sort bien. Le tunnel fonctionnera.'
 T_EN[relay_probe_v6]='Port 7443 is filtered over IPv4, but IPv6 works. Using %s instead.'
 T_FR[relay_probe_v6]='Le port 7443 est filtré en IPv4, mais IPv6 fonctionne. Utilisation de %s à la place.'
+T_EN[relay_probe_wss]='Port 7443 is blocked, but the tunnel goes through HTTPS on port 443. Using %s instead.'
+T_FR[relay_probe_wss]='Le port 7443 est bloqué, mais le tunnel passe en HTTPS sur le port 443. Utilisation de %s à la place.'
+T_EN[relay_probe_wss_try]='Port 7443 is blocked. Trying the tunnel over HTTPS, on port 443...'
+T_FR[relay_probe_wss_try]='Le port 7443 est bloqué. Essai du tunnel en HTTPS, sur le port 443...'
 T_EN[relay_probe_blocked]='Your network silently drops outbound port 7443. The tunnel cannot come up.'
 T_FR[relay_probe_blocked]='Votre réseau bloque silencieusement le port 7443 en sortie. Le tunnel ne pourra pas monter.'
 T_EN[relay_probe_hint]='This is a network restriction, not a mistake on your side. Company, university and institute networks often allow only 80 and 443.'
@@ -783,8 +787,8 @@ T_FR[sub_skipped]='Sous-domaine gratuit ignoré. Tu utiliseras https://%s'
 # §23 — Relay client systemd service
 T_EN[step_relay_client]='Configuring the Nodyx Relay Client service'
 T_FR[step_relay_client]='Configuration du service Nodyx Relay Client'
-T_EN[relay_client_started]='Nodyx Relay Client started — tunnel to relay.nodyx.org:7443 active'
-T_FR[relay_client_started]='Nodyx Relay Client démarré — tunnel vers relay.nodyx.org:7443 actif'
+T_EN[relay_client_started]='Nodyx Relay Client started — tunnel to %s active'
+T_FR[relay_client_started]='Nodyx Relay Client démarré — tunnel vers %s actif'
 T_EN[relay_client_url_soon]='Your instance will be reachable at https://%s in a few seconds.'
 T_FR[relay_client_url_soon]='Ton instance sera accessible sur https://%s dans quelques secondes.'
 
@@ -1814,6 +1818,32 @@ _relay_joignable() {
   timeout 8 bash -c "exec 3<>/dev/tcp/$1/$2" 2>/dev/null
 }
 
+# La porte WebSocket, en HTTPS sur 443.
+#
+# On n'accepte PAS une simple ouverture du port 443 comme preuve : un proxy
+# d'entreprise peut accepter la connexion, puis refuser la montée en WebSocket ou
+# la casser en inspectant le trafic. Le seul verdict qui engage est le 101
+# Switching Protocols, c'est-à-dire la poignée de main réellement aboutie.
+_relais_ws_joignable() {
+  local cle code
+  cle=$(head -c16 /dev/urandom | base64 2>/dev/null) || return 1
+
+  # Attention au code de SORTIE de curl : il ne dit rien de la réussite ici.
+  # curl n'est pas un client WebSocket. Une fois le 101 reçu il attend des
+  # données qui ne viendront pas, jusqu'à expiration du délai, et sort alors en
+  # code 28. Tester ce code de sortie faisait rejeter une porte parfaitement
+  # ouverte. Seul le code HTTP imprimé fait foi.
+  #
+  # Le délai est donc atteint à chaque essai RÉUSSI, et non l'inverse : il est
+  # court parce qu'il borne le succès, pas l'échec.
+  code=$(curl -s -o /dev/null -w '%{http_code}' -m 5 --http1.1 \
+    -H 'Connection: Upgrade' -H 'Upgrade: websocket' \
+    -H 'Sec-WebSocket-Version: 13' -H "Sec-WebSocket-Key: $cle" \
+    "https://$1/tunnel" 2>/dev/null)
+
+  [ "$code" = "101" ]
+}
+
 verifier_sortie_relais() {
   info "$(t relay_probe)"
 
@@ -1827,6 +1857,17 @@ verifier_sortie_relais() {
   if _relay_joignable relay6.nodyx.org 7443; then
     RELAY_SERVER="relay6.nodyx.org:7443"
     ok "$(printf "$(t relay_probe_v6)" "relay6.nodyx.org")"
+    return 0
+  fi
+
+  # 7443 est muré dans les deux familles. C'est le cas des réseaux d'entreprise,
+  # d'université et d'institut, qui ne laissent sortir que 80 et 443. Ce dernier
+  # essai est précisément ce pour quoi la porte WebSocket existe : un réseau qui
+  # bloque tout sauf le web laisse passer un tunnel déguisé en trafic web.
+  info "$(t relay_probe_wss_try)"
+  if _relais_ws_joignable tunnel.nodyx.org; then
+    RELAY_SERVER="wss://tunnel.nodyx.org/tunnel"
+    ok "$(printf "$(t relay_probe_wss)" "$RELAY_SERVER")"
     return 0
   fi
 
@@ -3070,7 +3111,7 @@ SVC
   systemctl daemon-reload
   systemctl enable nodyx-relay-client --quiet
   systemctl start nodyx-relay-client
-  ok "$(t relay_client_started)"
+  ok "$(printf "$(t relay_client_started)" "${RELAY_SERVER:-relay.nodyx.org:7443}")"
   info "$(printf "$(t relay_client_url_soon)" "${DOMAIN}")"
 fi
 
@@ -3461,7 +3502,7 @@ if ! $RELAY_MODE; then
   echo -e "     ${BOLD}$(t summ_voice)   ${RESET}stun/turn:${PUBLIC_IP}:3478 (nodyx-turn)"
 fi
 if $RELAY_MODE; then
-  echo -e "     ${BOLD}$(t summ_relay)   ${RESET}tunnel → relay.nodyx.org:7443"
+  echo -e "     ${BOLD}$(t summ_relay)   ${RESET}tunnel → ${RELAY_SERVER:-relay.nodyx.org:7443}"
 fi
 echo -e "     ${BOLD}$(t summ_version)   ${RESET}${NODYX_VERSION}"
 echo -e "     ${BOLD}$(t summ_dir)   ${RESET}${NODYX_DIR}"


### PR DESCRIPTION
## Ce qui change pour une instance

La porte WebSocket du relais est **en ligne** : `wss://tunnel.nodyx.org/tunnel`
repond `101` a travers Cloudflare puis Caddy. Elle ne servait a rien tant que
l'installeur l'ignorait.

La sonde gagne un troisieme essai, apres l'IPv4 et l'IPv6 sur 7443 : le meme
tunnel porte en **HTTPS sur le port 443**.

```
7443 en IPv4   ->  7443 en IPv6   ->  443 en HTTPS   ->  on previent l'utilisateur
```

C'est exactement le cas des reseaux d'entreprise, d'universite et d'institut,
qui ne laissent sortir que 80 et 443. Un institut bresilien est tombe dessus le
jour meme de son inscription.

## Pourquoi la sonde exige un 101

Une simple ouverture du port 443 ne prouve rien : un proxy d'entreprise peut
accepter la connexion, puis refuser la montee en protocole ou la casser en
inspectant le trafic. Seule la poignee de main reellement aboutie engage.

## Le piege rencontre en chemin

Le premier jet testait le **code de sortie de curl**. Il rejetait une porte
grande ouverte.

curl n'est pas un client WebSocket : une fois son `101` obtenu, il attend des
donnees qui ne viendront jamais, puis abandonne avec le code `28`. Ici, **la
sonde qui reussit est celle qui expire**. Seul le code HTTP imprime fait foi.

Mesure a l'appui :

```
code HTTP affiche par curl : 101
code de SORTIE de curl     : 28
```

Le piege est corrige, commente sur place dans `install.sh`, et ecrit dans la
documentation pour qui refera la sonde a la main.

## Les messages qui auraient menti

Deux endroits ecrivaient `relay.nodyx.org:7443` en dur et auraient annonce la
mauvaise route a une instance passee par la porte HTTPS : le message de
demarrage du client, et le resume de fin d'installation. Ils prennent desormais
`RELAY_SERVER`, comme le faisaient deja l'unite systemd et l'appel direct.

Compte au grep : 5 occurrences, dont 4 sont maintenant des valeurs de repli
`${RELAY_SERVER:-...}` et 1 est l'affectation initiale.

## Preuve

Sonde extraite du fichier reel, pas recopiee a la main, et executee :

```
tunnel.nodyx.org       -> OUI   (5s)
nodyx.org              -> NON   (0s)
library.nodyx.org      -> NON   (0s)
```

Elle discrimine : elle ne dit pas oui a n'importe quel hote en HTTPS.

## Documentation

La section du mur du port 7443 existait **en anglais seulement**. Elle est mise
a jour, et sa traduction francaise est ecrite : `fr` passe de 294 a 399 lignes,
contre 403 en anglais.

L'espagnol reste a 294 lignes. C'est une dette anterieure a ce lot, signalee et
non traitee ici.
