### PR TITLE
test(auth): assertion stricte sur l'IP capturée dans last_seen_ip

### DIFF
--- a/nodyx-core/src/tests/auth.test.ts
+++ b/nodyx-core/src/tests/auth.test.ts
@@ -285,7 +285,7 @@ describe('POST /api/v1/auth/login', () => {
     expect(JSON.parse(res.body)).toHaveProperty('requires_signet', true)
     const ipUpdate = vi.mocked(db.query).mock.calls.find(c => String(c[0]).includes('SET last_seen_ip'))
     expect(ipUpdate).toBeDefined()
-    expect(ipUpdate?.[1]).toEqual(expect.arrayContaining([FAKE_USER.id]))
+    expect(ipUpdate?.[1]).toEqual(['31.215.70.26', FAKE_USER.id])
   })
 
   it('pose last_seen_ip même quand le login s’arrête sur requires_totp', async () => {
@@ -310,7 +310,7 @@ describe('POST /api/v1/auth/login', () => {
     expect(JSON.parse(res.body)).toHaveProperty('requires_totp', true)
     const ipUpdate = vi.mocked(db.query).mock.calls.find(c => String(c[0]).includes('SET last_seen_ip'))
     expect(ipUpdate).toBeDefined()
-    expect(ipUpdate?.[1]).toEqual(expect.arrayContaining([FAKE_USER.id]))
+    expect(ipUpdate?.[1]).toEqual(['31.215.70.26', FAKE_USER.id])
   })
 })
 


### PR DESCRIPTION
Suite à l'auto-relecture demandée après le déploiement de #660 : les 2 tests de régression sur `last_seen_ip` (ajoutés dans d0d3c0f) vérifiaient seulement que l'id utilisateur apparaissait dans les paramètres de la requête (`arrayContaining`), pas que l'adresse IP capturée était la bonne. Un bug qui enverrait une IP vide ou erronée serait passé inaperçu. Assertion resserrée sur le tableau de paramètres exact.

Tests only, aucun changement de comportement. 986 nodyx-core tests verts.