### PR TITLE
docs: rattraper le CHANGELOG et le README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,83 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versio
 
 ## [Unreleased]
 
+Un mois de travail depuis la 2.12.0, sur plusieurs chantiers en parallèle. Résumé par thème,
+pas par commit : le détail de chacun reste dans son historique git et ses PR.
+
+### SDK d'extensions et place de marché (extensions.nodyx.org)
+
+Nodyx peut désormais être étendu par des tiers, sans toucher au cœur : un SDK complet, pensé
+sécurité d'abord (P0-A, P0-B). Une extension tourne dans une surface isolée, parle à l'hôte par
+un pont défini, stocke ses données dans un espace clé/valeur cloisonné par extension, ne voit
+qu'une identité projetée (jamais les vrais comptes), et sort vers le réseau par un proxy qui
+épingle l'adresse cible (protection anti SSRF). Un écran de permissions donne à l'admin le
+contrôle de ce qu'une extension peut faire. La première vraie extension (`next-event`) sert de
+preuve, tenue par des tests. `extensions.nodyx.org` héberge la vitrine, le registre et l'index :
+une extension s'installe depuis là, avec un premier paquet réel, téléchargeable et vérifiable.
+Les surfaces d'extension s'affichent sur la page d'accueil et entrent dans le Homepage Builder.
+
+### Activités communautaires dans les salons vocaux
+
+Un salon vocal peut désormais héberger une activité, un jeu joué à plusieurs pendant qu'on parle,
+sur le modèle des extensions : bundle applicatif livré par l'instance, relais temps réel dédié
+(`activity:*`), identité et avatars Nodyx résolus côté hôte pour l'activité. Une galerie façon
+Play Store remplace le lancement direct, le jeu se docke dans le salon avec un bouton plein
+écran, et la surface activity sert aussi de stockage applicatif (scores, état de partie).
+
+### Durcissement de la vitrine publique et des catégories d'annonce
+
+Suite à l'incident du 1er septembre (un compte `member` standard qui fait remonter du spam en
+page d'accueil et dans l'annuaire fédéré, sans aucune faille d'authentification) : les catégories
+peuvent désormais être restreintes par rôle (`post_min_role`), la vitrine publique et l'annuaire
+ne reprennent plus que les fils explicitement mis en avant par un admin, et le bannissement d'IP
+dit désormais la vérité (`ip_ban_applied`) au lieu d'un succès générique quand aucune adresse
+publique n'est connue pour le compte. CDC complet dans `SPECS/NODYX_DURCISSEMENT_VITRINE_CDC.md`.
+
+### Traduction et communauté
+
+Le portugais brésilien a atteint la parité complète (4567 clés), première locale communautaire à
+y arriver. La page `/translate` met en avant tous les contributeurs, pas seulement les
+traducteurs, avec un fond photo réel par langue en rotation façon guide touristique et un
+sélecteur de langue enfin traduit lui-même. Une cinquième porte i18n couvre désormais les
+fichiers `.ts`, angle mort des quatre portes précédentes. Fusionner une traduction déploie
+maintenant automatiquement (avant, une traduction mergée pouvait rester invisible plusieurs jours).
+
+### Réseau et sécurité du relais
+
+Le relais écoute en double pile et journalise l'adresse réelle du client derrière le proxy
+inverse. Une seconde porte WebSocket sur le port 443 permet de joindre le relais quand un réseau
+institutionnel ne laisse sortir que ce port (le cas du 7443 restait fermé pour certains). Modèle
+unifié des événements et décisions de sécurité, collecteur CrowdSec vers PostgreSQL, journal
+d'accès à ligne unique exploitable par GoAccess et CrowdSec : de quoi voir venir plutôt que
+découvrir après coup.
+
+### Corrigé
+
+- **`GET /admin/bans` renvoyait l'email des membres bannis en clair.** Le correctif d'août qui
+  avait masqué le tableau de bord et la liste des membres n'avait jamais couvert cette route.
+  Corrigé au même pattern : masqué par défaut, révélé par un geste tracé.
+- Identification du visiteur réel derrière le tunnel Cloudflare restaurée (les journaux
+  enregistraient l'adresse du proxy, pas celle du visiteur).
+- Éditeur : une vidéo insérée perdait sa mise en forme, un article se disloquait à la réouverture,
+  le sommaire ouvrait un onglet vide au lieu de descendre à l'ancre.
+  Alignement « dans le texte » ajouté pour les images.
+  N'importe qui pouvait réserver un sous-domaine d'infrastructure via l'annuaire fédéré.
+- Salon vocal : la fenêtre des réglages audio débordait de l'écran, sa croix de fermeture était
+  recouverte ou partait avec le défilement selon les cas. Le chat d'un salon vocal envahissait
+  l'écran sur téléphone.
+- Responsive : tableaux d'administration passés en cartes sous les petits écrans (14 tableaux),
+  page d'édition de profil, sidebar mobile qui mangeait 224 des 390 pixels disponibles.
+
+### Exploration (pas encore une décision)
+
+Spike de la Phase A du moteur média Rust natif (`str0m`), pour lever le verrou "zéro port ouvert"
+qui touche encore le SFU vocal (mediasoup est ICE-Lite, un auto-hébergeur derrière une box doit
+aujourd'hui ouvrir un port pour les salons qui dépassent le mesh). Code écrit et vérifié
+(`nodyx-p2p/crates/nodyx-sfu-str0m`) : un client STUN testé contre l'infrastructure réelle, un
+moteur qui implémente le contrat existant sans réécrire le métier. Le verdict du perçage NAT
+attend encore un test sur une vraie box résidentielle. Détail dans
+`SPECS/NODYX_MEDIA_ENGINE_RUST.md`.
+
 ---
 
 ## [2.12.0] — 2026-08-10

--- a/README.md
+++ b/README.md
@@ -194,7 +194,10 @@ Indexed forum with canonical URLs, JSON-LD and a sitemap · real-time chat with 
 A collaborative P2P canvas for whiteboarding in real time · WebRTC DataChannels carrying typing indicators and reactions peer-to-peer · a rich article editor with a table of contents, image resize handles, protected code blocks and two-column layouts, all safe through the sanitizer on the way back out.
 
 **Own your front door**
-A drag-and-drop **Homepage Builder**, rows and columns on a 12-unit grid · a **Widget Store** for installing external widgets from a `.zip`, no rebuild · a **Widget SDK** for building your own, plain JavaScript, no framework required.
+A drag-and-drop **Homepage Builder**, rows and columns on a 12-unit grid · an **Extension SDK** with a real security substrate (sandboxed identity, cloistered storage, a network proxy that pins the destination address), install from [extensions.nodyx.org](https://extensions.nodyx.org) in one click, no rebuild.
+
+**Play together, without leaving the call**
+Games and activities dock right inside a voice channel while you talk, a Play Store style gallery to pick one, full screen when you want it, the same extension surface as the marketplace above.
 
 **Run it from a spare laptop**
 Home server support with no port forwarding and no domain required · a federated community directory with cross-instance search · a collaborative jukebox, an event calendar with maps and RSVP, an asset library for frames, badges and banners, passwordless login via ECDSA P-256.
@@ -209,7 +212,7 @@ A native **Streamer Hub**: Soundboard with ID3 tags and a viewer queue, a `!ns` 
 
 ## Homepage Builder + Widget SDK
 
-Nodyx ships with a **drag-and-drop Homepage Builder** (rows split into resizable columns on a 12-unit grid, 9 native widgets, per-widget audience rules, draft/publish) and a complete **Widget SDK**, plain JavaScript Custom Elements, no React, no Vue, no npm required. Any developer can package a widget as a `.zip` and install it on any Nodyx instance in one click, no rebuild, no deploy. Two features that no other self-hosted community platform offers together.
+Nodyx ships with a **drag-and-drop Homepage Builder** (rows split into resizable columns on a 12-unit grid, 9 native widgets, per-widget audience rules, draft/publish) and a complete **Extension SDK**, plain JavaScript Custom Elements, no React, no Vue, no npm required. Any developer can package an extension as a `.zip` and install it on any Nodyx instance in one click, no rebuild, no deploy. An extension runs sandboxed: a projected identity instead of real accounts, storage cloistered per extension, network egress through a proxy that pins the target address. **[extensions.nodyx.org](https://extensions.nodyx.org)** hosts the marketplace, the registry and the index, games playable inside a voice channel included.
 
 → **[Homepage Builder, full guide](docs/en/HOMEPAGE-BUILDER.md)**, layout zones, native widgets, the Widget Store
 → **[Build your first widget](https://nodyx.dev/create-widget)**, step-by-step SDK guide for non-developers
@@ -478,7 +481,7 @@ Each Nodyx instance runs a **Gossip Protocol** scheduler that periodically pings
 
 ## What's built. What's coming.
 
-Nodyx has shipped 12 major releases since February 2026: the forum, chat and voice foundation, a full paranoid security audit (Argon2id, honeypots, fail2ban, 2FA), private E2E-encrypted DMs, a Homepage Builder with a Widget SDK, a native Streamer Hub, a verified backup system with one-click restore, OctoGuard native auto-moderation, and now an experimental Rust SFU carrying voice and screen sharing through your own server.
+Nodyx has shipped 12 major releases since February 2026: the forum, chat and voice foundation, a full paranoid security audit (Argon2id, honeypots, fail2ban, 2FA), private E2E-encrypted DMs, a Homepage Builder with an Extension SDK and its own marketplace, games that dock inside a voice channel, a native Streamer Hub, a verified backup system with one-click restore, OctoGuard native auto-moderation, and now an experimental Rust SFU carrying voice and screen sharing through your own server.
 
 → **[Full changelog, every version in detail](CHANGELOG.md)**
 → **[Roadmap, where we're going](docs/en/ROADMAP.md)**


### PR DESCRIPTION
Unreleased était vide depuis le 10/08 alors que six chantiers ont avancé en parallèle : SDK d'extensions + marketplace (extensions.nodyx.org), activités communautaires dans les salons vocaux, durcissement de la vitrine publique (#660), pt-BR à parité complète + refonte /translate, cinquième porte i18n pour les fichiers .ts, relais réseau (porte WebSocket 443) et modèle unifié des événements de sécurité. Regroupé par thème, pas par commit.

README : la section Homepage Builder + Widget SDK ne mentionnait pas extensions.nodyx.org ni le substrat de sécurité (identité projetée, stockage cloisonné, proxy réseau qui épingle l'adresse). Ajouté aussi les activités (jeux dockés dans un salon vocal) comme catégorie à part entière.