### PR TITLE
feat(musique): aperçu Discord propre par morceau partagé

### DIFF
--- a/nodyx-frontend/src/lib/locales/en.json
+++ b/nodyx-frontend/src/lib/locales/en.json
@@ -4625,6 +4625,7 @@
   "music.comment_count_plural": "{{n}} comments",
   "music.link_copied": "Link copied",
   "music.download_license": "License (PDF)",
+  "music.from_category": "from {{category}}",
   "amusic.page_title": "Music (admin)",
   "amusic.title": "Music",
   "amusic.subtitle": "Categories and tracks shown on the public /musique page.",

--- a/nodyx-frontend/src/lib/locales/fr.json
+++ b/nodyx-frontend/src/lib/locales/fr.json
@@ -4625,6 +4625,7 @@
   "music.comment_count_plural": "{{n}} commentaires",
   "music.link_copied": "Lien copié",
   "music.download_license": "Licence (PDF)",
+  "music.from_category": "extrait de {{category}}",
   "amusic.page_title": "Musique (admin)",
   "amusic.title": "Musique",
   "amusic.subtitle": "Catégories et morceaux affichés sur la page publique /musique.",

--- a/nodyx-frontend/src/routes/musique/[slug]/+page.server.ts
+++ b/nodyx-frontend/src/routes/musique/[slug]/+page.server.ts
@@ -2,7 +2,7 @@ import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { apiFetch } from '$lib/api';
 
