### PR TITLE
fix(front): /discover pouvait bloquer le rendu SSR sans timeout

### DIFF
--- a/nodyx-frontend/src/routes/discover/+page.server.ts
+++ b/nodyx-frontend/src/routes/discover/+page.server.ts
@@ -17,7 +17,13 @@ export const load: PageServerLoad = async ({ fetch, url }) => {
 		if (q)        params.set('q', q);
 		if (upcoming) params.set('upcoming', upcoming);
 
-		const res = await globalThis.fetch(`${DIRECTORY_URL}/api/directory/search?${params}`);
+		// Sans timeout, un directory qui ne répond jamais (pas une erreur immédiate,
+		// un vrai silence réseau) bloque le rendu SSR de la page indéfiniment.
+		// Même classe d'incident que celui déjà corrigé dans +layout.server.ts
+		// (page d'accueil à 27s, trouvé en audit de stabilité, F-040, 2026-09-11).
+		const res = await globalThis.fetch(`${DIRECTORY_URL}/api/directory/search?${params}`, {
+			signal: AbortSignal.timeout(5000)
+		});
 		if (res.ok) {
 			const json = await res.json();
 			results = json.results ?? [];

--- a/nodyx-frontend/src/routes/discover/page.server.test.ts
+++ b/nodyx-frontend/src/routes/discover/page.server.test.ts
@@ -1,0 +1,62 @@
+// ─── /discover ne doit jamais bloquer le rendu SSR indéfiniment ─────────────
+//
+// Trouvé en audit de stabilité (F-040, 2026-09-11) : ce fetch vers l'annuaire
+// fédéré n'avait aucun timeout, contrairement à +layout.server.ts (déjà
+// corrigé après un incident réel : page d'accueil bloquée 27s par un directory
+// muet, pas en erreur, juste silencieux). Ces tests tombent sur l'ancien code :
+// sans AbortSignal, un fetch qui ne répond jamais ne renverrait jamais l'erreur
+// de repli, il resterait en attente. cf feedback_test_first_critical.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { load } from './+page.server';
+
+function fakeEvent(searchParams: Record<string, string> = {}) {
+	const url = new URL('http://localhost/discover');
+	for (const [k, v] of Object.entries(searchParams)) url.searchParams.set(k, v);
+	return { fetch: vi.fn(), url } as any;
+}
+
+describe('/discover — load', () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('passe un AbortSignal borné au fetch du répertoire', async () => {
+		fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ results: [] }) });
+
+		await load(fakeEvent({ q: 'test' }));
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [, init] = fetchMock.mock.calls[0];
+		expect(init?.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it("renvoie un message d'erreur propre quand le répertoire ne répond jamais (timeout), au lieu de rester bloqué", async () => {
+		const abortError = new DOMException('The operation was aborted.', 'AbortError');
+		fetchMock.mockRejectedValueOnce(abortError);
+
+		const result = (await load(fakeEvent({ q: 'test' }))) as { error: string | null; results: unknown[] };
+
+		expect(result.error).toBe('Impossible de contacter le répertoire Nodyx.');
+		expect(result.results).toEqual([]);
+	});
+
+	it('renvoie les résultats normalement quand le répertoire répond', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ results: [{ id: '1', title: 'Un fil' }] })
+		});
+
+		const result = (await load(fakeEvent({ q: 'test' }))) as { error: string | null; results: unknown[] };
+
+		expect(result.error).toBeNull();
+		expect(result.results).toHaveLength(1);
+	});
+});

--- a/nodyx-frontend/src/tests/stub-env-dynamic-public.ts
+++ b/nodyx-frontend/src/tests/stub-env-dynamic-public.ts
@@ -1,0 +1,5 @@
+// Stub vitest du module virtuel SvelteKit $env/dynamic/public (env node).
+// Vide par défaut : chaque test qui a besoin d'une valeur précise la pose
+// lui-même sur process.env avant d'importer le module testé, ou mocke ce
+// stub directement (vi.mock('$env/dynamic/public', ...)).
+export const env: Record<string, string | undefined> = {}

--- a/nodyx-frontend/vitest.config.ts
+++ b/nodyx-frontend/vitest.config.ts
@@ -9,8 +9,9 @@ export default defineConfig({
 			// Résout $lib comme SvelteKit (nécessaire aux modules testés qui
 			// importent d'autres modules $lib, ex: voiceSfu → $lib/socket).
 			$lib: fileURLToPath(new URL('./src/lib', import.meta.url)),
-			// Module virtuel SvelteKit indisponible hors runtime Kit : stubbé.
+			// Modules virtuels SvelteKit indisponibles hors runtime Kit : stubbés.
 			'$app/environment': fileURLToPath(new URL('./src/tests/stub-app-environment.ts', import.meta.url)),
+			'$env/dynamic/public': fileURLToPath(new URL('./src/tests/stub-env-dynamic-public.ts', import.meta.url)),
 		},
 	},
 	test: {


### PR DESCRIPTION
Trouvé en audit de stabilité (F-040, 11/09) : ce fetch vers l'annuaire fédéré n'avait aucun `AbortSignal`, contrairement à `+layout.server.ts` (déjà corrigé après un incident réel : page d'accueil bloquée 27s par un directory muet). Même classe d'incident possible sur `/discover`.

3 tests, le premier prouvé rouge sur l'ancien code. Ajoute un stub vitest pour `$env/dynamic/public`, absent jusqu'ici (aucun `+page.server.ts` n'avait de test dans ce dépôt).