### PR TITLE
chore(contributeurs): ajouter orfeu, premier vrai traducteur pt-BR

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -143,6 +143,21 @@ One merged PR = one star. Typos count. Translations count. Bug reports that turn
       <br/>
       <sub><strong>First dual-stack hunter 🌐</strong></sub>
     </td>
+    <td align="center" width="200">
+      <a href="https://github.com/oorpheas">
+        <img src="https://github.com/oorpheas.png?size=120" width="120" height="120" style="border-radius:50%;" alt="orfeu"/>
+        <br/>
+        <sub><b>orfeu</b></sub>
+      </a>
+      <br/>
+      <sub>🌟 × 1</sub>
+      <br/>
+      <sub><a href="https://github.com/Pokled/nodyx/pull/626">PR #626</a></sub>
+      <br/>
+      <sub><em>Brazilian Portuguese translation, ~2,000 strings, careful gender-neutral phrasing</em></sub>
+      <br/>
+      <sub><strong>First pt-BR translator 🇧🇷</strong></sub>
+    </td>
   </tr>
 </table>
 


### PR DESCRIPTION
Suite a #626 : 1999 chaines traduites en portugais bresilien, avec une reflexion assumee sur le genre neutre (suffixe `obrigado/a/e` quand la formulation neutre sonnait mal).

Verifie avant la fusion : le fichier pt-BR.json existait deja mais comme squelette (miroir de l'anglais cree par Pokled le 2026-08-19, jamais reellement traduit). Il est donc bien le premier vrai traducteur humain de cette langue.