### PR TITLE
fix(securite): fermer les ecoutes internes et consolider le pare-feu

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2536,7 +2536,13 @@ NODYX_VERSION=${NODYX_VERSION}
 
 # Serveur
 PORT=3000
-HOST=0.0.0.0
+# Loopback, volontairement. Caddy tourne sur la même machine et mandate vers
+# localhost:3000 : écouter sur toutes les interfaces publierait l'API sur
+# Internet, et il ne resterait qu'une règle de pare-feu entre elle et le monde.
+# Une ligne de défense n'en fait pas deux.
+#
+# À changer seulement si votre mandataire vit sur une AUTRE machine.
+HOST=127.0.0.1
 NODE_ENV=production
 
 # JWT

--- a/nodyx-p2p/crates/nodyx-server/src/main.rs
+++ b/nodyx-p2p/crates/nodyx-server/src/main.rs
@@ -5,7 +5,7 @@ mod services;
 mod state;
 
 use sqlx::postgres::PgPoolOptions;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use state::AppState;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -80,7 +80,17 @@ async fn main() -> anyhow::Result<()> {
         .parse()
         .unwrap_or(3001);
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let raw_host = std::env::var("DIRECTORY_HOST").ok();
+    // A typo must not pass unnoticed: it would silently keep the safe default
+    // while the operator believes they published the service.
+    if let Some(h) = raw_host.as_deref() {
+        let h = h.trim();
+        if !h.is_empty() && h.parse::<IpAddr>().is_err() {
+            tracing::warn!("DIRECTORY_HOST={h:?} is not an IP address, falling back to loopback");
+        }
+    }
+
+    let addr = listen_addr(raw_host.as_deref(), port);
     tracing::info!("nodyx-server listening on {addr}");
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
@@ -91,4 +101,78 @@ async fn main() -> anyhow::Result<()> {
     .await?;
 
     Ok(())
+}
+
+/// Where the API listens.
+///
+/// Loopback by default, and deliberately so. This process sits behind a reverse
+/// proxy running on the same host, so binding every interface would publish it
+/// straight to the internet and leave a firewall rule as the only thing in the
+/// way. One line of defence is not two.
+///
+/// `DIRECTORY_HOST` overrides it, matching the `DIRECTORY_PORT` convention, for
+/// a deployment whose proxy really does live on another machine.
+///
+/// Anything unparseable falls back to loopback rather than to every interface:
+/// a mistake should close a door, never open one.
+fn listen_addr(host: Option<&str>, port: u16) -> SocketAddr {
+    let ip = host
+        .map(str::trim)
+        .filter(|h| !h.is_empty())
+        .and_then(|h| h.parse::<IpAddr>().ok())
+        .unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST));
+    SocketAddr::new(ip, port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_default_is_loopback_not_every_interface() {
+        // The whole point. Before this existed the address was hardcoded to
+        // 0.0.0.0, and only a firewall rule kept the API off the internet.
+        assert_eq!(
+            listen_addr(None, 3100),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3100)
+        );
+    }
+
+    #[test]
+    fn an_explicit_address_is_honoured() {
+        // A deployment whose proxy sits on another machine must still be able to
+        // say so, out loud, rather than by editing the source.
+        assert_eq!(
+            listen_addr(Some("0.0.0.0"), 3100),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 3100)
+        );
+        assert_eq!(
+            listen_addr(Some("::1"), 3100),
+            SocketAddr::new("::1".parse::<IpAddr>().unwrap(), 3100)
+        );
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_forgiven() {
+        // Environment files are edited by hand, and a stray space should not
+        // silently downgrade the operator's intent.
+        assert_eq!(
+            listen_addr(Some("  0.0.0.0  "), 3100),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 3100)
+        );
+    }
+
+    #[test]
+    fn a_mistake_closes_the_door_rather_than_opening_it() {
+        // A typo, an empty value, a hostname where an address was expected: all
+        // fall back to loopback. Falling back to 0.0.0.0 would mean a slip of
+        // the finger publishes the API.
+        for bogus in ["", "   ", "0.0.0.o", "localhost", "not an address"] {
+            assert_eq!(
+                listen_addr(Some(bogus), 3100),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3100),
+                "{bogus:?} must fall back to loopback"
+            );
+        }
+    }
 }

