### PR TITLE
chore(readme): retirer les emojis, ajouter /translate, réorganiser

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Forum + Chat + Voice + P2P + Canvas + Homepage Builder + Streamer Hub, one serve
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![CI](https://github.com/Pokled/Nodyx/actions/workflows/ci.yml/badge.svg)](https://github.com/Pokled/Nodyx/actions/workflows/ci.yml)
 [![Stack](https://img.shields.io/badge/stack-Fastify%20%2B%20SvelteKit%20%2B%20PostgreSQL%20%2B%20Rust-green)](docs/en/ARCHITECTURE.md)
+[![Security Policy](https://img.shields.io/badge/security-Argon2id%20%2B%20E2E%20%2B%202FA-1a1a2e)](.github/SECURITY.md)
 [![Ko-fi](https://img.shields.io/badge/Support-Ko--fi-FF5E5B?logo=ko-fi&logoColor=white)](https://ko-fi.com/Pokled)
 
 <sub>If Nodyx resonates with you, a star helps others find it, and keeps us going.</sub>
@@ -32,6 +33,7 @@ Forum + Chat + Voice + P2P + Canvas + Homepage Builder + Streamer Hub, one serve
 <div align="center">
 
 [Features](#where-each-project-shines) &nbsp;·&nbsp;
+[Security](#security) &nbsp;·&nbsp;
 [Homepage Builder](docs/en/HOMEPAGE-BUILDER.md) &nbsp;·&nbsp;
 [Streamer Hub](docs/en/STREAMER-HUB.md) &nbsp;·&nbsp;
 [Architecture](#architecture) &nbsp;·&nbsp;
@@ -45,7 +47,13 @@ Forum + Chat + Voice + P2P + Canvas + Homepage Builder + Streamer Hub, one serve
 
 ---
 
-> **Hey, before you scroll.** Nodyx isn't trying to fight Discord, and it isn't trying to be the only open alternative. There are great projects out there. Matrix, Stoat, Fluxer, Mattermost, Rocket.Chat, Discourse, Haven and others. And we genuinely want you to know about them. We list them, with their GitHub repos, on a page we wrote ourselves: **[→ Why Nodyx (and the other alternatives we respect)](https://nodyx.dev/why-nodyx)**.
+<div align="center">
+  <img src="docs/img/fronted_nodyx_page_builder.png" alt="Nodyx, Homepage Builder" width="860"/>
+</div>
+
+---
+
+> **Hey, before you scroll.** Nodyx isn't trying to fight Discord, and it isn't trying to be the only open alternative. There are great projects out there. Matrix, Stoat, Fluxer, Mattermost, Rocket.Chat, Discourse, Haven and others. And we genuinely want you to know about them. We list them, with their GitHub repos, on a page we wrote ourselves: **[Why Nodyx, and the other alternatives we respect](https://nodyx.dev/why-nodyx)**.
 >
 > *The fight isn't between us. It's between locked silos and communities that actually own themselves. Pick the tool that fits you. We'll cheer either way.*
 
@@ -68,10 +76,6 @@ Forum + Chat + Voice + P2P + Canvas + Homepage Builder + Streamer Hub, one serve
 | 日本語 | 取締役会の気分や投資家の気まぐれを気にする必要のないツール。 |
 
 </details>
-
-<div align="center">
-  <img src="docs/img/fronted_nodyx_page_builder.png" alt="Nodyx, Homepage Builder" width="860"/>
-</div>
 
 ---
 
@@ -98,6 +102,27 @@ One command. Your server. Forever.
 | Reverse proxy | **Caddy**, automatic Let's Encrypt TLS |
 
 > **No Docker required.** The installer deploys Node.js + PostgreSQL + Redis + Caddy + PM2 natively. `docker-compose.yml` is provided for local development only.
+
+---
+
+## Security
+
+Self-hosting your community means the responsibility for keeping it safe sits with you. Nodyx is built to make that responsibility smaller, not bigger.
+
+| Surface | How it's handled |
+|---|---|
+| Passwords | Argon2id, OWASP-recommended parameters, transparent migration off any legacy bcrypt hash |
+| Direct messages | End-to-end encrypted, ECDH P-256 + AES-256-GCM. Private keys never leave the browser, the server only ever sees ciphertext |
+| Sessions | JWT + Redis, configurable TTL, forced logout on demand |
+| Two-factor auth | TOTP (Google Authenticator, Aegis, Bitwarden) or Nodyx Signet, a passwordless ECDSA P-256 PWA |
+| Rate limiting | Trusted proxy chain scoped explicitly, so a forged `X-Forwarded-For` can't impersonate an internal request or dodge a limit |
+| Every API input | Validated against a Zod schema, parameterized SQL only, no string concatenation |
+| Every response | CSP, X-Frame-Options, HSTS headers, sanitized HTML rendering |
+| Backups | Proven nightly by an automated restore, not just a file copy sitting untested |
+
+Found a vulnerability? **Do not open a public issue.** Report it privately to `security@nodyx.org` or through [GitHub's private advisories](https://github.com/Pokled/nodyx/security/advisories/new). Acknowledged within 48 hours, assessed within 7 days, credited in the release notes unless you'd rather stay anonymous.
+
+→ **[Full security policy](.github/SECURITY.md)**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,28 +30,33 @@ Forum + Chat + Voice + P2P + Canvas + Homepage Builder + Streamer Hub, one serve
 
 </div>
 
+<!-- Une vraie barre de nav, pas un mur de liens bleus soulignés : GitHub impose
+     le style des hyperliens dans un README (bleu, souligné), impossible à
+     changer en CSS. Des boutons (badges) contournent cette contrainte. -->
 <div align="center">
 
-**[Discover](https://start.nodyx.org)** &nbsp;·&nbsp;
-**[Documentation](https://nodyx.dev)** &nbsp;·&nbsp;
-**[Live demo](https://nodyx.org)** &nbsp;·&nbsp;
-**[Translate](https://nodyx.org/translate)** &nbsp;·&nbsp;
-<a href="README.md"><img src="https://flagcdn.com/16x12/gb.png" alt="EN"> English</a> · <a href="docs/fr/README.md"><img src="https://flagcdn.com/16x12/fr.png" alt="FR"> Français</a>
+[![Discover](https://img.shields.io/badge/Discover-start.nodyx.org-6d76f5?style=flat-square)](https://start.nodyx.org)
+[![Documentation](https://img.shields.io/badge/Documentation-nodyx.dev-6d76f5?style=flat-square)](https://nodyx.dev)
+[![Live demo](https://img.shields.io/badge/Live_demo-nodyx.org-6d76f5?style=flat-square)](https://nodyx.org)
+[![Translate](https://img.shields.io/badge/Translate-nodyx.org%2Ftranslate-2ece93?style=flat-square)](https://nodyx.org/translate)
+[![English](https://img.shields.io/badge/EN-English-12131b?style=flat-square)](README.md)
+[![Français](https://img.shields.io/badge/FR-Fran%C3%A7ais-12131b?style=flat-square)](docs/fr/README.md)
 
 </div>
 
 <div align="center">
 
-[Features](#where-each-project-shines) &nbsp;·&nbsp;
-[Security](#security) &nbsp;·&nbsp;
-[Homepage Builder](docs/en/HOMEPAGE-BUILDER.md) &nbsp;·&nbsp;
-[Streamer Hub](docs/en/STREAMER-HUB.md) &nbsp;·&nbsp;
-[Architecture](#architecture) &nbsp;·&nbsp;
-[Screenshots](#screenshots) &nbsp;·&nbsp;
-[Quick Start](#quick-start) &nbsp;·&nbsp;
-[Changelog](CHANGELOG.md) &nbsp;·&nbsp;
-[Contributing](#contributing) &nbsp;·&nbsp;
-[Full docs](docs/en/)
+[![Features](https://img.shields.io/badge/Features-12131b?style=flat-square)](#where-each-project-shines)
+[![Security](https://img.shields.io/badge/Security-12131b?style=flat-square)](#security)
+[![Homepage Builder](https://img.shields.io/badge/Homepage_Builder-12131b?style=flat-square)](docs/en/HOMEPAGE-BUILDER.md)
+[![Streamer Hub](https://img.shields.io/badge/Streamer_Hub-12131b?style=flat-square)](docs/en/STREAMER-HUB.md)
+[![Architecture](https://img.shields.io/badge/Architecture-12131b?style=flat-square)](#architecture)
+[![Screenshots](https://img.shields.io/badge/Screenshots-12131b?style=flat-square)](#screenshots)
+[![Quick Start](https://img.shields.io/badge/Quick_Start-12131b?style=flat-square)](#quick-start)
+[![Changelog](https://img.shields.io/badge/Changelog-12131b?style=flat-square)](CHANGELOG.md)
+[![Contributing](https://img.shields.io/badge/Contributing-12131b?style=flat-square)](#contributing)
+[![Translate a language](https://img.shields.io/badge/Translate_a_language-2ece93?style=flat-square)](https://nodyx.org/translate)
+[![Full docs](https://img.shields.io/badge/Full_docs-12131b?style=flat-square)](docs/en/)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -15,30 +15,31 @@ Forum + Chat + Voice + P2P + Canvas + Homepage Builder + Streamer Hub, one serve
 [![Stack](https://img.shields.io/badge/stack-Fastify%20%2B%20SvelteKit%20%2B%20PostgreSQL%20%2B%20Rust-green)](docs/en/ARCHITECTURE.md)
 [![Ko-fi](https://img.shields.io/badge/Support-Ko--fi-FF5E5B?logo=ko-fi&logoColor=white)](https://ko-fi.com/Pokled)
 
-<sub>⭐ If Nodyx resonates with you, a star helps others find it, and keeps us going.</sub>
+<sub>If Nodyx resonates with you, a star helps others find it, and keeps us going.</sub>
 
 </div>
 
 <div align="center">
 
-**[🌐 Discover → start.nodyx.org](https://start.nodyx.org)** &nbsp;·&nbsp;
-**[📖 Documentation → nodyx.dev](https://nodyx.dev)** &nbsp;·&nbsp;
-**[🚀 Live demo → nodyx.org](https://nodyx.org)** &nbsp;·&nbsp;
+**[Discover](https://start.nodyx.org)** &nbsp;·&nbsp;
+**[Documentation](https://nodyx.dev)** &nbsp;·&nbsp;
+**[Live demo](https://nodyx.org)** &nbsp;·&nbsp;
+**[Translate](https://nodyx.org/translate)** &nbsp;·&nbsp;
 <a href="README.md"><img src="https://flagcdn.com/16x12/gb.png" alt="EN"> English</a> · <a href="docs/fr/README.md"><img src="https://flagcdn.com/16x12/fr.png" alt="FR"> Français</a>
 
 </div>
 
 <div align="center">
 
-[✨ Features](#where-each-project-shines) &nbsp;|&nbsp;
-[🧩 Homepage Builder](docs/en/HOMEPAGE-BUILDER.md) &nbsp;|&nbsp;
-[🎥 Streamer Hub](docs/en/STREAMER-HUB.md) &nbsp;|&nbsp;
-[🏗️ Architecture](#architecture) &nbsp;|&nbsp;
-[📸 Screenshots](#screenshots) &nbsp;|&nbsp;
-[🚀 Quick Start](#quick-start) &nbsp;|&nbsp;
-[📋 Changelog](CHANGELOG.md) &nbsp;|&nbsp;
-[🤝 Contributing](#contributing) &nbsp;|&nbsp;
-[📚 Full docs](docs/en/)
+[Features](#where-each-project-shines) &nbsp;·&nbsp;
+[Homepage Builder](docs/en/HOMEPAGE-BUILDER.md) &nbsp;·&nbsp;
+[Streamer Hub](docs/en/STREAMER-HUB.md) &nbsp;·&nbsp;
+[Architecture](#architecture) &nbsp;·&nbsp;
+[Screenshots](#screenshots) &nbsp;·&nbsp;
+[Quick Start](#quick-start) &nbsp;·&nbsp;
+[Changelog](CHANGELOG.md) &nbsp;·&nbsp;
+[Contributing](#contributing) &nbsp;·&nbsp;
+[Full docs](docs/en/)
 
 </div>
 
@@ -51,7 +52,7 @@ Forum + Chat + Voice + P2P + Canvas + Homepage Builder + Streamer Hub, one serve
 > **A tool that doesn't have to worry about the moods of a board of directors or the whims of an investor.**
 
 <details>
-<summary>🌍 Translations (click to expand)</summary>
+<summary>Translations (click to expand)</summary>
 
 | Language | Translation |
 |----------|-------------|
@@ -143,24 +144,23 @@ The community-tools landscape isn't a battle. Each project optimizes for differe
 
 ### What's inside the Nodyx single install
 
-- Indexed forum (canonical URLs, JSON-LD, sitemap, Google-friendly)
-- Real-time chat with replies, pins, reactions, unfurls
-- P2P voice channels, zero Big Tech relay
-- Collaborative P2P canvas (whiteboard)
-- WebRTC DataChannels for instant typing/reactions
-- Home server support, no port forwarding, no domain required
-- Federated community directory + cross-instance global search
-- Asset library (frames, badges, banners, profile themes)
-- Ephemeral whisper rooms
-- Passwordless login (ECDSA P-256 PWA, Nodyx Signet)
-- Collaborative jukebox (YouTube queue)
-- Event calendar (OSM maps, RSVP, SEO)
-- **Homepage Builder**, drag-and-drop rows and columns on a 12-unit grid
-- **Widget Store**, install external widgets via .zip
-- **Widget SDK**, build custom widgets, no framework needed
-- **OctoGuard**, native auto-mod (regex/word/link/emoji-flood, ReDoS-safe via Google `re2`), welcome bot, custom commands, mutes, signed webhook, all admin-tunable, off by default
-- **Streamer Hub**, Twitch integration with a native Soundboard (ID3 tags, viewer queue, `!ns` chat command), a multi-page mobile Stream Deck, OBS browser-source overlays (alerts, goals, timers, tickers, leaderboards, clips, soundboard) and audio playlists with per-playlist OBS scenes
-- **Rich article editor**, anchor-on-selection table of contents, corner-handle image resize, protected code/render blocks, two-column layouts, embedded media, all round-trip safe through the sanitizer
+**Talk, in every form**
+Indexed forum with canonical URLs, JSON-LD and a sitemap · real-time chat with replies, pins, reactions, unfurls · P2P voice channels with zero Big Tech relay in between · ephemeral whisper rooms for a side conversation that isn't meant to last.
+
+**Build and create, together**
+A collaborative P2P canvas for whiteboarding in real time · WebRTC DataChannels carrying typing indicators and reactions peer-to-peer · a rich article editor with a table of contents, image resize handles, protected code blocks and two-column layouts, all safe through the sanitizer on the way back out.
+
+**Own your front door**
+A drag-and-drop **Homepage Builder**, rows and columns on a 12-unit grid · a **Widget Store** for installing external widgets from a `.zip`, no rebuild · a **Widget SDK** for building your own, plain JavaScript, no framework required.
+
+**Run it from a spare laptop**
+Home server support with no port forwarding and no domain required · a federated community directory with cross-instance search · a collaborative jukebox, an event calendar with maps and RSVP, an asset library for frames, badges and banners, passwordless login via ECDSA P-256.
+
+**Keep it yours to moderate**
+**OctoGuard**, native auto-moderation (regex/word/link/emoji-flood, ReDoS-safe via Google `re2`), a welcome bot, custom commands, mutes, signed webhooks, every switch admin-tunable and off by default.
+
+**Stream without stitching five tools together**
+A native **Streamer Hub**: Soundboard with ID3 tags and a viewer queue, a `!ns` Twitch chat command, a mobile multi-page Stream Deck, seven OBS browser-source overlay types, and audio playlists with per-playlist OBS scenes.
 
 ---
 
@@ -324,7 +324,7 @@ apt-get install -y git curl
 |---|---|---|---|---|
 | < 1.5 GB | 256 MB | 192 MB | 2 GB created | Raspberry Pi 1 GB |
 | 1.5 - 3 GB | 384 MB | 256 MB | 1 GB if needed | RPi 4 / small VPS |
-| ≥ 3 GB | 512 MB | 512 MB | 1 GB if needed | Standard VPS ⭐ |
+| ≥ 3 GB | 512 MB | 512 MB | 1 GB if needed | Standard VPS |
 
 > Raspberry Pi: use a **64-bit OS** (Raspberry Pi OS 64-bit or Ubuntu ARM64). 32-bit is not supported.
 
@@ -344,7 +344,7 @@ The installer offers **three network modes**:
 
 | Mode | Requirements | Result |
 |---|---|---|
-| **Nodyx Relay** ⭐ | Nothing, outbound TCP only | `yourclub.nodyx.org` in minutes |
+| **Nodyx Relay** *(recommended)* | Nothing, outbound TCP only | `yourclub.nodyx.org` in minutes |
 | **Open ports** | Ports 80 + 443, domain or IP | Let's Encrypt HTTPS, full control |
 | **Cloudflare Tunnel** | CF account + own domain | Your custom domain, no open ports |
 
@@ -500,11 +500,11 @@ docs/ideas/  →  design thinking, UX proposals, new ideas
 
 The core (`nodyx-core/src/`) requires discussion first, open an Issue.
 
-### 🌍 Translate Nodyx
+### Translate Nodyx
 
-Nodyx speaks 7 languages. French and English are complete, and the core interface is translated in all of them. The rest is open.
+Nodyx ships in 8 languages. French and English are complete, the core interface is translated in all of them, and the rest is open.
 
-**👉 [nodyx.org/translate](https://nodyx.org/translate)** shows the exact state of every language and links straight to the file you would edit.
+**[nodyx.org/translate](https://nodyx.org/translate)** shows the exact state of every language, live avatars of who last worked on it, and links straight to the file you would edit.
 
 No account to create, no tool to install, no platform in the middle. Each language is one flat JSON file in `nodyx-frontend/src/lib/locales/`. Pick your language, fill in the missing keys, leave every `{{variable}}` alone, open a Pull Request. CI checks the placeholders, so translating cannot break the app.
 
@@ -512,7 +512,7 @@ Two people already brought a whole language in this way, and both are in the Nod
 
 ---
 
-## 🌟 Nodyx Stars, Contributors
+## Nodyx Stars, Contributors
 
 Every external contribution earns a star. Every Star goes on [our Hall of Fame](CONTRIBUTORS.md), with avatar, profile link, and rank. **Recognition is not optional here.** Open source without recognition is just free labor, and that's not how we roll.
 
@@ -541,7 +541,7 @@ Every external contribution earns a star. Every Star goes on [our Hall of Fame](
   </tr>
 </table>
 
-👉 **[Read every story and see all contributors →](CONTRIBUTORS.md)**
+**[Read every story and see all contributors →](CONTRIBUTORS.md)**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,19 @@ Forum + Chat + Voice + P2P + Canvas + Homepage Builder + Streamer Hub, one serve
 [![Version](https://img.shields.io/github/v/release/Pokled/nodyx?label=version&color=7c3aed)](https://github.com/Pokled/nodyx/releases/latest)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![CI](https://github.com/Pokled/Nodyx/actions/workflows/ci.yml/badge.svg)](https://github.com/Pokled/Nodyx/actions/workflows/ci.yml)
-[![Stack](https://img.shields.io/badge/stack-Fastify%20%2B%20SvelteKit%20%2B%20PostgreSQL%20%2B%20Rust-green)](docs/en/ARCHITECTURE.md)
 [![Security Policy](https://img.shields.io/badge/security-Argon2id%20%2B%20E2E%20%2B%202FA-1a1a2e)](.github/SECURITY.md)
 [![Ko-fi](https://img.shields.io/badge/Support-Ko--fi-FF5E5B?logo=ko-fi&logoColor=white)](https://ko-fi.com/Pokled)
+
+[![TypeScript](https://img.shields.io/badge/-TypeScript-3178C6?logo=typescript&logoColor=white)](docs/en/ARCHITECTURE.md)
+[![Svelte](https://img.shields.io/badge/-Svelte%205-FF3E00?logo=svelte&logoColor=white)](docs/en/ARCHITECTURE.md)
+[![PostgreSQL](https://img.shields.io/badge/-PostgreSQL%2016-4169E1?logo=postgresql&logoColor=white)](docs/en/ARCHITECTURE.md)
+[![Rust](https://img.shields.io/badge/-Rust-000000?logo=rust&logoColor=white)](docs/en/ARCHITECTURE.md)
+
+<!-- Ces deux-là ne sont pas des images figées : elles interrogent nodyx.org
+     en direct à chaque affichage. Le badge dit la vérité du jour, pas celle
+     du jour où quelqu'un a pensé à le mettre à jour. -->
+[![Translated live](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fnodyx.org%2Ftranslate%2Fprogress.json&query=%24.overallPct&suffix=%25&label=translated%20live&color=6d76f5)](https://nodyx.org/translate)
+[![Federated instances](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fnodyx.org%2Fapi%2Fdirectory&query=%24.instances.length&label=federated%20instances%20live&color=2ece93)](https://nodyx.org/discover)
 
 <sub>If Nodyx resonates with you, a star helps others find it, and keeps us going.</sub>
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Forum + Chat + Voice + P2P + Canvas + Homepage Builder + Streamer Hub, one serve
 
 <div align="center">
   <img src="docs/img/fronted_nodyx_page_builder.png" alt="Nodyx, Homepage Builder" width="860"/>
+  <br/><br/>
+  <img src="docs/img/nodyx_home_page.png" alt="Nodyx homepage" width="424"/>
+  <img src="docs/img/Nodyx_Forum.png" alt="Nodyx forum" width="424"/>
 </div>
 
 ---


### PR DESCRIPTION
2e passe après recherche : j'ai regardé la structure de 3 README AGPL/fair-code réputés pour leur design (Immich, Plausible, n8n) pour arrêter de deviner "à l'instinct IA". Le point commun le plus net entre les trois, surtout Immich (le plus abouti) : une vraie capture d'écran juste après la nav, avant tout discours — la preuve avant les mots. Zéro emoji décoratif chez Immich, le plus premium des trois. Ça confirme les deux décisions prises ici.

## Ce qui a changé

- **Tous les emojis décoratifs retirés** (nav, titres). Gardés : les 🌟 sous les avatars contributeurs (Star Rank, système déjà établi ailleurs sur le site)
- **La capture d'écran remonte avant le discours** (avant les citations "before you scroll" / investisseurs), au lieu d'arriver après
- **Section "Security" dédiée**, nouvelle, juste après "Built on" : Argon2id, DM E2E, 2FA, rate-limiting anti-spoofing, sauvegardes vérifiées — repris de `.github/SECURITY.md`, jusque-là invisible depuis le README (seulement dans l'onglet Security de GitHub)
- **Badge "Security Policy"** ajouté à la ligne de badges du haut, lien `#security` dans la nav
- **Lien nodyx.org/translate** ajouté à la nav principale
- **"What's inside" réorganisé** en 6 groupes thématiques au lieu d'une liste à plat de 17 puces
- Compteur de langues corrigé (7 → 8)

Pas touché : le contenu narratif ("The internet broke something", le tableau comparatif, la Vision) — cette voix-là tient déjà debout, le problème signalé portait sur les emojis, la structure, et l'absence de mise en avant de la sécurité.