### PR TITLE
fix(caddy): n'accepter les en-tetes de transfert que de nos propres portes

### DIFF
--- a/scripts/ops/caddy/README.md
+++ b/scripts/ops/caddy/README.md
@@ -16,9 +16,48 @@ modification passe donc par l'API d'administration, jamais par un rechargement.
 |---|---|
 | `sauvegarder.sh` | photographie l'état avant toute modification |
 | `verifier.sh` | dit si le domaine va bien, en comparant à un relevé |
+| `verifier-identification.sh` | dit si un visiteur légitime est encore identifié |
 | `poser-route-tunnel.sh` | pose la route du tunnel WebSocket, avec repli automatique |
 | `annuler-route-tunnel.sh` | retire cette route |
+| `poser-filtre-entetes.sh` | empêche un inconnu de se faire passer pour quelqu'un d'autre |
+| `annuler-filtre-entetes.sh` | retire ce filtre |
+| `plages-de-confiance.py` | lit les plages Cloudflare depuis `client_ip.rs` |
 | `restaurer.sh` | remet un état sauvegardé |
+
+## Le filtre des en-têtes de transfert
+
+Le VPS accepte les connexions directes sur 443 : `ufw` autorise
+`443 ALLOW IN Anywhere`, et rien n'oblige à passer par Cloudflare. Caddy
+transmettait les en-têtes de transfert tels quels, quelle que soit leur
+provenance. Comme le pair TCP vu par les applications est toujours Caddy
+lui-même, donc du loopback, donc de confiance, l'en-tête était cru sur parole.
+
+Mesuré depuis Internet le 20 août 2026, pas supposé :
+
+- le bannissement anti-force-brute du relais était contournable, il suffisait de
+  changer de `CF-Connecting-IP` à chaque tentative ;
+- la limitation de débit de **toute l'API** l'était de la même façon : une
+  adresse fabriquée mais routable obtenait son propre seau Redis.
+
+`poser-filtre-entetes.sh` insère en tête une route **non terminale** qui retire
+`CF-Connecting-IP`, `X-Forwarded-For`, `X-Real-IP`, `True-Client-IP` et
+`CF-IPCountry` quand la source n'est pas l'une des nôtres. Caddy repose ensuite
+lui-même un `X-Forwarded-For` contenant le vrai pair : l'usurpateur se retrouve
+désigné par sa propre adresse.
+
+**Aucun visiteur légitime ne perd quoi que ce soit.** Pour qui arrive en direct,
+on retire ce qu'il prétendait être et Caddy repose sa vraie adresse.
+
+Les plages de confiance sont **lues depuis `client_ip.rs`**, jamais recopiées :
+le relais et Caddy doivent avoir une seule notion de « nos propres portes ». Deux
+listes qui divergent, c'est une faille qui s'ouvre le jour où l'une est mise à
+jour sans l'autre. `plages-de-confiance.py` refuse de produire une liste
+tronquée, parce qu'un ensemble vide ferait correspondre le filtre à **tout** le
+trafic, Cloudflare compris.
+
+`verifier-identification.sh` surveille exactement cette panne, que `verifier.sh`
+ne verrait pas : le site répondrait 200 partout pendant que tous les visiteurs
+tomberaient dans le même seau sous `127.0.0.1`.
 
 ## Le retour arrière, à trois niveaux
 