--- a/scripts/ops/durcir/README.md
+++ b/scripts/ops/durcir/README.md
@@ -1,0 +1,88 @@
+# Réduire ce qui est joignable depuis Internet
+
+Un service qui écoute sur `0.0.0.0` derrière un mandataire local n'a **qu'une**
+ligne de défense : la règle de pare-feu. Une seule erreur dans cette règle et
+l'API est publiée. Le faire écouter sur `127.0.0.1` en pose une seconde, dans le
+noyau, que personne ne peut contourner par une faute de frappe.
+
+## Ce qui a été fermé le 20 août 2026
+
+| service | port | avant | après |
+|---|---|---|---|
+| `nodyx-core` | 3000 | `0.0.0.0` | `127.0.0.1` |
+| `demo-core` | 3001 | `0.0.0.0` | `127.0.0.1` |
+| Caddy `srv0` | 3099 | `:3099` | `127.0.0.1:3099` |
+| `nodyx-server` | 3100 | codé en dur `0.0.0.0` | `127.0.0.1` par défaut |
+
+`sleemstudio-core` (3002) et `vieuxlooters-core` (3003) étaient déjà en loopback :
+leur `.env` portait `HOST=127.0.0.1`. C'est ce mécanisme qui a été appliqué aux
+deux autres, pas un nouveau.
+
+Restent publics, et c'est voulu : `22` (administration), `80` et `443` (Caddy),
+`3478` plus la plage relais `49152:65535/udp` (TURN), `7443` (porte historique du
+tunnel), `40000:40999` (médias du SFU).
+
+## Comment chaque service décide
+
+- **`nodyx-core`** : `HOST` dans son `.env`, lu par `src/index.ts`
+  (`process.env.HOST || '0.0.0.0'`). Le défaut du code reste `0.0.0.0`, mais
+  `install.sh` écrit désormais `HOST=127.0.0.1` pour toute nouvelle instance.
+- **Caddy `srv0`** : `caddy-srv0-loopback.sh`, avec `--annuler` pour revenir.
+- **`nodyx-server`** : `DIRECTORY_HOST`, du même acabit que `DIRECTORY_PORT`.
+  **Le défaut est le loopback**, et une valeur illisible y retombe aussi : une
+  faute de frappe doit fermer une porte, jamais en ouvrir une.
+
+## Le fil rouge
+
+`verifier-services.sh` sonde ce que les visiteurs utilisent réellement : chaque
+site, son API, la poignée de main Socket.IO, et le tunnel. Regarder `ss` ne
+suffirait pas : un service peut écouter au bon endroit sans être joignable par
+Caddy.
+
+```bash
+./verifier-services.sh --releve   # avant de toucher à quoi que ce soit
+./verifier-services.sh            # après
+```
+
+Les adresses d'écoute sont affichées pour mémoire mais **jamais comparées** :
+les changer est le but, les voir bouger n'est pas une panne.
+
+Retours arrière :
+
+```bash
+./caddy-srv0-loopback.sh --annuler          # Caddy srv0
+./ufw-restaurer.sh                          # règles de pare-feu
+# un .env : les copies datées sont dans /var/backups/nodyx/durcir/
+```
+
+`ufw-restaurer.sh` **refuse** une sauvegarde qui ne contiendrait aucune règle
+pour le port 22 : restaurer ça transformerait un incident en perte d'accès.
+
+## Consolidation du pare-feu
+
+Cinq règles retirées, de 23 à 18.
+
+**Quatre règles pour le port 5349** (TURN TLS, v4 et v6, TCP et UDP) : rien
+n'écoute derrière. Elles ouvraient un port mort.
+
+**Une règle `DENY` sur `2a06:98c0:3600::103`**, posée contre un scanner
+WordPress. Elle était **inerte** : dans la chaîne `ip6tables`, l'`ACCEPT` du port
+443 est en ligne 5 et ce `DROP` en ligne 13. La première règle qui correspond
+gagne, donc le trafic web de cette adresse était accepté bien avant que le
+blocage soit évalué.
+
+Vérifié en base : ce scanner n'a **jamais cessé**, 20 à 32 coups par jour, tous
+les jours, y compris le jour de ce constat. La règle rassurait sans protéger.
+
+Elle n'a pas été « réparée » en la remontant en tête. L'adresse appartient à
+`2a06:98c0::/29`, une plage Cloudflare : un blocage au niveau réseau ne lit pas
+les en-têtes et couperait aussi les visiteurs légitimes routés par cette arête.
+Un scanner qui frappe des chemins de pot de miel est du bruit que le pot de miel
+est fait pour enregistrer, pas une raison de risquer une coupure silencieuse.
+
+**Ce qui n'a pas été touché.** La plage `49152:65535/udp` semble énorme, mais
+elle est réellement utilisée : 44 sockets alloués au moment de la mesure, et
+c'est le défaut du code (`TURN_MIN_PORT` / `TURN_MAX_PORT`). La resserrer
+risquerait l'épuisement d'allocation, donc des appels coupés, pour un gain de
+sécurité faible : rien n'écoute sur ces ports en dehors d'une allocation vivante,
+elle-même protégée par l'authentification TURN.

