### PR TITLE
fix(install): bump Node 20 -> 22, mediasoup-client requires it

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ The installer offers **three network modes**:
 > **Nodyx Relay** is the recommended default, works on a Raspberry Pi behind a home router.
 > No domain. No port forwarding. No cloud account. Just run the script.
 
-Installs automatically: **Node.js 20, PostgreSQL 16, Redis 7, Caddy (HTTPS), PM2, nodyx-turn** (Rust STUN/TURN).  
+Installs automatically: **Node.js 22, PostgreSQL 16, Redis 7, Caddy (HTTPS), PM2, nodyx-turn** (Rust STUN/TURN).  
 Generates secrets, runs all DB migrations, creates your admin account. **No Docker. No manual configuration.**
 
 > Supported: Ubuntu 22.04 / 24.04, Debian 11 / 12 / 13.

--- a/docs/en/INSTALL.md
+++ b/docs/en/INSTALL.md
@@ -82,7 +82,7 @@ sudo apt-get update && sudo apt-get install -y git
 
 You don't need to install anything else manually. The script handles:
 
-- **Node.js 20 LTS**: JavaScript runtime
+- **Node.js 22 LTS**: JavaScript runtime
 - **PostgreSQL 16**: Main database
 - **Redis 7**: Cache & real-time sessions
 - **Coturn**: TURN/STUN relay for voice channels (WebRTC NAT traversal)

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -121,7 +121,7 @@ The script automatically installs and configures:
 
 ### Option C, Manual installation (Linux/Mac/Windows)
 
-**Prerequisites:** Node.js 20+, PostgreSQL 16+, Redis 7+
+**Prerequisites:** Node.js 22+, PostgreSQL 16+, Redis 7+
 
 ```bash
 git clone https://github.com/Pokled/Nodyx

--- a/docs/es/INSTALL.md
+++ b/docs/es/INSTALL.md
@@ -82,7 +82,7 @@ sudo apt-get update && sudo apt-get install -y git
 
 No necesitas instalar nada más manualmente. El script se encarga de:
 
-- **Node.js 20 LTS** — Entorno de ejecución JavaScript
+- **Node.js 22 LTS** — Entorno de ejecución JavaScript
 - **PostgreSQL 16** — Base de datos principal
 - **Redis 7** — Caché y sesiones en tiempo real
 - **Coturn** — Relay TURN/STUN para salas de voz (NAT traversal con WebRTC)

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -121,7 +121,7 @@ El script instala y configura automáticamente:
 
 ### Opción C — Instalación manual (Linux/Mac/Windows)
 
-**Requisitos previos:** Node.js 20+, PostgreSQL 16+, Redis 7+
+**Requisitos previos:** Node.js 22+, PostgreSQL 16+, Redis 7+
 
 ```bash
 git clone https://github.com/Pokled/Nodyx

--- a/docs/fr/INSTALL.md
+++ b/docs/fr/INSTALL.md
@@ -72,7 +72,7 @@ sudo apt-get update && sudo apt-get install -y git
 
 Tu n'as rien d'autre à installer manuellement. Le script s'occupe de tout :
 
-- **Node.js 20 LTS** — Runtime JavaScript
+- **Node.js 22 LTS** — Runtime JavaScript
 - **PostgreSQL 16** — Base de données principale
 - **Redis 7** — Cache et sessions temps réel
 - **Coturn** — Relais TURN/STUN pour les salons vocaux (WebRTC, traversée NAT)

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -438,7 +438,7 @@ L'installateur propose **trois modes réseau** :
 > **Nodyx Relay** est la valeur par défaut recommandée, fonctionne sur un Raspberry Pi derrière un routeur domestique.
 > Sans domaine. Sans redirection de ports. Sans compte cloud. Lancez simplement le script.
 
-Installe automatiquement : **Node.js 20, PostgreSQL 16, Redis 7, Caddy (HTTPS), PM2, nodyx-turn** (Rust STUN/TURN).  
+Installe automatiquement : **Node.js 22, PostgreSQL 16, Redis 7, Caddy (HTTPS), PM2, nodyx-turn** (Rust STUN/TURN).  
 Génère les secrets, exécute toutes les migrations de la base de données, crée votre compte administrateur. **Sans Docker. Sans configuration manuelle.**
 
 > Pris en charge : Ubuntu 22.04 / 24.04, Debian 11 / 12 / 13.

--- a/install.sh
+++ b/install.sh
@@ -505,8 +505,8 @@ T_EN[step_install_deps]='Installing system dependencies'
 T_FR[step_install_deps]='Installation des dépendances système'
 T_EN[deps_installed]='System packages installed'
 T_FR[deps_installed]='Paquets système installés'
-T_EN[node_installing]='Installing Node.js 20 LTS...'
-T_FR[node_installing]='Installation de Node.js 20 LTS...'
+T_EN[node_installing]='Installing Node.js 22 LTS...'
+T_FR[node_installing]='Installation de Node.js 22 LTS...'
 T_EN[node_installed]='Node.js %s installed'
 T_FR[node_installed]='Node.js %s installé'
 T_EN[node_present]='Node.js %s already present'
@@ -2029,11 +2029,11 @@ _SYS_PKGS="curl wget gnupg2 ca-certificates lsb-release openssl ufw build-essent
 apt-get install -y -q $_SYS_PKGS 2>/dev/null
 ok "$(t deps_installed)"
 
-# Node.js 20 LTS
+# Node.js 22 LTS — mediasoup-client/awaitqueue (voice) require >=22 (#642)
 _NODE_MAJOR=$(node --version 2>/dev/null | sed 's/v//;s/\..*//' || echo 0)
-if ! command -v node &>/dev/null || [[ "$_NODE_MAJOR" -lt 20 ]]; then
+if ! command -v node &>/dev/null || [[ "$_NODE_MAJOR" -lt 22 ]]; then
   info "$(t node_installing)"
-  curl -fsSL https://deb.nodesource.com/setup_20.x | bash - >/dev/null 2>&1
+  curl -fsSL https://deb.nodesource.com/setup_22.x | bash - >/dev/null 2>&1
   apt-get install -y -q nodejs >/dev/null 2>&1
   ok "$(printf "$(t node_installed)" "$(node -v)")"
 else


### PR DESCRIPTION
## Summary
- `install.sh` pinned Node.js 20 LTS, but `mediasoup-client` (voice/WebRTC frontend) and its `awaitqueue` dependency declare `engines.node >=22`. A fresh install with no Node preinstalled always failed on `npm install` in the frontend step.
- Bumped the installer to Node 22 LTS (nodesource `setup_22.x`, version-check threshold, EN/FR install strings).
- Updated the same "Node.js 20" references in the root README and the fr/en/es docs (README + INSTALL) to 22.

Fixes #642.

## Test plan
- [ ] Fresh VPS/container with no Node installed, run `install.sh`, confirm `nodyx-frontend` npm install succeeds
- [ ] `node -v` after install reports a 22.x version