### PR TITLE
hardening(musique): validation serveur + requête N+1

### DIFF
--- a/nodyx-core/src/models/musicComment.ts
+++ b/nodyx-core/src/models/musicComment.ts
@@ -19,6 +19,28 @@ export async function listByTrack(trackId: string): Promise<MusicComment[]> {
   return rows
 }
 
+// Une requête pour N morceaux plutôt que N requêtes (utilisé par
+// GET /categories/:slug, qui embarque les commentaires de tous ses morceaux
+// d'un coup pour l'affichage sans clic).
+export async function listByTrackIds(trackIds: string[]): Promise<Map<string, MusicComment[]>> {
+  const byTrack = new Map<string, MusicComment[]>()
+  if (trackIds.length === 0) return byTrack
+
+  const { rows } = await db.query<MusicComment>(
+    `SELECT id, track_id, author_name, body, created_at
+     FROM music_track_comments
+     WHERE track_id = ANY($1)
+     ORDER BY created_at DESC`,
+    [trackIds]
+  )
+  for (const row of rows) {
+    const list = byTrack.get(row.track_id)
+    if (list) list.push(row)
+    else byTrack.set(row.track_id, [row])
+  }
+  return byTrack
+}
+
 export async function create(data: {
   track_id:    string
   author_name: string

--- a/nodyx-core/src/routes/music.ts
+++ b/nodyx-core/src/routes/music.ts
@@ -77,6 +77,9 @@ export default async function musicRoutes(app: FastifyInstance) {
     if (body.title !== undefined && body.title !== null && body.title.length > 120) {
       return reply.code(400).send({ error: 'title must be 120 characters or fewer', code: 'INVALID_TITLE' })
     }
+    if (body.subtitle !== undefined && body.subtitle !== null && body.subtitle.length > 300) {
+      return reply.code(400).send({ error: 'subtitle must be 300 characters or fewer', code: 'INVALID_SUBTITLE' })
+    }
     const communityId = await getCommunityId()
     if (!communityId) return reply.code(503).send({ error: 'Community not configured' })
 
@@ -118,10 +121,10 @@ export default async function musicRoutes(app: FastifyInstance) {
 
     // Commentaires embarqués : affichés d'emblée sur la page publique (pas
     // de clic pour les révéler), donc chargés ici en une seule reponse plutot
-    // que d'un aller-retour par morceau depuis le client.
-    const tracksWithComments = await Promise.all(
-      tracks.map(async (track) => ({ ...track, comments: await MusicCommentModel.listByTrack(track.id) }))
-    )
+    // que d'un aller-retour par morceau depuis le client. Une seule requete
+    // pour tous les morceaux (pas N), meme a mesure que la categorie grossit.
+    const commentsByTrack = await MusicCommentModel.listByTrackIds(tracks.map(t => t.id))
+    const tracksWithComments = tracks.map(track => ({ ...track, comments: commentsByTrack.get(track.id) ?? [] }))
     return reply.send({ category, tracks: tracksWithComments })
   })
 
@@ -220,6 +223,9 @@ export default async function musicRoutes(app: FastifyInstance) {
     if (!title || title.trim().length < 2 || title.length > 120) {
       return reply.code(400).send({ error: 'title must be 2 to 120 characters', code: 'INVALID_TITLE' })
     }
+    if (description !== undefined && description.length > 500) {
+      return reply.code(400).send({ error: 'description must be 500 characters or fewer', code: 'INVALID_DESCRIPTION' })
+    }
     const communityId = await getCommunityId()
     if (!communityId) return reply.code(503).send({ error: 'Community not configured' })
 
@@ -236,6 +242,12 @@ export default async function musicRoutes(app: FastifyInstance) {
     const body = request.body as { title?: string; description?: string | null; license_note?: string | null; image_asset_id?: string | null; position?: number }
     if (body.title !== undefined && (body.title.trim().length < 2 || body.title.length > 120)) {
       return reply.code(400).send({ error: 'title must be 2 to 120 characters', code: 'INVALID_TITLE' })
+    }
+    if (body.description !== undefined && body.description !== null && body.description.length > 500) {
+      return reply.code(400).send({ error: 'description must be 500 characters or fewer', code: 'INVALID_DESCRIPTION' })
+    }
+    if (body.license_note !== undefined && body.license_note !== null && body.license_note.length > 4000) {
+      return reply.code(400).send({ error: 'license_note must be 4000 characters or fewer', code: 'INVALID_LICENSE_NOTE' })
     }
     const category = await MusicCategoryModel.update(id, body)
     if (!category) return reply.code(404).send({ error: 'Category not found', code: 'NOT_FOUND' })
@@ -262,6 +274,9 @@ export default async function musicRoutes(app: FastifyInstance) {
     if (!body.title || body.title.trim().length < 1 || body.title.length > 150) {
       return reply.code(400).send({ error: 'title must be 1 to 150 characters', code: 'INVALID_TITLE' })
     }
+    if (body.description !== undefined && body.description.length > 500) {
+      return reply.code(400).send({ error: 'description must be 500 characters or fewer', code: 'INVALID_DESCRIPTION' })
+    }
     const category = await MusicCategoryModel.findById(body.category_id)
     if (!category) return reply.code(404).send({ error: 'Category not found', code: 'NOT_FOUND' })
 
@@ -280,6 +295,9 @@ export default async function musicRoutes(app: FastifyInstance) {
     const body = request.body as { title?: string; description?: string | null; image_asset_id?: string | null; position?: number }
     if (body.title !== undefined && (body.title.trim().length < 1 || body.title.length > 150)) {
       return reply.code(400).send({ error: 'title must be 1 to 150 characters', code: 'INVALID_TITLE' })
+    }
+    if (body.description !== undefined && body.description !== null && body.description.length > 500) {
+      return reply.code(400).send({ error: 'description must be 500 characters or fewer', code: 'INVALID_DESCRIPTION' })
     }
     const track = await MusicTrackModel.update(id, body)
     if (!track) return reply.code(404).send({ error: 'Track not found', code: 'NOT_FOUND' })


### PR DESCRIPTION
## Résumé

Revue "senior architecte" avant une passe de polish plus large (2h de main libre accordées par Jonathan). Deux trous trouvés en relisant `music.ts` au complet.

1. Plusieurs champs texte (description catégorie/morceau, sous-titre de page, note de licence) n'avaient de limite que côté client (`maxlength` HTML, contournable par un appel API direct). Ajoute les mêmes bornes côté serveur.
2. `GET /categories/:slug` faisait une requête SQL par morceau pour ses commentaires (N requêtes en parallèle). Remplacé par une seule requête groupée.

Aucun changement de comportement pour un appelant légitime (le frontend respectait déjà ces limites) : juste une garde serveur qui manquait, et une requête plus propre.

## Vérifications

- `npm test` : 1018 tests verts
- `npx tsc --noEmit` : 0 erreur