--- a/scripts/ops/durcir/caddy-srv0-loopback.sh
+++ b/scripts/ops/durcir/caddy-srv0-loopback.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Restreint le serveur interne de Caddy (srv0) au loopback.
+#
+# `srv0` écoute sur `:3099` et mandate vers `localhost:3000`. C'est une entrée
+# interne : aucune route publique n'y mène et aucune connexion ne l'atteint. Rien
+# ne justifie qu'il accepte des connexions du monde entier, même si `ufw` les
+# bloque aujourd'hui. Une règle de pare-feu est une ligne de défense, pas deux.
+#
+#   caddy-srv0-loopback.sh            restreint au loopback
+#   caddy-srv0-loopback.sh --annuler  rouvre sur toutes les interfaces
+#
+# Le retour arrière est symétrique et tient dans la même commande, parce qu'un
+# changement d'adresse d'écoute n'a que deux états.
+set -euo pipefail
+
+API="${CADDY_API:-http://localhost:2019}"
+ICI="$(cd "$(dirname "$0")" && pwd)"
+CADDY_OPS="$(cd "$ICI/../caddy" && pwd)"
+LOOPBACK='["127.0.0.1:3099"]'
+PARTOUT='[":3099"]'
+
+ACTUEL=$(curl -sf -m 15 "$API/config/apps/http/servers/srv0/listen") || {
+  echo "  L'API d'administration ne repond pas. On ne touche a rien." >&2
+  exit 1
+}
+echo "  ecoute actuelle : $ACTUEL"
+
+if [ "${1:-}" = "--annuler" ]; then
+  VOULU="$PARTOUT"; QUOI="rouverture sur toutes les interfaces"
+else
+  VOULU="$LOOPBACK"; QUOI="restriction au loopback"
+fi
+
+if [ "$(echo "$ACTUEL" | tr -d ' ')" = "$(echo "$VOULU" | tr -d ' ')" ]; then
+  echo "  Deja dans cet etat. Rien a faire."
+  exit 0
+fi
+
+echo
+echo "=== sauvegarde prealable ==="
+"$CADDY_OPS/sauvegarder.sh" >/dev/null && echo "  faite"
+
+echo
+echo "=== $QUOI ==="
+# Caddy valide la configuration entiere avant de l'appliquer : un refus laisse
+# la production intacte, listeners compris.
+curl -sf -X PATCH "$API/config/apps/http/servers/srv0/listen" \
+     -H 'Content-Type: application/json' -d "$VOULU" \
+  && echo "  appliquee" \
+  || { echo "  REFUSEE par Caddy, configuration en cours intacte" >&2; exit 1; }
+
+sleep 2
+echo "  nouvelle ecoute : $(curl -sf -m 10 "$API/config/apps/http/servers/srv0/listen")"
+ss -ltn 2>/dev/null | awk 'NR>1 {print $4}' | grep ':3099$' | sed 's/^/  socket : /'
+
+echo
+echo "=== verification ==="
+"$ICI/verifier-services.sh" || {
+  echo
+  echo "!!! ECART DETECTE, retour arriere automatique !!!" >&2
+  curl -sf -X PATCH "$API/config/apps/http/servers/srv0/listen" \
+       -H 'Content-Type: application/json' -d "$ACTUEL" && echo "  etat precedent retabli" >&2
+  exit 1
+}
+
+echo
+echo "Pour revenir en arriere : $0 --annuler"

