### PR TITLE
fix(core): unifier la garde anti-SSRF, directory.ts ne résolvait jamais le DNS

### DIFF
--- a/nodyx-core/src/routes/chat.ts
+++ b/nodyx-core/src/routes/chat.ts
@@ -9,61 +9,12 @@ import { rateLimit } from '../middleware/rateLimit'
 import { requireAuth } from '../middleware/auth'
 import * as ChannelModel from '../models/channel'
 import { redis } from '../config/database'
-import dns from 'dns/promises'
-import net from 'net'
 import https from 'https'
 import http from 'http'
-
-// ── SSRF guard — bloque les IPs privées / loopback / link-local ───────────────
-
-function isPrivateIp(ip: string): boolean {
-  // IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1 or ::ffff:7f00:1) — bypass critique
-  const mapped4 = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i)
-  if (mapped4) return isPrivateIp(mapped4[1])
-  // IPv4-in-IPv6 hex notation (e.g. ::ffff:7f00:0001 = 127.0.0.1)
-  const mapped4hex = ip.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i)
-  if (mapped4hex) {
-    const a = parseInt(mapped4hex[1], 16)
-    const b = parseInt(mapped4hex[2], 16)
-    const ipv4 = `${(a >> 8) & 0xff}.${a & 0xff}.${(b >> 8) & 0xff}.${b & 0xff}`
-    return isPrivateIp(ipv4)
-  }
-
-  // IPv6 loopback et private
-  if (ip === '::1' || ip === '::') return true
-  if (ip.startsWith('fc') || ip.startsWith('fd')) return true  // fc00::/7
-  if (ip.startsWith('fe80')) return true                        // link-local
-  if (ip.startsWith('2001:db8')) return true                    // documentation (RFC 3849)
-
-  // IPv4
-  if (!net.isIPv4(ip)) return false
-  const parts = ip.split('.').map(Number)
-  const [a, b] = parts
-  return (
-    a === 10 ||                          // 10.0.0.0/8
-    a === 127 ||                         // 127.0.0.0/8 loopback
-    a === 0 ||                           // 0.0.0.0/8
-    (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12
-    (a === 192 && b === 168) ||          // 192.168.0.0/16
-    (a === 169 && b === 254) ||          // 169.254.0.0/16 link-local (cloud metadata)
-    (a === 100 && b >= 64 && b <= 127)   // 100.64.0.0/10 shared address space
-  )
-}
-
-/**
- * Résout le hostname UNE FOIS et retourne l'IP résolue si sûre, null sinon.
- * On retourne l'IP pour que le fetch l'utilise directement (anti-DNS rebinding).
- */
-async function resolveSsrfSafe(hostname: string): Promise<string | null> {
-  // Adresse IP directe — valider sans DNS
-  if (net.isIP(hostname)) return isPrivateIp(hostname) ? null : hostname
-  try {
-    const { address } = await dns.lookup(hostname)
-    return isPrivateIp(address) ? null : address
-  } catch {
-    return null
-  }
-}
+// Garde anti-SSRF partagée (F-055, 2026-09-12) : vivait ici en copie locale,
+// consolidée avec linkPreview.ts et directory.ts dans un seul module — ce
+// dernier était le seul des trois à ne PAS résoudre le DNS avant de juger.
+import { resolveSsrfSafe } from '../utils/ssrfGuard'
 
 // ── Resolve instance community (cached) ──────────────────────────────────────
 

--- a/nodyx-core/src/routes/directory.ts
+++ b/nodyx-core/src/routes/directory.ts
@@ -1,13 +1,10 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { randomBytes } from 'crypto';
-import { lookup } from 'dns';
-import { promisify } from 'util';
-import https from 'https';
-import http from 'http';
 import sanitizeHtml from 'sanitize-html';
 import { db, redis } from '../config/database';
 import { getClientIp, estPubliquementRoutable } from '../utils/clientIp'
 import { isReservedSlug } from '../utils/reservedSlugs'
+import { resolveSsrfSafe } from '../utils/ssrfGuard'
 
 // Strict rate-limit for public search endpoint (30 req/min per IP)
 async function searchRateLimit(request: FastifyRequest, reply: FastifyReply): Promise<void> {
@@ -20,8 +17,6 @@ async function searchRateLimit(request: FastifyRequest, reply: FastifyReply): Pr
     return reply.code(429).send({ error: 'Too many requests', code: 'RATE_LIMITED' });
   }
 }
