### PR TITLE
feat(musique): note de licence par défaut

### DIFF
--- a/nodyx-core/src/migrations/124_music_default_license.sql
+++ b/nodyx-core/src/migrations/124_music_default_license.sql
@@ -1,0 +1,9 @@
+-- ─── Note de licence par défaut ───────────────────────────────────────────────
+--
+-- Retaper la meme note de licence a chaque nouvelle categorie (meme studio,
+-- meme jeu, meme outil) est une friction reelle, vecue en session (5 fois de
+-- suite a la main). Une note par defaut, reglee une fois pour l'instance,
+-- est appliquee automatiquement a la creation d'une categorie (modifiable
+-- ensuite comme n'importe quelle note de licence existante).
+
+ALTER TABLE communities ADD COLUMN IF NOT EXISTS music_default_license_note TEXT;

--- a/nodyx-core/src/models/musicCategory.ts
+++ b/nodyx-core/src/models/musicCategory.ts
@@ -59,9 +59,10 @@ export async function findById(id: string): Promise<MusicCategory | null> {
 }
 
 export async function create(data: {
-  community_id: string
-  title:        string
-  description?: string | null
+  community_id:  string
+  title:         string
+  description?:  string | null
+  license_note?: string | null
 }): Promise<MusicCategory> {
   const baseSlug = generateCategorySlug(data.title)
 
@@ -84,9 +85,9 @@ export async function create(data: {
   )
 
   const { rows } = await db.query<{ id: string }>(
-    `INSERT INTO music_categories (community_id, slug, title, description, position)
-     VALUES ($1, $2, $3, $4, $5) RETURNING id`,
-    [data.community_id, slug, data.title, data.description ?? null, posRows[0].next]
+    `INSERT INTO music_categories (community_id, slug, title, description, license_note, position)
+     VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
+    [data.community_id, slug, data.title, data.description ?? null, data.license_note ?? null, posRows[0].next]
   )
   return (await findById(rows[0].id))!
 }

--- a/nodyx-core/src/routes/music.ts
+++ b/nodyx-core/src/routes/music.ts
@@ -41,14 +41,18 @@ async function getCommunityId(): Promise<string | null> {
 }
 
 interface MusicPageSettings {
-  title:      string | null
-  subtitle:   string | null
-  banner_url: string | null
+  title:                string | null
+  subtitle:             string | null
+  banner_url:           string | null
+  default_license_note: string | null
 }
 
 async function getPageSettings(communityId: string): Promise<MusicPageSettings> {
-  const { rows } = await db.query<{ music_page_title: string | null; music_page_subtitle: string | null; file_path: string | null }>(
-    `SELECT c.music_page_title, c.music_page_subtitle, a.file_path
+  const { rows } = await db.query<{
+    music_page_title: string | null; music_page_subtitle: string | null
+    music_default_license_note: string | null; file_path: string | null
+  }>(
+    `SELECT c.music_page_title, c.music_page_subtitle, c.music_default_license_note, a.file_path
      FROM communities c
      LEFT JOIN community_assets a ON a.id = c.music_page_banner_asset_id
      WHERE c.id = $1`,
@@ -56,9 +60,10 @@ async function getPageSettings(communityId: string): Promise<MusicPageSettings> 
   )
   const row = rows[0]
   return {
-    title:      row?.music_page_title ?? null,
-    subtitle:   row?.music_page_subtitle ?? null,
-    banner_url: row?.file_path ? `/uploads/${row.file_path}` : null,
+    title:                row?.music_page_title ?? null,
+    subtitle:             row?.music_page_subtitle ?? null,
+    banner_url:           row?.file_path ? `/uploads/${row.file_path}` : null,
+    default_license_note: row?.music_default_license_note ?? null,
   }
 }
 
@@ -74,12 +79,15 @@ export default async function musicRoutes(app: FastifyInstance) {
   })
 
   app.patch('/settings', { preHandler: [rateLimit, adminOnly] }, async (request, reply) => {
-    const body = request.body as { title?: string | null; subtitle?: string | null; banner_asset_id?: string | null }
+    const body = request.body as { title?: string | null; subtitle?: string | null; banner_asset_id?: string | null; default_license_note?: string | null }
     if (body.title !== undefined && body.title !== null && body.title.length > 120) {
       return reply.code(400).send({ error: 'title must be 120 characters or fewer', code: 'INVALID_TITLE' })
     }
     if (body.subtitle !== undefined && body.subtitle !== null && body.subtitle.length > 300) {
       return reply.code(400).send({ error: 'subtitle must be 300 characters or fewer', code: 'INVALID_SUBTITLE' })
+    }
+    if (body.default_license_note !== undefined && body.default_license_note !== null && body.default_license_note.length > 4000) {
+      return reply.code(400).send({ error: 'default_license_note must be 4000 characters or fewer', code: 'INVALID_LICENSE_NOTE' })
     }
     const communityId = await getCommunityId()
     if (!communityId) return reply.code(503).send({ error: 'Community not configured' })
@@ -87,9 +95,10 @@ export default async function musicRoutes(app: FastifyInstance) {
     const fields: string[] = []
     const values: unknown[] = []
     let i = 1
-    if (body.title           !== undefined) { fields.push(`music_page_title = $${i++}`);           values.push(body.title) }
-    if (body.subtitle        !== undefined) { fields.push(`music_page_subtitle = $${i++}`);         values.push(body.subtitle) }
-    if (body.banner_asset_id !== undefined) { fields.push(`music_page_banner_asset_id = $${i++}`);  values.push(body.banner_asset_id) }
+    if (body.title                 !== undefined) { fields.push(`music_page_title = $${i++}`);              values.push(body.title) }
+    if (body.subtitle              !== undefined) { fields.push(`music_page_subtitle = $${i++}`);            values.push(body.subtitle) }
+    if (body.banner_asset_id       !== undefined) { fields.push(`music_page_banner_asset_id = $${i++}`);     values.push(body.banner_asset_id) }
+    if (body.default_license_note  !== undefined) { fields.push(`music_default_license_note = $${i++}`);    values.push(body.default_license_note) }
     if (fields.length > 0) {
       values.push(communityId)
       await db.query(`UPDATE communities SET ${fields.join(', ')} WHERE id = $${i}`, values)
@@ -230,10 +239,16 @@ export default async function musicRoutes(app: FastifyInstance) {
     const communityId = await getCommunityId()
     if (!communityId) return reply.code(503).send({ error: 'Community not configured' })
 
+    // Applique la note de licence par defaut de l'instance si elle existe :
+    // evite de la retaper a chaque nouvelle categorie (meme studio, meme
+    // jeu, meme outil dans la grande majorite des cas reels).
+    const settings = await getPageSettings(communityId)
+
     const category = await MusicCategoryModel.create({
       community_id: communityId,
       title:        title.trim(),
       description:  description?.trim() || null,
+      license_note: settings.default_license_note,
     })
     return reply.code(201).send({ category })
   })

--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -4632,6 +4632,8 @@
   "amusic.page_settings": "Public page (title, subtitle, banner)",
   "amusic.field_subtitle": "Subtitle",
   "amusic.field_banner": "Banner",
+  "amusic.default_license_note": "Default license note",
+  "amusic.default_license_note_help": "Applied automatically to any new category (still editable per category afterwards).",
   "amusic.upload_banner": "Add a banner",
   "amusic.remove_banner": "Remove banner",
   "amusic.new_category": "New category",

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -4632,6 +4632,8 @@
   "amusic.page_settings": "Page publique (titre, sous-titre, bannière)",
   "amusic.field_subtitle": "Sous-titre",
   "amusic.field_banner": "Bannière",
+  "amusic.default_license_note": "Note de licence par défaut",
+  "amusic.default_license_note_help": "Appliquée automatiquement à toute nouvelle catégorie (modifiable ensuite catégorie par catégorie).",
   "amusic.upload_banner": "Ajouter une bannière",
   "amusic.remove_banner": "Retirer la bannière",
   "amusic.new_category": "Nouvelle catégorie",

--- a/nodyx-frontend/src/routes/admin/music/+page.svelte
+++ b/nodyx-frontend/src/routes/admin/music/+page.svelte
@@ -24,14 +24,14 @@
 		const s = Math.round(seconds % 60).toString().padStart(2, '0');
 		return `${m}:${s}`;
 	}
-	interface Settings { title: string | null; subtitle: string | null; banner_url: string | null; }
+	interface Settings { title: string | null; subtitle: string | null; banner_url: string | null; default_license_note: string | null; }
 
 	let categories  = $state<Category[]>(data.categories ?? []);
 	let tracksByCat = $state<Record<string, Track[]>>({});
 	let openCat     = $state<string | null>(null);
 	let busy        = $state<string | null>(null); // clé de l'opération en cours (feedback UI)
 	let errorMsg    = $state<string | null>(null);
-	let settings    = $state<Settings>(data.settings ?? { title: null, subtitle: null, banner_url: null });
+	let settings    = $state<Settings>(data.settings ?? { title: null, subtitle: null, banner_url: null, default_license_note: null });
 	let bannerInput = $state<HTMLInputElement | null>(null);
 
 	// ── Nouvelle catégorie ───────────────────────────────────────────────────
@@ -70,7 +70,7 @@
 		categories = json.categories;
 	}
 
-	async function patchSettings(patch: { title?: string | null; subtitle?: string | null; banner_asset_id?: string | null }) {
+	async function patchSettings(patch: { title?: string | null; subtitle?: string | null; banner_asset_id?: string | null; default_license_note?: string | null }) {
 		const json = await api('/settings', {
 			method: 'PATCH',
 			headers: { 'Content-Type': 'application/json' },
@@ -79,7 +79,7 @@
 		settings = json.settings;
 	}
 
-	async function updateSettingsText(patch: { title?: string | null; subtitle?: string | null }) {
+	async function updateSettingsText(patch: { title?: string | null; subtitle?: string | null; default_license_note?: string | null }) {
 		busy = 'settings';
 		errorMsg = null;
 		try {
@@ -429,6 +429,14 @@
 					placeholder={tFn('music.subtitle')}
 					onblur={(e) => { const v = (e.target as HTMLTextAreaElement).value.trim(); if (v !== (settings.subtitle ?? '')) updateSettingsText({ subtitle: v || null }); }}
 					class="w-full rounded-lg bg-gray-800 border border-gray-700 px-3 py-2 text-white text-sm focus:outline-none focus:border-indigo-500">{settings.subtitle ?? ''}</textarea>
+			</div>
+			<div>
+				<label for="page-default-license" class="block text-xs text-gray-400 mb-1">{tFn('amusic.default_license_note')}</label>
+				<p class="text-[11px] text-gray-500 mb-1">{tFn('amusic.default_license_note_help')}</p>
+				<textarea id="page-default-license" rows="3" maxlength="4000"
+					placeholder={tFn('amusic.license_note_ph')}
+					onblur={(e) => { const v = (e.target as HTMLTextAreaElement).value.trim(); if (v !== (settings.default_license_note ?? '')) updateSettingsText({ default_license_note: v || null }); }}
+					class="w-full rounded-lg bg-gray-800 border border-gray-700 px-3 py-2 text-white text-xs focus:outline-none focus:border-indigo-500">{settings.default_license_note ?? ''}</textarea>
 			</div>
 			<div>
 				<p class="block text-xs text-gray-400 mb-1">{tFn('amusic.field_banner')}</p>


### PR DESCRIPTION
## Résumé

Retaper la même note de licence à chaque nouvelle catégorie (même studio, même jeu, même outil dans l'immense majorité des cas) était une friction réelle, vécue en session (5 fois de suite à la main en base). Réglable une fois dans le panneau "Page publique" de `/admin/music`, appliquée automatiquement à toute catégorie créée ensuite. Toujours modifiable catégorie par catégorie après coup.

## Vérifications

- `npm test` (nodyx-core) : 1018 tests verts, `npx tsc --noEmit` : 0 erreur
- `npm run check` (nodyx-frontend) : 0 erreur, 4 portes i18n vertes

## Test plan

- [ ] Migration appliquée automatiquement au redémarrage de nodyx-core
- [ ] Régler une note par défaut, créer une nouvelle catégorie, vérifier qu'elle l'a déjà