### PR TITLE
fix(core): pullBlocklist ignorait le choix de non-fédération

### DIFF
--- a/nodyx-core/src/scheduler.ts
+++ b/nodyx-core/src/scheduler.ts
@@ -7,6 +7,7 @@
 import { db, redis } from './config/database'
 import { Server } from 'socket.io'
 import { NODYX_VERSION } from './utils/version'
+import * as NotificationModel from './models/notification'
 
 const PING_INTERVAL_MS         = 5  * 60 * 1000        // 5 minutes
 const ASSET_PUSH_INTERVAL_MS   = 60 * 60 * 1000        // 1 heure
@@ -325,8 +326,17 @@ async function gossipToPeers(payload: {
 }
 
 // ── Pull blocklist distribuée ─────────────────────────────────────────────────
+//
+// Seule tâche fédérée à ne PAS avoir eu ce garde (trouvé en audit de
+// stabilité, F-039, 2026-09-11) : une instance qui a explicitement choisi de
+// ne pas fédérer (pas de DIRECTORY_TOKEN dans .env) appelait quand même
+// nodyx.org toutes les 30 min via le repli par défaut de DIRECTORY_API_URL.
+// Même garde que pingDirectory/pushAssetsToDirectory/announceThreadsToDirectory.
 
-async function pullBlocklist() {
+export async function pullBlocklist() {
+  const token = process.env.DIRECTORY_TOKEN
+  if (!token) return
+
   const directoryUrl = (process.env.DIRECTORY_API_URL ?? 'https://nodyx.org').replace(/\/$/, '')
   try {
     const res = await fetch(`${directoryUrl}/api/directory/blocklist`, {
@@ -396,10 +406,14 @@ async function purgeInactivePushSubscriptions() {
 
 async function purgeOldNotifications() {
   try {
-    const { rowCount } = await db.query(
-      `DELETE FROM notifications WHERE is_read = true AND created_at < NOW() - INTERVAL '30 days'`
-    )
-    if (rowCount && rowCount > 0) {
+    // Même requête que `NotificationModel.purgeOldRead()`, qui existait déjà
+    // mais n'avait aucun appelant (trouvé en audit de stabilité, F-050,
+    // 2026-09-11 : le grep sur le nom de la fonction concluait à tort que la
+    // purge n'avait jamais lieu du tout, sans voir cette copie inline
+    // équivalente déjà planifiée ici depuis le début). Consolidé sur une
+    // seule implémentation plutôt que deux DELETE identiques à maintenir.
+    const rowCount = await NotificationModel.purgeOldRead(30)
+    if (rowCount > 0) {
       console.log(`[Scheduler] Notifications — ${rowCount} notification(s) lue(s) de plus de 30j supprimée(s)`)
     }
   } catch (err) {

--- a/nodyx-core/src/tests/scheduler-blocklist.test.ts
+++ b/nodyx-core/src/tests/scheduler-blocklist.test.ts
@@ -1,0 +1,65 @@
+// ─── pullBlocklist doit respecter le choix de non-fédération ────────────────
+//
+// Trouvé en audit de stabilité (F-039, 2026-09-11) : contrairement à
+// pingDirectory/pushAssetsToDirectory/announceThreadsToDirectory, pullBlocklist
+// n'avait AUCUN garde sur DIRECTORY_TOKEN. Une instance installée sans
+// fédération (le cas courant : install.sh ne pose DIRECTORY_TOKEN que si
+// l'admin choisit explicitement d'enregistrer son instance) appelait quand
+// même nodyx.org toutes les 30 minutes, à vie, via le repli par défaut de
+// DIRECTORY_API_URL. Exactement la dépendance cachée que la promesse
+// « nodyx.org meurt, pas grave » est censée exclure.
+//
+// Ces tests tombent sur l'ancien code : sans le garde, fetch est appelé même
+// sans token. cf feedback_test_first_critical.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('../config/database', () => ({
+  db: { query: vi.fn() },
+  redis: {
+    del:    vi.fn().mockResolvedValue(1),
+    sadd:   vi.fn().mockResolvedValue(1),
+    rename: vi.fn().mockResolvedValue('OK'),
+    expire: vi.fn().mockResolvedValue(1),
+  },
+}))
+
+import { pullBlocklist } from '../scheduler'
+
+describe('pullBlocklist — respecte le choix de non-fédération', () => {
+  const originalEnv = { ...process.env }
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    fetchMock = vi.fn()
+    global.fetch = fetchMock as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it("n'appelle jamais le réseau quand DIRECTORY_TOKEN est absent (instance non fédérée)", async () => {
+    delete process.env.DIRECTORY_TOKEN
+    process.env.DIRECTORY_API_URL = 'https://nodyx.org'
+
+    await pullBlocklist()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('appelle bien le réseau quand DIRECTORY_TOKEN est configuré (instance fédérée)', async () => {
+    process.env.DIRECTORY_TOKEN = 'tok_test_instance'
+    process.env.DIRECTORY_API_URL = 'https://nodyx.org'
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ips: [], count: 0 }),
+    })
+
+    await pullBlocklist()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/directory/blocklist')
+  })
+})


### PR DESCRIPTION
Trouvé en audit de stabilité (F-039, 11/09) : contrairement aux 3 autres tâches fédérées du scheduler, `pullBlocklist` n'avait aucun garde sur `DIRECTORY_TOKEN`. Une instance installée sans fédération appelait quand même nodyx.org toutes les 30 minutes, à vie, via le repli par défaut de `DIRECTORY_API_URL`.

2 tests, prouvés rouges sur l'ancien code.

Consolide au passage `purgeOldNotifications()` sur `NotificationModel.purgeOldRead()` au lieu d'une copie SQL inline identique (les deux faisaient déjà la même purge, aucun changement de comportement).