-
-const dnsLookup = promisify(lookup);
 
 const CF_BASE = 'https://api.cloudflare.com/client/v4';
 
@@ -42,48 +37,14 @@ async function cfRequest(method: string, path: string, body?: object) {
   return res.json() as Promise<any>;
 }
 
-function isPrivateHostname(hostname: string): boolean {
-  const h = hostname.toLowerCase()
-  // Loopback
-  if (h === 'localhost' || h === '127.0.0.1' || h === '::1' || h === '0.0.0.0') return true
-  // IPv6-mapped IPv4 (e.g. ::ffff:127.0.0.1 or [::ffff:7f00:1])
-  if (/^::ffff:/i.test(h)) {
-    const v4 = h.slice(7)
-    if (isPrivateHostname(v4)) return true
-  }
-  // RFC 1918 private ranges
-  if (h.startsWith('192.168.') || h.startsWith('10.')) return true
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return true
-  // Link-local + CGNAT
-  if (h.startsWith('169.254.') || h.startsWith('100.64.')) return true
-  // IPv6 private (ULA, link-local)
-  if (h.startsWith('fc') || h.startsWith('fd') || h.startsWith('fe80')) return true
-  // Other loopback range (127.x.x.x)
-  if (/^127\./.test(h)) return true
-  return false
-}
-
-async function checkUrl(url: string): Promise<boolean> {
-  return new Promise((resolve) => {
-    try {
-      const parsed = new URL(url);
-      // Bloquer les adresses privées / loopback (anti-SSRF)
-      if (isPrivateHostname(parsed.hostname)) return resolve(false);
-      // En production, exiger HTTPS
-      if (process.env.NODE_ENV === 'production' && parsed.protocol !== 'https:') return resolve(false);
-      const lib = parsed.protocol === 'https:' ? https : http;
-      const req = lib.request(
-        { hostname: parsed.hostname, path: '/', method: 'HEAD', timeout: 5000 },
-        (res) => { resolve((res.statusCode ?? 0) < 500); }
-      );
-      req.on('error', () => resolve(false));
-      req.on('timeout', () => { req.destroy(); resolve(false); });
-      req.end();
-    } catch {
-      resolve(false);
-    }
-  });
-}
+// isPrivateHostname/checkUrl (validation littérale du hostname, sans résolution
+// DNS) ont été retirés le 12/09/2026 (F-055, audit de stabilité) : checkUrl
+// n'avait AUCUN appelant depuis sa création (2026-03-17, vérifié par grep sur
+// tout le dépôt), et isPrivateHostname jugeait la CHAÎNE du hostname, jamais
+// l'adresse réellement résolue — un domaine qui pointe vers une IP privée au
+// moment de la connexion (DNS rebinding) passait la validation. Remplacé par
+// `resolveSsrfSafe` (utils/ssrfGuard.ts, partagé avec chat.ts), qui résout le
+// DNS et rejette si l'adresse OBTENUE est privée.
 
 async function createCloudflareSubdomain(slug: string, ip: string): Promise<string | null> {
   try {
@@ -218,7 +179,9 @@ export default async function directoryRoutes(app: FastifyInstance) {
       if (parsed.protocol !== 'https:') {
         return reply.status(400).send({ error: 'URL must use HTTPS' });
       }
-      if (isPrivateHostname(parsed.hostname)) {
+      // Résout le DNS avant de juger (anti rebinding, F-055) : un hostname
+      // dont le nom semble innocent peut pointer vers une IP privée.
+      if ((await resolveSsrfSafe(parsed.hostname)) === null) {
         return reply.status(400).send({ error: 'Private or reserved IP addresses are not allowed' });
       }
     } catch {
@@ -598,10 +561,11 @@ export default async function directoryRoutes(app: FastifyInstance) {
       }
 
       // Validation du schéma HTTPS + rejet des IPs privées (anti-SSRF / directory poisoning)
+      // Résout le DNS avant de juger (anti rebinding, F-055).
       try {
         const parsed = new URL(instance_url);
         if (parsed.protocol !== 'https:') throw new Error('https required');
-        if (isPrivateHostname(parsed.hostname)) throw new Error('private ip');
+        if ((await resolveSsrfSafe(parsed.hostname)) === null) throw new Error('private ip');
       } catch {
         return reply.status(400).send({ error: 'invalid instance_url' });
       }

--- a/nodyx-core/src/tests/directory-register-ssrf.test.ts
+++ b/nodyx-core/src/tests/directory-register-ssrf.test.ts
@@ -1,0 +1,79 @@
+// ─── POST /directory/register résiste au DNS rebinding ──────────────────────
+//
+// Trouvé en audit de stabilité (F-055, 2026-09-11) : la validation anti-SSRF
+// de cette route (et de /directory/gossip/receive) jugeait la CHAÎNE du
+// hostname, jamais l'adresse réellement résolue. Un domaine au nom innocent
+// qui pointe vers une IP privée passait la validation. Ce test tombe sur
+// l'ancien code : sans résolution DNS, aucune raison de rejeter un hostname
+// qui NE CONTIENT aucun motif d'IP privée dans son nom. cf feedback_test_first_critical.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('dns/promises', () => ({
+  default: { lookup: vi.fn() },
+}))
+
+vi.mock('../config/database', () => ({
+  db: { query: vi.fn() },
+  redis: {
+    incr: vi.fn().mockResolvedValue(1),
+    expire: vi.fn().mockResolvedValue(1),
+    ttl: vi.fn().mockResolvedValue(60),
+  },
+}))
+
+import dns from 'dns/promises'
+import { db } from '../config/database'
+import { buildApp } from './helpers/buildApp'
+import directoryRoutes from '../routes/directory'
+
+async function register(url: string) {
+  const app = await buildApp(async (a) => { await a.register(directoryRoutes, { prefix: '/api' }) })
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/directory/register',
+    payload: { name: 'Test', slug: 'test-instance', url },
+  })
+  await app.close()
+  return res
+}
+
+describe('POST /api/directory/register — anti rebinding DNS', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    // Par défaut : pas de slug existant. Les tests qui passent la garde SSRF
+    // et continuent plus loin dans la route (Cloudflare, activation) ne sont
+    // pas notre objet ici — seule la garde anti-rebinding est sous test.
+    vi.mocked(db.query).mockResolvedValue({ rows: [{ id: 'fake-instance-id' }] } as never)
+  })
+
+  it("rejette un hostname au nom innocent qui résout vers une IP privée (rebinding)", async () => {
+    vi.mocked(dns.lookup).mockResolvedValueOnce({ address: '169.254.169.254', family: 4 } as never)
+
+    const res = await register('https://metadonnees-legitimes.example.com')
+
+    expect(res.statusCode).toBe(400)
+    expect(JSON.parse(res.body).error).toMatch(/private|reserved/i)
+    expect(dns.lookup).toHaveBeenCalledWith('metadonnees-legitimes.example.com')
+  })
+
+  it('rejette toujours une IP privée littérale, sans même consulter le DNS', async () => {
+    const res = await register('https://127.0.0.1')
+
+    expect(res.statusCode).toBe(400)
+    expect(dns.lookup).not.toHaveBeenCalled()
+  })
+
+  it('accepte un hostname qui résout vers une vraie adresse publique', async () => {
+    vi.mocked(dns.lookup).mockResolvedValueOnce({ address: '203.0.113.42', family: 4 } as never)
+
+    const res = await register('https://une-vraie-instance-federee.org')
+
+    // Passe la garde SSRF : la résolution DNS a eu lieu, et le rejet
+    // spécifique « private/reserved » (celui que testent les 2 cas ci-dessus)
+    // n'est pas ce qui a produit la réponse.
+    expect(dns.lookup).toHaveBeenCalledWith('une-vraie-instance-federee.org')
+    const body = JSON.parse(res.body)
+    if (body?.error) expect(body.error).not.toMatch(/private|reserved/i)
+  })
+})

