### PR TITLE
feat(musique): duree du morceau affichee avant lecture

### DIFF
--- a/nodyx-core/src/migrations/123_music_track_duration.sql
+++ b/nodyx-core/src/migrations/123_music_track_duration.sql
@@ -1,0 +1,7 @@
+-- ─── Durée d'un morceau ────────────────────────────────────────────────────
+--
+-- Affichée avant même de lancer la lecture (mm:ss), comme n'importe quel
+-- service d'écoute sérieux. Extraite une fois à l'upload (music-metadata),
+-- jamais recalculée à la volée.
+
+ALTER TABLE music_tracks ADD COLUMN IF NOT EXISTS duration_seconds INT;

--- a/nodyx-core/src/models/musicTrack.ts
+++ b/nodyx-core/src/models/musicTrack.ts
@@ -8,6 +8,7 @@ export interface MusicTrack {
   audio_url:   string
   image_url:   string | null
   likes:       number
+  duration_seconds: number | null
   position:    number
   created_at:  string
   updated_at:  string
@@ -15,7 +16,7 @@ export interface MusicTrack {
 
 const SELECT = `
   SELECT
-    mt.id, mt.category_id, mt.title, mt.description, mt.likes, mt.position,
+    mt.id, mt.category_id, mt.title, mt.description, mt.likes, mt.duration_seconds, mt.position,
     mt.created_at, mt.updated_at,
     '/uploads/' || audio.file_path AS audio_url,
     CASE WHEN img.thumbnail_path IS NOT NULL THEN '/uploads/' || img.thumbnail_path
@@ -40,20 +41,21 @@ export async function findById(id: string): Promise<MusicTrack | null> {
 }
 
 export async function create(data: {
-  category_id:     string
-  title:           string
-  description?:    string | null
-  audio_asset_id:  string
-  image_asset_id?: string | null
+  category_id:       string
+  title:             string
+  description?:      string | null
+  audio_asset_id:    string
+  image_asset_id?:   string | null
+  duration_seconds?: number | null
 }): Promise<MusicTrack> {
   const { rows: posRows } = await db.query<{ next: number }>(
     `SELECT COALESCE(MAX(position), -1) + 1 AS next FROM music_tracks WHERE category_id = $1`,
     [data.category_id]
   )
   const { rows } = await db.query<{ id: string }>(
-    `INSERT INTO music_tracks (category_id, title, description, audio_asset_id, image_asset_id, position)
-     VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
-    [data.category_id, data.title, data.description ?? null, data.audio_asset_id, data.image_asset_id ?? null, posRows[0].next]
+    `INSERT INTO music_tracks (category_id, title, description, audio_asset_id, image_asset_id, duration_seconds, position)
+     VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
+    [data.category_id, data.title, data.description ?? null, data.audio_asset_id, data.image_asset_id ?? null, data.duration_seconds ?? null, posRows[0].next]
   )
   return (await findById(rows[0].id))!
 }

--- a/nodyx-core/src/routes/music.ts
+++ b/nodyx-core/src/routes/music.ts
@@ -12,6 +12,7 @@ import { FastifyInstance } from 'fastify'
 import { rateLimit } from '../middleware/rateLimit'
 import { adminOnly } from '../middleware/adminOnly'
 import { db } from '../config/database'
+import { parseBuffer } from 'music-metadata'
 import { scanBuffer } from '../services/fileScanner'
 import { uploadAsset } from '../services/assetService'
 import { generateLicensePdf } from '../services/licenseDocument'
@@ -266,7 +267,7 @@ export default async function musicRoutes(app: FastifyInstance) {
   app.post('/tracks', { preHandler: [rateLimit, adminOnly] }, async (request, reply) => {
     const body = request.body as {
       category_id?: string; title?: string; description?: string
-      audio_asset_id?: string; image_asset_id?: string
+      audio_asset_id?: string; image_asset_id?: string; duration_seconds?: number
     }
     if (!body.category_id || !body.audio_asset_id) {
       return reply.code(400).send({ error: 'category_id and audio_asset_id are required', code: 'MISSING_FIELDS' })
@@ -281,11 +282,12 @@ export default async function musicRoutes(app: FastifyInstance) {
     if (!category) return reply.code(404).send({ error: 'Category not found', code: 'NOT_FOUND' })
 
     const track = await MusicTrackModel.create({
-      category_id:     body.category_id,
-      title:           body.title.trim(),
-      description:     body.description?.trim() || null,
-      audio_asset_id:  body.audio_asset_id,
-      image_asset_id:  body.image_asset_id || null,
+      category_id:       body.category_id,
+      title:             body.title.trim(),
+      description:       body.description?.trim() || null,
+      audio_asset_id:    body.audio_asset_id,
+      image_asset_id:    body.image_asset_id || null,
+      duration_seconds:  Number.isFinite(body.duration_seconds) ? body.duration_seconds : null,
     })
     return reply.code(201).send({ track })
   })
@@ -342,7 +344,17 @@ export default async function musicRoutes(app: FastifyInstance) {
       assetType:        'sound',
       name:             data.filename,
     })
-    return reply.send({ asset_id: asset.id, url: `/uploads/${asset.file_path}` })
+
+    // Duree extraite une fois ici, jamais recalculee a la volee. Best-effort :
+    // un fichier au format inhabituel ne doit pas faire echouer l'upload,
+    // juste laisser la duree vide (l'affichage s'en passe proprement).
+    let durationSeconds: number | null = null
+    try {
+      const metadata = await parseBuffer(buffer, data.mimetype)
+      if (metadata.format.duration) durationSeconds = Math.round(metadata.format.duration)
+    } catch { /* duree non critique, l'upload reste valide */ }
+
+    return reply.send({ asset_id: asset.id, url: `/uploads/${asset.file_path}`, duration_seconds: durationSeconds })
   })
 
   app.post('/upload/image', { preHandler: [rateLimit, adminOnly] }, async (request, reply) => {

--- a/nodyx-frontend/src/routes/admin/music/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/music/+page.svelte
@@ -15,7 +15,14 @@
 	}
 	interface Track {
 		id: string; category_id: string; title: string; description: string | null;
-		audio_url: string; image_url: string | null; position: number;
+		audio_url: string; image_url: string | null; position: number; duration_seconds: number | null;
+	}
+
+	function formatDuration(seconds: number | null): string {
+		if (!seconds || seconds <= 0) return '';
+		const m = Math.floor(seconds / 60);
+		const s = Math.round(seconds % 60).toString().padStart(2, '0');
+		return `${m}:${s}`;
 	}
 	interface Settings { title: string | null; subtitle: string | null; banner_url: string | null; }
 
@@ -43,7 +50,7 @@
 		return res.status === 204 ? null : res.json();
 	}
 
-	async function uploadFile(kind: 'audio' | 'image', file: File): Promise<{ asset_id: string; url: string }> {
+	async function uploadFile(kind: 'audio' | 'image', file: File): Promise<{ asset_id: string; url: string; duration_seconds?: number | null }> {
 		const fd = new FormData();
 		fd.append('file', file);
 		const res = await fetch(`/api/v1/music/upload/${kind}`, {
@@ -269,6 +276,7 @@
 					description:    (newTrackDesc[cat.id] ?? '').trim() || undefined,
 					audio_asset_id: audioUp.asset_id,
 					image_asset_id: imageUp?.asset_id,
+					duration_seconds: audioUp.duration_seconds ?? undefined,
 				}),
 			});
 
@@ -583,10 +591,15 @@
 										<input type="text" value={track.title} maxlength="150"
 											onblur={(e) => { const v = (e.target as HTMLInputElement).value.trim(); if (v && v !== track.title) updateTrackText(cat, track, v, track.description ?? ''); }}
 											class="w-full bg-transparent text-sm text-white font-medium focus:outline-none focus:border-b focus:border-indigo-500" />
-										<input type="text" value={track.description ?? ''} maxlength="500"
-											placeholder={tFn('amusic.field_description')}
-											onblur={(e) => { const v = (e.target as HTMLInputElement).value.trim(); if (v !== (track.description ?? '')) updateTrackText(cat, track, track.title, v); }}
-											class="w-full bg-transparent text-xs text-gray-500 focus:outline-none focus:border-b focus:border-indigo-500" />
+										<div class="flex items-center gap-2">
+											<input type="text" value={track.description ?? ''} maxlength="500"
+												placeholder={tFn('amusic.field_description')}
+												onblur={(e) => { const v = (e.target as HTMLInputElement).value.trim(); if (v !== (track.description ?? '')) updateTrackText(cat, track, track.title, v); }}
+												class="flex-1 min-w-0 bg-transparent text-xs text-gray-500 focus:outline-none focus:border-b focus:border-indigo-500" />
+											{#if formatDuration(track.duration_seconds)}
+												<span class="shrink-0 text-xs text-gray-500 font-mono">{formatDuration(track.duration_seconds)}</span>
+											{/if}
+										</div>
 										<audio src={track.audio_url} controls class="w-full h-8 mt-1"></audio>
 									</div>
 									<button type="button" onclick={() => toggleTrackComments(track)}

--- a/nodyx-frontend/src/routes/musique/[slug]/+page.svelte
+++ b/nodyx-frontend/src/routes/musique/[slug]/+page.svelte
@@ -9,7 +9,14 @@
 
 	interface Comment { id: string; author_name: string; body: string; created_at: string }
 	interface Category { id: string; slug: string; title: string; description: string | null; license_note: string | null; image_url: string | null; views: number }
-	interface Track { id: string; title: string; description: string | null; audio_url: string; image_url: string | null; likes: number; comments: Comment[] }
+	interface Track { id: string; title: string; description: string | null; audio_url: string; image_url: string | null; likes: number; duration_seconds: number | null; comments: Comment[] }
+
+	function formatDuration(seconds: number | null): string {
+		if (!seconds || seconds <= 0) return '';
+		const m = Math.floor(seconds / 60);
+		const s = Math.round(seconds % 60).toString().padStart(2, '0');
+		return `${m}:${s}`;
+	}
 	interface Settings { title: string | null; subtitle: string | null; banner_url: string | null; }
 
 	const category = $derived(data.category as Category);
@@ -194,7 +201,12 @@
 					{/if}
 					<div class="mus-track-main">
 						<div class="mus-track-head">
-							<p class="mus-track-title">{track.title}</p>
+							<p class="mus-track-title">
+								{track.title}
+								{#if formatDuration(track.duration_seconds)}
+									<span class="mus-track-duration">{formatDuration(track.duration_seconds)}</span>
+								{/if}
+							</p>
 							<span class="mus-track-actions">
 								<button type="button" class="mus-share-btn mus-like-btn" class:mus-like-btn--active={likedTracks.has(track.id)}
 									onclick={() => likeTrack(track)} disabled={likedTracks.has(track.id)}
@@ -430,6 +442,15 @@
 		font-weight: 600;
 		color: #fff;
 		margin: 0;
+	}
+
+	.mus-track-duration {
+		font-family: ui-monospace, 'JetBrains Mono', SFMono-Regular, Menlo, Consolas, monospace;
+		font-size: 0.75rem;
+		font-weight: 400;
+		color: rgba(255, 255, 255, 0.35);
+		margin-left: 8px;
+		font-variant-numeric: tabular-nums;
 	}
 
 	.mus-track-actions {


### PR DESCRIPTION
## Résumé

Durée affichée en mm:ss à côté du titre de chaque morceau, avant même de lancer la lecture (comme Spotify/Bandcamp). Extraite une fois à l'upload avec `music-metadata`, déjà une dépendance du projet (Soundboard du Streamer Hub), pas un nouvel ajout.

Best-effort : un fichier audio au format inhabituel ne fait pas échouer l'upload, la durée reste simplement absente pour ce morceau.

## Vérifications

- `npm test` (nodyx-core) : 1018 tests verts, `npx tsc --noEmit` : 0 erreur
- Extraction testée en vrai sur 3 fichiers déjà en prod (259s, 264s, 218s)
- `npm run check` (nodyx-frontend) : 0 erreur, `i18n:check` vert

## Test plan

- [ ] Migration appliquée automatiquement au redémarrage de nodyx-core
- [ ] Ajouter un morceau depuis `/admin/music`, vérifier que la durée apparaît
- [ ] Vérifier l'affichage sur `/musique/<categorie>`