### PR TITLE
fix(musique): commentaires affichés directement, plus de clic

### DIFF
--- a/nodyx-core/src/routes/music.ts
+++ b/nodyx-core/src/routes/music.ts
@@ -115,7 +115,14 @@ export default async function musicRoutes(app: FastifyInstance) {
       MusicCategoryModel.incrementViews(category.id),
     ])
     category.views += 1 // reflète l'incrément dans la reponse sans re-selectionner la ligne
-    return reply.send({ category, tracks })
+
+    // Commentaires embarqués : affichés d'emblée sur la page publique (pas
+    // de clic pour les révéler), donc chargés ici en une seule reponse plutot
+    // que d'un aller-retour par morceau depuis le client.
+    const tracksWithComments = await Promise.all(
+      tracks.map(async (track) => ({ ...track, comments: await MusicCommentModel.listByTrack(track.id) }))
+    )
+    return reply.send({ category, tracks: tracksWithComments })
   })
 
   // POST /tracks/:id/like : "j'aime" public, anonyme, un entier qui monte.
@@ -151,6 +158,14 @@ export default async function musicRoutes(app: FastifyInstance) {
     }
     if (commentBody.length < 1 || commentBody.length > 1000) {
       return reply.code(400).send({ error: 'body must be 1 to 1000 characters', code: 'INVALID_BODY' })
+    }
+    // Ni lien ni domaine dans un commentaire public sans compte : evite qu'un
+    // commentaire serve de vecteur de spam/phishing. Le rendu cote client
+    // n'a de toute facon jamais transforme un lien en URL cliquable, mais on
+    // refuse la source elle-meme plutot que de compter sur le seul affichage.
+    const LINK_PATTERN = /https?:\/\/|www\.|\b[a-z0-9-]+\.(com|net|org|io|fr|gg|xyz|info|biz|ru|cn)\b/i
+    if (LINK_PATTERN.test(authorName) || LINK_PATTERN.test(commentBody)) {
+      return reply.code(422).send({ error: 'Les liens ne sont pas autorisés dans les commentaires', code: 'LINK_NOT_ALLOWED' })
     }
     const nameCheck = checkContent(authorName)
     if (!nameCheck.ok) return reply.code(422).send({ error: nameCheck.reason, code: 'CONTENT_BLOCKED' })

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -4621,6 +4621,8 @@
   "music.comment_body_ph": "Your thoughts on this track",
   "music.comment_send": "Send",
   "music.comment_error": "The comment could not be sent.",
+  "music.comment_count_one": "{{n}} comment",
+  "music.comment_count_plural": "{{n}} comments",
   "music.link_copied": "Link copied",
   "music.download_license": "License (PDF)",
   "amusic.page_title": "Music (admin)",

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -4621,6 +4621,8 @@
   "music.comment_body_ph": "Votre avis sur ce morceau",
   "music.comment_send": "Envoyer",
   "music.comment_error": "Le commentaire n'a pas pu être envoyé.",
+  "music.comment_count_one": "{{n}} commentaire",
+  "music.comment_count_plural": "{{n}} commentaires",
   "music.link_copied": "Lien copié",
   "music.download_license": "Licence (PDF)",
   "amusic.page_title": "Musique (admin)",

--- a/nodyx-frontend/src/routes/musique/[slug]/+page.svelte
+++ b/nodyx-frontend/src/routes/musique/[slug]/+page.svelte
@@ -7,13 +7,15 @@
 
 	let { data }: { data: PageData } = $props();
 
+	interface Comment { id: string; author_name: string; body: string; created_at: string }
 	interface Category { id: string; slug: string; title: string; description: string | null; license_note: string | null; image_url: string | null; views: number }
-	interface Track { id: string; title: string; description: string | null; audio_url: string; image_url: string | null; likes: number }
+	interface Track { id: string; title: string; description: string | null; audio_url: string; image_url: string | null; likes: number; comments: Comment[] }
 	interface Settings { title: string | null; subtitle: string | null; banner_url: string | null; }
 
 	const category = $derived(data.category as Category);
 	const tracks   = $derived(data.tracks as Track[]);
 	const settings = $derived(data.settings as Settings | null);