--- a/nodyx-core/src/tests/ssrf-guard.test.ts
+++ b/nodyx-core/src/tests/ssrf-guard.test.ts
@@ -1,0 +1,93 @@
+// ─── Garde anti-SSRF partagée ────────────────────────────────────────────────
+//
+// Consolidation de 3 implémentations divergentes (F-055, audit du 11/09/2026).
+// Ces tests couvrent les cas qui distinguaient les trois versions avant
+// fusion : notation IPv4-mappée-IPv6 hexadécimale (seul chat.ts l'avait),
+// multicast/réservé (seul linkPreview.ts l'avait), et le rebinding DNS que
+// SEUL directory.ts ne détectait pas (cf tests de directory.ts).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('dns/promises', () => ({
+  default: { lookup: vi.fn() },
+}))
+
+import dns from 'dns/promises'
+import { isPrivateIp, resolveSsrfSafe } from '../utils/ssrfGuard'
+
+describe('isPrivateIp', () => {
+  it.each([
+    ['10.0.0.1', true],
+    ['172.16.0.1', true],
+    ['172.31.255.255', true],
+    ['172.32.0.1', false], // hors plage 172.16-31
+    ['192.168.1.1', true],
+    ['127.0.0.1', true],
+    ['0.0.0.0', true],
+    ['169.254.1.1', true],   // link-local / metadata cloud
+    ['100.64.0.1', true],    // CGNAT
+    ['8.8.8.8', false],
+    ['1.1.1.1', false],
+  ])('%s → %s (IPv4)', (ip, expected) => {
+    expect(isPrivateIp(ip)).toBe(expected)
+  })
+
+  it('détecte le multicast/réservé (>= 224), absent de la version chat.ts avant fusion', () => {
+    expect(isPrivateIp('224.0.0.1')).toBe(true)
+    expect(isPrivateIp('240.0.0.1')).toBe(true)
+  })
+
+  it('détecte une IPv4 encodée en IPv6-mappé, notation décimale', () => {
+    expect(isPrivateIp('::ffff:127.0.0.1')).toBe(true)
+    expect(isPrivateIp('::ffff:8.8.8.8')).toBe(false)
+  })
+
+  it('détecte une IPv4 encodée en IPv6-mappé, notation hexadécimale (::ffff:7f00:1 = 127.0.0.1)', () => {
+    expect(isPrivateIp('::ffff:7f00:1')).toBe(true)
+  })
+
+  it.each([
+    ['::1', true],
+    ['fc00::1', true],
+    ['fd12::1', true],
+    ['fe80::1', true],
+    ['2001:db8::1', true], // plage documentation
+    ['2001:4860:4860::8888', false], // Google DNS IPv6, publique
+  ])('%s → %s (IPv6)', (ip, expected) => {
+    expect(isPrivateIp(ip)).toBe(expected)
+  })
+})
+
+describe('resolveSsrfSafe — anti rebinding DNS', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('accepte une IP littérale publique sans DNS', async () => {
+    const result = await resolveSsrfSafe('8.8.8.8')
+    expect(result).toBe('8.8.8.8')
+    expect(dns.lookup).not.toHaveBeenCalled()
+  })
+
+  it('rejette une IP littérale privée sans DNS', async () => {
+    const result = await resolveSsrfSafe('127.0.0.1')
+    expect(result).toBeNull()
+    expect(dns.lookup).not.toHaveBeenCalled()
+  })
+
+  it("résout un hostname et rejette si l'adresse résolue est privée, même si le nom semble innocent", async () => {
+    vi.mocked(dns.lookup).mockResolvedValueOnce({ address: '169.254.169.254', family: 4 } as never)
+    const result = await resolveSsrfSafe('metadonnees-cloud-legitimes.example.com')
+    expect(result).toBeNull()
+  })
+
+  it('résout un hostname public et renvoie son IP RÉSOLUE (pas le hostname), pour usage anti-rebinding', async () => {
+    vi.mocked(dns.lookup).mockResolvedValueOnce({ address: '203.0.113.42', family: 4 } as never)
+    const result = await resolveSsrfSafe('exemple-instance-federee.org')
+    expect(result).toBe('203.0.113.42')
+  })
+
+  it('renvoie null proprement si la résolution DNS échoue', async () => {
+    vi.mocked(dns.lookup).mockRejectedValueOnce(new Error('ENOTFOUND'))
+    const result = await resolveSsrfSafe('domaine-inexistant.invalid')
+    expect(result).toBeNull()
+  })
+})

