### PR TITLE
fix(ops): étendre le gardien de veille au relais, au serveur Rust et au frontend

### DIFF
--- a/scripts/ops/veille/verifier-ecoute.sh
+++ b/scripts/ops/veille/verifier-ecoute.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Détecte un cœur PM2 vivant mais muet, et le relance.
+# Détecte un service vivant mais muet, et le relance.
 #
 # Le défaut qu'il corrige, observé le 22/08/2026 : `unattended-upgrade` a
 # redémarré PostgreSQL (coupure de 5 secondes). demo-core, sleemstudio-core et
@@ -9,9 +9,18 @@
 # rien ne les a jamais relancés. Injoignables pendant près de 5 heures, sans
 # la moindre alerte.
 #
-# Un `pm2 restart` planifié ne suffit pas : le symptôme est spécifique, un
-# processus vivant qui n'écoute plus. On ne redémarre QUE ce cas précis, jamais
-# une instance qui fonctionne.
+# ÉLARGI le 12/09/2026 (audit de stabilité, F-042) : ce gardien ne surveillait
+# que 4 cœurs Node/PM2, jamais nodyx-frontend, ni nodyx-relay/nodyx-server
+# (Rust, systemd, pas PM2) — alors que nodyx-relay porte la promesse « zéro
+# port ouvert » (project_promesse_zero_port) : s'il se fige, silencieusement,
+# tous les auto-hébergeurs qui en dépendent pour franchir leur NAT perdent
+# leur vocal sans que personne ne le sache. Chaque cible porte maintenant son
+# TYPE (pm2 ou systemd) pour savoir COMMENT la relancer : `pm2 restart <nom>`
+# pour les cœurs Node, `systemctl restart <nom>.service` pour les daemons Rust.
+#
+# Un `pm2 restart`/`systemctl restart` planifié ne suffit pas : le symptôme
+# est spécifique, un processus vivant qui n'écoute plus. On ne redémarre QUE
+# ce cas précis, jamais un service qui fonctionne.
 #
 # Deux passages consécutifs en échec avant d'agir : un redémarrage légitime en
 # cours laisse aussi le port muet une poignée de secondes, et ne doit pas
@@ -21,13 +30,18 @@ set -euo pipefail
 ETAT="${VEILLE_ETAT:-/var/backups/nodyx/veille}"
 mkdir -p "$ETAT"
 
