### PR TITLE
fix(musique): apercu Discord correct (image absolue, plus de doublon)

### DIFF
--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -4609,6 +4609,8 @@
   "music.track_count_plural": "{{n}} tracks",
   "music.views_one": "{{n}} view",
   "music.views_plural": "{{n}} views",
+  "music.category_count_one": "{{n}} category",
+  "music.category_count_plural": "{{n}} categories",
   "music.composed_for": "Composed for",
   "music.share_category": "Copy the link to this mood",
   "music.share_track": "Copy the link to this track",

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -4609,6 +4609,8 @@
   "music.track_count_plural": "{{n}} morceaux",
   "music.views_one": "{{n}} vue",
   "music.views_plural": "{{n}} vues",
+  "music.category_count_one": "{{n}} catégorie",
+  "music.category_count_plural": "{{n}} catégories",
   "music.composed_for": "Composé pour",
   "music.share_category": "Copier le lien de cette ambiance",
   "music.share_track": "Copier le lien de ce morceau",

--- a/nodyx-frontend/src/routes/+layout.svelte
+++ b/nodyx-frontend/src/routes/+layout.svelte
@@ -44,6 +44,8 @@
 		'/users/[username]',
 		'/users/[username]/card',
 		'/calendar/[id]',
+		'/musique',
+		'/musique/[slug]',
 	]);
 	const ownsOgImage = $derived(PAGES_WITH_OWN_OG.has(page.route.id ?? ''));
 

--- a/nodyx-frontend/src/routes/musique/+page.svelte
+++ b/nodyx-frontend/src/routes/musique/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import { t } from '$lib/i18n';
 	import type { PageData } from './$types';
 
@@ -17,16 +18,42 @@
 
 	const pageTitle    = $derived(settings?.title    || tFn('music.title'));
 	const pageSubtitle = $derived(settings?.subtitle || tFn('music.subtitle'));