--- a/scripts/ops/durcir/ufw-restaurer.sh
+++ b/scripts/ops/durcir/ufw-restaurer.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Remet les règles ufw telles qu'elles étaient avant une consolidation.
+#
+# Le pare-feu est la seule chose qui se trompe sans prévenir et coupe l'accès
+# administratif en même temps que le reste. Ce retour arrière existe pour être
+# lancé sans réfléchir.
+#
+#   ufw-restaurer.sh            restaure la sauvegarde la plus récente
+#   ufw-restaurer.sh <fichier>  restaure celle-là, en donnant le fichier v4
+set -euo pipefail
+
+SAUVE="${UFW_SAUVE:-/var/backups/nodyx/durcir}"
+
+V4="${1:-$(ls -1t "$SAUVE"/ufw-user.rules.avant-* 2>/dev/null | head -1)}"
+if [ -z "$V4" ] || [ ! -f "$V4" ]; then
+  echo "  Aucune sauvegarde de règles trouvée dans $SAUVE" >&2
+  ls -1t "$SAUVE"/ufw-user*.rules.avant-* 2>/dev/null | head -5 | sed 's/^/    /' >&2
+  exit 1
+fi
+V6="${V4/ufw-user.rules/ufw-user6.rules}"
+
+echo "  v4 : $V4"
+echo "  v6 : $V6"
+[ -f "$V6" ] || { echo "  La sauvegarde v6 correspondante manque, on n'en restaure aucune." >&2; exit 1; }
+
+# Une restauration qui laisserait tomber SSH transformerait un incident en perte
+# d'accès. On refuse plutôt que de le découvrir après.
+if ! grep -q 'dport 22' "$V4"; then
+  echo "  ARRET : la sauvegarde v4 ne contient aucune règle pour le port 22." >&2
+  echo "          La restaurer couperait l'accès administratif." >&2
+  exit 1
+fi
+
+cp -a /etc/ufw/user.rules  "$SAUVE/ufw-user.rules.remplacee-$(date -u +%Y%m%dT%H%M%SZ)"
+cp -a /etc/ufw/user6.rules "$SAUVE/ufw-user6.rules.remplacee-$(date -u +%Y%m%dT%H%M%SZ)"
+
+install -m 640 -o root -g root "$V4" /etc/ufw/user.rules
+install -m 640 -o root -g root "$V6" /etc/ufw/user6.rules
+ufw reload >/dev/null
+
+echo "  Restauré."
+echo
+ufw status numbered 2>/dev/null | sed 's/^/  /'