-# name pm2 = port a verifier, en loopback : ce sont les quatre coeurs durcis le
-# 20/08/2026, injoignables depuis l'exterieur mais tous locaux a cette machine.
+# nom = "port:type", en loopback : type pm2 = coeur Node relance par
+# `pm2 restart <nom>` ; type systemd = daemon Rust relance par
+# `systemctl restart <nom>.service`. Le nom PM2/systemd doit etre exactement
+# celui de l'ecosysteme/l'unite (ecosystem.config.js, /etc/systemd/system/*).
 declare -A CIBLES=(
-  [nodyx-core]=3000
-  [demo-core]=3001
-  [sleemstudio-core]=3002
-  [vieuxlooters-core]=3003
+  [nodyx-core]="3000:pm2"
+  [demo-core]="3001:pm2"
+  [sleemstudio-core]="3002:pm2"
+  [vieuxlooters-core]="3003:pm2"
+  [nodyx-frontend]="5173:pm2"
+  [nodyx-relay]="7001:systemd"
+  [nodyx-server]="3100:systemd"
 )
 
 alerter() {
@@ -45,9 +59,37 @@ print(json.dumps({'embeds': [{'title': sys.argv[1], 'description': sys.argv[2], 
     >/dev/null 2>&1 || true
 }
 
+statut_avant() {
+  local nom="$1" type="$2"
+  if [ "$type" = "pm2" ]; then
+    sudo -u nodyx PM2_HOME=/home/nodyx/.pm2 pm2 jlist 2>/dev/null \
+      | python3 -c "
+import json, sys
+for p in json.load(sys.stdin):
+    if p['name'] == '$nom':
+        print(f\"statut={p['pm2_env']['status']} redemarrages={p['pm2_env']['restart_time']}\")
+        break
+" 2>/dev/null || echo "inconnu"
+  else
+    systemctl show "$nom.service" -p ActiveState -p SubState -p NRestarts 2>/dev/null \
+      | tr '\n' ' ' || echo "inconnu"
+  fi
+}
+
+relancer() {
+  local nom="$1" type="$2"
+  if [ "$type" = "pm2" ]; then
+    sudo -u nodyx PM2_HOME=/home/nodyx/.pm2 pm2 restart "$nom" >/dev/null 2>&1 || true
+  else
+    systemctl restart "$nom.service" >/dev/null 2>&1 || true
+  fi
+}
+
 ECHECS_DETECTES=0
 for nom in "${!CIBLES[@]}"; do
-  port="${CIBLES[$nom]}"
+  cible="${CIBLES[$nom]}"
+  port="${cible%%:*}"
+  type="${cible##*:}"
   FICHIER="$ETAT/$nom.echecs"
 
   if timeout 3 bash -c "</dev/tcp/127.0.0.1/$port" 2>/dev/null; then
@@ -68,18 +110,10 @@ for nom in "${!CIBLES[@]}"; do
   fi
 
   ECHECS_DETECTES=$((ECHECS_DETECTES + 1))
-  echo "  $nom : muet sur le port $port DEPUIS DEUX PASSAGES, relance"
+  echo "  $nom : muet sur le port $port DEPUIS DEUX PASSAGES, relance ($type)"
 
-  STATUT_AVANT=$(sudo -u nodyx PM2_HOME=/home/nodyx/.pm2 pm2 jlist 2>/dev/null \
-    | python3 -c "
-import json, sys
-for p in json.load(sys.stdin):
-    if p['name'] == '$nom':
-        print(f\"statut={p['pm2_env']['status']} redemarrages={p['pm2_env']['restart_time']}\")
-        break
-" 2>/dev/null || echo "inconnu")
-
-  sudo -u nodyx PM2_HOME=/home/nodyx/.pm2 pm2 restart "$nom" >/dev/null 2>&1 || true
+  STATUT_AVANT=$(statut_avant "$nom" "$type")
+  relancer "$nom" "$type"
   rm -f "$FICHIER"
 
   sleep 5
@@ -90,7 +124,7 @@ for p in json.load(sys.stdin):
   else
     echo "    -> ENCORE MUET apres relance, ceci depasse ce script"
     alerter "🚨 $nom injoignable, la relance automatique a échoué" \
-      "Toujours muet sur le port $port après \`pm2 restart\`. Intervention manuelle nécessaire." 15158332
+      "Toujours muet sur le port $port après relance ($type). Intervention manuelle nécessaire." 15158332
   fi
 done
 


### PR DESCRIPTION
Trouvé en audit de stabilité (F-042/F-044, 11/09) : `nodyx-frontend` (PM2), `nodyx-relay` et `nodyx-server` (Rust, systemd, pas PM2) n'étaient surveillés par aucun mécanisme de type « process vivant mais muet ». Seul `Restart=on-failure` les couvrait, qui ne réagit que si le process se termine, jamais s'il reste bloqué en écoutant plus rien.

Grave spécifiquement pour `nodyx-relay` : c'est le composant qui porte la promesse zéro-port. S'il se fige, tous les auto-hébergeurs qui en dépendent pour franchir leur NAT perdent leur vocal sans que personne ne le sache.

Chaque cible porte maintenant son type (pm2 ou systemd) pour savoir comment la relancer. **Testé en conditions réelles** : `nodyx-server` arrêté volontairement (zéro trafic réel actuellement), le script l'a détecté au 1er passage, relancé au 2e via `systemctl`, le port écoutait à nouveau. `nodyx-relay` non testé en direct (trafic vocal réel possible), même chemin de code déjà prouvé sur `nodyx-server`.

Le service systemd exécute directement ce fichier depuis le dépôt, déjà actif sur ce VPS depuis le test.