### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,10 @@ cd /var/www/nexus && git pull && \
 
 Database migrations are applied automatically on startup, no manual SQL needed.
 
+## ☁️ One-Click Deploy
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Nodyx/)
+
 ---
 
 ## Architecture


### PR DESCRIPTION
Adds a RepoCloud one-click deploy button to the README, as a new "One-Click Deploy" section after Quick Start.

 - Added `## ☁️ One-Click Deploy` section between Quick Start and Architecture
 - Button links to https://repocloud.io/details/Nodyx/