### PR TITLE
fix(install): restart relay client instead of start when reconfiguring

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3116,7 +3116,7 @@ SVC
 
   systemctl daemon-reload
   systemctl enable nodyx-relay-client --quiet
-  systemctl start nodyx-relay-client
+  systemctl restart nodyx-relay-client
   ok "$(printf "$(t relay_client_started)" "${RELAY_SERVER:-relay.nodyx.org:7443}")"
   info "$(printf "$(t relay_client_url_soon)" "${DOMAIN}")"
 fi


### PR DESCRIPTION
## Summary
- `install.sh` overwrites `nodyx-relay-client.service` with the fresh `--slug`/`--token` during setup, but called `systemctl start` afterward instead of `restart`.
- `start` is a no-op when the unit is already active, so if a previous instance's relay client was still running at that moment, the new slug/token were written to disk but never actually applied to the running process — it kept advertising the old instance.

## Test plan
- [ ] Reproduce: have a running `nodyx-relay-client` (any slug), reinstall over an existing `/opt/nodyx`, confirm the new slug shows up in `journalctl -u nodyx-relay-client` without a manual restart.