+	const totalComments = $derived(tracks.reduce((sum, t) => sum + (commentsByTrack[t.id] ?? t.comments).length, 0));
 
 	// Discord/Twitter/Facebook exigent une URL absolue et n'exécutent aucun JS :
 	// on résout ici, côté SSR, jamais via window.
@@ -39,15 +41,13 @@
 		].filter(Boolean).join(' · ')
 	);
 
-	interface Comment { id: string; author_name: string; body: string; created_at: string }
-
 	let copiedId = $state<string | null>(null);
 
 	// Commentaires publics par morceau : sert le vrai usage (un développeur
-	// destinataire laisse un avis), aucun compte requis. Chargés à la demande
-	// (pas d'un coup pour tous les morceaux au chargement de la page).
+	// destinataire laisse un avis), aucun compte requis. Affichés d'emblée,
+	// deja fournis avec la categorie (pas de clic pour les revéler, pas
+	// d'aller-retour supplementaire au chargement).
 	const COMMENT_NAME_KEY = 'nodyx-music-comment-name';
-	let openComments   = $state<Set<string>>(new Set());
 	let commentsByTrack = $state<Record<string, Comment[]>>({});
 	let commentName    = $state('');
 	let commentBodies  = $state<Record<string, string>>({});
@@ -60,22 +60,8 @@
 		} catch { /* localStorage indisponible : le champ reste simplement vide */ }
 	});
 
