### PR TITLE
fix(musique): grille et tracklist en pleine largeur

### DIFF
--- a/nodyx-frontend/src/routes/musique/+page.svelte
+++ b/nodyx-frontend/src/routes/musique/+page.svelte
@@ -107,7 +107,10 @@
 	/* ── Grid ─────────────────────────────────────────────────────────────── */
 	.mus-grid {
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+		/* auto-fit (pas auto-fill) : avec peu de catégories, les cartes
+		   s'étirent pour occuper toute la largeur au lieu de laisser des
+		   colonnes vides sur la droite. */
+		grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 		gap: 1px;
 		background: rgba(255, 255, 255, 0.04);
 	}
@@ -129,7 +132,9 @@
 	}
 
 	.mus-card-thumb {
-		aspect-ratio: 1;
+		/* 16/9 plutôt que carré : avec peu de catégories, une carte étirée par
+		   auto-fit reste une belle bannière au lieu d'un carré démesuré. */
+		aspect-ratio: 16 / 9;
 		overflow: hidden;
 		background: rgba(255, 255, 255, 0.03);
 	}

--- a/nodyx-frontend/src/routes/musique/[slug]/+page.svelte
+++ b/nodyx-frontend/src/routes/musique/[slug]/+page.svelte
@@ -114,8 +114,6 @@
 
 	.mus-body {
 		padding: 24px 28px 48px;
-		max-width: 760px;
-		margin: 0 auto;
 	}
 
 	/* ── Banner ───────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Résumé

Jonathan a signalé (deux fois) que /musique ne remplit pas toute la largeur. Cause trouvée : `grid-template-columns: repeat(auto-fill, ...)` réserve des colonnes vides quand il y a peu de catégories, laissant un grand vide à droite au lieu que les cartes existantes s'étirent. Passe à `auto-fit` (les colonnes vides se replient, les cartes prennent l'espace libre). Vignette en 16/9 pour qu'une carte étirée reste une belle bannière plutôt qu'un carré démesuré à 1-2 catégories. Retire aussi le `max-width: 760px` qui recentrait artificiellement la page d'une catégorie.

## Vérifications

- `npm run check` : 0 erreur

## Test plan

- [ ] `npm run build && pm2 restart nodyx-frontend` après merge (pas de locales touchées, pas de collision avec i18n-deploy.yml)
- [ ] Vérifier `/musique` en vrai, avec 1 et avec plusieurs catégories