### PR TITLE
feat(activities): records par joueur + classement d'instance

### DIFF
--- a/SPECS/NODYX_ACTIVITIES_CDC.md
+++ b/SPECS/NODYX_ACTIVITIES_CDC.md
@@ -1,7 +1,7 @@
 # CDC, Nodyx Activities — une application interactive dans un canal vocal
 
-Statut : **PROPOSÉ, en attente de validation du propriétaire** (nodyx-core = SANCTUAIRE)
-Date : 2026-08-30 (r1) · **r2 2026-08-30 : l'activité s'auto-héberge, plus de dépendance runtime à nodyx.org**
+Statut : **VALIDÉ (r1 + r2 livrés sur nodyx.org)** — nodyx-core = SANCTUAIRE
+Date : 2026-08-30 (r1) · **r2 2026-08-30 : l'activité s'auto-héberge, plus de dépendance runtime à nodyx.org** · **r3 2026-08-30 : records par joueur + classement d'instance (§10), valide A7/A8 amendés**
 Auteur : session Nodyx
 Préalable au code (règle maison : CDC formel avant tout module critique)
 Banc d'essai : **NodyxBattle** (`Pokled/nodyx-battle`) devient la première activité installable.
@@ -18,8 +18,8 @@ Banc d'essai : **NodyxBattle** (`Pokled/nodyx-battle`) devient la première acti
 | A4 | Transport temps-réel | Nouveau handler `socket/activity.ts`, **calqué verbatim sur `jukebox:update`** (`voice.ts:371-378`). L'hôte (le composant Svelte) relaie pour l'activité via le **socket déjà authentifié de la page**, uniquement dans `voice:<channelId>`. L'activité n'a **ni socket ni token propre**. |
 | A5 | Nouvelle capacité | `permissions.realtime` (booléen), marquée **sensible** sur l'écran de permissions (code tiers + diffusion dans le salon). |
 | A6 | Qui arbitre (host) ? | Le membre au plus petit `seatIndex` du salon vocal — déterministe sur tous les clients depuis `voice:channel_update`, zéro état backend, promotion auto si le host part. **Pas** le propriétaire de communauté (éviterait un `ownerUserId` de plus dans le roster = surface SANCTUAIRE élargie). |
-| A7 | Persistance | **Aucune** en v1. Pas de `/session`, pas de token → pas de `storage`/`core`/`network` pour une activité. ELO / historique = chantier suivant (ajouter `activity:<id>` au mint + `RE_SURFACE`). |
-| A8 | Migration | **Aucune.** `installed_extensions.granted` (JSONB) portera juste `"realtime"`. Activités éphémères, rien à persister. |
+| A7 | Persistance | ~~Aucune en v1~~ **AMENDÉ r3 (§10)** : la surface `activity:<id>` devient une **surface de stockage de plein droit**. `RE_SURFACE` accepte `activity:<id>`, `/session` frappe un jeton court pour elle, la frame (same-origin) appelle `POST /extensions/:id/storage` directement. `storage.user` (records par joueur) + `storage.instance.*` (classement). Pas de `core`/`network` pour une activité. |
+| A8 | Migration | **Aucune.** `installed_extensions.granted` (JSONB) porte `"realtime"` et, si accordées, `"storage.user"` / `"storage.instance.read"` / `"storage.instance.write"`. La table `extension_storage` existe déjà (SDK widget/page). |
 
 ---
 
@@ -326,7 +326,8 @@ les embeds YouTube/Twitch/Vimeo). **Aucun sous-domaine, aucun hébergeur externe
 - Surface `page` (jamais montée aujourd'hui — cf `NODYX_SDK_CDC.md` D4, dette G1).
 - `nodyx.ui.embed` : inutile ici, l'activité **est** l'embed.
 - `core.get`, renouvellement de jeton, `nodyx.imageUrl` (dettes G4/G5/G6 du SDK).
-- Persistance d'activité (ELO, historique de match) : pas de `/session`, pas de `storage` pour une activité.
+- ~~Persistance d'activité~~ **livré r3, cf §10** (records par joueur + classement d'instance).
+  Reste hors périmètre : validateur anti-triche du classement, historique de match détaillé.
 - Sélecteur si plusieurs activités installées (v1 ouvre la première).
 - Mise à jour incrémentale du bundle (v1 : nouveau `version` = nouveau dossier `app/` complet).
 - Lockstep déterministe, features multi jalon 2 du jeu.