--- a/nodyx-core/src/utils/ssrfGuard.ts
+++ b/nodyx-core/src/utils/ssrfGuard.ts
@@ -1,0 +1,73 @@
+// ─── Garde anti-SSRF partagée ────────────────────────────────────────────────
+//
+// Avant ce fichier (trouvé en audit de stabilité, F-055, 2026-09-11) : trois
+// implémentations indépendantes de la détection d'IP privée existaient
+// (chat.ts, linkPreview.ts, directory.ts), déjà divergées entre elles. La
+// version de directory.ts (validation des URLs d'instances fédérées, la
+// surface la plus exposée puisqu'alimentée par d'autres instances) était la
+// SEULE des trois à ne faire aucune résolution DNS : elle jugeait la chaîne du
+// hostname littéral, jamais l'adresse réellement résolue. Un domaine qui
+// pointe vers une IP privée au moment de la connexion (DNS rebinding) passait
+// donc la validation, alors que chat.ts s'en protège explicitement depuis
+// l'incident qui l'a fait naître.
+//
+// Ce module consolide sur la version la plus complète (chat.ts : IPv4-mappé-
+// IPv6 en notation décimale ET hexadécimale, IPv6 ULA/link-local/documentation)
+// et y ajoute le seul contrôle que linkPreview.ts avait en plus
+// (multicast/réservé, a >= 224).
+
+import dns from 'dns/promises'
+import net from 'net'
+
+/** Une adresse IP (v4 ou v6) est-elle privée, loopback, link-local ou réservée ? */
+export function isPrivateIp(ip: string): boolean {
+  // IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1 or ::ffff:7f00:1) — bypass critique
+  const mapped4 = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i)
+  if (mapped4) return isPrivateIp(mapped4[1])
+  // IPv4-in-IPv6 hex notation (e.g. ::ffff:7f00:0001 = 127.0.0.1)
+  const mapped4hex = ip.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i)
+  if (mapped4hex) {
+    const a = parseInt(mapped4hex[1], 16)
+    const b = parseInt(mapped4hex[2], 16)
+    const ipv4 = `${(a >> 8) & 0xff}.${a & 0xff}.${(b >> 8) & 0xff}.${b & 0xff}`
+    return isPrivateIp(ipv4)
+  }
+
+  // IPv6 loopback, ULA, link-local, plage de documentation
+  if (ip === '::1' || ip === '::') return true
+  if (ip.startsWith('fc') || ip.startsWith('fd')) return true  // fc00::/7 (ULA)
+  if (ip.startsWith('fe80')) return true                        // link-local
+  if (ip.startsWith('2001:db8')) return true                    // documentation (RFC 3849)
+
+  // IPv4
+  if (!net.isIPv4(ip)) return false
+  const parts = ip.split('.').map(Number)
+  const [a, b] = parts
+  return (
+    a === 10 ||                          // 10.0.0.0/8
+    a === 127 ||                         // 127.0.0.0/8 loopback
+    a === 0 ||                           // 0.0.0.0/8
+    (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12
+    (a === 192 && b === 168) ||          // 192.168.0.0/16
+    (a === 169 && b === 254) ||          // 169.254.0.0/16 link-local (cloud metadata)
+    (a === 100 && b >= 64 && b <= 127) || // 100.64.0.0/10 shared address space (CGNAT)
+    a >= 224                             // multicast (224-239) + réservé (240-255)
+  )
+}
+
+/**
+ * Résout le hostname UNE FOIS et retourne l'IP résolue si sûre, null sinon.
+ * On retourne l'IP pour que l'appelant l'utilise directement pour la
+ * connexion (anti-DNS-rebinding) : re-résoudre plus tard laisserait le temps
+ * à un attaquant de changer la réponse DNS entre la vérification et l'usage.
+ */
+export async function resolveSsrfSafe(hostname: string): Promise<string | null> {
+  // Adresse IP directe — valider sans DNS
+  if (net.isIP(hostname)) return isPrivateIp(hostname) ? null : hostname
+  try {
+    const { address } = await dns.lookup(hostname)
+    return isPrivateIp(address) ? null : address
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
Trouvé en audit de stabilité (F-055, 11/09) : trois implémentations indépendantes de la détection d'IP privée (`chat.ts`, `linkPreview.ts`, `directory.ts`), déjà divergées. `directory.ts` (validation des URLs d'instances fédérées, la surface la plus exposée) était la seule à juger la chaîne du hostname littéral, jamais l'adresse réellement résolue : un domaine qui pointe vers une IP privée au moment de la connexion (DNS rebinding) passait la validation.

Nouveau module `utils/ssrfGuard.ts` (`isPrivateIp` + `resolveSsrfSafe`), consolidé sur la version la plus complète. `chat.ts` importe désormais ce module au lieu d'une copie locale.

`directory.ts` : `isPrivateHostname` (littéral) et `checkUrl` retirés. `checkUrl` n'avait **aucun appelant** depuis sa création le 2026-03-17 (vérifié par grep sur tout le dépôt) : code mort qui laissait croire à une vérification de joignabilité qui n'a jamais existé. Les 2 vrais points d'appel (`POST /directory/register`, `POST /directory/gossip/receive`) utilisent maintenant `resolveSsrfSafe`.

28 tests nouveaux, 2 prouvés rouges sur l'ancien code. 1018 tests core, tsc propre.