### PR TITLE
feat(activities): galerie de jeux (sélecteur façon Play Store)

### DIFF
--- a/nodyx-core/src/extensions/manifest.ts
+++ b/nodyx-core/src/extensions/manifest.ts
@@ -247,7 +247,11 @@ const manifestSchema = z.object({
   default_locale: z.string().regex(RE_LOCALE),
   label:          messageKey,
   description:    messageKey,
+  /** Accroche courte pour la galerie (une phrase). `description` reste le texte long. */
+  tagline:        messageKey.optional(),
   icon:           z.string().refine(isSafePackagePath, 'chemin de paquet invalide').optional(),
+  /** Captures d'écran empaquetées dans le `.nyx`, servies par la route assets. Pour la vitrine. */
+  screenshots:    z.array(z.string().refine(isSafePackagePath, 'chemin de paquet invalide')).max(6).optional(),
   family:         z.enum(['media', 'gaming', 'community', 'esport', 'social', 'content']).optional(),
   surfaces:       z.array(surface).min(1),
   app:            appBundle.optional(),
@@ -283,7 +287,7 @@ export type ValidationResult =
 export function collectMessageKeys(m: ExtensionManifest): string[] {
   const keys = new Set<string>()
   const add = (v?: string) => { if (v) keys.add(v.slice(1)) }
-  add(m.label); add(m.description)
+  add(m.label); add(m.description); add(m.tagline)
   for (const s of m.surfaces) {
     add(s.label); add(s.description)
     if (s.type === 'page') { add(s.nav?.label) }

--- a/nodyx-core/src/routes/extensions.ts
+++ b/nodyx-core/src/routes/extensions.ts
@@ -257,7 +257,11 @@ export async function extensionRoutes(app: FastifyInstance) {
           version:     row.version,
           label:       tr(m.label),
           description: tr(m.description),
+          tagline:     tr(m.tagline) ?? null,
           icon:        m.icon ? `/api/v1/extensions/${m.id}/${row.version}/assets/${m.icon}` : null,
+          screenshots: (m.screenshots ?? []).map((p) => `/api/v1/extensions/${m.id}/${row.version}/assets/${p}`),
+          author:      m.author ?? null,
+          source:      m.source ?? null,
           family:      m.family ?? 'content',
           messages:    dict,
           surfaces:    m.surfaces.map((s) => {

--- a/nodyx-core/src/tests/extensionManifest.test.ts
+++ b/nodyx-core/src/tests/extensionManifest.test.ts
@@ -145,6 +145,31 @@ describe('identité et forme', () => {
   })
 })
 
+describe('vitrine : tagline + captures', () => {
+  it('accepte tagline + jusqu à 6 captures empaquetées', () => {
+    const r = validateManifest({
+      ...base(),
+      tagline: '@tagline',
+      screenshots: ['media/1.png', 'media/2.webp', 'shots/3.jpg'],
+    })
+    expect(r.ok).toBe(true)
+  })
+
+  it('collecte la tagline comme clé de message', () => {
+    const r = validateManifest({ ...base(), tagline: '@game.tagline' })
+    if (!r.ok) throw new Error('refusé')
+    expect(collectMessageKeys(r.manifest)).toContain('game.tagline')
+  })
+
+  it('refuse une capture qui remonte hors du paquet', () => {
+    expect(issues({ ...base(), screenshots: ['../secret.png'] }).length).toBeGreaterThan(0)
+  })
+
+  it('refuse plus de 6 captures', () => {
+    expect(issues({ ...base(), screenshots: Array(7).fill('media/x.png') }).length).toBeGreaterThan(0)
+  })
+})
+
 describe('i18n : toute chaîne visible est une clé', () => {
   it('refuse un libellé écrit en dur', () => {
     expect(issues({ ...base(), label: 'Mon widget' }).length).toBeGreaterThan(0)

--- a/nodyx-core/src/tests/extensionRoutes.test.ts
+++ b/nodyx-core/src/tests/extensionRoutes.test.ts
@@ -444,6 +444,21 @@ describe('liste publique', () => {
     expect(e.icon).toBe('/api/v1/extensions/demo-ext/1.0.0/assets/icon.svg')
   })
 
+  it('resout tagline + captures pour la vitrine, jamais le chemin brut', async () => {
+    dbQuery.mockResolvedValue({ rows: [{
+      id: 'demo-ext', version: '1.0.0',
+      messages: { en: { label: 'Demo', desc: 'A demo.', tag: 'Un jeu de folie' } },
+      manifest: { ...M, tagline: '@tag', screenshots: ['media/cover.png', 'media/shot1.webp'] },
+    }] })
+    const e = JSON.parse((await publicList()).body).extensions[0]
+    expect(e.tagline).toBe('Un jeu de folie')
+    expect(e.screenshots).toEqual([
+      '/api/v1/extensions/demo-ext/1.0.0/assets/media/cover.png',
+      '/api/v1/extensions/demo-ext/1.0.0/assets/media/shot1.webp',
+    ])
+    expect((await publicList()).body).not.toContain('"media/cover.png"')
+  })
+
   it('ne liste que les extensions activees', async () => {
     await publicList()
     expect(dbQuery.mock.calls[0][0]).toContain('WHERE enabled = true')

--- a/nodyx-frontend/src/lib/components/ActivityGallery.svelte
+++ b/nodyx-frontend/src/lib/components/ActivityGallery.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+	// Galerie des jeux (activités d'extension) installés sur l'instance.
+	// Ouverte par le bouton « Jeux » d'un canal vocal ; on y choisit le jeu à
+	// lancer, qui est ensuite monté par ActivitySurface.
+	//
+	// Les métadonnées (couverture, icône, accroche, catégorie) viennent de
+	// /extensions/public, résolues côté serveur. Cf SPECS/NODYX_ACTIVITIES_CDC.md.
+
+	import { onDestroy } from 'svelte'
+	import { portal } from '$lib/actions/portal'
+	import { t } from '$lib/i18n'
+
+	const tFn = $derived($t)
+
+	export interface GalleryActivity {
+		id:          string
+		version:     string
+		surfaceId:   string
+		appUrl:      string
+		label:       string
+		tagline:     string | null
+		description: string | null
+		icon:        string | null
+		screenshots: string[]
+		family:      string
+		author:      { name: string; url?: string } | null
+	}
+
+	let { activities = [] as GalleryActivity[], onselect, onclose }: {
+		activities?: GalleryActivity[]
+		onselect: (a: GalleryActivity) => void
+		onclose:  () => void
+	} = $props()
+
+	const FAMILIES = ['gaming', 'media', 'community', 'esport', 'social', 'content']
+	const familyLabel = (f: string) =>
+		tFn(`games.family.${FAMILIES.includes(f) ? f : 'gaming'}`)
+
+	// Défilement des captures : une carte survolée/focus fait tourner ses images.
+	let hovered = $state<string | null>(null)
+	let shotIndex = $state(0)
+	let timer: ReturnType<typeof setInterval> | null = null
+
+	$effect(() => {
+		if (timer) { clearInterval(timer); timer = null }
+		shotIndex = 0
+		const a = activities.find((x) => x.id === hovered)
+		if (a && a.screenshots.length > 1) {
+			timer = setInterval(() => { shotIndex = (shotIndex + 1) % a.screenshots.length }, 2600)
+		}
+	})
+	onDestroy(() => { if (timer) clearInterval(timer) })
+
+	function cover(a: GalleryActivity): string | null {
+		if (a.screenshots.length === 0) return null
+		return a.id === hovered ? a.screenshots[shotIndex % a.screenshots.length] : a.screenshots[0]
+	}
+
+	function onKey(e: KeyboardEvent) {
+		if (e.key === 'Escape') onclose()
+	}
+</script>
+
+<svelte:window on:keydown={onKey} />
+
+<div use:portal role="dialog" aria-label={tFn('games.gallery_title')} class="gal-overlay">
+	<div class="gal-bar">
+		<div class="gal-head">
+			<span class="gal-title">{tFn('games.gallery_title')}</span>
+			<span class="gal-sub">{tFn('games.gallery_subtitle')}</span>
+		</div>
+		<button class="gal-x" onclick={onclose} aria-label={tFn('games.close')}>✕</button>
+	</div>
+
+	{#if activities.length === 0}
+		<div class="gal-empty">
+			<p class="gal-empty-t">{tFn('games.none')}</p>
+			<p class="gal-empty-h">{tFn('games.none_hint')}</p>
+		</div>
+	{:else}
+		<div class="gal-grid">
+			{#each activities as a (a.id + ':' + a.surfaceId)}
+				<button
+					class="gal-card"
+					onclick={() => onselect(a)}
+					onmouseenter={() => hovered = a.id}
+					onmouseleave={() => { if (hovered === a.id) hovered = null }}
+					onfocus={() => hovered = a.id}
+					onblur={() => { if (hovered === a.id) hovered = null }}
+				>
+					<div class="gal-cover" class:gal-cover-empty={!cover(a)}>
+						{#if cover(a)}
+							<img src={cover(a)} alt="" loading="lazy" />
+						{:else if a.icon}
+							<img class="gal-cover-icon" src={a.icon} alt="" />
+						{/if}
+						<span class="gal-badge">{familyLabel(a.family)}</span>
+						{#if a.id === hovered && a.screenshots.length > 1}
+							<span class="gal-dots" aria-hidden="true">
+								{#each a.screenshots as _, i}
+									<span class="gal-dot" class:on={i === shotIndex}></span>
+								{/each}
+							</span>
+						{/if}
+					</div>
+
+					<div class="gal-body">
+						{#if a.icon}
+							<img class="gal-icon" src={a.icon} alt="" />
+						{/if}
+						<div class="gal-txt">
+							<span class="gal-name">{a.label}</span>
+							<span class="gal-tag">{a.tagline || a.description || ''}</span>
+							{#if a.author?.name}
+								<span class="gal-by">{tFn('games.by', { name: a.author.name })}</span>
+							{/if}
+						</div>
+						<span class="gal-play">{tFn('games.play')}</span>
+					</div>
+				</button>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.gal-overlay {
+		position: fixed; inset: 0; z-index: 9999;
+		background: #07070c;
+		display: flex; flex-direction: column; overflow: hidden;
+	}
+	.gal-bar {
+		flex-shrink: 0;
+		display: flex; align-items: center; justify-content: space-between;
+		padding: 12px 18px;
+		background: #0d0d14; border-bottom: 1px solid rgba(255,255,255,0.06);
+	}
+	.gal-head { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+	.gal-title { font-size: 15px; font-weight: 800; color: #e8ecf4; letter-spacing: .01em; }
+	.gal-sub { font-size: 11px; color: #6b7280; }
+	.gal-x {
+		flex: none; width: 30px; height: 30px; border-radius: 8px; cursor: pointer;
+		color: #cbd5e1; background: rgba(255,255,255,0.06);
+		border: 1px solid rgba(255,255,255,0.12); font-size: 13px; line-height: 1;
+	}
+	.gal-x:hover { background: rgba(255,255,255,0.12); }
+
+	.gal-grid {
+		flex: 1; overflow-y: auto; overflow-x: hidden;
+		display: grid; gap: 18px;
+		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+		padding: 22px;
+		align-content: start;
+	}
+
+	.gal-card {
+		display: flex; flex-direction: column; text-align: left;
+		background: #12121b; border: 1px solid rgba(255,255,255,0.07);
+		border-radius: 14px; overflow: hidden; cursor: pointer;
+		padding: 0; color: inherit; font: inherit;
+		transition: border-color .15s, transform .15s, box-shadow .15s;
+	}
+	.gal-card:hover, .gal-card:focus-visible {
+		border-color: rgba(115,204,140,0.5);
+		transform: translateY(-2px);
+		box-shadow: 0 10px 30px -12px rgba(0,0,0,0.7);
+		outline: none;
+	}
+
+	.gal-cover {
+		position: relative; aspect-ratio: 16 / 9; width: 100%;
+		background: #0b0b12; overflow: hidden;
+	}
+	.gal-cover img { width: 100%; height: 100%; object-fit: cover; display: block; }
+	.gal-cover-empty {
+		background: radial-gradient(120% 120% at 30% 20%, #1c2740, #0b0b12);
+		display: flex; align-items: center; justify-content: center;
+	}
+	.gal-cover-icon { width: 44% !important; height: auto !important; object-fit: contain !important; opacity: .85; }
+	.gal-badge {
+		position: absolute; top: 8px; left: 8px;
+		font-size: 9px; font-weight: 800; letter-spacing: .06em; text-transform: uppercase;
+		color: #cbd5e1; background: rgba(7,7,12,0.72);
+		border: 1px solid rgba(255,255,255,0.14); border-radius: 999px;
+		padding: 3px 8px; backdrop-filter: blur(3px);
+	}
+	.gal-dots { position: absolute; bottom: 8px; left: 50%; transform: translateX(-50%); display: flex; gap: 4px; }
+	.gal-dot { width: 5px; height: 5px; border-radius: 999px; background: rgba(255,255,255,0.3); }
+	.gal-dot.on { background: #73cc8c; }
+
+	.gal-body { display: flex; align-items: center; gap: 12px; padding: 12px 14px; }
+	.gal-icon { width: 38px; height: 38px; border-radius: 9px; flex: none; background: #0b0b12; object-fit: contain; }
+	.gal-txt { display: flex; flex-direction: column; gap: 2px; min-width: 0; flex: 1; }
+	.gal-name { font-size: 14px; font-weight: 700; color: #e8ecf4; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+	.gal-tag {
+		font-size: 11.5px; color: #8b93a3; line-height: 1.35;
+		display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+	}
+	.gal-by { font-size: 10px; color: #565e6d; margin-top: 1px; }
+	.gal-play {
+		flex: none; align-self: center;
+		font-size: 11px; font-weight: 800; letter-spacing: .03em;
+		color: #0b1f13; background: #73cc8c; border-radius: 999px; padding: 6px 14px;
+	}
+	.gal-card:hover .gal-play, .gal-card:focus-visible .gal-play { background: #8be0a4; }
+
+	.gal-empty {
+		flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center;
+		gap: 6px; text-align: center; padding: 40px;
+	}
+	.gal-empty-t { font-size: 15px; font-weight: 700; color: #cbd5e1; }
+	.gal-empty-h { font-size: 12px; color: #6b7280; max-width: 340px; }
+</style>

--- a/nodyx-frontend/src/lib/components/ActivitySurface.svelte
+++ b/nodyx-frontend/src/lib/components/ActivitySurface.svelte
@@ -294,6 +294,7 @@
 	<!-- Chrome dessiné par l'HÔTE : une activité ne peut ni l'imiter ni le
 	     masquer. Sans lui, un faux écran de connexion serait indiscernable. -->
 	<div class="act-bar">
+		<button class="act-back" onclick={onclose}>‹ {tFn('games.back_to_list')}</button>
 		<span class="act-marker" aria-label={tFn('activity.marker_aria', { name: label })}>
 			<span class="act-dot" aria-hidden="true"></span>
 			<span class="act-name">{label}</span>
@@ -333,10 +334,16 @@
 		padding: 0 10px;
 		background: #0d0d14; border-bottom: 1px solid rgba(255,255,255,0.06);
 	}
+	.act-back {
+		flex: none; padding: 4px 10px; font-size: 11px; font-weight: 700; cursor: pointer;
+		color: #9aa3b2; background: transparent; border: 0; border-radius: 6px;
+	}
+	.act-back:hover { color: #cbd5e1; background: rgba(255,255,255,0.06); }
 	.act-marker {
 		display: flex; align-items: center; gap: 8px;
 		font-size: 10px; letter-spacing: .04em; text-transform: uppercase;
 		color: var(--nx-text-muted, #6b7280); min-width: 0;
+		flex: 1; justify-content: center;
 	}
 	.act-dot { width: 5px; height: 5px; border-radius: 999px; background: #73cc8c; flex: none; }
 	.act-name { color: var(--nx-text, #cbd5e1); font-weight: 700; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/nodyx-frontend/src/lib/components/VoiceRoom.svelte
+++ b/nodyx-frontend/src/lib/components/VoiceRoom.svelte
@@ -4,6 +4,7 @@
 	import Table          from '$lib/components/Table.svelte';
 	import NodyxCanvas    from '$lib/components/NodyxCanvas.svelte';
 	import ActivitySurface from '$lib/components/ActivitySurface.svelte';
+	import ActivityGallery from '$lib/components/ActivityGallery.svelte';
 	import VoiceJukebox   from '$lib/components/VoiceJukebox.svelte';
 	import { localScreenStore, remoteScreenStore, screenShareStore } from '$lib/voice';
 	import { openStage, stageOpenStore } from '$lib/stageStore';
@@ -39,7 +40,11 @@
 		onjoinCurrentVoice: () => Promise<void>;
 	} = $props();
 
-	type ActivityEntry = { id: string; version: string; surfaceId: string; appUrl: string; label: string };
+	type ActivityEntry = {
+		id: string; version: string; surfaceId: string; appUrl: string; label: string;
+		tagline: string | null; description: string | null; icon: string | null;
+		screenshots: string[]; family: string; author: { name: string; url?: string } | null;
+	};
 
 	const localScreen      = $derived($localScreenStore);
 	const remoteScreens    = $derived($remoteScreenStore);
@@ -162,11 +167,10 @@
 	const connected = $derived(voiceState.active && voiceState.channelId === selectedChannel.id);
 	const peerCount = $derived(connected ? voiceState.peers.length + 1 : 0);
 
-	// ── Activité (jeu dans le canal vocal) ───────────────────────────────────
-	// v1 : on ouvre la première activité installée. Un sélecteur viendra si
-	// plusieurs sont installées.
-	let showActivity = $state(false);
-	const activity = $derived(activities[0] ?? null);
+	// ── Activités (jeux dans le canal vocal) ─────────────────────────────────
+	// Le bouton « Jeux » ouvre la galerie ; on y choisit le jeu à lancer.
+	let showGames = $state(false);
+	let selectedActivity = $state<ActivityEntry | null>(null);
 	// Le roster de l'activité = les membres du canal vocal, avec leur siège.
 	// L'arbitre (host) est déterministe côté activité : le plus petit seatIndex.
 	const activityMembers = $derived(
@@ -179,7 +183,7 @@
 			]
 			: [],
 	);
-	$effect(() => { if (!connected) showActivity = false; });
+	$effect(() => { if (!connected) { showGames = false; selectedActivity = null; } });
 
 	// ⚠ Ne JAMAIS réassigner srcObject sans avoir vérifié qu'il change vraiment.
 	// Assigner srcObject déclenche l'algorithme de chargement du média MÊME quand on
@@ -323,16 +327,16 @@
 		<span>Fichiers</span>
 	</button>
 
-	<!-- Jeux (activité) -->
+	<!-- Jeux (galerie d'activités) -->
 	<button
-		onclick={() => { if (activity && connected) showActivity = !showActivity; }}
-		disabled={!activity || !connected}
-		class="toolbar-btn {showActivity ? 'active-emerald' : ''} {!activity || !connected ? 'opacity-35' : ''}"
-		title={!activity
+		onclick={() => { if (activities.length && connected) showGames = true; }}
+		disabled={!activities.length || !connected}
+		class="toolbar-btn {showGames ? 'active-emerald' : ''} {!activities.length || !connected ? 'opacity-35' : ''}"
+		title={!activities.length
 			? tFn('voice_room.games_none')
 			: !connected ? tFn('voice_room.games_join_first') : tFn('voice_room.games')}
 	>
-		{#if showActivity}
+		{#if showGames}
 			<span class="relative flex w-1.5 h-1.5 shrink-0">
 				<span class="absolute inline-flex h-full w-full rounded-full bg-emerald-400/60 animate-ping"></span>
 				<span class="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-400"></span>
@@ -533,14 +537,21 @@
 	/>
 {/if}
 
-<!-- ── Activité (jeu) overlay ──────────────────────────────────────────────── -->
-{#if showActivity && activity && connected && voiceState.channelId}
+<!-- ── Jeux : galerie puis activité, en overlay plein écran ─────────────────── -->
+{#if showGames && connected && !selectedActivity}
+	<ActivityGallery
+		activities={activities}
+		onselect={(a) => selectedActivity = a}
+		onclose={() => showGames = false}
+	/>
+{/if}
+{#if showGames && selectedActivity && connected && voiceState.channelId}
 	<ActivitySurface
-		activityId={activity.id}
-		surfaceId={activity.surfaceId}
-		version={activity.version}
-		appUrl={activity.appUrl}
-		label={activity.label}
+		activityId={selectedActivity.id}
+		surfaceId={selectedActivity.surfaceId}
+		version={selectedActivity.version}
+		appUrl={selectedActivity.appUrl}
+		label={selectedActivity.label}
 		channelId={voiceState.channelId}
 		socket={socket}
 		{token}
@@ -549,7 +560,7 @@
 		userAvatar={myAvatar}
 		members={activityMembers}
 		locale={$locale}
-		onclose={() => showActivity = false}
+		onclose={() => selectedActivity = null}
 	/>
 {/if}
 

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -4572,5 +4572,19 @@
   "nav.bar_directory": "Explore",
   "nav.bar_profile": "Profile",
   "calendar.page_title": "Calendar",
-  "ucard.meta_description": "Profile of {{name}} on Nodyx, level {{level}}, {{posts}} posts, {{xp}} XP"
+  "ucard.meta_description": "Profile of {{name}} on Nodyx, level {{level}}, {{posts}} posts, {{xp}} XP",
+  "games.gallery_title": "Games",
+  "games.gallery_subtitle": "Pick a game to launch in the voice room",
+  "games.play": "Play",
+  "games.close": "Close",
+  "games.none": "No games installed",
+  "games.none_hint": "An admin can install some from the extensions.",
+  "games.by": "by {{name}}",
+  "games.back_to_list": "Games",
+  "games.family.gaming": "Game",
+  "games.family.media": "Media",
+  "games.family.community": "Community",
+  "games.family.esport": "Esport",
+  "games.family.social": "Social",
+  "games.family.content": "Content"
 }

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -4572,5 +4572,19 @@
   "nav.bar_directory": "Réseau",
   "nav.bar_profile": "Profil",
   "calendar.page_title": "Calendrier",
-  "ucard.meta_description": "Profil de {{name}} sur Nodyx, niveau {{level}}, {{posts}} messages, {{xp}} XP"
+  "ucard.meta_description": "Profil de {{name}} sur Nodyx, niveau {{level}}, {{posts}} messages, {{xp}} XP",
+  "games.gallery_title": "Jeux",
+  "games.gallery_subtitle": "Choisis un jeu à lancer dans le salon vocal",
+  "games.play": "Jouer",
+  "games.close": "Fermer",
+  "games.none": "Aucun jeu installé",
+  "games.none_hint": "Un administrateur peut en installer depuis les extensions.",
+  "games.by": "par {{name}}",
+  "games.back_to_list": "Jeux",
+  "games.family.gaming": "Jeu",
+  "games.family.media": "Média",
+  "games.family.community": "Communauté",
+  "games.family.esport": "Esport",
+  "games.family.social": "Social",
+  "games.family.content": "Contenu"
 }

--- a/nodyx-frontend/src/lib/locales/pt-BR.json
+++ b/nodyx-frontend/src/lib/locales/pt-BR.json
@@ -4572,5 +4572,19 @@
   "translate.contributors.view_pr": "Ver o pull request #{{n}}",
   "translate.contributors.view_commit": "Ver o commit",
   "translate.contributors.close": "Fechar",
-  "translate.newlang.horizon": "O Nodyx ainda não chegou a esse horizonte."
+  "translate.newlang.horizon": "O Nodyx ainda não chegou a esse horizonte.",
+  "games.gallery_title": "Jogos",
+  "games.gallery_subtitle": "Escolha um jogo para iniciar na sala de voz",
+  "games.play": "Jogar",
+  "games.close": "Fechar",
+  "games.none": "Nenhum jogo instalado",
+  "games.none_hint": "Um administrador pode instalar alguns nas extensões.",
+  "games.by": "por {{name}}",
+  "games.back_to_list": "Jogos",
+  "games.family.gaming": "Jogo",
+  "games.family.media": "Mídia",
+  "games.family.community": "Comunidade",
+  "games.family.esport": "Esport",
+  "games.family.social": "Social",
+  "games.family.content": "Conteúdo"
 }

--- a/nodyx-frontend/src/routes/chat/+page.server.ts
+++ b/nodyx-frontend/src/routes/chat/+page.server.ts
@@ -19,7 +19,19 @@ export const load: PageServerLoad = async ({ fetch, cookies }) => {
 	const activities = extensions.flatMap((e: any) =>
 		(e.surfaces ?? [])
 			.filter((s: any) => s.type === 'activity' && s.appUrl)
-			.map((s: any) => ({ id: e.id, version: e.version, surfaceId: s.id, appUrl: s.appUrl, label: s.label })),
+			.map((s: any) => ({
+				id: e.id,
+				version: e.version,
+				surfaceId: s.id,
+				appUrl: s.appUrl,
+				label: s.label ?? e.label,
+				tagline: e.tagline ?? null,
+				description: s.description ?? e.description ?? null,
+				icon: e.icon ?? null,
+				screenshots: e.screenshots ?? [],
+				family: e.family ?? 'gaming',
+				author: e.author ?? null,
+			})),
 	);
 
 	return { channels, token, activities };


### PR DESCRIPTION
Le bouton **Jeux** d'un canal vocal lançait directement la 1re activité installée (`activity = activities[0]`). Un 2e jeu arrive → il faut une page de sélection.

## Core (SANCTUAIRE, forward-only, aucune migration)
- `manifest.ts` : `tagline` (accroche courte, clé de message) + `screenshots` (≤6 chemins de paquet, sûrs). `collectMessageKeys` prend `tagline`.
- `/extensions/public` expose `tagline` (traduit), `screenshots` (URLs résolues vers la route `assets/*` existante), `author`, `source`. Les `.png/.jpg/.webp` sont déjà autorisés dans le `.nyx` et servis par la route assets — rien d'autre à faire.

## Frontend
- **`ActivityGallery.svelte`** *(nouveau)* : overlay plein écran, grille de cartes — couverture 16:9 (carrousel des captures au survol), pastille d'icône, nom, accroche, badge de catégorie, bouton **Jouer**.
- `VoiceRoom` : `showGames` + `selectedActivity`. Jeux → galerie → jeu. « Quitter » / « ‹ Jeux » reviennent à la galerie. Quitter la voix ferme tout.
- `ActivitySurface` : lien retour dans la barre.
- i18n `games.*` dans fr / en / **pt-BR** (parité).

## Tests
- core **971** (nouveaux : `screenshots` accepté / chemin non sûr rejeté / cap 6 ; `tagline` collecté ; `/extensions/public` résout captures + tagline, pas de chemin brut)
- svelte-check 0 erreur, build OK, **5 portes i18n vertes**

## Suite (hors PR)
King's Race gagne `screenshots` + `tagline` (release à part). Puis extraction d'un pont Godot partagé pour le 2e jeu.