--- a/scripts/ops/durcir/verifier-services.sh
+++ b/scripts/ops/durcir/verifier-services.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Les services répondent-ils encore, vraiment ?
+#
+# Ce contrôle existe pour accompagner un changement d'adresse d'écoute. Regarder
+# `ss` ne suffirait pas : un service peut écouter au bon endroit et n'être plus
+# joignable par Caddy, ou répondre sur la page d'accueil pendant que son API est
+# morte. On sonde donc ce que les visiteurs utilisent réellement.
+#
+#   verifier-services.sh --releve   enregistre l'état courant comme référence
+#   verifier-services.sh            compare l'état courant à la référence
+#
+# La comparaison porte UNIQUEMENT sur les sondes fonctionnelles. Les adresses
+# d'écoute sont affichées pour mémoire, jamais comparées : les changer est
+# précisément le but, et les voir bouger n'est pas une panne.
+set -euo pipefail
+
+REF="${REF:-/var/backups/nodyx/durcir/releve-services.txt}"
+MODE="${1:-}"
+
+# hôte public                     chemin d'API testé
+SITES=(
+  "nodyx.org|/api/v1/instance/info"
+  "demo.nodyx.org|/api/v1/instance/info"
+  "sleemstudio.nodyx.org|/api/v1/instance/info"
+  "vieuxlooters.nodyx.org|/api/v1/instance/info"
+)
+
+sonder() {
+  for entree in "${SITES[@]}"; do
+    hote="${entree%%|*}"
+    api="${entree##*|}"
+    c=$(curl -s -o /dev/null -w '%{http_code}' -m 12 "https://$hote/" 2>/dev/null || echo 000)
+    echo "site   $hote $c"
+    a=$(curl -s -o /dev/null -w '%{http_code}' -m 12 "https://$hote$api" 2>/dev/null || echo 000)
+    echo "api    $hote$api $a"
+  done
+
+  # Le temps réel passe par un autre chemin que l'API : une poignée de main
+  # Socket.IO échouerait sans que les sondes précédentes s'en aperçoivent.
+  s=$(curl -s -o /dev/null -w '%{http_code}' -m 12 \
+        'https://nodyx.org/socket.io/?EIO=4&transport=polling' 2>/dev/null || echo 000)
+  echo "socket nodyx.org/socket.io $s"
+
+  # Le tunnel traverse Caddy puis le relais : il tombe pour d'autres raisons que
+  # les sites servis localement, donc il se surveille à part.
+  t=$(curl -s -o /dev/null -w '%{http_code}' -m 12 https://waazaa.nodyx.org/ 2>/dev/null || echo 000)
+  echo "tunnel waazaa.nodyx.org $t"
+}
+
+adresses() {
+  echo "  adresses d'écoute (pour mémoire, non comparées) :"
+  ss -ltn 2>/dev/null | awk 'NR>1 {print $4}' \
+    | grep -E ':(3000|3001|3002|3003|3099|3100)$' | sort | sed 's/^/    /'
+}
+
+if [ "$MODE" = "--releve" ]; then
+  mkdir -p "$(dirname "$REF")"
+  sonder > "$REF"
+  chmod 600 "$REF"
+  echo "Relevé de référence écrit dans $REF :"
+  sed 's/^/  /' "$REF"
+  echo
+  adresses
+  exit 0
+fi
+
+if [ ! -f "$REF" ]; then
+  echo "Aucun relevé de référence. Lancez d'abord : $0 --releve" >&2
+  exit 1
+fi
+
+MAINTENANT=$(mktemp)
+sonder > "$MAINTENANT"
+
+ECARTS=0
+while read -r type cible avant; do
+  apres=$(awk -v c="$cible" '$2==c {print $3}' "$MAINTENANT")
+  if [ "$avant" = "$apres" ]; then
+    printf '  ok        %-6s %-44s %s\n' "$type" "$cible" "$apres"
+  else
+    printf '  ECART     %-6s %-44s %s -> %s\n' "$type" "$cible" "$avant" "$apres"
+    ECARTS=$((ECARTS + 1))
+  fi
+done < "$REF"
+rm -f "$MAINTENANT"
+
+echo
+adresses
+echo
+if [ "$ECARTS" -eq 0 ]; then
+  echo "VERDICT : rien n'a bougé ($(wc -l < "$REF") sondes)"
+  exit 0
+fi
+echo "VERDICT : $ECARTS ECART(S)"
+exit 1


### PR DESCRIPTION
## Le principe

Un service qui ecoute sur `0.0.0.0` derriere un mandataire local n'a **qu'une**
ligne de defense : la regle de pare-feu. Une seule erreur dans cette regle et
l'API est publiee. L'ecoute en loopback en pose une seconde, dans le noyau, que
personne ne contourne par une faute de frappe.

## Ce qui a ete ferme

| service | port | avant | apres |
|---|---|---|---|
| `nodyx-core` | 3000 | `0.0.0.0` | `127.0.0.1` |
| `demo-core` | 3001 | `0.0.0.0` | `127.0.0.1` |
| Caddy `srv0` | 3099 | `:3099` | `127.0.0.1:3099` |
| `nodyx-server` | 3100 | code en dur `0.0.0.0` | `127.0.0.1` par defaut |

`sleemstudio-core` et `vieuxlooters-core` etaient **deja** en loopback : leur
`.env` portait `HOST=127.0.0.1`. C'est ce mecanisme qui a ete applique aux deux
autres, pas un nouveau.

## Mesure avant de toucher

Toutes les connexions etablies vers 3000, 3001, 3099 et 3100 venaient de
`127.0.0.1`. **Pas un seul pair externe.** Et `3100` n'apparaissait nulle part
dans la configuration Caddy, zero connexion, aucune ligne de journal en 24 h.

Zero friction constatee a chaque etape : 10 sondes fonctionnelles inchangees
apres chacun des quatre changements.

## `nodyx-server`

Son adresse etait codee en dur. Il lit desormais `DIRECTORY_HOST`, du meme acabit
que `DIRECTORY_PORT` deja en place, **avec le loopback par defaut**.

Une valeur illisible y retombe egalement : *une faute de frappe doit fermer une
porte, jamais en ouvrir une.* Un avertissement est journalise pour que l'operateur
ne croie pas avoir publie le service.

Quatre tests, dont un qui parcourt `""`, `"   "`, `"0.0.0.o"`, `"localhost"` et
`"not an address"` pour verifier ce repli.

## `install.sh`

Ecrit desormais `HOST=127.0.0.1`. Toute nouvelle instance auto-hebergee heritait
jusqu'ici de `0.0.0.0`.

## Le fil rouge

`verifier-services.sh` sonde ce que les visiteurs utilisent reellement : chaque
site, son API, la poignee de main Socket.IO, le tunnel. Regarder `ss` ne
suffirait pas, un service peut ecouter au bon endroit sans etre joignable par
Caddy.

`ufw-restaurer.sh` **refuse** une sauvegarde ne contenant aucune regle pour le
port 22 : la restaurer transformerait un incident en perte d'acces.

## Pare-feu : de 23 a 18 regles

**Quatre regles ouvraient le port 5349** alors que rien n'ecoute derriere.

**La cinquieme etait INERTE.** Un `DENY` pose contre un scanner WordPress. Dans
la chaine `ip6tables` :

```
ligne  5 : -A ufw6-user-input -p tcp --dport 443 -j ACCEPT
ligne 13 : -A ufw6-user-input -s 2a06:98c0:3600::103/128 -j DROP
```

La premiere regle qui correspond gagne. Le trafic web de cette adresse etait
accepte huit lignes avant que le blocage soit evalue.

Verifie en base, le scanner **n'a jamais cesse** :

```
2026-08-20 : 13 coups     2026-08-17 : 20
2026-08-19 : 24           2026-08-16 : 32
2026-08-18 : 25           2026-08-15 : 20
```

La regle rassurait sans proteger.

### Pourquoi elle n'a pas ete remontee en tete

L'adresse appartient a `2a06:98c0::/29`, une plage Cloudflare. Un blocage au
niveau reseau ne lit pas les en-tetes : il couperait aussi les visiteurs
legitimes routes par cette arete. Un scanner qui frappe des chemins de pot de
miel est du bruit que le pot de miel est fait pour enregistrer, pas une raison de
risquer une coupure silencieuse.

### Ce qui n'a pas ete touche

La plage `49152:65535/udp` semble enorme mais elle est reellement utilisee : 44
sockets alloues au moment de la mesure, et c'est le defaut du code TURN. La
resserrer risquerait l'epuisement d'allocation, donc des appels coupes, pour un
gain faible : rien n'ecoute sur ces ports en dehors d'une allocation vivante,
elle-meme protegee par l'authentification TURN.