-	async function toggleComments(track: Track) {
-		const next = new Set(openComments);
-		if (next.has(track.id)) {
-			next.delete(track.id);
-			openComments = next;
-			return;
-		}
-		next.add(track.id);
-		openComments = next;
-		if (!commentsByTrack[track.id]) {
-			const res = await fetch(`/api/v1/music/tracks/${track.id}/comments`);
-			if (res.ok) {
-				const json = await res.json();
-				commentsByTrack = { ...commentsByTrack, [track.id]: json.comments };
-			}
-		}
+	function commentsFor(track: Track): Comment[] {
+		return commentsByTrack[track.id] ?? track.comments;
 	}
 
 	async function submitComment(track: Track) {
@@ -95,7 +81,7 @@
 				throw new Error(err.error ?? tFn('music.comment_error'));
 			}
 			const { comment } = await res.json();
-			commentsByTrack = { ...commentsByTrack, [track.id]: [comment, ...(commentsByTrack[track.id] ?? [])] };
+			commentsByTrack = { ...commentsByTrack, [track.id]: [comment, ...commentsFor(track)] };
 			commentBodies = { ...commentBodies, [track.id]: '' };
 			try { localStorage.setItem(COMMENT_NAME_KEY, name); } catch { /* pas bloquant */ }
 		} catch (e) {
@@ -190,6 +176,9 @@
 			{#if category.views > 0}
 				<span class="mus-views">{tFn(category.views === 1 ? 'music.views_one' : 'music.views_plural').replace('{{n}}', String(category.views))}</span>
 			{/if}
+			{#if totalComments > 0}
+				<span class="mus-views">{tFn(totalComments === 1 ? 'music.comment_count_one' : 'music.comment_count_plural').replace('{{n}}', String(totalComments))}</span>
+			{/if}
 		</div>
 	</div>
 
@@ -233,12 +222,6 @@
 									</svg>
 									{copiedId === track.id ? tFn('music.link_copied') : tFn('music.share_track')}
 								</button>
-								<button type="button" class="mus-share-btn" onclick={() => toggleComments(track)}>
-									<svg class="mus-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-										<path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-									</svg>
-									{tFn('music.comments')}{#if commentsByTrack[track.id]?.length} ({commentsByTrack[track.id].length}){/if}
-								</button>
 							</span>
 						</div>
 						{#if track.description}
@@ -251,42 +234,38 @@
 							download="1"
 						></nodyx-audio-player>
 
-						{#if openComments.has(track.id)}
-							<div class="mus-comments">
-								{#if commentError}
-									<p class="mus-comment-error">{commentError}</p>
-								{/if}
-								{#if commentsByTrack[track.id]}
-									{#each commentsByTrack[track.id] as comment (comment.id)}
-										<div class="mus-comment">
-											<div class="mus-comment-head">
-												<span class="mus-comment-author">{comment.author_name}</span>
-												<span class="mus-comment-date">{formatCommentDate(comment.created_at)}</span>
-											</div>
-											<p class="mus-comment-body">{comment.body}</p>
-										</div>
-									{:else}
-										<p class="mus-comment-empty">{tFn('music.no_comments')}</p>
-									{/each}
-								{/if}
-
-								<div class="mus-comment-form">
-									<input type="text" bind:value={commentName} maxlength="60"
-										placeholder={tFn('music.comment_name_ph')}
-										class="mus-comment-input mus-comment-input--name" />
-									<textarea rows="2" maxlength="1000"
-										value={commentBodies[track.id] ?? ''}
-										oninput={(e) => { commentBodies = { ...commentBodies, [track.id]: (e.target as HTMLTextAreaElement).value }; }}
-										placeholder={tFn('music.comment_body_ph')}
-										class="mus-comment-input"></textarea>
-									<button type="button" class="mus-comment-submit"
-										disabled={commentBusy === track.id || !commentName.trim() || !(commentBodies[track.id] ?? '').trim()}
-										onclick={() => submitComment(track)}>
-										{commentBusy === track.id ? tFn('common.loading') : tFn('music.comment_send')}
-									</button>
+						<div class="mus-comments">
+							{#if commentError}
+								<p class="mus-comment-error">{commentError}</p>
+							{/if}
+							{#each commentsFor(track) as comment (comment.id)}
+								<div class="mus-comment">
+									<div class="mus-comment-head">
+										<span class="mus-comment-author">{comment.author_name}</span>
+										<span class="mus-comment-date">{formatCommentDate(comment.created_at)}</span>
+									</div>
+									<p class="mus-comment-body">{comment.body}</p>
 								</div>
+							{:else}
+								<p class="mus-comment-empty">{tFn('music.no_comments')}</p>
+							{/each}
+
+							<div class="mus-comment-form">
+								<input type="text" bind:value={commentName} maxlength="60"
+									placeholder={tFn('music.comment_name_ph')}
+									class="mus-comment-input mus-comment-input--name" />
+								<textarea rows="2" maxlength="1000"
+									value={commentBodies[track.id] ?? ''}
+									oninput={(e) => { commentBodies = { ...commentBodies, [track.id]: (e.target as HTMLTextAreaElement).value }; }}
+									placeholder={tFn('music.comment_body_ph')}
+									class="mus-comment-input"></textarea>
+								<button type="button" class="mus-comment-submit"
+									disabled={commentBusy === track.id || !commentName.trim() || !(commentBodies[track.id] ?? '').trim()}
+									onclick={() => submitComment(track)}>
+									{commentBusy === track.id ? tFn('common.loading') : tFn('music.comment_send')}
+								</button>
 							</div>
-						{/if}
+						</div>
 					</div>
 				</article>
 			{/each}


### PR DESCRIPTION
## Résumé

Suite au retour "je suis obligé de cliquer pour les voir" : les commentaires sont maintenant embarqués directement dans la réponse de la catégorie (`GET /categories/:slug`) et affichés d'emblée sous chaque morceau, plus aucun clic requis. Ajoute aussi le nombre total de commentaires à côté du nombre de vues dans le bandeau de catégorie.

Ajoute une garde côté serveur (demandée explicitement) : aucun lien (`http`, `www`, domaine) n'est accepté dans un commentaire, ni dans le nom ni dans le texte, pour éviter qu'un espace de retour public sans compte serve de vecteur de spam/phishing.

## Vérifications

- `npm test` (nodyx-core) : 1018 tests verts, `npx tsc --noEmit` : 0 erreur
- `npm run check` (nodyx-frontend) : 0 erreur
- 4 portes i18n : vertes

## Test plan

- [ ] `npm run build && pm2 restart nodyx-frontend` après merge
- [ ] Vérifier que les commentaires existants s'affichent sans clic sur `/musique/<categorie>`
- [ ] Essayer de poster un commentaire avec un lien, vérifier le refus