### PR TITLE
docs(contributors): update oorpheas to 3 stars

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -106,6 +106,21 @@ One merged PR = one star. Typos count. Translations count. Bug reports that turn
       <br/>
       <sub><strong>First Vietnamese contributor 🇻🇳</strong></sub>
     </td>
+    <td align="center" width="200">
+      <a href="https://github.com/oorpheas">
+        <img src="https://github.com/oorpheas.png?size=120" width="120" height="120" style="border-radius:50%;" alt="orfeu"/>
+        <br/>
+        <sub><b>orfeu</b></sub>
+      </a>
+      <br/>
+      <sub>🌟 × 3</sub>
+      <br/>
+      <sub><a href="https://github.com/Pokled/nodyx/pull/626">PR #626</a> · <a href="https://github.com/Pokled/nodyx/issues/642">#642</a> · <a href="https://github.com/Pokled/nodyx/pull/644">PR #644</a></sub>
+      <br/>
+      <sub><em>Brazilian Portuguese translation (0% → 67%), plus a precisely diagnosed installer bug (Node 20 vs mediasoup's Node 22 requirement)</em></sub>
+      <br/>
+      <sub><strong>First pt-BR translator 🇧🇷</strong></sub>
+    </td>
   </tr>
 </table>
 
@@ -143,21 +158,6 @@ One merged PR = one star. Typos count. Translations count. Bug reports that turn
       <br/>
       <sub><strong>First dual-stack hunter 🌐</strong></sub>
     </td>
-    <td align="center" width="200">
-      <a href="https://github.com/oorpheas">
-        <img src="https://github.com/oorpheas.png?size=120" width="120" height="120" style="border-radius:50%;" alt="orfeu"/>
-        <br/>
-        <sub><b>orfeu</b></sub>
-      </a>
-      <br/>
-      <sub>🌟 × 1</sub>
-      <br/>
-      <sub><a href="https://github.com/Pokled/nodyx/pull/626">PR #626</a></sub>
-      <br/>
-      <sub><em>Brazilian Portuguese translation, ~2,000 strings, careful gender-neutral phrasing</em></sub>
-      <br/>
-      <sub><strong>First pt-BR translator 🇧🇷</strong></sub>
-    </td>
   </tr>
 </table>
 
@@ -187,6 +187,8 @@ Sometimes a contribution isn't a PR. Sometimes it's just being there at exactly 
 
 | Contributor | Contribution | Type | Issue / PR | Fix / polish | Date |
 |---|---|---|---|---|---|
+| [@oorpheas](https://github.com/oorpheas) | Second Brazilian Portuguese translation pass: ~1,050 new/fixed strings, coverage jumped from 23% to 67%. Also corrected an earlier mistranslation (`"Stream Deck"` → `"Painel de Transmissão"` instead of the literal `"Conjunto de Stream"`). | `feat(i18n)` | [#644](https://github.com/Pokled/nodyx/pull/644) | _merged as-is, 0 placeholder errors_ | 2026-08-25 |
+| [@oorpheas](https://github.com/oorpheas) | Reported the frontend install failure on a clean machine: `install.sh` pinned Node 20, but `mediasoup-client`/`awaitqueue` (voice frontend) require Node ≥22, so `npm install` always failed with `EBADENGINE`. Included the full install log and traced it to the exact dependency. | `bug(installer)` | [#642](https://github.com/Pokled/nodyx/issues/642) | [#643](https://github.com/Pokled/nodyx/pull/643) | 2026-08-24 |
 | [@oorpheas](https://github.com/oorpheas) | Brazilian Portuguese translation: ~1,999 strings (44% coverage), with a deliberate approach to gender-neutral phrasing explained in the PR description, and only 2 entries honestly flagged `(*revisar)` where context was missing rather than guessed. | `feat(i18n)` | [#626](https://github.com/Pokled/nodyx/pull/626) | _merged as-is, 0 placeholder errors_ | 2026-08-22 |
 | [@oorpheas](https://github.com/oorpheas) | Requested a `pt-BR` locale, distinct from `pt-PT`. First real end-to-end test of the "request a language" process promised by the issue template: language added to the picker with a seeded starter file, then translated by the requester. | `feat(i18n)` | [#601](https://github.com/Pokled/nodyx/issues/601) | [`c2e4f2d`](https://github.com/Pokled/nodyx/commit/c2e4f2d) | 2026-08-19 |
 | [@JoeJoeflyn](https://github.com/JoeJoeflyn) | Unified the dark theme across login, register and forgot-password with a responsive split layout, and made the side panels resizable: drag handles, collapse, cookie persistence, and server side reads so the first paint is already correct. | `feat(auth)` | [#344](https://github.com/Pokled/nodyx/pull/344) | [#458](https://github.com/Pokled/nodyx/pull/458), polish below | 2026-08-06 |


### PR DESCRIPTION
## Summary
- Adds two log entries for oorpheas: the Node 22 installer bug report (#642) and the second pt-BR translation pass (#644).
- Moves his Hall of Fame card from Rookies to Regulars (1 star -> 3 stars).

## Test plan
- [x] Visual check of the diff, no broken table markup