-export const load: PageServerLoad = async ({ fetch, params }) => {
+export const load: PageServerLoad = async ({ fetch, params, url }) => {
 	const res = await apiFetch(fetch, `/music/categories/${params.slug}`);
 	if (res.status === 404) error(404, 'Category not found.');
 	if (!res.ok) error(500, 'Server error.');
@@ -11,5 +11,12 @@ export const load: PageServerLoad = async ({ fetch, params }) => {
 	const settingsRes = await apiFetch(fetch, '/music/settings');
 	const settingsJson = settingsRes.ok ? await settingsRes.json() : { settings: null };
 
-	return { category, tracks, settings: settingsJson.settings ?? null };
+	// ?t=<id> : le lien de partage d'un morceau précis (bouton "Partager" sur
+	// chaque piste) porte son propre id, pour que l'aperçu Discord montre CE
+	// morceau (titre, image) plutôt que celui de la catégorie entière. Le
+	// contenu affiché au visiteur humain ne change pas, seules les balises
+	// og: changent (voir +page.svelte).
+	const featuredTrackId = url.searchParams.get('t');
+
+	return { category, tracks, settings: settingsJson.settings ?? null, featuredTrackId };
 };

--- a/nodyx-frontend/src/routes/musique/[slug]/+page.svelte
+++ b/nodyx-frontend/src/routes/musique/[slug]/+page.svelte
@@ -24,6 +24,12 @@
 	const settings = $derived(data.settings as Settings | null);
 	const totalComments = $derived(tracks.reduce((sum, t) => sum + (commentsByTrack[t.id] ?? t.comments).length, 0));
 
+	// ?t=<id> (voir +page.server.ts) : le lien de partage d'un morceau precis
+	// porte son propre id, pour que l'apercu Discord montre CE morceau (titre,
+	// image) plutot que celui de la categorie entiere. Contenu affiche au
+	// visiteur humain inchange, seules les balises og: en dependent.
+	const featuredTrack = $derived(tracks.find(t => t.id === data.featuredTrackId) ?? null);
+
 	// Discord/Twitter/Facebook exigent une URL absolue et n'exécutent aucun JS :
 	// on résout ici, côté SSR, jamais via window.
 	function absolutize(url: string | null | undefined, origin: string): string | null {
@@ -32,20 +38,29 @@
 		return origin + url;
 	}
 
-	// Couverture de la catégorie → image du 1er morceau → bannière de la page
-	// musique → bannière/logo de la communauté → image par défaut du site.
+	// Couverture du morceau partagé (si un lien de morceau précis) → couverture
+	// de la catégorie → image du 1er morceau → bannière de page → bannière/logo
+	// de communauté → image par défaut du site.
 	const shareImage = $derived(
 		absolutize(
-			category.image_url ?? tracks[0]?.image_url ?? settings?.banner_url ?? (page.data as any).communityBannerUrl ?? (page.data as any).communityLogoUrl,
+			featuredTrack?.image_url ?? category.image_url ?? tracks[0]?.image_url ?? settings?.banner_url ?? (page.data as any).communityBannerUrl ?? (page.data as any).communityLogoUrl,
 			page.url.origin,
 		) ?? `${page.url.origin}/og-image.jpg`,
 	);
 
+	const shareTitle = $derived(featuredTrack ? `${featuredTrack.title} · ${category.title}` : category.title);
+
 	const richDescription = $derived(
-		[
-			category.description,
-			`${tFn(tracks.length === 1 ? 'music.track_count_one' : 'music.track_count_plural').replace('{{n}}', String(tracks.length))}${category.views > 0 ? ' · ' + tFn(category.views === 1 ? 'music.views_one' : 'music.views_plural').replace('{{n}}', String(category.views)) : ''}`,
-		].filter(Boolean).join(' · ')
+		featuredTrack
+			? [
+				featuredTrack.description,
+				formatDuration(featuredTrack.duration_seconds),
+				tFn('music.from_category').replace('{{category}}', category.title),
+			].filter(Boolean).join(' · ')
+			: [
+				category.description,
+				`${tFn(tracks.length === 1 ? 'music.track_count_one' : 'music.track_count_plural').replace('{{n}}', String(tracks.length))}${category.views > 0 ? ' · ' + tFn(category.views === 1 ? 'music.views_one' : 'music.views_plural').replace('{{n}}', String(category.views)) : ''}`,
+			].filter(Boolean).join(' · ')
 	);
 
 	let copiedId = $state<string | null>(null);
@@ -136,7 +151,9 @@
 	}
 
 	async function copyTrackLink(id: string) {
-		const url = `${location.origin}${location.pathname}#${id}`;
+		// ?t=<id> donne son propre apercu Discord au morceau (voir shareTitle/
+		// shareImage plus haut) ; #<id> fait defiler jusqu'a lui a l'ouverture.
+		const url = `${location.origin}${location.pathname}?t=${id}#${id}`;
 		try {
 			await navigator.clipboard.writeText(url);
 			copiedId = id;
@@ -146,9 +163,9 @@
 </script>
 
 <svelte:head>
-	<title>{category.title} · {tFn('music.title')}</title>
+	<title>{shareTitle} · {tFn('music.title')}</title>
 	<meta name="description" content={richDescription} />
-	<meta property="og:title" content={category.title} />
+	<meta property="og:title" content={shareTitle} />
 	<meta property="og:description" content={richDescription} />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content={page.url.href} />


### PR DESCRIPTION
## Résumé

Le bouton "Partager" d'un morceau ne donnait que le lien de la catégorie : Discord affichait l'image et le titre de la catégorie entière, jamais ceux du morceau précis qu'on voulait montrer (un des points relevés sur la liste des manques).

Le lien porte désormais `?t=<id>` en plus de l'ancre `#<id>`. La page reste identique pour un visiteur humain (même contenu, défilement jusqu'au morceau), mais les balises `og:title`/`og:image`/description mettent en avant CE morceau (sa propre image si elle existe, sa durée, la catégorie d'origine) plutôt que la catégorie générique.

## Vérifications

- `npm run check` : 0 erreur
- 4 portes i18n : vertes

## Test plan

- [ ] `npm run build && pm2 restart nodyx-frontend` après merge
- [ ] Copier le lien d'un morceau avec image propre, vérifier l'aperçu Discord (titre + image du morceau)