--- a/scripts/ops/caddy/annuler-filtre-entetes.sh
+++ b/scripts/ops/caddy/annuler-filtre-entetes.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Retire le filtre des en-têtes de transfert.
+#
+# La route est retrouvée par son CONTENU, jamais par un index noté quelque part :
+# entre la pose et l'annulation, une autre opération a pu décaler les routes, et
+# supprimer l'index 0 par habitude reviendrait à supprimer ce qui s'y trouve
+# maintenant.
+#
+# Attention à ce que cette annulation rouvre : sans ce filtre, n'importe qui
+# atteignant l'origine sur 443 peut se faire passer pour l'adresse de son choix,
+# et contourner aussi bien le bannissement du relais que la limitation de débit
+# de l'API. À n'annuler que si le filtre casse quelque chose de pire.
+set -euo pipefail
+
+API="${CADDY_API:-http://localhost:2019}"
+TEMOIN=CF-Connecting-IP
+
+INDEX=$(curl -sf -m 15 "$API/config/apps/http/servers/srv1/routes" | python3 -c "
+import json, sys
+routes = json.load(sys.stdin)
+trouves = []
+for i, r in enumerate(routes):
+    for h in r.get('handle', []):
+        if h.get('handler') == 'headers':
+            if '$TEMOIN' in (h.get('request', {}).get('delete') or []):
+                trouves.append(i)
+                break
+if len(trouves) != 1:
+    sys.exit(f'{len(trouves)}')
+print(trouves[0])
+") || {
+  echo "  Aucune route unique de filtrage des en-tetes. Rien annule." >&2
+  echo "  Inspecter : curl -s $API/config/apps/http/servers/srv1/routes | python3 -m json.tool" >&2
+  exit 1
+}
+
+echo "  Filtre trouve a l'index $INDEX"
+curl -sf -X DELETE "$API/config/apps/http/servers/srv1/routes/$INDEX" \
+  && echo "  Retire. L'usurpation d'adresse redevient possible depuis l'origine." \
+  || { echo "  ECHEC de la suppression, configuration intacte" >&2; exit 1; }
+
+echo
+"$(dirname "$0")/verifier.sh" || true