@@ -353,3 +354,62 @@ les embeds YouTube/Twitch/Vimeo). **Aucun sous-domaine, aucun hébergeur externe
 7. **Phase infra (simplifiée) :** publier `kings-race-app-<ver>.zip` (GitHub Releases) + son sha256 dans
    le `manifest.json` du `.nyx` ; `pack_widget.sh` ; installer le `.nyx` (+ zip en option hors-ligne) ;
    recette bout-en-bout 2 utilisateurs. **Plus de sous-domaine, plus de route Caddy, plus de patch CSP prod.**
+
+---
+
+## 10. Persistance — records par joueur & classement d'instance (r3)
+
+**Amende A7.** Une activité peut désormais persister. Le stockage clé/valeur du SDK
+(`src/extensions/storage.ts`, table `extension_storage`, route `POST /extensions/:id/storage`,
+quotas au manifeste, plafonds fins, `writesPerMinute: 30`) est **déjà complet** : il ne connaissait
+pas les activités uniquement parce que `RE_SURFACE` ne matchait que `page` / `widget:<id>`.
+
+### 10.1 Changements nodyx-core (minimes, forward-only, AUCUNE migration)
+
+- `src/routes/extensions.ts` — `RE_SURFACE` : `^(page|widget:<id>|activity:<id>)$` (mêmes bornes
+  `RE_SURFACE_ID` que `widget:`). Sert `/storage`, `/fetch`, `/session`.
+- `src/routes/extensions.ts` — check « surface connue » de `POST /session` : accepte
+  `surface === 'activity:' + s.id` quand `s.type === 'activity'`.
+- `src/extensions/protocol.ts` — `RE_SURFACE` alignée (cohérence ; l'activité ne passe pas par
+  `parseRequest` aujourd'hui, mais un futur pont RPC d'activité le ferait).
+- `nodyx-frontend/src/lib/extensions/host.ts` — `RE_SURFACE` alignée.
+- `src/extensions/manifest.ts`, `capabilities.ts`, `limits.ts` — **inchangés**.
+  `storagePermission` + le mapping `storage.user` / `storage.instance.read` / `storage.instance.write`
+  (déjà `sensitive`) fonctionnent tels quels.
+
+### 10.2 Le jeton voyage dans le boot payload
+
+La frame d'activité est **same-origin** avec l'instance (§2.3). Elle appelle `POST /extensions/:id/storage`
+**directement** (`connect-src 'self'` de la CSP document l'autorise) — pas de round-trip par le port.
+
+- `ActivitySurface.svelte` : `openSession()` (`POST /session`, `surface: 'activity:<id>'`) →
+  ajoute `token` + `storageSurface` au boot payload. Ré-émission ~8 min : `port.postMessage({ event: 'session', token })`.
+- `host.ts` : `ActivityBootPayload` gagne `token?`, `storageSurface?`. `createActivityHostHandler`
+  inchangé (le stockage ne transite pas par le port).
+- Jeton court (`SURFACE.tokenTtlSeconds` = 600 s), `userId` projeté côté serveur depuis la session
+  réelle de la page (comme page/widget) → `scope: user` porte le vrai `claims.sub`.
+
+### 10.3 Modèle d'écriture
+
+| Donnée | scope | clé | écrit par |
+|---|---|---|---|
+| Records perso (parties, victoires, défaites, meilleure vague) | `user` | `stats` | chaque joueur, en fin de partie |
+| Classement d'instance (top 20 : id, nom, victoires…) | `instance` | `leaderboard` | **l'arbitre seul** (membre siège 0), une écriture en fin de COURSE AUX ROIS |
+
+`scope: instance` en écriture = `storage.instance.write`, **capacité sensible**, accordée
+explicitement par l'admin à l'installation. Compromis assumé : l'activité (code tiers) peut écrire
+n'importe quoi dans la clé `leaderboard`. Borné par : bundle épinglé sha256 + validé par l'admin,
+`writesPerMinute: 30`, quota `instance` (64 Ko), merge idempotent (`ON CONFLICT DO UPDATE`, tableau
+trié + plafonné). Un **validateur de classement** (recoupement des `MatchDirector.cmd_log`) est
+renvoyé au jalon 3.
+
+### 10.4 Tests (même session que le code)
+
+| Fichier | Cas |
+|---|---|
+| `src/tests/extensionRoutes.test.ts` | `/session` frappe un jeton `activity:battle` si le manifeste a la surface ; refuse `activity:inconnu` ; `/storage` avec ce jeton : `set`/`get`/`list` scope `user` ; `set` scope `instance` refusé sans `storage.instance.write`, accepté avec |
+| `src/tests/extensionManifest.test.ts` | manifeste `activity` + `permissions.storage` accepté ; `storage.instance.write` dans les capacités sensibles |
+
+### 10.5 Hors périmètre (toujours)
+
+Validateur anti-triche du classement · classement multi-instances · records chiffrés.

--- a/nodyx-core/src/extensions/protocol.ts
+++ b/nodyx-core/src/extensions/protocol.ts
@@ -48,7 +48,7 @@ export interface ProtocolEvent {
 
 const RE_ID      = /^[A-Za-z0-9_-]{1,64}$/
 const RE_EXT     = /^[a-z][a-z0-9-]{2,38}$/
-const RE_SURFACE = /^(page|widget:[a-z][a-z0-9-]{0,30})$/
+const RE_SURFACE = /^(page|(widget|activity):[a-z][a-z0-9-]{0,30})$/
 
 export type ParseResult =
   | { ok: true;  request: ProtocolRequest }

--- a/nodyx-core/src/routes/extensions.ts
+++ b/nodyx-core/src/routes/extensions.ts
@@ -28,7 +28,7 @@ import type { GrantedNetwork } from '../extensions/net'
 import { PACKAGE, SURFACE }      from '../extensions/limits'
 
 const RE_ID      = /^[a-z][a-z0-9-]{2,38}$/
-const RE_SURFACE = /^(page|widget:[a-z][a-z0-9-]{0,30})$/
+const RE_SURFACE = /^(page|(widget|activity):[a-z][a-z0-9-]{0,30})$/
 
 interface InstalledRow {
   id:       string
@@ -479,7 +479,9 @@ export async function extensionRoutes(app: FastifyInstance) {
     if (!parsed.ok) return reply.code(500).send({ error: 'Manifeste installé invalide', code: 'MANIFEST_CORRUPT' })
 
     const known = parsed.manifest.surfaces.some(s =>
-      s.type === 'page' ? surface === 'page' : surface === `widget:${s.id}`,
+      s.type === 'page'     ? surface === 'page'
+      : s.type === 'activity' ? surface === `activity:${s.id}`
+      :                         surface === `widget:${s.id}`,
     )
     if (!known) return reply.code(404).send({ error: 'Surface inconnue', code: 'SURFACE_NOT_FOUND' })
 

--- a/nodyx-core/src/tests/extensionManifest.test.ts
+++ b/nodyx-core/src/tests/extensionManifest.test.ts
@@ -3,6 +3,7 @@ import {
   validateManifest, collectMessageKeys, parseSize, isSafePackagePath,
   type ExtensionManifest,
 } from '../extensions/manifest'
+import { requestedCapabilities, sensitiveCapabilities } from '../extensions/capabilities'
 
 // Manifeste minimal valide : le socle de tous les cas négatifs ci dessous.
 function base(): Record<string, unknown> {
@@ -265,6 +266,18 @@ describe('surface activity + bundle applicatif', () => {
   it('realtime accepté avec activity, refusé sans', () => {
     expect(validateManifest({ ...activity(), permissions: { realtime: true } }).ok).toBe(true)
     expect(issues({ ...base(), permissions: { realtime: true } })).toContain('REALTIME_WITHOUT_ACTIVITY')
+  })
+
+  it('accepte le stockage (records perso + classement) sur une activité', () => {
+    const r = validateManifest({
+      ...activity(),
+      permissions: { storage: { user: '16kb', instance: '64kb', instance_write: true } },
+    })
+    if (!r.ok) throw new Error('refusé : ' + JSON.stringify(r.issues))
+    expect(requestedCapabilities(r.manifest)).toEqual(expect.arrayContaining([
+      'storage.user', 'storage.instance.read', 'storage.instance.write',
+    ]))
+    expect(sensitiveCapabilities(r.manifest)).toContain('storage.instance.write')
   })
 })
 

--- a/nodyx-core/src/tests/extensionRoutes.test.ts
+++ b/nodyx-core/src/tests/extensionRoutes.test.ts
@@ -167,6 +167,78 @@ describe('frappe du jeton de surface', () => {
   })
 })
 
+// ── Surface activity : jeton + stockage (records, classement) ──────────────
+// Cf SPECS/NODYX_ACTIVITIES_CDC.md §10. Une activité est une surface de
+// stockage de plein droit : `RE_SURFACE` accepte `activity:<id>`, `/session`
+// lui frappe un jeton, `/storage` marche tel quel.
+
+describe('surface activity : jeton + stockage', () => {
+  const MANIFEST_ACTIVITY = {
+    ...MANIFEST,
+    icon: 'icon.svg',
+    surfaces: [{ type: 'activity', id: 'battle', entry: 'index.html', label: '@label' }],
+    app: { url: 'https://github.com/x/y/releases/download/v1.0.0/app.zip', sha256: 'a'.repeat(64), bytes: 5000 },
+    permissions: { storage: { user: '16kb', instance: '64kb', instance_write: true } },
+  }
+
+  const storeCall = (token: string, body: unknown) => app.inject({
+    method: 'POST', url: '/api/v1/extensions/demo-ext/storage',
+    headers: { authorization: `Bearer ${token}`, 'x-nodyx-surface': 'activity:battle' },
+    payload: body,
+  })
+
+  async function activityToken(granted: string[]) {
+    dbQuery.mockResolvedValue({ rows: [installedRow({ manifest: MANIFEST_ACTIVITY, granted })] })
+    const r = await session({ surface: 'activity:battle' }, 'Bearer membre')
+    return JSON.parse(r.body).token as string
+  }
+
+  it('frappe un jeton pour la surface activity du manifeste, lié à l utilisateur', async () => {
+    const token = await activityToken(['storage.user'])
+    const v = verifyExtensionToken(token, { instanceId: ORIGIN, extensionId: 'demo-ext', surface: 'activity:battle' }, SECRET)
+    expect(v.ok).toBe(true)
+    if (v.ok) expect(v.claims.sub).toBe('user-42')
+  })
+
+  it('refuse une surface activity absente du manifeste', async () => {
+    dbQuery.mockResolvedValue({ rows: [installedRow({ manifest: MANIFEST_ACTIVITY })] })
+    const r = await session({ surface: 'activity:inconnu' }, 'Bearer membre')
+    expect(r.statusCode).toBe(404)
+    expect(JSON.parse(r.body).code).toBe('SURFACE_NOT_FOUND')
+  })
+
+  it('écrit un record perso (scope user)', async () => {
+    const token = await activityToken(['storage.user'])
+    dbQuery.mockReset()
+    dbQuery
+      .mockResolvedValueOnce({ rows: [{ manifest: MANIFEST_ACTIVITY, enabled: true }] })
+      .mockResolvedValueOnce({ rows: [{ n: 0, total: 0 }] })
+      .mockResolvedValueOnce({ rows: [] })
+    const r = await storeCall(token, { op: 'set', key: 'stats', value: { games: 1, wins: 1 }, scope: 'user' })
+    expect(r.statusCode).toBe(200)
+  })
+
+  it('refuse le classement partagé sans storage.instance.write', async () => {
+    const token = await activityToken(['storage.user'])
+    dbQuery.mockReset()
+    dbQuery.mockResolvedValue({ rows: [{ manifest: MANIFEST_ACTIVITY, enabled: true }] })
+    const r = await storeCall(token, { op: 'set', key: 'leaderboard', value: [], scope: 'instance' })
+    expect(r.statusCode).toBe(403)
+    expect(JSON.parse(r.body).code).toBe('PERMISSION_DENIED')
+  })
+
+  it('accepte le classement partagé avec storage.instance.write (écriture de l arbitre)', async () => {
+    const token = await activityToken(['storage.instance.read', 'storage.instance.write'])
+    dbQuery.mockReset()
+    dbQuery
+      .mockResolvedValueOnce({ rows: [{ manifest: MANIFEST_ACTIVITY, enabled: true }] })
+      .mockResolvedValueOnce({ rows: [{ n: 0, total: 0 }] })
+      .mockResolvedValueOnce({ rows: [] })
+    const r = await storeCall(token, { op: 'set', key: 'leaderboard', value: [{ id: 'u-1', wins: 3 }], scope: 'instance' })
+    expect(r.statusCode).toBe(200)
+  })
+})
+
 describe('administration', () => {
   it('exige une authentification sur la liste', async () => {
     const r = await app.inject({ method: 'GET', url: '/api/v1/admin/extensions' })

--- a/nodyx-frontend/src/lib/components/ActivitySurface.svelte
+++ b/nodyx-frontend/src/lib/components/ActivitySurface.svelte
@@ -32,6 +32,8 @@
 
 	interface Props {
 		activityId: string
+		/** Id de la surface `activity` dans le manifeste (ex. 'battle'). */
+		surfaceId:  string
 		version:    string
 		/** Chemin relatif servi par l'instance : /api/v1/extensions/<id>/<version>/app/<entry> */
 		appUrl:     string
@@ -50,11 +52,36 @@
 	}
 
 	let {
-		activityId, version, appUrl, label, channelId, socket,
+		activityId, surfaceId, version, appUrl, label, channelId, socket,
 		userId, username, userAvatar = null,
 		members = [], locale = 'fr', theme = {},
 		onclose = () => {},
 	}: Props = $props()
+
+	// ── Persistance (records, classement) ──────────────────────────────────
+	// Jeton court frappé par l'hôte (la frame n'a pas de session) et passé dans
+	// le boot. La frame étant same-origin, elle appelle /storage directement.
+	// Cf SPECS/NODYX_ACTIVITIES_CDC.md §10.
+	const storageSurface = `activity:${surfaceId}`
+	const storageUrl     = `/api/v1/extensions/${activityId}/storage`
+	let storageToken: string | null = $state(null)
+	let mintTimer: ReturnType<typeof setInterval> | null = null
+
+	async function mintToken(): Promise<string | null> {
+		try {
+			const res = await fetch(`/api/v1/extensions/${activityId}/session`, {
+				method:  'POST',
+				headers: { 'content-type': 'application/json' },
+				body:    JSON.stringify({ surface: storageSurface }),
+			})
+			if (!res.ok) return null
+			const body = await res.json()
+			storageToken = body.token ?? null
+			return storageToken
+		} catch {
+			return null
+		}
+	}
 
 	// Le bundle est servi sur notre propre origine.
 	const activityOrigin = typeof window !== 'undefined' ? window.location.origin : ''
@@ -193,6 +220,11 @@
 		channel.port1.onmessage = (ev) => {
 			if (ev.data?.event === 'ready') { status = 'ready'; clearBootTimer(); return }
 			if (ev.data?.event === 'error') { status = 'error'; clearBootTimer(); return }
+			// La frame demande un jeton frais (le sien a expiré en pleine partie).
+			if (ev.data?.type === 'session.refresh') {
+				mintToken().then((tok) => toGuest({ event: 'session', token: tok }))
+				return
+			}
 			handle(ev.data)
 		}
 		channel.port1.start()
@@ -204,6 +236,7 @@
 			members: snap,
 			locale,
 			theme:   $state.snapshot(theme) as Record<string, string>,
+			storage: { url: storageUrl, surface: storageSurface, token: storageToken },
 		})
 		frame.contentWindow?.postMessage(boot, activityOrigin, [channel.port2])
 		resolvePending(snap)   // les avatars qui manquent arriveront en `member_update`
@@ -217,6 +250,11 @@
 		if (!browser) return
 		if (!activityOrigin) { status = 'error'; return }
 		resolvePending(members)   // pré-charge les avatars pendant que le wasm télécharge
+		void mintToken()          // jeton prêt avant le boot (sinon la frame en redemandera un)
+		// Le jeton vit 600 s : on le renouvelle et on le pousse dans la frame.
+		mintTimer = setInterval(() => {
+			void mintToken().then((tok) => { if (status === 'ready') toGuest({ event: 'session', token: tok }) })
+		}, 8 * 60 * 1000)
 		window.addEventListener('message', onWindowMessage)
 		bootTimer = setTimeout(() => { if (status === 'loading') status = 'error' }, 15000)
 		socket?.on('activity:msg',          onActivityMsg)
@@ -229,6 +267,7 @@
 		if (!browser) return
 		window.removeEventListener('message', onWindowMessage)
 		clearBootTimer()
+		if (mintTimer) clearInterval(mintTimer)
 		channel?.port1.close()
 		socket?.off('activity:msg',          onActivityMsg)
 		socket?.off('activity:snap',         onActivitySnap)

--- a/nodyx-frontend/src/lib/components/VoiceRoom.svelte
+++ b/nodyx-frontend/src/lib/components/VoiceRoom.svelte
@@ -537,6 +537,7 @@
 {#if showActivity && activity && connected && voiceState.channelId}
 	<ActivitySurface
 		activityId={activity.id}
+		surfaceId={activity.surfaceId}
 		version={activity.version}
 		appUrl={activity.appUrl}
 		label={activity.label}

--- a/nodyx-frontend/src/lib/extensions/host.ts
+++ b/nodyx-frontend/src/lib/extensions/host.ts
@@ -61,7 +61,7 @@ export type Envelope =
 	| { p: number; id: string; ok: false; error: { code: string; message: string } }
 
 const RE_REQ_ID  = /^[A-Za-z0-9_-]{1,64}$/
-const RE_SURFACE = /^(page|widget:[a-z][a-z0-9-]{0,30})$/
+const RE_SURFACE = /^(page|(widget|activity):[a-z][a-z0-9-]{0,30})$/
 
 /**
  * Chemins internes acceptés pour le routeur d'une extension.
@@ -325,6 +325,9 @@ export interface ActivityBootPayload {
 	members:  ActivityMember[]
 	locale:   string
 	theme:    Record<string, string>
+	/** Persistance : la frame est same-origin, elle appelle `url` directement
+	 *  (jamais par le port). `token` court, ré-émis via l'event `session`. */
+	storage?: { url: string; surface: string; token: string | null }
 }
 
 export interface ActivityActions {


### PR DESCRIPTION
## Pourquoi

L'activité King's Race tourne dans un canal vocal mais **ne persiste rien** : ni les
victoires/défaites d'un joueur, ni un classement. Une activité n'avait ni jeton ni session
(l'identité passe par les props), donc pas d'accès à \`extension_storage\`.

## Ce que ça fait

La surface \`activity:<id>\` devient une **surface de stockage de plein droit**, exactement
comme \`page\` / \`widget:<id>\`. Le stockage clé/valeur du SDK était déjà complet ; il ne
connaissait pas les activités uniquement parce que \`RE_SURFACE\` ne matchait pas \`activity:<id>\`.

### Core (SANCTUAIRE — minime, forward-only, **aucune migration**)
- \`RE_SURFACE\` accepte \`activity:<id>\` (\`protocol.ts\`, \`routes/extensions.ts\`, + \`host.ts\` côté front)
- \`POST /session\` frappe un jeton pour une surface \`activity\` du manifeste installé
- \`storage.user\` / \`storage.instance.*\` fonctionnent tels quels (capacités, quotas, plafonds
  inchangés ; \`storage.instance.write\` était déjà *sensible*)
- \`extension_storage\` existe déjà (SDK widget/page)

### Frontend
- \`ActivitySurface\` frappe le jeton court (\`openSession\`) et le passe dans le boot payload ;
  la frame étant **same-origin** avec l'instance, elle appelle \`/storage\` directement (jamais
  par le port). Ré-émission ~8 min + réponse à \`session.refresh\`.
- \`host.ts\` : \`ActivityBootPayload.storage { url, surface, token }\`

### Modèle d'écriture (côté jeu)
| donnée | scope | clé | écrit par |
|---|---|---|---|
| records perso | \`user\` | \`stats\` | chaque joueur, fin de partie |
| classement d'instance | \`instance\` | \`leaderboard\` | l'arbitre seul (siège 0) |

\`storage.instance.write\` = capacité sensible, accordée explicitement par l'admin. Compromis
assumé (code tiers épinglé sha256 + \`writesPerMinute: 30\` + quota + merge idempotent),
documenté dans le CDC §10.

## CDC

\`SPECS/NODYX_ACTIVITIES_CDC.md\` §10 (amende A7/A8 « aucune persistance »).

## Tests

- \`core\` : **966**, toutes vertes (nouveaux cas activity:battle) (nouveaux : \`/session\` + \`/storage\` pour \`activity:battle\`, scope user
  + instance, refus sans \`storage.instance.write\` ; manifeste activité + storage)
- \`svelte-check\` 0 erreur, build OK, 5 portes i18n vertes (aucune chaîne user-facing nexus :
  le panneau records est rendu par Godot)

Côté jeu (\`Pokled/nodyx-battle\`, release **v0.4.0**) : autoload \`Records\`, carte « TES RECORDS »
+ top 5 de l'instance sur l'écran de setup. Inclut aussi la **reconnexion mid-match** et la
**migration d'hôte** (100 % jeu, aucun changement nexus).