### PR TITLE
fix(ops): relancer un coeur PM2 vivant mais muet, avant que ça ne dure des heures

### DIFF
--- a/scripts/ops/veille/README.md
+++ b/scripts/ops/veille/README.md
@@ -1,0 +1,55 @@
+# Le gardien des cœurs PM2
+
+## Ce qu'il corrige
+
+Le 22 août 2026, `unattended-upgrade` a redémarré PostgreSQL (coupure de
+5 secondes). `demo-core`, `sleemstudio-core` et `vieuxlooters-core` s'y sont
+pris juste au mauvais moment pendant leurs migrations de démarrage. Aucun n'a
+planté : ils sont restés **bloqués avant `server.listen()`**. PM2 les affichait
+« online » sans discontinuer, rien ne les a jamais relancés.
+
+Injoignables pendant près de 5 heures, sans la moindre alerte. C'est ce
+symptôme précis, processus vivant mais port muet, que `nodyx-core` (le
+principal) n'a pas eu ce jour-là, et que rien ne surveillait.
+
+## Le mécanisme
+
+`verifier-ecoute.sh` sonde en local les quatre ports des cœurs (3000 à 3003).
+**Deux passages consécutifs en échec** avant d'agir, jamais un seul : un
+redémarrage légitime laisse aussi le port muet une poignée de secondes, et ne
+doit pas déclencher d'intervention.
+
+Au second échec : `pm2 restart`, vérification que le port répond de nouveau,
+puis une alerte Discord sur `SECURITY_DISCORD_WEBHOOK`, le canal déjà utilisé
+par les alertes de sécurité existantes (`auth.ts`), pas un nouveau créé pour
+l'occasion.
+
+Un minuteur `systemd` le lance toutes les deux minutes, la même cadence que
+`nodyx-security-collector` déjà en place. Dans le pire cas, une instance muette
+est détectée et relancée en moins de 5 minutes, au lieu de 5 heures.
+
+## Vérifié, pas supposé
+
+Testé en coupant volontairement `demo-core` :
+
+```
+premier passage  : constat, aucune action
+second passage   : relance, port de nouveau joignable
+demo.nodyx.org   : 200 depuis l'extérieur
+```
+
+Et sur l'état sain : aucune sortie, aucun fichier d'état créé, aucune instance
+touchée.
+
+## Limites, assumées
+
+Ce script traite le **symptôme**, pas la cause. Il ne dit pas pourquoi la
+migration de démarrage peut se bloquer indéfiniment sur une erreur de connexion
+transitoire au lieu d'échouer proprement ou de réessayer avec un délai. Cette
+question touche au code de `nodyx-core`, qui est sanctuarisé : elle attend une
+décision séparée, pas un correctif d'infrastructure.
+
+Si une instance a besoin d'être relancée à répétition, ce script continuera de
+le faire à chaque fois, sans jamais renoncer ni alerter différemment. C'est
+volontaire : mieux vaut relancer inutilement de temps en temps que rater une
+vraie panne parce qu'un compteur de suppression l'a fait taire.

--- a/scripts/ops/veille/nodyx-veille-ecoute.service
+++ b/scripts/ops/veille/nodyx-veille-ecoute.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Nodyx — relance un coeur PM2 vivant mais muet
+Documentation=file:///var/www/nexus/scripts/ops/veille/README.md
+After=postgresql.service
+
+[Service]
+Type=oneshot
+# Root : necessaire pour `sudo -u nodyx pm2 restart`. Il ne fait rien d'autre
+# que sonder des ports locaux et relancer via pm2, jamais nftables ni Caddy.
+User=root
+ExecStart=/var/www/nexus/scripts/ops/veille/verifier-ecoute.sh
+TimeoutStartSec=60
+
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+NoNewPrivileges=yes
+ReadWritePaths=/var/backups/nodyx/veille
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/ops/veille/nodyx-veille-ecoute.timer
+++ b/scripts/ops/veille/nodyx-veille-ecoute.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Nodyx — surveillance des coeurs PM2 toutes les 2 minutes
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=2min
+# Meme cadence que le collecteur de securite : assez frais pour ne pas laisser
+# une instance muette des heures, assez espace pour ne rien peser. Le
+# 22/08/2026, une instance coincee au demarrage l'est restee 5h sans surveillance.
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target

