### PR TITLE
fix(relais): borner l'attente d'un appelant qui ne s'annonce jamais

### DIFF
--- a/nodyx-p2p/crates/nexus-relay/Cargo.toml
+++ b/nodyx-p2p/crates/nexus-relay/Cargo.toml
@@ -63,6 +63,12 @@ tokio-tungstenite = { version = "0.30", default-features = false, features = [
 # the adapter uses the traits directly.
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 
+[dev-dependencies]
+# `test-util` gives the suite a paused clock, so a test about a ten second
+# deadline costs no real seconds. It is deliberately NOT part of tokio's "full"
+# feature, and it stays out of the shipped binary by living here.
+tokio = { version = "1", features = ["full", "test-util"] }
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/nodyx-p2p/crates/nexus-relay/src/server/session.rs
+++ b/nodyx-p2p/crates/nexus-relay/src/server/session.rs
@@ -12,7 +12,7 @@ use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
 use dashmap::DashMap;
 use std::net::IpAddr;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
@@ -39,6 +39,35 @@ pub const BAN_DURATION_SECS: u64 = 300; // 5 minutes
 /// the far end die unnoticed.
 const PING_INTERVAL_SECS: u64 = 30;
 
+/// How long a fresh connection has to say who it is.
+///
+/// Without this bound a connection that completes the handshake and then falls
+/// silent holds a task and a socket for as long as it pleases, and **no ban can
+/// ever apply** because no authentication was attempted: the ban map only counts
+/// failures. Opening many such connections costs the attacker almost nothing.
+///
+/// The client sends `Register` immediately on connect, so ten seconds is far
+/// more than a real one needs, even on a slow link.
+const REGISTER_DEADLINE: Duration = Duration::from_secs(10);
+
+/// Read the very first message, or give up.
+///
+/// Split out from [`run`] so the deadline can be tested on its own: reaching
+/// [`run`] would need a live database, and a rule this cheap to break deserves a
+/// test that does not depend on one.
+async fn read_registration<R>(reader: &mut R, culprit: IpAddr) -> anyhow::Result<Option<ClientMessage>>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    match tokio::time::timeout(REGISTER_DEADLINE, read_msg::<_, ClientMessage>(reader)).await {
+        Ok(res) => Ok(res?),
+        Err(_) => Err(anyhow::anyhow!(
+            "{culprit} opened a connection and never registered within {}s",
+            REGISTER_DEADLINE.as_secs()
+        )),
+    }
+}
+
 /// Compile-time guard on the keep-alive budget.
 ///
 /// Cloudflare closes an idle WebSocket at around 100 s, and TCP keepalive only
@@ -48,6 +77,9 @@ const PING_INTERVAL_SECS: u64 = 30;
 /// Checked here rather than in a test: the build should fail, not the suite.
 const _: () = assert!(PING_INTERVAL_SECS < 90);
 const _: () = assert!(READ_DEADLINE_SECS > PING_INTERVAL_SECS * 2);
+
+/// An unauthenticated connection must never outlive an authenticated idle one.
+const _: () = assert!(REGISTER_DEADLINE.as_secs() < READ_DEADLINE_SECS);
 
 /// [`READ_DEADLINE`] in seconds, so the guard above can be evaluated at compile time.
 const READ_DEADLINE_SECS: u64 = READ_DEADLINE.as_secs();
@@ -140,9 +172,10 @@ where
 {
     let (mut reader, mut writer) = tokio::io::split(stream);
 
-    // 1. Expect Register as the very first message.
+    // 1. Expect Register as the very first message, and do not wait forever for
+    //    it: an unauthenticated caller must not be able to hold a task open.
     let Some(ClientMessage::Register { slug, token }) =
-        read_msg::<_, ClientMessage>(&mut reader).await?
+        read_registration(&mut reader, culprit).await?
     else {
         write_msg(
             &mut writer,
@@ -316,6 +349,46 @@ mod tests {
 
     fn ip(s: &str) -> IpAddr {
         s.parse().expect("test address should parse")
+    }
+
+    /// The defect this guards against, reproduced.
+    ///
+    /// A caller completes the handshake and then says nothing at all. No
+    /// authentication is attempted, so the ban map never sees it and no ban can
+    /// ever apply. Before the deadline existed this waited forever, and opening
+    /// such connections by the thousand cost the caller almost nothing.
+    ///
+    /// Time is paused, so this test spends no real seconds waiting.
+    #[tokio::test(start_paused = true)]
+    async fn a_caller_that_never_registers_is_dropped() {
+        // The far end is held open on purpose: dropping it would signal EOF,
+        // which is a different case entirely and would not exercise the deadline.
+        let (_far_end, mut near_end) = tokio::io::duplex(64);
+
+        let err = read_registration(&mut near_end, ip("203.0.113.9"))
+            .await
+            .expect_err("a silent caller must not be waited on forever");
+
+        assert!(
+            format!("{err}").contains("never registered"),
+            "the failure must name what went wrong, got: {err}"
+        );
+    }
+
+    /// The deadline must not be so long that it fails to bound anything.
+    ///
+    /// The client sends `Register` on connect, so anything past a few seconds is
+    /// only patience for an attacker.
+    #[test]
+    fn the_registration_deadline_actually_bounds_something() {
+        assert!(
+            REGISTER_DEADLINE.as_secs() >= 3 && REGISTER_DEADLINE.as_secs() <= 30,
+            "unreasonable registration deadline: {REGISTER_DEADLINE:?}"
+        );
+        // An unauthenticated connection must never outlive an authenticated idle
+        // one. Also asserted at compile time; kept here so the intent is visible
+        // to anyone reading the suite.
+        assert!(REGISTER_DEADLINE.as_secs() < READ_DEADLINE.as_secs());
     }
 
     #[test]


### PR DESCRIPTION
Trouve pendant la passe d'audit securite qui a suivi l'ouverture de la porte
WebSocket.

## Le defaut

Le premier message d'une session, celui de l'enregistrement, etait lu **sans
aucun delai**. La boucle principale est bornee a 90 secondes, mais pas lui.

Un appelant pouvait terminer la poignee de main puis se taire, et garder une
tache et une prise ouvertes aussi longtemps qu'il le voulait. **Aucun
bannissement ne pouvait s'appliquer** : la carte des bannissements compte les
ECHECS d'authentification, et il n'y en avait aucun puisqu'aucune tentative
n'etait faite.

## Mesure avant correctif

Cinq connexions muettes montees sur la production, puis plus un octet :

```
connexions etablies au depart              : 0
5 connexions montees, aucun message envoye
connexions etablies juste apres            : 5
apres 10s de silence total                 : 5
apres 20s de silence total                 : 5
apres fermeture PAR LE CLIENT              : 0
```

Elles ne se fermaient que lorsque le client le decidait.

## Le correctif

`REGISTER_DEADLINE` vaut dix secondes. Le client envoie `Register` des la
connexion, donc c'est large meme sur un lien lent.

Une garde a la compilation interdit qu'il depasse le delai d'une session
authentifiee au repos : **une connexion anonyme ne doit jamais survivre plus
longtemps qu'une connexion legitime inactive.**

La lecture est sortie dans `read_registration` pour etre testable seule. Passer
par `run()` demanderait une base vivante, et une regle aussi facile a casser
merite un test qui n'en depende pas.

## Le test tombe bien sur l'ancien code

Verifie, pas suppose. Avec la lecture non bornee remise :

```
code 143 : le test a ete tue apres 60 secondes sans finir
```

Il pend indefiniment, donc il attrape le defaut.

## Une premiere version du test etait fausse

A signaler, parce que c'est le genre de piege qui se represente.

Avec l'horloge en pause, tokio avance le temps tout seul : **tout delai fini
passe, meme 24 heures.** Ma premiere verification de non-regression remplacait le
delai par 86400 secondes, le test passait, et j'aurais pu conclure qu'il ne
prouvait rien alors que le vrai probleme etait ma retro-modification.

Le test est donc double d'une assertion sur la valeur elle-meme, bornee entre 3
et 30 secondes. L'un prouve qu'un delai existe, l'autre qu'il est court.

## Dependance

`tokio` gagne `test-util` en dependance de **developpement seulement**. Cette
fonctionnalite ne fait deliberement pas partie de `full` chez tokio, et elle
n'entre pas dans le binaire livre.

44 tests passent. Les quatre remarques de clippy sur ce module **preexistent**,
dans `db.rs`, `http_proxy.rs` et `registry.rs`, aucune dans le code touche ici.
