### PR TITLE
docs: module vitrine musique dans le changelog et le readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versio
 Un mois de travail depuis la 2.12.0, sur plusieurs chantiers en parallèle. Résumé par thème,
 pas par commit : le détail de chacun reste dans son historique git et ses PR.
 
+### Vitrine musique, un module pensé pour devenir générique
+
+Nouveau module public, `/musique`, géré entièrement depuis `/admin/music`. Né pour héberger une
+bande originale de jeu vidéo composée en interne et la distribuer à un studio partenaire, mais
+pas figé sur ce seul usage : titre, sous-titre et bannière de la page publique sont éditables par
+l'admin, avec repli propre sur des valeurs par défaut si rien n'est renseigné. Catégories
+illustrées et réordonnables (boutons monter/descendre, pas de glisser-déposer fragile), morceaux
+uploadés en un geste depuis l'admin (audio et image, scan anti-malware avant stockage, même
+garde que le reste des uploads), titre et description corrigeables en place sans jamais recréer
+un morceau pour une coquille. Chaque catégorie porte une note de licence libre qui alimente une
+attestation PDF générée à la volée et téléchargeable à côté de chaque morceau : une preuve de
+provenance datée, pas un avis juridique.
+
 ### SDK d'extensions et place de marché (extensions.nodyx.org)
 
 Nodyx peut désormais être étendu par des tiers, sans toucher au cœur : un SDK complet, pensé

--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ Games and activities dock right inside a voice channel while you talk, a Play St
 **Run it from a spare laptop**
 Home server support with no port forwarding and no domain required · a federated community directory with cross-instance search · a collaborative jukebox, an event calendar with maps and RSVP, an asset library for frames, badges and banners, passwordless login via ECDSA P-256.
 
+**Show what you make**
+A public media showcase at `/musique`, categories and tracks managed entirely from the admin, reorder with a click, a provenance PDF generated on demand for anything you need to prove was made in-house. Title, subtitle and banner are editable too, not tied to any single use case.
+
 **Keep it yours to moderate**
 **OctoGuard**, native auto-moderation (regex/word/link/emoji-flood, ReDoS-safe via Google `re2`), a welcome bot, custom commands, mutes, signed webhooks, every switch admin-tunable and off by default.
 


### PR DESCRIPTION
## Résumé

Documente le nouveau module `/musique` + `/admin/music` (catégories, morceaux, licence PDF, page éditable) dans `CHANGELOG.md` (section Unreleased) et `README.md` (nouvelle puce "Show what you make").

Aucun changement de code.