--- a/scripts/ops/veille/verifier-ecoute.sh
+++ b/scripts/ops/veille/verifier-ecoute.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Détecte un cœur PM2 vivant mais muet, et le relance.
+#
+# Le défaut qu'il corrige, observé le 22/08/2026 : `unattended-upgrade` a
+# redémarré PostgreSQL (coupure de 5 secondes). demo-core, sleemstudio-core et
+# vieuxlooters-core s'y sont pris juste au mauvais moment pendant leurs
+# migrations de démarrage. Leur processus n'a jamais planté : il est resté
+# bloqué avant `server.listen()`. PM2 les affichait "online" sans discontinuer,
+# rien ne les a jamais relancés. Injoignables pendant près de 5 heures, sans
+# la moindre alerte.
+#
+# Un `pm2 restart` planifié ne suffit pas : le symptôme est spécifique, un
+# processus vivant qui n'écoute plus. On ne redémarre QUE ce cas précis, jamais
+# une instance qui fonctionne.
+#
+# Deux passages consécutifs en échec avant d'agir : un redémarrage légitime en
+# cours laisse aussi le port muet une poignée de secondes, et ne doit pas
+# déclencher une intervention.
+set -euo pipefail
+
+ETAT="${VEILLE_ETAT:-/var/backups/nodyx/veille}"
+mkdir -p "$ETAT"
+
+# name pm2 = port a verifier, en loopback : ce sont les quatre coeurs durcis le
+# 20/08/2026, injoignables depuis l'exterieur mais tous locaux a cette machine.
+declare -A CIBLES=(
+  [nodyx-core]=3000
+  [demo-core]=3001
+  [sleemstudio-core]=3002
+  [vieuxlooters-core]=3003
+)
+
+alerter() {
+  local titre="$1" description="$2" couleur="$3"
+  local url="${SECURITY_DISCORD_WEBHOOK:-}"
+  # Lu depuis le .env du coeur principal : c'est deja le canal des alertes de
+  # securite existantes (src/routes/auth.ts), on n'en cree pas un second.
+  [ -z "$url" ] && url=$(grep -h '^SECURITY_DISCORD_WEBHOOK=' /var/www/nexus/nodyx-core/.env 2>/dev/null | cut -d= -f2-)
+  [ -z "$url" ] && return 0
+  curl -sf -m 8 -X POST "$url" -H 'Content-Type: application/json' \
+    -d "$(python3 -c "
+import json, sys
+print(json.dumps({'embeds': [{'title': sys.argv[1], 'description': sys.argv[2], 'color': int(sys.argv[3])}]}))
+" "$titre" "$description" "$couleur")" \
+    >/dev/null 2>&1 || true
+}
+
+ECHECS_DETECTES=0
+for nom in "${!CIBLES[@]}"; do
+  port="${CIBLES[$nom]}"
+  FICHIER="$ETAT/$nom.echecs"
+
+  if timeout 3 bash -c "</dev/tcp/127.0.0.1/$port" 2>/dev/null; then
+    # Vivant et joignable : on efface tout historique d'echec.
+    rm -f "$FICHIER"
+    continue
+  fi
+
+  # Muet. Est-ce la premiere fois, ou la seconde de suite ?
+  N=0
+  [ -f "$FICHIER" ] && N=$(cat "$FICHIER" 2>/dev/null || echo 0)
+  N=$((N + 1))
+  echo "$N" > "$FICHIER"
+
+  if [ "$N" -lt 2 ]; then
+    echo "  $nom : muet sur le port $port (1er constat, on attend confirmation)"
+    continue
+  fi
+
+  ECHECS_DETECTES=$((ECHECS_DETECTES + 1))
+  echo "  $nom : muet sur le port $port DEPUIS DEUX PASSAGES, relance"
+
+  STATUT_AVANT=$(sudo -u nodyx PM2_HOME=/home/nodyx/.pm2 pm2 jlist 2>/dev/null \
+    | python3 -c "
+import json, sys
+for p in json.load(sys.stdin):
+    if p['name'] == '$nom':
+        print(f\"statut={p['pm2_env']['status']} redemarrages={p['pm2_env']['restart_time']}\")
+        break
+" 2>/dev/null || echo "inconnu")
+
+  sudo -u nodyx PM2_HOME=/home/nodyx/.pm2 pm2 restart "$nom" >/dev/null 2>&1 || true
+  rm -f "$FICHIER"
+
+  sleep 5
+  if timeout 3 bash -c "</dev/tcp/127.0.0.1/$port" 2>/dev/null; then
+    echo "    -> relance reussie, $nom ecoute a nouveau"
+    alerter "🔧 $nom relancé automatiquement" \
+      "Bloqué sur le port $port sans écouter ($STATUT_AVANT). Relance réussie." 3066993
+  else
+    echo "    -> ENCORE MUET apres relance, ceci depasse ce script"
+    alerter "🚨 $nom injoignable, la relance automatique a échoué" \
+      "Toujours muet sur le port $port après \`pm2 restart\`. Intervention manuelle nécessaire." 15158332
+  fi
+done
+
+exit 0


### PR DESCRIPTION
## Ce que ce lot corrige

Le 22 aout 2026, `unattended-upgrade` a redemarre PostgreSQL, coupure de 5 secondes. `demo-core`, `sleemstudio-core` et `vieuxlooters-core` s'y sont pris juste au mauvais moment pendant leurs migrations de demarrage. Aucun n'a plante : ils sont restes **bloques avant `server.listen()`**. PM2 les affichait online sans discontinuer, rien ne les a jamais relances.

**Injoignables pendant pres de 5 heures, sans la moindre alerte.**

## Le mecanisme

`verifier-ecoute.sh` sonde en local les quatre ports des coeurs. **Deux passages consecutifs en echec** avant d'agir : un redemarrage legitime laisse aussi le port muet quelques secondes, et ne doit pas declencher d'intervention.

Au second echec : `pm2 restart`, verification que le port repond de nouveau, alerte sur `SECURITY_DISCORD_WEBHOOK` (canal deja existant, reutilise depuis `auth.ts`).

Minuteur systemd toutes les 2 minutes, meme cadence que `nodyx-security-collector`. Pire cas : detection et relance en moins de 5 minutes au lieu de 5 heures.

## Verifie, pas suppose

Coupure volontaire de `demo-core` :

```
premier passage  : constat, aucune action
second passage   : relance, port de nouveau joignable
demo.nodyx.org   : 200 depuis l'exterieur
```

Sur l'etat sain : zero sortie, zero fichier d'etat, zero instance touchee.

## Ce que ce lot ne fait pas

Il traite le symptome, pas la cause. `nodyx-core` est sanctuarise : pourquoi la migration se bloque indefiniment sur une erreur transitoire plutot que d'echouer proprement reste une decision separee.