--- a/scripts/ops/caddy/plages-de-confiance.py
+++ b/scripts/ops/caddy/plages-de-confiance.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Les plages autorisées à dire qui est le visiteur.
+
+Lues depuis `client_ip.rs`, et non recopiées ici : le relais et Caddy doivent
+avoir **une seule** notion de « nos propres portes ». Deux listes qui divergent,
+c'est une faille qui s'ouvre le jour où l'une est mise à jour sans l'autre.
+
+Sortie : un tableau JSON de CIDR, sur la sortie standard.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+RUST = Path("/var/www/nexus/nodyx-p2p/crates/nexus-relay/src/client_ip.rs")
+
+# Ce que `is_trusted_peer` accepte en plus des plages Cloudflare : nos propres
+# machines. Un attaquant sur Internet ne peut pas émettre depuis ces adresses,
+# donc les inclure n'ouvre rien.
+LOCALES = [
+    "127.0.0.0/8",
+    "::1/128",
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+    "fc00::/7",
+    "fe80::/10",
+]
+
+# Une liste tronquée serait pire qu'une absence de filtre : `not remote_ip` sur
+# un ensemble vide correspond à TOUT le trafic, donc Cloudflare y compris, et
+# plus aucun visiteur ne serait identifié. On refuse plutôt que de dégrader.
+MINIMUM_CLOUDFLARE = 20
+
+
+def main() -> int:
+    if not RUST.is_file():
+        print(f"source introuvable : {RUST}", file=sys.stderr)
+        return 1
+
+    src = RUST.read_text()
+    try:
+        bloc = src.split("const CLOUDFLARE: &[Cidr] = &[")[1].split("];")[0]
+    except IndexError:
+        print("bloc CLOUDFLARE introuvable dans client_ip.rs", file=sys.stderr)
+        return 1
+
+    plages = []
+    for a, b, c, d, p in re.findall(
+        r"v4\((\d+),\s*(\d+),\s*(\d+),\s*(\d+),\s*(\d+)\)", bloc
+    ):
+        plages.append(f"{a}.{b}.{c}.{d}/{p}")
+
+    for groupes, p in re.findall(r"v6\(\[([^\]]+)\],\s*(\d+)\)", bloc):
+        mots = [m.strip() for m in groupes.split(",")]
+        hextets = [
+            f"{int(m, 16):x}" if m.startswith("0x") else f"{int(m):x}" for m in mots
+        ]
+        adresse = re.sub(r"(:0)+$", "::", ":".join(hextets))
+        plages.append(f"{adresse}/{p}")
+
+    if len(plages) < MINIMUM_CLOUDFLARE:
+        print(
+            f"seulement {len(plages)} plages Cloudflare lues, {MINIMUM_CLOUDFLARE} "
+            "attendues au minimum. La lecture du Rust a échoué, on refuse de "
+            "produire une liste tronquée.",
+            file=sys.stderr,
+        )
+        return 1
+
+    json.dump(plages + LOCALES, sys.stdout, indent=1)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ops/caddy/poser-filtre-entetes.sh
+++ b/scripts/ops/caddy/poser-filtre-entetes.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Empêche un inconnu de se faire passer pour quelqu'un d'autre.
+#
+# # Le défaut que ceci corrige
+#
+# Le VPS accepte les connexions directes sur 443 : `ufw` autorise
+# `443 ALLOW IN Anywhere`, et rien n'oblige à passer par Cloudflare. Or Caddy
+# transmettait les en-têtes de transfert TELS QUELS, quelle que soit leur
+# provenance. Comme le pair TCP vu par les applications est toujours Caddy
+# lui-même, donc du loopback, donc de confiance, l'en-tête était cru sur parole.
+#
+# Conséquences mesurées le 2026-08-20, depuis Internet et non en théorie :
+#
+#   - le bannissement anti-force-brute du relais devient inopérant, il suffit de
+#     changer de `CF-Connecting-IP` à chaque tentative ;
+#   - la limitation de débit de TOUTE l'API devient inopérante de la même façon :
+#     une adresse fabriquée mais routable obtient son propre seau Redis.
+#
+# # La parade
+#
+# Une route en tête de liste, NON terminale, qui retire les en-têtes de transfert
+# quand la source n'est pas l'une des nôtres. Caddy repose ensuite lui-même un
+# `X-Forwarded-For` contenant le VRAI pair, donc l'usurpateur est désigné par sa
+# propre adresse.
+#
+# Les plages de confiance sont lues depuis `client_ip.rs` et non recopiées : le
+# relais et Caddy doivent avoir une seule notion de « nos propres portes ».
+set -euo pipefail
+
+API="${CADDY_API:-http://localhost:2019}"
+SAUVE="${CADDY_SAUVE:-/var/backups/nodyx/caddy}"
+ICI="$(cd "$(dirname "$0")" && pwd)"
+TEMOIN=CF-Connecting-IP
+
+echo "=== 0. le filtre est-il deja pose ? ==="
+DEJA=$(curl -sf -m 15 "$API/config/apps/http/servers/srv1/routes" | python3 -c "
+import json, sys
+for r in json.load(sys.stdin):
+    for h in r.get('handle', []):
+        if h.get('handler') == 'headers':
+            if '$TEMOIN' in (h.get('request', {}).get('delete') or []):
+                print('oui'); raise SystemExit
+print('non')
+")
+if [ "$DEJA" = "oui" ]; then
+  echo "  Le filtre existe deja. Rien a faire."
+  echo "  Pour le retirer : $ICI/annuler-filtre-entetes.sh"
+  exit 0
+fi
+echo "  non, on peut poser"
+
+echo
+echo "=== 1. plages de confiance, lues depuis le Rust ==="
+PLAGES=$(python3 "$ICI/plages-de-confiance.py") || {
+  echo "  Lecture impossible, on ne pose RIEN." >&2
+  echo "  Une liste tronquee ferait correspondre le filtre a TOUT le trafic," >&2
+  echo "  Cloudflare compris, et plus aucun visiteur ne serait identifie." >&2
+  exit 1
+}
+echo "  $(echo "$PLAGES" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))') plages"
+
+echo
+echo "=== 2. sauvegarde prealable ==="
+"$ICI/sauvegarder.sh" "$SAUVE"
+
+echo
+echo "=== 3. releves de reference ==="
+"$ICI/verifier.sh" --releve > /dev/null && echo "  domaine : releve pris"
+"$ICI/verifier-identification.sh" | tail -1 | sed 's/^/  identification avant : /'
+
+echo
+echo "=== 4. pose, en tete de liste et NON terminale ==="
+python3 - "$PLAGES" > /tmp/.filtre-entetes.$$ <<'PY'
+import json, sys
+plages = json.loads(sys.argv[1])
+json.dump({
+    # « la source n'est PAS des notres »
+    "match": [{"not": [{"remote_ip": {"ranges": plages}}]}],
+    "handle": [{
+        "handler": "headers",
+        "request": {"delete": [
+            "CF-Connecting-IP", "X-Forwarded-For", "X-Real-IP",
+            "True-Client-IP", "CF-IPCountry",
+        ]},
+    }],
+    # pas de "terminal" : la requete continue vers les routes suivantes, elle
+    # est seulement debarrassee de ce qu'elle pretendait etre.
+}, sys.stdout)
+PY
+
+curl -sf -X PUT "$API/config/apps/http/servers/srv1/routes/0" \
+     -H 'Content-Type: application/json' \
+     --data-binary "@/tmp/.filtre-entetes.$$" \
+  && echo "  posee" \
+  || { echo "  REFUSEE par Caddy, configuration en cours intacte" >&2; rm -f "/tmp/.filtre-entetes.$$"; exit 1; }
+rm -f "/tmp/.filtre-entetes.$$"
+
+echo
+echo "=== 5. verification ==="
+sleep 2
+ECHEC=0
+"$ICI/verifier.sh" | tail -2 | sed 's/^/  /' || ECHEC=1
+"$ICI/verifier-identification.sh" | tail -1 | sed 's/^/  /' || ECHEC=1
+
+if [ "$ECHEC" -ne 0 ]; then
+  echo
+  echo "!!! ECART DETECTE, annulation automatique !!!" >&2
+  "$ICI/annuler-filtre-entetes.sh"
+  exit 1
+fi
+
+echo
+echo "Pour annuler : $ICI/annuler-filtre-entetes.sh"

--- a/scripts/ops/caddy/verifier-identification.sh
+++ b/scripts/ops/caddy/verifier-identification.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Un visiteur légitime est-il encore identifié par sa vraie adresse ?
+#
+# `verifier.sh` regarde des codes de retour. Il ne verrait PAS la panne que ce
+# contrôle cherche : un filtre trop large qui retirerait `CF-Connecting-IP` au
+# trafic Cloudflare lui-même. Le site répondrait 200 partout, et tous les
+# visiteurs de la Terre se retrouveraient dans le même seau de limitation, sous
+# `127.0.0.1`. Panne silencieuse, exactement celle du 8 août 2026.
+#
+# Méthode : on se comporte en vrai visiteur, on sort par Cloudflare et on
+# revient, puis on vérifie que le coeur nous a rangés sous NOTRE adresse
+# publique et non sous du loopback.
+set -euo pipefail
+
+CIBLE="${CIBLE:-https://nodyx.org/api/v1/instance/info}"
+
+echo "--- adresses publiques de cette machine ---"
+V4=$(curl -s -m 8 https://api.ipify.org 2>/dev/null || echo "")
+V6=$(curl -s -m 8 https://api64.ipify.org 2>/dev/null || echo "")
+echo "  v4 : ${V4:-indisponible}"
+echo "  v6 : ${V6:-indisponible}"
+
+if [ -z "$V4" ] && [ -z "$V6" ]; then
+  echo "  Impossible de connaître notre propre adresse, contrôle non concluant." >&2
+  exit 2
+fi
+
+echo "--- appel légitime, par Cloudflare ---"
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 15 "$CIBLE" 2>/dev/null || echo 000)
+echo "  $CIBLE -> HTTP $CODE"
+if [ "$CODE" = "000" ]; then
+  echo "  Aucune réponse : le contrôle ne peut rien conclure." >&2
+  exit 2
+fi
+
+sleep 1
+
+echo "--- sous quelle adresse le coeur nous a-t-il rangés ? ---"
+TROUVE=""
+for ip in "$V6" "$V4"; do
+  [ -z "$ip" ] && continue
+  if [ "$(redis-cli EXISTS "nodyx:rate:$ip" 2>/dev/null)" = "1" ]; then
+    TROUVE="$ip"
+    break
+  fi
+done
+
+echo
+if [ -n "$TROUVE" ]; then
+  echo "VERDICT : identifié sous $TROUVE, l'identification des visiteurs est intacte"
+  exit 0
+fi
+
+echo "VERDICT : AUCUNE clé pour notre adresse publique."
+echo "          Les visiteurs sont probablement tous rangés sous 127.0.0.1."
+echo "          Faire machine arrière : $(dirname "$0")/annuler-filtre-entetes.sh"
+exit 1


### PR DESCRIPTION
## Le probleme

Une application derriere un mandataire ne voit jamais le visiteur : elle voit le
mandataire. Elle lit donc l'adresse reelle dans un en-tete, et ne peut le faire
sans danger que si cet en-tete vient d'une source de confiance.

Caddy transmettait ces en-tetes **tels quels, quelle que soit leur provenance**.
Comme le pair TCP vu par les applications est toujours Caddy lui-meme, donc du
loopback, donc de confiance, la valeur annoncee etait crue sur parole. Et rien
n'oblige a passer par le mandataire de tete pour joindre l'origine.

Deux protections reposent sur l'identite de l'appelant. Les deux devenaient
contournables :

| protection | etat avant | etat apres |
|---|---|---|
| bannissement anti-force-brute du relais | contournable | l'appelant est designe par sa vraie adresse |
| limitation de debit de toute l'API | contournable | aucun seau pour une adresse fabriquee |

Mesure, pas supposition : verifie depuis l'exterieur avant et apres, en rejouant
exactement les memes commandes.

## La parade

Une route **en tete de liste** et **non terminale** qui retire `CF-Connecting-IP`,
`X-Forwarded-For`, `X-Real-IP`, `True-Client-IP` et `CF-IPCountry` quand la
source n'est pas l'une des notres. Caddy repose ensuite lui-meme un
`X-Forwarded-For` contenant le vrai pair.

**Aucun visiteur legitime ne perd quoi que ce soit.** Pour qui arrive en direct,
on retire ce qu'il pretendait etre et Caddy repose sa vraie adresse. C'est meme
plus juste qu'avant.

## Une seule source de verite

Les plages de confiance sont **lues depuis `client_ip.rs`**, jamais recopiees. Le
relais et Caddy doivent avoir une seule notion de « nos propres portes » : deux
listes qui divergent, c'est une faille qui s'ouvre le jour ou l'une est mise a
jour sans l'autre.

`plages-de-confiance.py` **refuse** de produire une liste tronquee. Un ensemble
vide ferait correspondre le filtre a TOUT le trafic, Cloudflare compris, et plus
aucun visiteur ne serait identifie. Le garde-fou est teste : sur une source
amputee, le script sort en erreur au lieu de degrader.

## Le controle que verifier.sh ne savait pas faire

`verifier.sh` regarde des codes de retour. Il ne verrait **pas** un filtre trop
large : le site repondrait 200 partout pendant que tous les visiteurs de la Terre
tomberaient dans le meme seau sous `127.0.0.1`.

C'est exactement la panne du 8 aout 2026, et elle avait mis des semaines a se
voir. `verifier-identification.sh` la surveille : il se comporte en vrai
visiteur, sort par Cloudflare, revient, et verifie que le coeur l'a range sous sa
propre adresse publique. `poser-filtre-entetes.sh` annule tout seul si ce
controle echoue.

## Eprouve sur maquette avant la production

| essai | resultat |
|---|---|
| source inconnue | en-tetes fabriques **retires**, `X-Forwarded-For` repose avec le vrai pair |
| source approuvee | en-tetes **intacts** |
| position | index 0, `terminal: false`, la requete continue |
| liste tronquee | refus, code de sortie non nul |
| seconde pose | refusee avant toute sauvegarde |
| annulation | route retrouvee par contenu, joker intact |

## Suite possible

Une instance auto-hebergee derriere un mandataire peut presenter la meme
exposition. Durcir la configuration Caddy produite par `install.sh` merite une
discussion separee.