+	const totalTracks  = $derived(categories.reduce((sum, c) => sum + c.track_count, 0));
+
+	// Discord/Twitter/Facebook exigent une URL absolue et n'exécutent aucun JS :
+	// on résout ici, cote SSR, jamais via window.
+	function absolutize(url: string | null | undefined, origin: string): string | null {
+		if (!url) return null;
+		if (/^https?:\/\//.test(url)) return url;
+		return origin + url;
+	}
+
+	// Bannière de page → couverture de la première catégorie → bannière/logo de
+	// la communauté → image par défaut du site. Toujours une seule og:image.
+	const shareImage = $derived(
+		absolutize(
+			settings?.banner_url ?? categories[0]?.image_url ?? (page.data as any).communityBannerUrl ?? (page.data as any).communityLogoUrl,
+			page.url.origin,
+		) ?? `${page.url.origin}/og-image.jpg`,
+	);
+
+	const richDescription = $derived(
+		categories.length > 0
+			? `${pageSubtitle} · ${tFn(categories.length === 1 ? 'music.category_count_one' : 'music.category_count_plural').replace('{{n}}', String(categories.length))} · ${tFn(totalTracks === 1 ? 'music.track_count_one' : 'music.track_count_plural').replace('{{n}}', String(totalTracks))}`
+			: pageSubtitle
+	);
 </script>
 
 <svelte:head>
 	<title>{pageTitle}</title>
-	<meta name="description" content={pageSubtitle} />
+	<meta name="description" content={richDescription} />
 	<meta property="og:title" content={pageTitle} />
-	<meta property="og:description" content={pageSubtitle} />
-	{#if settings?.banner_url ?? categories[0]?.image_url}
-		<meta property="og:image" content={settings?.banner_url ?? categories[0].image_url} />
-	{/if}
+	<meta property="og:description" content={richDescription} />
+	<meta property="og:type" content="website" />
+	<meta property="og:url" content={page.url.href} />
+	<meta property="og:image" content={shareImage} />
+	<meta name="twitter:image" content={shareImage} />
+	<meta property="og:site_name" content={(page.data as any).communityName ?? 'Nodyx'} />
 </svelte:head>
 
 {#if settings?.banner_url}

--- a/nodyx-frontend/src/routes/musique/[slug]/+page.server.ts
+++ b/nodyx-frontend/src/routes/musique/[slug]/+page.server.ts
@@ -7,5 +7,9 @@ export const load: PageServerLoad = async ({ fetch, params }) => {
 	if (res.status === 404) error(404, 'Category not found.');
 	if (!res.ok) error(500, 'Server error.');
 	const { category, tracks } = await res.json();
-	return { category, tracks };
+
+	const settingsRes = await apiFetch(fetch, '/music/settings');
+	const settingsJson = settingsRes.ok ? await settingsRes.json() : { settings: null };
+
+	return { category, tracks, settings: settingsJson.settings ?? null };
 };

--- a/nodyx-frontend/src/routes/musique/[slug]/+page.svelte
+++ b/nodyx-frontend/src/routes/musique/[slug]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import { t } from '$lib/i18n';
 	import type { PageData } from './$types';
 
@@ -8,9 +9,35 @@
 
 	interface Category { id: string; slug: string; title: string; description: string | null; license_note: string | null; image_url: string | null; views: number }
 	interface Track { id: string; title: string; description: string | null; audio_url: string; image_url: string | null; likes: number }
+	interface Settings { title: string | null; subtitle: string | null; banner_url: string | null; }
 
 	const category = $derived(data.category as Category);
 	const tracks   = $derived(data.tracks as Track[]);
+	const settings = $derived(data.settings as Settings | null);
+
+	// Discord/Twitter/Facebook exigent une URL absolue et n'exécutent aucun JS :
+	// on résout ici, côté SSR, jamais via window.
+	function absolutize(url: string | null | undefined, origin: string): string | null {
+		if (!url) return null;
+		if (/^https?:\/\//.test(url)) return url;
+		return origin + url;
+	}
+
+	// Couverture de la catégorie → image du 1er morceau → bannière de la page
+	// musique → bannière/logo de la communauté → image par défaut du site.
+	const shareImage = $derived(
+		absolutize(
+			category.image_url ?? tracks[0]?.image_url ?? settings?.banner_url ?? (page.data as any).communityBannerUrl ?? (page.data as any).communityLogoUrl,
+			page.url.origin,
+		) ?? `${page.url.origin}/og-image.jpg`,
+	);
+
+	const richDescription = $derived(
+		[
+			category.description,
+			`${tFn(tracks.length === 1 ? 'music.track_count_one' : 'music.track_count_plural').replace('{{n}}', String(tracks.length))}${category.views > 0 ? ' · ' + tFn(category.views === 1 ? 'music.views_one' : 'music.views_plural').replace('{{n}}', String(category.views)) : ''}`,
+		].filter(Boolean).join(' · ')
+	);
 
 	let copiedId = $state<string | null>(null);
 
@@ -59,12 +86,14 @@
 
 <svelte:head>
 	<title>{category.title} · {tFn('music.title')}</title>
-	<meta name="description" content={category.description ?? tFn('music.meta_desc')} />
+	<meta name="description" content={richDescription} />
 	<meta property="og:title" content={category.title} />
-	<meta property="og:description" content={category.description ?? tFn('music.meta_desc')} />
-	{#if category.image_url}
-		<meta property="og:image" content={category.image_url} />
-	{/if}
+	<meta property="og:description" content={richDescription} />
+	<meta property="og:type" content="website" />
+	<meta property="og:url" content={page.url.href} />
+	<meta property="og:image" content={shareImage} />
+	<meta name="twitter:image" content={shareImage} />
+	<meta property="og:site_name" content={(page.data as any).communityName ?? 'Nodyx'} />
 </svelte:head>
 
 <div class="mus-header">


### PR DESCRIPTION
## Résumé

Suite à la demande d'améliorer l'aperçu Discord des liens /musique, deux vrais bugs trouvés :

1. **`og:image` était un chemin relatif** (`/uploads/...`). Les scrapers Discord/Twitter/Facebook n'exécutent aucun JS et exigent une URL absolue (`https://nodyx.org/uploads/...`). L'aperçu ne montrait probablement jamais la vraie image de catégorie.
2. **`/musique` et `/musique/[slug]` étaient absents de `PAGES_WITH_OWN_OG`** dans le layout racine : le `og:image` par défaut du site (`/og-image.jpg`) était émis EN PLUS du nôtre. Discord affiche alors une petite galerie de deux images, potentiellement la mauvaise en premier.

## Amélioration demandée en plus

- Chaîne de repli pour l'image (catégorie → 1er morceau → bannière de page → bannière/logo de communauté → image par défaut), même motif déjà en place sur les fils de forum.
- Description enrichie avec de vraies statistiques (nombre de morceaux, vues) au lieu du seul sous-titre brut.
- `og:url`, `og:site_name`, `twitter:image` ajoutés (le `twitter:card=summary_large_image` et le `theme-color` étaient déjà posés globalement par le layout).

## Vérifications

- `npm run check` : 0 erreur
- 4 portes i18n : vertes

## Test plan

- [ ] `npm run build && pm2 restart nodyx-frontend` après merge
- [ ] Coller un lien `/musique/<categorie>` dans Discord, vérifier une seule image (la bonne) et une description plus riche