### PR TITLE
fix(admin): GET /bans servait l'email des membres bannis en clair

### DIFF
--- a/nodyx-core/src/routes/admin.ts
+++ b/nodyx-core/src/routes/admin.ts
@@ -454,7 +454,15 @@ export default async function adminRoutes(app: FastifyInstance) {
        ORDER BY cb.banned_at DESC`,
       [communityId]
     )
-    return reply.send(rows)
+    // Même règle que GET /members (#540) : l'adresse part masquée, le geste
+    // de la révéler passe par GET /members/:userId/email et laisse une trace
+    // d'audit. Cette route servait l'adresse en clair, angle mort du fix #540
+    // qui n'avait couvert que le tableau de bord et la liste des membres.
+    const bans = (rows as Array<Record<string, unknown>>).map((b) => ({
+      ...b,
+      email: maskEmail(b.email as string | null),
+    }))
+    return reply.send(bans)
   })
 
   // POST /api/v1/admin/members/:userId/ban — ban member (kick + blacklist)

--- a/nodyx-core/src/tests/admin.test.ts
+++ b/nodyx-core/src/tests/admin.test.ts
@@ -175,6 +175,58 @@ describe('GET /api/v1/admin/members', () => {
   })
 })
 
+// ── Tests — GET /admin/bans ────────────────────────────────────
+//
+// Trouvé en audit de stabilité (2026-09-11) : cette route servait l'email des
+// membres bannis en clair, angle mort du fix #540 (qui n'avait couvert que le
+// tableau de bord et GET /members). Même règle ici : masqué par défaut.
+
+describe('GET /api/v1/admin/bans', () => {
+  let app: Awaited<ReturnType<typeof buildApp>>
+
+  beforeEach(async () => {
+    vi.resetAllMocks()
+    app = await buildApp(a => a.register(adminRoutes, { prefix: '/api/v1/admin' }))
+  })
+
+  it('returns 401 without auth', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/admin/bans' })
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('renvoie l’email masqué, jamais en clair', async () => {
+    const fakeBan = {
+      user_id:             USER_UUID,
+      username:            'nerti',
+      email:               'jonathan.dupont@gmail.com',
+      avatar:              null,
+      reason:              'spam',
+      banned_at:           new Date(),
+      banned_by_username:  'Pokled',
+    }
+    vi.mocked(db.query).mockImplementation(async (sql: string) => {
+      if (typeof sql === 'string' && sql.includes('SELECT id FROM communities')) {
+        return { rows: [{ id: COMMUNITY_UUID }], rowCount: 1 } as any
+      }
+      return { rows: [fakeBan], rowCount: 1 } as any
+    })
+
+    const res = await app.inject({
+      method:  'GET',
+      url:     '/api/v1/admin/bans',
+      headers: { Authorization: `Bearer ${makeAdminToken()}` },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(Array.isArray(body)).toBe(true)
+    expect(body[0].username).toBe('nerti')
+    expect(body[0].email).not.toBe('jonathan.dupont@gmail.com')
+    expect(body[0].email).not.toContain('dupont')
+    expect(body[0].email).toMatch(/^j•+@g•+\.com$/)
+  })
+})
+
 // ── Tests — PATCH /admin/members/:userId ─────────────────────
 
 describe('PATCH /api/v1/admin/members/:userId', () => {

--- a/nodyx-frontend/src/routes/admin/members/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/members/+page.svelte
@@ -293,7 +293,19 @@
 										</div>
 										<div>
 											<p class="font-medium text-gray-300">{ban.username}</p>
-											<p class="text-xs text-gray-600">{ban.email}</p>
+											<!-- Même masquage par défaut que la liste des membres (#540) :
+											     ce panneau s'ouvre parfois en direct/partage d'écran. -->
+											<div class="text-xs text-gray-600 flex items-center gap-1.5">
+												<span>{revealed[ban.user_id] ?? ban.email}</span>
+												{#if !revealed[ban.user_id]}
+													<button
+														type="button"
+														class="text-[10px] text-gray-500 hover:text-gray-300 underline underline-offset-2"
+														onclick={() => revealEmail(ban.user_id)}
+														disabled={revealing[ban.user_id]}
+													>{revealing[ban.user_id] ? tFn('amem.revealing') : tFn('amem.reveal_email')}</button>
+												{/if}
+											</div>
 										</div>
 									</div>
 								</td>


### PR DESCRIPTION
Trouvé en audit de stabilité (F-036, 11/09/2026), triple vérifié avant correction.

Le fix #540 (14/08) a masqué les emails du tableau de bord et de `GET /members`, mais n'a jamais couvert `GET /bans` : cette route renvoyait `u.email` tel quel. Vérifié dans tout l'historique git (aucun commit ne touche `maskEmail` près de cette route) et sur le fichier actuellement en prod. Même exposition que l'incident qui avait fait arrêter un stream (#540), sur un écran différent du même panneau admin.

Corrigé à l'identique du pattern #540 : email masqué par défaut, révélé par le bouton et la route déjà audités (`GET /members/:userId/email`).

Test ajouté, prouvé rouge sur l'ancien code puis vert. 988 tests core (+2), 150 frontend, svelte-check 0 erreur.