### PR TITLE
chore(deps): fastify 5.12.1 + trustProxy sans compteur de hops (corrige l'alerte #224)

### DIFF
--- a/nodyx-core/package-lock.json
+++ b/nodyx-core/package-lock.json
@@ -18,7 +18,7 @@
         "argon2": "0.44.0",
         "bcrypt": "6.0.0",
         "dotenv": "17.4.2",
-        "fastify": "^5.9.0",
+        "fastify": "^5.12.1",
         "ioredis": "5.11.1",
         "jsonwebtoken": "9.0.3",
         "music-metadata": "^11.13.0",
@@ -2578,9 +2578,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.9.0.tgz",
-      "integrity": "sha512-VMS5lE0zj+MZlJpQa3Qv5iGjfun0H2N7VRgoBwpcTNQ2bdIQpv7fDpb+HGteGbicBsGkzGS+X+hdx9mmrfWuHQ==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.12.1.tgz",
+      "integrity": "sha512-FWi+tQvwxR/PeRX7Z2mhfEF5ozJ3jn9asiiclzKXNSzJRHAYcU924aIOKAdHFJ+YIKieh3cqr1IwCOvTr41B3Q==",
       "funding": [
         {
           "type": "github",
@@ -2599,11 +2599,11 @@
         "@fastify/proxy-addr": "^5.0.0",
         "abstract-logging": "^2.0.1",
         "avvio": "^9.0.0",
-        "fast-json-stringify": "^6.0.0",
+        "fast-json-stringify": "^7.0.0",
         "find-my-way": "^9.6.0",
         "light-my-request": "^6.0.0",
         "pino": "^9.14.0 || ^10.1.0",
-        "process-warning": "^5.0.0",
+        "process-warning": "^5.1.0",
         "rfdc": "^1.3.1",
         "secure-json-parse": "^4.0.0",
         "semver": "^7.6.0",
@@ -2625,6 +2625,46 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/fastify/node_modules/fast-json-stringify": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+      "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^4.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fastify/node_modules/fast-uri": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -4077,9 +4117,9 @@
       }
     },
     "node_modules/process-warning": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
       "funding": [
         {
           "type": "github",

--- a/nodyx-core/package.json
+++ b/nodyx-core/package.json
@@ -31,7 +31,7 @@
     "argon2": "0.44.0",
     "bcrypt": "6.0.0",
     "dotenv": "17.4.2",
-    "fastify": "^5.9.0",
+    "fastify": "^5.12.1",
     "ioredis": "5.11.1",
     "jsonwebtoken": "9.0.3",
     "music-metadata": "^11.13.0",

--- a/nodyx-core/src/config/trustedProxies.ts
+++ b/nodyx-core/src/config/trustedProxies.ts
@@ -46,19 +46,32 @@ const LOCAL_RANGES = ['loopback', 'linklocal', 'uniquelocal']
  *
  * Réglages d'échappatoire, pour les topologies non prévues (autre CDN, proxy
  * maison en frontal) :
- *   - TRUST_PROXY            : override COMPLET. 'true'/'false', un nombre de
- *                              hops, ou une liste d'IP/CIDR séparée par virgules.
+ *   - TRUST_PROXY            : override COMPLET. 'true'/'false', ou une liste
+ *                              d'IP/CIDR séparée par virgules.
  *   - TRUSTED_PROXIES_EXTRA  : CIDR supplémentaires à AJOUTER à la liste par
  *                              défaut (ex: l'IP d'un reverse proxy en amont).
+ *
+ * Le mode « nombre de hops » (`TRUST_PROXY=2`) n'est plus accepté : fastify
+ * 5.12.1 l'a retiré (GHSA — usurpation des en-têtes X-Forwarded-*). Un compteur
+ * de hops ne valide pas l'adresse du pair immédiat, donc un client direct peut
+ * pré-écrire de fausses lignes. On ignore toute valeur purement numérique, avec
+ * un avertissement, plutôt que de laisser proxy-addr lever au démarrage.
  */
-export function getTrustProxy(): boolean | number | string[] {
+export function getTrustProxy(): boolean | string[] {
   const override = process.env.TRUST_PROXY?.trim()
   if (override) {
     if (override === 'true')  return true
     if (override === 'false') return false
-    const n = Number(override)
-    if (Number.isInteger(n) && n >= 0) return n
-    return override.split(',').map((s) => s.trim()).filter(Boolean)
+    const list = override.split(',').map((s) => s.trim()).filter(Boolean)
+    const numeric = list.filter((s) => /^\d+$/.test(s))
+    if (numeric.length) {
+      console.warn(
+        `[trustProxy] valeur numérique ignorée (${numeric.join(', ')}) : `
+        + 'le mode compteur de hops a été retiré par fastify. '
+        + 'Utilisez une liste IP/CIDR.',
+      )
+    }
+    return list.filter((s) => !/^\d+$/.test(s))
   }
 
   const extra = (process.env.TRUSTED_PROXIES_EXTRA ?? '')

--- a/nodyx-core/src/tests/trusted-proxies.test.ts
+++ b/nodyx-core/src/tests/trusted-proxies.test.ts
@@ -76,9 +76,11 @@ describe('getTrustProxy — réglages d\'échappatoire', () => {
     delete process.env.TRUST_PROXY
   })
 
-  it('TRUST_PROXY=2 est interprété comme un nombre de hops', () => {
+  it('TRUST_PROXY=2 (compteur de hops) est ignoré : fastify a retiré ce mode', () => {
     process.env.TRUST_PROXY = '2'
-    expect(getTrustProxy()).toBe(2)
+    // Plus de nombre : une valeur purement numérique est écartée (over-restrictif,
+    // jamais une faille) au lieu d'usurpable via X-Forwarded-*.
+    expect(getTrustProxy()).toEqual([])
     delete process.env.TRUST_PROXY
   })
 


### PR DESCRIPTION
## Pourquoi

L'alerte Dependabot **#224** (`fastify` — usurpation `X-Forwarded-*` sous `trustProxy` en compteur de hops, *medium*) n'était corrigeable ni par **#661** ni par **#655** : leur CI `nodyx-core` tombe.

`fastify` 5.12.1 **retire** le mode « nombre de hops » de `trustProxy` (un compteur de hops ne valide pas l'adresse du pair immédiat → un client direct peut pré-écrire de fausses lignes `X-Forwarded-*`). Le type n'accepte donc plus `number`, et `src/index.ts:71` passe `getTrustProxy()` qui pouvait en renvoyer un. Les 3 erreurs TS de #661/#655 découlent toutes de là.

## Ce que fait cette PR

- `fastify` `^5.9.0` → `^5.12.1` (rebasé sur `main` après le merge de #659, d'où pas de conflit de lockfile comme #661).
- `getTrustProxy()` : retour `boolean | string[]` (plus de `number`). La branche `TRUST_PROXY=<n>` est supprimée ; une valeur purement numérique est **ignorée avec un `console.warn`** plutôt que de faire lever `proxy-addr` au démarrage.
- Test `TRUST_PROXY=2` adapté : le mode hops est ignoré (`[]`, over-restrictif, jamais une faille).

## Impact production : nul

Le défaut prod (`[...LOCAL_RANGES, ...CLOUDFLARE_RANGES]`) est déjà une `string[]` — la méthode recommandée par l'avis. Aucune instance n'utilise `TRUST_PROXY=<n>`.

## Vérifs

- `npx tsc --noEmit` : clean
- `npm test` : **971/971**
- `npm ci` reproductible (lockfile synchro)

## Remplace

Ferme **#661** et couvre le volet `fastify` de **#655** (à rebaser derrière).

## À part (pas dans cette PR)

`npm audit` signale encore `fast-uri` 3.1.5 (*high*, SSRF/host-confusion) via un **autre** chemin (`ajv`, pas `fastify` — 5.12.1 embarque `fast-uri@4.1.4` corrigé). Non listé dans les alertes Dependabot. Mérite sa propre PR.
